### PR TITLE
Put _kernel.h in the correct path

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -22,7 +22,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-pkginclude_HEADERS = pocl.h _kernel.h pocl_device.h _kernel_c.h pocl_features.h pocl_types.h
+# Directory containing "private" headers
+pkgdataincludedir = $(pkgdatadir)/include
+pkgdatainclude_HEADERS = _kernel.h _kernel_c.h
+
+# Public - and default - includes dir
+pkginclude_HEADERS = pocl.h pocl_device.h pocl_features.h pocl_types.h
 include_HEADERS = poclu.h utlist.h
 
 SUBDIRS = CL OpenCL


### PR DESCRIPTION
Previously _kernel.h landed in pkgincludedir instead of in
pkgdatadir/include. The rationale behind this is, that headers required
by pocl should go to pkgdatadir/include, where as headers required by
3rd parties to build against pocl go into pkgcinludedir.

Signed-off-by: Fabian Deutsch fabiand@fedoraproject.org
