### PR TITLE
Fixed llvm-link command to use the version found by configure.

### DIFF
--- a/scripts/pocl-standalone.in
+++ b/scripts/pocl-standalone.in
@@ -106,7 +106,7 @@ pocl_lib="@abs_top_builddir@/lib/llvmopencl/.libs/llvmopencl.so"
 full_target_dir="@abs_top_builddir@/lib/kernel/${target_dir}"
 # END REMOVE ONCE INSTALLED
 
-llvm-link -o ${linked_bc} ${kernel_bc} ${full_target_dir}/kernel*.bc
+@LLVM_LINK@ -o ${linked_bc} ${kernel_bc} ${full_target_dir}/kernel*.bc
 
 OPT_SWITCH="-O3"
 


### PR DESCRIPTION
Bug was found while creating homebrew formula for 0.8 tarball. Homebrew has only versioned llvm33 package, whose llvm-link command is actually llvm-link-3.3.
