### PR TITLE
dropped out data pointer from write/read image command struct, since it is not needed.

### DIFF
--- a/include/pocl.h
+++ b/include/pocl.h
@@ -139,7 +139,6 @@ typedef struct
 /* clEnqueue(Write/Read)Image */
 typedef struct
 {
-  void *data;
   void *device_ptr;
   void *host_ptr;
   size_t origin[3];

--- a/lib/CL/clEnqueueReadImage.c
+++ b/lib/CL/clEnqueueReadImage.c
@@ -87,7 +87,6 @@ CL_API_SUFFIX__VERSION_1_0
       return status;
     }
   
-  cmd->command.rw_image.data = command_queue->device->data;
   cmd->command.rw_image.device_ptr = 
     image->device_ptrs[command_queue->device->dev_id];
   cmd->command.rw_image.host_ptr = ptr;

--- a/lib/CL/clEnqueueWriteImage.c
+++ b/lib/CL/clEnqueueWriteImage.c
@@ -68,7 +68,6 @@ POname(clEnqueueWriteImage)(cl_command_queue    command_queue,
       return status;
     }  
 
-  cmd->command.rw_image.data = command_queue->device->data;
   cmd->command.rw_image.device_ptr = 
     image->device_ptrs[command_queue->device->dev_id];
   cmd->command.rw_image.host_ptr = (void*) ptr;

--- a/lib/CL/clFinish.c
+++ b/lib/CL/clFinish.c
@@ -149,25 +149,25 @@ static void exec_commands (_cl_command_node *node_list)
         case CL_COMMAND_WRITE_IMAGE:
           POCL_UPDATE_EVENT_RUNNING(event, command_queue); 
           node->device->ops->write_rect 
-            (node->command.map_image.data, node->command.map_image.map_ptr,
-             node->command.map_image.device_ptr, node->command.map_image.origin,
-             node->command.map_image.origin, node->command.map_image.region, 
-             node->command.map_image.rowpitch, 
-             node->command.map_image.slicepitch,
-             node->command.map_image.rowpitch,
-             node->command.map_image.slicepitch);
+            (node->device->data, node->command.rw_image.host_ptr,
+             node->command.rw_image.device_ptr, node->command.rw_image.origin,
+             node->command.rw_image.origin, node->command.rw_image.region, 
+             node->command.rw_image.rowpitch, 
+             node->command.rw_image.slicepitch,
+             node->command.rw_image.rowpitch,
+             node->command.rw_image.slicepitch);
           POCL_UPDATE_EVENT_COMPLETE(event, command_queue);
           break;
         case CL_COMMAND_READ_IMAGE:
           POCL_UPDATE_EVENT_RUNNING(event, command_queue); 
           node->device->ops->read_rect 
-            (node->command.map_image.data, node->command.map_image.map_ptr,
-             node->command.map_image.device_ptr, node->command.map_image.origin,
-             node->command.map_image.origin, node->command.map_image.region, 
-             node->command.map_image.rowpitch, 
-             node->command.map_image.slicepitch,
-             node->command.map_image.rowpitch,
-             node->command.map_image.slicepitch);
+            (node->device->data, node->command.rw_image.host_ptr,
+             node->command.rw_image.device_ptr, node->command.rw_image.origin,
+             node->command.rw_image.origin, node->command.rw_image.region, 
+             node->command.rw_image.rowpitch, 
+             node->command.rw_image.slicepitch,
+             node->command.rw_image.rowpitch,
+             node->command.rw_image.slicepitch);
           POCL_UPDATE_EVENT_COMPLETE(event, command_queue);
           break;
         case CL_COMMAND_UNMAP_MEM_OBJECT:


### PR DESCRIPTION
dropped out data pointer from write/read image command struct, since it is not needed.
