### PR TITLE
Fix LLVM 3.4 compilation issues

### DIFF
--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -76,7 +76,7 @@
 using namespace clang;
 using namespace llvm;
 
-#if defined LLVM_3_2 || defined LLVM_3_3
+#if defined LLVM_3_2 || defined LLVM_3_3 || defined LLVM_3_4
 #include "llvm/Support/raw_ostream.h"
 #define F_Binary llvm::raw_fd_ostream::F_Binary
 #else

--- a/lib/llvmopencl/GenerateHeader.cc
+++ b/lib/llvmopencl/GenerateHeader.cc
@@ -107,7 +107,7 @@ GenerateHeader::runOnModule(Module &M)
   FunctionMapping kernels;
 
   string ErrorInfo;
-  #if defined LLVM_3_2 or defined LLVM_3_3 
+  #if defined LLVM_3_2 or defined LLVM_3_3 or defined LLVM_3_4
   raw_fd_ostream out(Header.c_str(), ErrorInfo, raw_fd_ostream::F_Append);
   #else
   raw_fd_ostream out(Header.c_str(), ErrorInfo, sys::fs::F_Append);

--- a/lib/llvmopencl/TargetAddressSpaces.cc
+++ b/lib/llvmopencl/TargetAddressSpaces.cc
@@ -204,7 +204,7 @@ TargetAddressSpaces::runOnModule(llvm::Module &M) {
            ++ii) {
         llvm::Instruction *instr = ii;
 
-#if !(defined(LLVM_3_2) || defined(LLVM_3_3))
+#if !(defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4))
         if (isa<AddrSpaceCastInst>(instr)) {
           // Convert (now illegal) addresspacecasts to bitcasts.
 

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -483,13 +483,13 @@ createWorkgroup(Module &M, Function *F)
      * as is to the function, no need to load form it first. */
     Value *value;
     if (ii->hasByValAttr()) {
-#if defined(LLVM_3_2) || defined(LLVM_3_3)
+#if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4)
         value = builder.CreateBitCast(pointer, t);
 #else
         value = builder.CreatePointerCast(pointer, t);
 #endif
     } else {
-#if defined(LLVM_3_2) || defined(LLVM_3_3)
+#if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4)
         value = builder.CreateBitCast(pointer, t->getPointerTo());
 #else
         value = builder.CreatePointerCast(pointer, t->getPointerTo());
@@ -551,7 +551,7 @@ createWorkgroupFast(Module &M, Function *F)
     if (t->isPointerTy()) {
       if (!ii->hasByValAttr()) {
         /* Assume the pointer is directly in the arg array. */
-#if defined(LLVM_3_2) || defined(LLVM_3_3)
+#if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4)
         arguments.push_back(builder.CreateBitCast(pointer, t));
 #else
         arguments.push_back(builder.CreatePointerCast(pointer, t));
@@ -566,7 +566,7 @@ createWorkgroupFast(Module &M, Function *F)
 
     /* If it's a pass by value pointer argument, we just pass the pointer
      * as is to the function, no need to load from it first. */
-#if defined(LLVM_3_2) || defined(LLVM_3_3)
+#if defined(LLVM_3_2) || defined(LLVM_3_3) || defined(LLVM_3_4)
     Value *value = builder.CreateBitCast
       (pointer, t->getPointerTo(POCL_ADDRESS_SPACE_GLOBAL));
 #else

--- a/lib/llvmopencl/WorkitemLoops.cc
+++ b/lib/llvmopencl/WorkitemLoops.cc
@@ -304,7 +304,7 @@ WorkitemLoops::CreateLoopAround
   // We now have
   //   !1 = metadata !{metadata !1} <- self-referential root
 
-#ifdef LLVM_3_3
+#if defined(LLVM_3_3) || defined(LLVM_3_4)
   loopBranch->setMetadata("llvm.loop.parallel", Root);
 #else
   loopBranch->setMetadata("llvm.loop", Root);


### PR DESCRIPTION
This fixes compilation issues I had when compiling pocl on ubuntu 13.10 with clang/llvm version 3.4.
