### PR TITLE
Fix compilation against LLVM 3.4

### DIFF
--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -87,14 +87,12 @@
 using namespace clang;
 using namespace llvm;
 
-#if defined LLVM_3_2 || defined LLVM_3_3
-#include "llvm/Support/raw_ostream.h"
-#define F_Binary llvm::raw_fd_ostream::F_Binary
-#elif defined LLVM_3_4
-using llvm::sys::fs::F_Binary;
+#if defined LLVM_3_2 || defined LLVM_3_3 || defined LLVM_3_4
+  #include "llvm/Support/raw_ostream.h"
+  #define F_Binary llvm::raw_fd_ostream::F_Binary
 #else
-// a binary file is "not a text file"
-#define F_Binary llvm::sys::fs::F_None
+  // a binary file is "not a text file"
+  #define F_Binary llvm::sys::fs::F_None
 #endif
 
 

--- a/lib/llvmopencl/GenerateHeader.cc
+++ b/lib/llvmopencl/GenerateHeader.cc
@@ -112,10 +112,10 @@ GenerateHeader::runOnModule(Module &M)
   FunctionMapping kernels;
 
   string ErrorInfo;
-  #if defined LLVM_3_2 or defined LLVM_3_3 
-  raw_fd_ostream out(Header.c_str(), ErrorInfo, raw_fd_ostream::F_Append);
+  #if ( defined LLVM_3_2 or defined LLVM_3_3 or defined LLVM_3_4 )
+    raw_fd_ostream out(Header.c_str(), ErrorInfo, raw_fd_ostream::F_Append);
   #else
-  raw_fd_ostream out(Header.c_str(), ErrorInfo, sys::fs::F_Append);
+    raw_fd_ostream out(Header.c_str(), ErrorInfo, sys::fs::F_Append);
   #endif
 
   for (Module::iterator mi = M.begin(), me = M.end(); mi != me; ++mi) {

--- a/lib/llvmopencl/TargetAddressSpaces.cc
+++ b/lib/llvmopencl/TargetAddressSpaces.cc
@@ -198,7 +198,7 @@ TargetAddressSpaces::runOnModule(llvm::Module &M) {
            ++ii) {
         llvm::Instruction *instr = ii;
 
-#if !(defined(LLVM_3_2) || defined(LLVM_3_3))
+#if !( defined(LLVM_3_2) || defined(LLVM_3_3) || defined LLVM_3_4 )
         if (isa<AddrSpaceCastInst>(instr)) {
           // Convert (now illegal) addresspacecasts to bitcasts.
 


### PR DESCRIPTION
On Mint Linux x86_64, compilation was failing. (LLVM 3.4, and Clang 3.4, were used.)

This commit fixes the build. Regarding whether things actually work: most the regressions tests seem to succeed, but:

test_structs_as_args produces:

``` c++
ERROR: clEnqueueNDRangeKernel(-52)
```

test_constant_array produces:

``` c++
/tmp/poclnrWIKE/program.cl:7:10: error: passing 'char *' to parameter of type '__constant char *' changes address space of pointer
  printf("sum=%g\n", s);
         ^~~~~~~~~~
/usr/local/share/pocl/include/_kernel.h:2123:40: note: passing argument to parameter 'format' here
int _cl_printf(constant char* restrict format, ...);
                                       ^
1 error generated.
ERROR: clBuildProgram(-11)
```

test_infinite_loop produces:

``` c++
/tmp/poclAjAOiO/program.cl:7:10: error: passing 'char *' to parameter of type '__constant char *' changes address space of pointer
  printf("sum=%g\n", s);
         ^~~~~~~~~~
/usr/local/share/pocl/include/_kernel.h:2123:40: note: passing argument to parameter 'format' here
int _cl_printf(constant char* restrict format, ...);
                                       ^
1 error generated.
ERROR: clBuildProgram(-11)
```

Still more tests fail outside the regression-tests collection.

Without my changes to TargetAddressSpaces.cc, I see the following (from g++ version 4.8.1):

``` c++
 TargetAddressSpaces.cc: In member function 'virtual bool pocl::TargetAddressSpaces::runOnModule(llvm::Module&)':
 TargetAddressSpaces.cc:202:17: error: 'AddrSpaceCastInst' was not declared in this scope
          if (isa<AddrSpaceCastInst>(instr)) {
                  ^
 TargetAddressSpaces.cc:202:41: error: no matching function for call to 'isa(llvm::Instruction*&)'
          if (isa<AddrSpaceCastInst>(instr)) {
                                          ^
 TargetAddressSpaces.cc:202:41: note: candidate is:
 In file included from /usr/lib/llvm-3.4/include/llvm/IR/Type.h:19:0,
                  from /usr/lib/llvm-3.4/include/llvm/IR/DerivedTypes.h:21,
                  from /usr/lib/llvm-3.4/include/llvm/IR/Instructions.h:23,
                  from TargetAddressSpaces.cc:31:
 /usr/lib/llvm-3.4/include/llvm/Support/Casting.h:134:13: note: template<class X, class Y> bool llvm::isa(const Y&)
  inline bool isa(const Y &Val) {
              ^
 /usr/lib/llvm-3.4/include/llvm/Support/Casting.h:134:13: note:   template argument deduction/substitution failed:
 TargetAddressSpaces.cc:202:41: error: template argument 1 is invalid
          if (isa<AddrSpaceCastInst>(instr)) {
                                          ^
```
