### PR TITLE
Devices: Init long_name from short name if not assigned

### DIFF
--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -70,6 +70,8 @@ pocl_device_common_init(struct _cl_device_id* dev)
     dev->version = "OpenCL 1.2 pocl";
 
   dev->short_name = strdup(dev->ops->device_name);
+  if(dev->long_name == NULL)
+    dev->long_name = dev->short_name;
 }
 
 void 


### PR DESCRIPTION
Assign short name to long name if long name is not set. This still allow to override it later. It avoids to segfault in clGetDeviceInfo for long_name .
