### PR TITLE
ARMv7-debian assembler fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -824,7 +824,7 @@ case $host_cpu in
   armv7l)
     AC_MSG_NOTICE([using the ARM optimized kernel lib for the native device])
     #GNU as does not understand 'march=cortex-a8' that clang sends it
-    HOST_CLANG_FLAGS="$HOST_CLANG_FLAGS -integrated-as"
+    #HOST_CLANG_FLAGS="$HOST_CLANG_FLAGS -integrated-as"
     # check for gnueabihf, and set clang target accordingly
     case $host in
       armv7l*gnueabihf)

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -100,7 +100,7 @@ llvm_codegen (const char* tmpdir) {
 #endif
 
       error = snprintf (command, COMMAND_LENGTH,
-			CLANG " " HOST_CLANG_FLAGS " -c -o %s.o %s " ADDITIONAL_CMD_STR,
+			CLANG " -c -o %s.o %s " ADDITIONAL_CMD_STR,
 			module,
 			assembly);
       assert (error >= 0);


### PR DESCRIPTION
This commit is needed for pocl to be able to compile kernels on ARM.
The integrated LLVM assembler is still broken (I'll send bugs to LLVM about this, but I don't think these will end up to 3.4), so a work-around the driving of GNU as is needed. 
Doe the change (remove HOST_CLANG_FLAGS from clang when acting as assembler driver) break for anyone. If so, the driving command needs to be #ifdef'ed.
