### PR TITLE
Runtime errors as path to kernel bc file had an extra KERNEL_DIR("host") string

### DIFF
--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -925,7 +925,6 @@ int call_pocl_workgroup(cl_device_id device,
     {
       // TODO: vefify this is the correct place!
       kernellib = PKGDATADIR;
-      kernellib += KERNEL_DIR;
       kernellib += "/kernel-";
       kernellib += device->llvm_target_triplet;
       kernellib += ".bc";


### PR DESCRIPTION
In call_pocl_workgroup, kernellib was referring to /usr/local/share/poclhost instead of /usr/local/share/pocl because of this extra addition. Verified on ARM & x64 machines
