### PR TITLE
Suggestions for resolving memory leaks

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,14 @@ Bugfixes
 - Fix falsely detecting operations with side-effects (especially atomic
   operations) as uniform. This caused deadlock/race situations due to 
   illegal implicit barrier injection.
+- Fix reference counting in _cl_command_queue object to release the object.
+- Fix reference counting in _cl_device_id object, which is included in _cl_context object.
+- Fix reference counting in _cl_mem object, when clEnqueueMapBuffer and clEnqueueUnmapMemObject are used.
+- Fix memory leak of _cl_event list object, which is allocated in clEnqueueMapBuffer in temporary.
+- Fix memory leaks of mem_mapping_t object, which is allocated in pocl_create_command.
+- Fix memory leaks of _cl_device_id object, which is included in _cl_program object, and allocated in clCreateProgramWithBinary.
+- Fix missing the initialization of mutex in device.c and pocl_mem_management.c
+- Fix the wrong placement of clReleaseEvent in the function "exec_commands" in clFinish.c
 
 Misc.
 -----

--- a/CREDITS
+++ b/CREDITS
@@ -32,3 +32,4 @@ Martin Stumpf
 James Price
 Lars-Dominik Braun
 Daniel Sanders
+Lee Ki-ju

--- a/lib/CL/clCreateContextFromType.c
+++ b/lib/CL/clCreateContextFromType.c
@@ -41,8 +41,8 @@ POname(clCreateContextFromType)(const cl_context_properties *properties,
 {
   int num_devices;
   int errcode;
-  int i;                     // [Suggested by leekiju]
-  cl_device_id device_ptr;   // [Suggested by leekiju]
+  int i;
+  cl_device_id device_ptr;
 
   /* initialize libtool here, LT will be needed when loading the kernels */     
   lt_dlinit();
@@ -94,7 +94,7 @@ POname(clCreateContextFromType)(const cl_context_properties *properties,
 
   pocl_get_devices(device_type, context->devices, num_devices);
 
-  for (i = 0; i < num_devices; ++i)  // [Suggested by leekiju] device object could be retained like clCreateContext
+  for (i = 0; i < num_devices; ++i)
     {
       device_ptr = context->devices[i];
       if (device_ptr == NULL)

--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -289,7 +289,7 @@ POname(clEnqueueNDRangeKernel)(cl_command_queue command_queue,
 
   command_node->next = NULL; 
   
-  //POname(clRetainCommandQueue) (command_queue);  // [Suggested by leekiju] Could be removed. the only function, which includes clReatainCommandQueue, is clEnqueueNDRAngeKernel
+  
   POname(clRetainKernel) (kernel);
 
   command_node->command.run.arg_buffer_count = 0;

--- a/lib/CL/clFinish.c
+++ b/lib/CL/clFinish.c
@@ -201,7 +201,7 @@ static void exec_commands (_cl_command_node *node_list)
           DL_DELETE((node->command.unmap.memobj)->mappings, 
                     node->command.unmap.mapping);
           (node->command.unmap.memobj)->map_count--;
-          if((node->command.unmap.memobj)->map_count == 0) //[Suggested bu leekiju] For decreasing mem object's reference count, which was increased in clEnqueueMapBuffer
+          if((node->command.unmap.memobj)->map_count == 0)
             {
               POname(clReleaseMemObject) (node->command.unmap.memobj);
               free(node->command.unmap.mapping);
@@ -268,18 +268,18 @@ static void exec_commands (_cl_command_node *node_list)
           break;
         }   
 
-        if (event)  // [Suggested by leekiju] Should be included in the loop
-        {
-          /* event callback handling 
-          just call functions in the same order they were added */
-          for (cb_ptr = (*event)->callback_list; cb_ptr; cb_ptr = cb_ptr->next)
+        if (event)
           {
-             cb_ptr->callback_function ((*event), cb_ptr->trigger_status, 
-                                        cb_ptr->user_data);
+            /* event callback handling 
+               just call functions in the same order they were added */
+            for (cb_ptr = (*event)->callback_list; cb_ptr; cb_ptr = cb_ptr->next)
+              {
+                cb_ptr->callback_function ((*event), cb_ptr->trigger_status, 
+                                           cb_ptr->user_data);
+              }
+            if ((*event)->implicit_event)
+              POname(clReleaseEvent) (*event);
           }
-          if ((*event)->implicit_event)
-          POname(clReleaseEvent) (*event);
-        }
     }
 
 
@@ -292,7 +292,7 @@ static void exec_commands (_cl_command_node *node_list)
       _cl_command_node *tmp;
       tmp = node->next;
       pocl_mem_manager_free_command (node);
-      if(node->event_wait_list != NULL)  // [Suggested by leekiju] Should be de-allocated
+      if(node->event_wait_list != NULL)
         free(node->event_wait_list);
       node = tmp;
     }

--- a/lib/CL/clReleaseProgram.c
+++ b/lib/CL/clReleaseProgram.c
@@ -52,7 +52,6 @@ POname(clReleaseProgram)(cl_program program) CL_API_SUFFIX__VERSION_1_0
       POCL_RELEASE_OBJECT (program->context, new_refcount);
       free (program->source);
 
-      // [Suggested by leekiju] In case of clCreateProgramWithBinary, context.devices and program.devices are different.
       if(program->devices != program->context->devices)
         free (program->devices);
       

--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -167,7 +167,7 @@ pocl_init_devices()
   char dev_name[MAX_DEV_NAME_LEN] = {0};
   unsigned int device_count[POCL_NUM_DEVICE_TYPES];
 
-  if (init_done == 0) // [Suggested by leekiju] Create at once
+  if (init_done == 0)
     POCL_INIT_LOCK(pocl_init_lock);
   POCL_LOCK(pocl_init_lock);
   if (init_done) 

--- a/lib/CL/pocl_mem_management.c
+++ b/lib/CL/pocl_mem_management.c
@@ -41,7 +41,7 @@ void pocl_init_mem_manager (void)
   static unsigned int init_done = 0;
   static pocl_lock_t pocl_init_lock = POCL_LOCK_INITIALIZER;
 
-  if(!init_done)  // [Suggested by leekiju] Created at once
+  if(!init_done)
     {
       POCL_INIT_LOCK(pocl_init_lock);
       init_done = 1;


### PR DESCRIPTION
These changes are suggestions for resolving memory leaks
And the some buffers, which are allocated by "pocl_aligned_malloc", are
deallocated by "free". It makes some troubles. I also suggest all malloc
and calloc should be changed to "pocl_aligned_malloc" also "free" should
be changed to "pocl_aligned_free"
