### PR TITLE
Initialize event pointer with NULL to avoid SEGV.

### DIFF
--- a/lib/CL/clFinish.c
+++ b/lib/CL/clFinish.c
@@ -94,7 +94,7 @@ POsym(clFinish)
 static void exec_commands (_cl_command_node *node_list)
 {
   int i;
-  cl_event *event;
+  cl_event *event = NULL;
   _cl_command_node *node;
   cl_command_queue command_queue = NULL;
   event_callback_item* cb_ptr;


### PR DESCRIPTION
The event pointer in exec_command in clFinish.c was not
initialized.  In some cases, some uninitialized value will
be dereferenced and result in SEGV.
