### PR TITLE
Remove duplicated AC_DEFINE().

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -590,9 +590,6 @@ then
 	CFLAGS="$CFLAGS -Wno-unused-result -Werror"
 fi
 
-AC_DEFINE([HAVE_GL_GL_H], [], [OpenGL])
-AC_DEFINE([HAVE_OPENGL_OPENGL_H], [], [OpenGL on Apple])
-
 AC_CHECK_HEADERS([GL/gl.h OpenGL/OpenGL.h], [opengl_found="ok"; break])
 
 test -z "$opengl_found" && AC_MSG_FAILURE([Please install an OpenGL implementation with gl.h or OpenGL.h. It is required by the C++ bindings.])


### PR DESCRIPTION
Both HAVE_GL_GL_H and HAVE_OPENGL_OPENGL_H might be defined
by the AC_CHECK_HEADER(), so we should not define them with
AC_DEFINE().

This commit fixes the incorrect configure result of
AC_C_BIGENDIAN() when we add -Werror to CPPFLAGS.
