### PR TITLE
clSetKernelArg: more check to conform to the spec

### DIFF
--- a/lib/CL/clSetKernelArg.c
+++ b/lib/CL/clSetKernelArg.c
@@ -47,6 +47,13 @@ POname(clSetKernelArg)(cl_kernel kernel,
   if (kernel->dyn_arguments == NULL)
     return CL_INVALID_KERNEL;
 
+  if (arg_size == 0 && kernel->arg_is_local[arg_index])
+    return CL_INVALID_ARG_SIZE;
+
+  if ((kernel->arg_is_pointer[arg_index] || kernel->arg_is_image[arg_index])
+        && (!kernel->arg_is_local[arg_index]) && (arg_size != sizeof(cl_mem)))
+    return CL_INVALID_ARG_SIZE;
+
   p = &(kernel->dyn_arguments[arg_index]);  
   
   if (arg_value != NULL && 

--- a/tests/regression/test_null_arg.cpp
+++ b/tests/regression/test_null_arg.cpp
@@ -95,7 +95,7 @@ main(void)
 
         // Set kernel args
         kernel.setArg(0, inBuffer);
-        kernel.setArg(1, 0);
+        kernel.setArg(1, (cl::Buffer) 0);
         kernel.setArg(2, outBuffer);
 
         // Create command queue


### PR DESCRIPTION
This patch adds more check in clSetKernelArgs (OpenCL 1.2 specification)
test test_null_arg.cpp was also fixed to pass the testsuite.
