### PR TITLE
Remove the old arrays of arg_is_* and check for arguments to be set in clEnqueueNDRangeKernel

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,7 +14,8 @@ OpenCL Runtime/Platform API support
 - OpenCL-C shuffle() and shuffle2() implementation added
 - Device probing modified to allow for device driver to detect device during
   runtime. POCL_DEVICES still supported.
-- Checks in clSetKernelArgs for argument validity
+- Checks in clSetKernelArgs() for argument validity
+- Checks in clEnqueueNDRange() for arguments to be all set
 
 Misc
 ----

--- a/include/pocl_device.h
+++ b/include/pocl_device.h
@@ -53,10 +53,6 @@ typedef struct {
     /* TODO: remove these if no (private) branch needs them
        anymore. Also from pocl_llvm_api.cc */
     unsigned short alocal_sizes[MAX_KERNEL_ARGS];
-    char arg_is_local[MAX_KERNEL_ARGS];
-    char arg_is_pointer[MAX_KERNEL_ARGS];
-    char arg_is_image[MAX_KERNEL_ARGS];
-    char arg_is_sampler[MAX_KERNEL_ARGS];
 #endif
     pocl_workgroup work_group_func;
 } __kernel_metadata;

--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -97,6 +97,14 @@ POname(clEnqueueNDRangeKernel)(cl_command_queue command_queue,
   if (global_x == 0 || global_y == 0 || global_z == 0)
     return CL_INVALID_GLOBAL_WORK_SIZE;
 
+  for (i = 0; i < kernel->num_args; i++)
+    {
+      if (!kernel->arg_info[i].is_set)
+        {
+          return CL_INVALID_KERNEL_ARGS;
+        }
+    }
+
   if (local_work_size != NULL) 
     {
       local_x = local_work_size[0];
@@ -291,7 +299,7 @@ POname(clEnqueueNDRangeKernel)(cl_command_queue command_queue,
   for (i = 0; i < kernel->num_args; ++i)
   {
     struct pocl_argument *al = &(kernel->dyn_arguments[i]);
-    if (!kernel->arg_is_local[i] && kernel->arg_is_pointer[i] && al->value != NULL)
+    if (!kernel->arg_info[i].is_local && kernel->arg_info[i].type == POCL_ARG_TYPE_POINTER && al->value != NULL)
       ++command_node->command.run.arg_buffer_count;
   }
   
@@ -302,7 +310,7 @@ POname(clEnqueueNDRangeKernel)(cl_command_queue command_queue,
   for (i = 0; i < kernel->num_args; ++i)
   {
     struct pocl_argument *al = &(kernel->dyn_arguments[i]);
-    if (!kernel->arg_is_local[i] && kernel->arg_is_pointer[i] && al->value != NULL)
+    if (!kernel->arg_info[i].is_local && kernel->arg_info[i].type == POCL_ARG_TYPE_POINTER && al->value != NULL)
       {
         cl_mem buf;
 #if 0

--- a/lib/CL/clGetKernelWorkGroupInfo.c
+++ b/lib/CL/clGetKernelWorkGroupInfo.c
@@ -80,7 +80,7 @@ POname(clGetKernelWorkGroupInfo)
       /* Count the host-allocated locals. */
       for (i = 0; i < kernel->num_args; ++i)
         {
-          if (!kernel->arg_is_local[i]) continue;
+          if (!kernel->arg_info[i].is_local) continue;
           local_size += kernel->dyn_arguments[i].size;
         }
       /* Count the automatic locals. */

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -460,12 +460,12 @@ pocl_basic_run
   for (i = 0; i < kernel->num_args; ++i)
     {
       al = &(cmd->command.run.arguments[i]);
-      if (kernel->arg_is_local[i])
+      if (kernel->arg_info[i].is_local)
         {
           arguments[i] = malloc (sizeof (void *));
           *(void **)(arguments[i]) = pocl_basic_malloc(data, 0, al->size, NULL);
         }
-      else if (kernel->arg_is_pointer[i])
+      else if (kernel->arg_info[i].type == POCL_ARG_TYPE_POINTER)
         {
           /* It's legal to pass a NULL pointer to clSetKernelArguments. In 
              that case we must pass the same NULL forward to the kernel.
@@ -479,7 +479,7 @@ pocl_basic_run
           else
             arguments[i] = &((*(cl_mem *) (al->value))->device_ptrs[device].mem_ptr);
         }
-      else if (kernel->arg_is_image[i])
+      else if (kernel->arg_info[i].type == POCL_ARG_TYPE_IMAGE)
         {
           dev_image_t di;
           fill_dev_image_t (&di, al, device);
@@ -489,7 +489,7 @@ pocl_basic_run
           *(void **)(arguments[i]) = devptr; 
           pocl_basic_write (data, &di, devptr, sizeof(dev_image_t));
         }
-      else if (kernel->arg_is_sampler[i])
+      else if (kernel->arg_info[i].type == POCL_ARG_TYPE_SAMPLER)
         {
           dev_sampler_t ds;
           
@@ -529,7 +529,7 @@ pocl_basic_run
     }
   for (i = 0; i < kernel->num_args; ++i)
     {
-      if (kernel->arg_is_local[i])
+      if (kernel->arg_info[i].is_local)
         pocl_basic_free(data, 0, *(void **)(arguments[i]));
     }
   for (i = kernel->num_args;

--- a/lib/CL/devices/cellspu/cellspu.c
+++ b/lib/CL/devices/cellspu/cellspu.c
@@ -370,7 +370,7 @@ pocl_cellspu_run
   for (i = 0; i < kernel->num_args; ++i)
     {
       al = &(kernel->dyn_arguments[i]);
-      if (kernel->arg_is_local[i])
+      if (kernel->arg_info[i].is_local)
         {
           chunk_info_t* local_chunk = cellspu_malloc_local (d, al->size);
           if (local_chunk == NULL)
@@ -379,7 +379,7 @@ pocl_cellspu_run
           dev_cmd.args[i] = local_chunk->start_address;
 
         }
-      else if (kernel->arg_is_pointer[i])
+      else if (kernel->arg_info[i].type == POCL_ARG_TYPE_POINTER)
         {
           /* It's legal to pass a NULL pointer to clSetKernelArguments. In 
              that case we must pass the same NULL forward to the kernel.
@@ -393,7 +393,7 @@ pocl_cellspu_run
                 (al->value))->device_ptrs[0]))->start_address;
 		//TODO: '0' above is the device number... don't hard-code!
         }
-      else if (kernel->arg_is_image[i])
+      else if (kernel->arg_info[i].type == POCL_ARG_TYPE_IMAGE)
         {
           POCL_ABORT_UNIMPLEMENTED();
 //          dev_image2d_t di;      
@@ -410,7 +410,7 @@ pocl_cellspu_run
 //          *(void **)(arguments[i]) = devptr; 
 //          pocl_cellspu_write (data, &di, devptr, sizeof(dev_image2d_t));
         }
-      else if (kernel->arg_is_sampler[i])
+      else if (kernel->arg_info[i].type == POCL_ARG_TYPE_SAMPLER)
         {
           POCL_ABORT_UNIMPLEMENTED();
 //          dev_sampler_t ds;
@@ -478,7 +478,7 @@ pocl_cellspu_run
   // Clean-up ? 
   for (i = 0; i < kernel->num_args; ++i)
     {
-      if (kernel->arg_is_local[i])
+      if (kernel->arg_info[i].is_local)
         pocl_cellspu_free(data, 0, *(void **)(arguments[i]));
     }
   for (i = kernel->num_args;

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -660,12 +660,12 @@ workgroup_thread (void *p)
   for (i = 0; i < kernel->num_args; ++i)
     {
       al = &(ta->kernel_args[i]);
-      if (kernel->arg_is_local[i])
+      if (kernel->arg_info[i].is_local)
         {
           arguments[i] = malloc (sizeof (void *));
           *(void **)(arguments[i]) = pocl_pthread_malloc(ta->data, 0, al->size, NULL);
         }
-      else if (kernel->arg_is_pointer[i])
+      else if (kernel->arg_info[i].type == POCL_ARG_TYPE_POINTER)
       {
         /* It's legal to pass a NULL pointer to clSetKernelArguments. In 
            that case we must pass the same NULL forward to the kernel.
@@ -682,7 +682,7 @@ workgroup_thread (void *p)
               &((*(cl_mem *)(al->value))->device_ptrs[ta->device].mem_ptr);
           }
       }
-      else if (kernel->arg_is_image[i])
+      else if (kernel->arg_info[i].type == POCL_ARG_TYPE_IMAGE)
         {
           dev_image_t di;
           fill_dev_image_t(&di, al, ta->device);
@@ -691,7 +691,7 @@ workgroup_thread (void *p)
           *(void **)(arguments[i]) = devptr;       
           pocl_pthread_write (ta->data, &di, devptr, sizeof(dev_image_t));
         }
-      else if (kernel->arg_is_sampler[i])
+      else if (kernel->arg_info[i].type == POCL_ARG_TYPE_SAMPLER)
         {
           dev_sampler_t ds;
           
@@ -735,13 +735,13 @@ workgroup_thread (void *p)
 
   for (i = 0; i < kernel->num_args; ++i)
     {
-      if (kernel->arg_is_local[i] )
+      if (kernel->arg_info[i].is_local )
         {
           pocl_pthread_free (ta->data, 0, *(void **)(arguments[i]));
           free (arguments[i]);
         }
-      else if (kernel->arg_is_sampler[i] || kernel->arg_is_image[i] || 
-               (kernel->arg_is_pointer[i] && *(void**)arguments[i] == NULL))
+      else if (kernel->arg_info[i].type == POCL_ARG_TYPE_SAMPLER || kernel->arg_info[i].type == POCL_ARG_TYPE_IMAGE || 
+               (kernel->arg_info[i].type == POCL_ARG_TYPE_POINTER && *(void**)arguments[i] == NULL))
         {
           free (arguments[i]);
         }

--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -453,7 +453,7 @@ pocl_tce_run
   for (i = 0; i < cmd->command.run.kernel->num_args; ++i)
     {
       al = &(cmd->command.run.arguments[i]);
-      if (cmd->command.run.kernel->arg_is_local[i])
+      if (cmd->command.run.kernel->arg_info[i].is_local)
         {
           chunk_info_t* local_chunk = pocl_tce_malloc_local (d, al->size);
           if (local_chunk == NULL)
@@ -466,7 +466,7 @@ pocl_tce_run
 #endif
           tempChunks.push_back(local_chunk);
         }
-      else if (cmd->command.run.kernel->arg_is_pointer[i])
+      else if (cmd->command.run.kernel->arg_info[i].type == POCL_ARG_TYPE_POINTER)
         {
           /* It's legal to pass a NULL pointer to clSetKernelArguments. In 
              that case we must pass the same NULL forward to the kernel.

--- a/lib/CL/devices/tce/ttasim/ttasim.cc
+++ b/lib/CL/devices/tce/ttasim/ttasim.cc
@@ -268,7 +268,7 @@ public:
     for (int i = 0; i < run_cmd->kernel->num_args; ++i)
       {
         struct pocl_argument *al = &(run_cmd->arguments[i]);
-        if (run_cmd->kernel->arg_is_pointer[i])
+        if (run_cmd->kernel->arg_info[i].type == POCL_ARG_TYPE_POINTER)
           {
             if (al->value == NULL) continue;
             unsigned start_addr = 
@@ -289,7 +289,7 @@ public:
             }
             out << std::endl << "}; " << std::endl << std::endl;
           } 
-        else if (!run_cmd->kernel->arg_is_local[i])
+        else if (!run_cmd->kernel->arg_info[i].is_local)
           {
             /* Scalars are stored to global buffers automatically. Dump them to buffers. */
             unsigned start_addr = BSWAP(dev_cmd.args[i]);
@@ -346,13 +346,13 @@ public:
         struct pocl_argument *al = &(run_cmd->arguments[a]);
         out << "\tkernel_command.args[" << std::dec << a << "] = ";
         
-        if (run_cmd->kernel->arg_is_local[a] || a >= run_cmd->kernel->num_args)
+        if (run_cmd->kernel->arg_info[a].is_local || a >= run_cmd->kernel->num_args)
           {
             /* Local buffers are managed by the host so the local
                addresses are already valid. */
             out << "(uint32_t)" << "0x" << std::hex << BSWAP(dev_cmd.args[a]);
           }
-        else if (run_cmd->kernel->arg_is_pointer[a] && dev_cmd.args[a] != 0)
+        else if (run_cmd->kernel->arg_info[a].type == POCL_ARG_TYPE_POINTER && dev_cmd.args[a] != 0)
           {
             unsigned start_addr = 
               ((chunk_info_t*)((*(cl_mem *) (al->value))->device_ptrs[parent->dev_id].mem_ptr))->start_address;

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -195,6 +195,22 @@ struct pocl_argument {
   void *value;
 };
 
+/**
+ * Enumeration for kernel argument types
+ */
+typedef enum {
+  POCL_ARG_TYPE_NONE = 0,
+  POCL_ARG_TYPE_POINTER = 1,
+  POCL_ARG_TYPE_IMAGE = 2,
+  POCL_ARG_TYPE_SAMPLER = 3,
+} pocl_argument_type;
+
+struct pocl_argument_info {
+  pocl_argument_type type;
+  char is_local;
+  char is_set;
+};
+
 struct pocl_device_ops {
   char *device_name;
   void (*init_device_infos) (struct _cl_device_id*);
@@ -468,10 +484,7 @@ struct _cl_kernel {
   cl_program program;
   /* implementation */
   lt_dlhandle dlhandle;
-  cl_int *arg_is_pointer;
-  cl_int *arg_is_local;
-  cl_int *arg_is_image;
-  cl_int *arg_is_sampler;
+  struct pocl_argument_info *arg_info;
   cl_uint num_locals;
   int *reqd_wg_size;
   /* The kernel arguments that are set with clSetKernelArg().


### PR DESCRIPTION
This patch add a new struct pocl_arguments_info in kernel holding the necessary informations for the kernel arguments (local, set and type).
It also add check for all arguments to be set before enqueing the kernel with clEnqueueNDRangeKernel
