### PR TITLE
GetDeviceInfo: return device vendor string

### DIFF
--- a/lib/CL/clGetDeviceInfo.c
+++ b/lib/CL/clGetDeviceInfo.c
@@ -201,7 +201,7 @@ POname(clGetDeviceInfo)(cl_device_id   device,
     POCL_RETURN_DEVICE_INFO_STR(device->long_name);
    
   case CL_DEVICE_VENDOR                            : 
-    POCL_RETURN_DEVICE_INFO_STR("unknown"); /* TODO: CPUID */
+    POCL_RETURN_DEVICE_INFO_STR(device->vendor);
 
   case CL_DRIVER_VERSION:
     POCL_RETURN_DEVICE_INFO_STR(device->driver_version);


### PR DESCRIPTION
Vendor string can be returned independently for all devices.
The CPUID comment was probably there since it should be detected using CPUID for pthread/basic which should set the vendor themselves.
