### PR TITLE
Clean up multiple definitions of POCL_RETURN_*_GETINFO macros

### DIFF
--- a/lib/CL/clGetCommandQueueInfo.c
+++ b/lib/CL/clGetCommandQueueInfo.c
@@ -21,22 +21,8 @@
    THE SOFTWARE.
 */
 
-#include "pocl_cl.h"
 #include "pocl_util.h"
 
-
-
-#define POCL_RETURN_QUEUE_INFO(__TYPE__, __VALUE__)                     \
-  {                                                                     \
-    size_t const value_size = sizeof(__TYPE__);                         \
-    if (param_value) {                                                  \
-      if (param_value_size < value_size) return CL_INVALID_VALUE;       \
-      *(__TYPE__*)param_value = __VALUE__;                              \
-    }                                                                   \
-    if (param_value_size_ret)                                           \
-      *param_value_size_ret = value_size;                               \
-    return CL_SUCCESS;                                                  \
-  }
 
 
 

--- a/lib/CL/clGetContextInfo.c
+++ b/lib/CL/clGetContextInfo.c
@@ -22,19 +22,7 @@
 */
 
 #include <assert.h>
-#include <string.h>
-#include "pocl_cl.h"
-
-#define POCL_RETURN_CONTEXT_INFO(__SIZE__, __VALUE__)                   \
-  {                                                                     \
-    if (param_value) {                                                  \
-      if (param_value_size < __SIZE__) return CL_INVALID_VALUE;       \
-      memcpy(param_value, __VALUE__, __SIZE__);                         \
-    }                                                                   \
-    if (param_value_size_ret)                                           \
-      *param_value_size_ret = __SIZE__;                                 \
-    return CL_SUCCESS;                                                  \
-  }
+#include "pocl_util.h"
 
 
 CL_API_ENTRY cl_int CL_API_CALL
@@ -53,18 +41,18 @@ POname(clGetContextInfo)(cl_context context,
   case CL_CONTEXT_REFERENCE_COUNT:
     {
       cl_uint refcount = context->pocl_refcount;
-      POCL_RETURN_CONTEXT_INFO(sizeof(cl_uint), &refcount);
+      POCL_RETURN_GETINFO(cl_uint, refcount);
     }
   case CL_CONTEXT_DEVICES:
     value_size = context->num_devices * sizeof(cl_device_id);
-    POCL_RETURN_CONTEXT_INFO(value_size, context->devices);
+    POCL_RETURN_GETINFO_SIZE(value_size, context->devices);
   case CL_CONTEXT_NUM_DEVICES:
-    POCL_RETURN_CONTEXT_INFO(sizeof(cl_uint), &context->num_devices);
+    POCL_RETURN_GETINFO(cl_uint, context->num_devices);
   case CL_CONTEXT_PROPERTIES:
     if (context->properties)
       {
         value_size = (context->num_properties * 2 + 1) * sizeof(cl_context_properties);
-        POCL_RETURN_CONTEXT_INFO(value_size, context->devices);
+        POCL_RETURN_GETINFO_SIZE(value_size, context->properties);
       }
     else
       {

--- a/lib/CL/clGetDeviceInfo.c
+++ b/lib/CL/clGetDeviceInfo.c
@@ -21,9 +21,7 @@
    THE SOFTWARE.
 */
 
-#include "pocl_cl.h"
 #include "pocl_util.h"
-#include <string.h>
 
 /* A version for querying the info and in case the device returns 
    a zero, assume the device info query hasn't been implemented 
@@ -43,18 +41,6 @@
     return CL_SUCCESS;                                              \
   } 
 
-#define POCL_RETURN_DEVICE_INFO_STR(__STR__)                        \
-  {                                                                 \
-    size_t const value_size = strlen(__STR__) + 1;                  \
-    if (param_value)                                                \
-      {                                                             \
-        if (param_value_size < value_size) return CL_INVALID_VALUE; \
-        memcpy(param_value, __STR__, value_size);                   \
-      }                                                             \
-    if (param_value_size_ret)                                       \
-      *param_value_size_ret = value_size;                           \
-    return CL_SUCCESS;                                              \
-  }                                                                 \
     
 
   
@@ -198,19 +184,19 @@ POname(clGetDeviceInfo)(cl_device_id   device,
     POCL_RETURN_GETINFO(cl_command_queue_properties, device->queue_properties);
    
   case CL_DEVICE_NAME:
-    POCL_RETURN_DEVICE_INFO_STR(device->long_name);
+    POCL_RETURN_GETINFO_STR(device->long_name);
    
   case CL_DEVICE_VENDOR                            : 
-    POCL_RETURN_DEVICE_INFO_STR(device->vendor);
+    POCL_RETURN_GETINFO_STR(device->vendor);
 
   case CL_DRIVER_VERSION:
-    POCL_RETURN_DEVICE_INFO_STR(device->driver_version);
+    POCL_RETURN_GETINFO_STR(device->driver_version);
   case CL_DEVICE_PROFILE                           : 
-    POCL_RETURN_DEVICE_INFO_STR(device->profile);
+    POCL_RETURN_GETINFO_STR(device->profile);
   case CL_DEVICE_VERSION                           : 
-    POCL_RETURN_DEVICE_INFO_STR(device->version); 
+    POCL_RETURN_GETINFO_STR(device->version);
   case CL_DEVICE_EXTENSIONS                        : 
-    POCL_RETURN_DEVICE_INFO_STR(device->extensions);
+    POCL_RETURN_GETINFO_STR(device->extensions);
   case CL_DEVICE_PLATFORM                          :
     {
       /* Return the first platform id, assuming this is the only
@@ -242,9 +228,9 @@ POname(clGetDeviceInfo)(cl_device_id   device,
   case CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF          : 
     POCL_RETURN_DEVICE_INFO_WITH_IMPL_CHECK(cl_uint, device->native_vector_width_half);
   case CL_DEVICE_OPENCL_C_VERSION                  :
-    POCL_RETURN_DEVICE_INFO_STR("OpenCL C 1.2");
+    POCL_RETURN_GETINFO_STR("OpenCL C 1.2");
   case CL_DEVICE_BUILT_IN_KERNELS                  :
-    POCL_RETURN_DEVICE_INFO_STR("");
+    POCL_RETURN_GETINFO_STR("");
 
   /* TODO proper device partition support. For the time being,
    * the values returned only serve the purpose of indicating

--- a/lib/CL/clGetEventInfo.c
+++ b/lib/CL/clGetEventInfo.c
@@ -1,17 +1,4 @@
-#include "pocl_cl.h"
-
-#define POCL_RETURN_EVENT_INFO(__TYPE__, __VALUE__)                 \
-  {                                                                 \
-    size_t const value_size = sizeof(__TYPE__);                     \
-    if (param_value)                                                \
-      {                                                             \
-        if (param_value_size < value_size) return CL_INVALID_VALUE; \
-        *(__TYPE__*)param_value = __VALUE__;                        \
-      }                                                             \
-    if (param_value_size_ret)                                       \
-      *param_value_size_ret = value_size;                           \
-    return CL_SUCCESS;                                              \
-  } 
+#include "pocl_util.h"
 
 CL_API_ENTRY cl_int CL_API_CALL
 POname(clGetEventInfo)(cl_event          event ,
@@ -24,15 +11,15 @@ CL_API_SUFFIX__VERSION_1_0
   switch (param_name)
     {
     case CL_EVENT_COMMAND_EXECUTION_STATUS:
-      POCL_RETURN_EVENT_INFO (cl_int, event->status);
+      POCL_RETURN_GETINFO (cl_int, event->status);
     case CL_EVENT_COMMAND_QUEUE:
-      POCL_RETURN_EVENT_INFO(cl_command_queue, event->queue);
+      POCL_RETURN_GETINFO(cl_command_queue, event->queue);
     case CL_EVENT_COMMAND_TYPE:
-      POCL_RETURN_EVENT_INFO(cl_command_type, event->command_type);
+      POCL_RETURN_GETINFO(cl_command_type, event->command_type);
     case CL_EVENT_REFERENCE_COUNT:
-      POCL_RETURN_EVENT_INFO(cl_uint, event->pocl_refcount);
+      POCL_RETURN_GETINFO(cl_uint, event->pocl_refcount);
     case CL_EVENT_CONTEXT:
-      POCL_RETURN_EVENT_INFO(cl_context, event->queue->context);
+      POCL_RETURN_GETINFO(cl_context, event->queue->context);
     default:
       break;
     }

--- a/lib/CL/clGetImageInfo.c
+++ b/lib/CL/clGetImageInfo.c
@@ -1,18 +1,6 @@
-#include "pocl_cl.h"
+#include "pocl_util.h"
 #include "pocl_image_util.h"
 
-#define POCL_RETURN_IMAGE_INFO(__TYPE__, __VALUE__)                 \
-  {                                                                 \
-    size_t const value_size = sizeof(__TYPE__);                     \
-    if (param_value)                                                \
-      {                                                             \
-        if (param_value_size < value_size) return CL_INVALID_VALUE; \
-        *(__TYPE__*)param_value = __VALUE__;                        \
-      }                                                             \
-    if (param_value_size_ret)                                       \
-      *param_value_size_ret = value_size;                           \
-    return CL_SUCCESS;                                              \
-  } 
 
 CL_API_ENTRY cl_int CL_API_CALL
 POname(clGetImageInfo)(cl_mem            image ,
@@ -27,27 +15,27 @@ CL_API_SUFFIX__VERSION_1_0
   switch (param_name)
     {
     case CL_IMAGE_FORMAT:
-      POCL_RETURN_IMAGE_INFO (cl_image_format, image_format);
+      POCL_RETURN_GETINFO (cl_image_format, image_format);
     case CL_IMAGE_ELEMENT_SIZE:
-      POCL_RETURN_IMAGE_INFO (size_t, image->image_channels * image->image_elem_size);
+      POCL_RETURN_GETINFO (size_t, image->image_channels * image->image_elem_size);
     case CL_IMAGE_ROW_PITCH:
-      POCL_RETURN_IMAGE_INFO (size_t, image->image_row_pitch);
+      POCL_RETURN_GETINFO (size_t, image->image_row_pitch);
     case CL_IMAGE_SLICE_PITCH:
-      POCL_RETURN_IMAGE_INFO (size_t, image->image_slice_pitch);
+      POCL_RETURN_GETINFO (size_t, image->image_slice_pitch);
     case CL_IMAGE_WIDTH:
-      POCL_RETURN_IMAGE_INFO (size_t, image->image_width);
+      POCL_RETURN_GETINFO (size_t, image->image_width);
     case CL_IMAGE_HEIGHT:
-      POCL_RETURN_IMAGE_INFO (size_t, image->image_height);
+      POCL_RETURN_GETINFO (size_t, image->image_height);
     case CL_IMAGE_DEPTH:
-      POCL_RETURN_IMAGE_INFO (size_t, image->image_depth);
+      POCL_RETURN_GETINFO (size_t, image->image_depth);
     case CL_IMAGE_ARRAY_SIZE:
-      POCL_RETURN_IMAGE_INFO (size_t, image->image_array_size);
+      POCL_RETURN_GETINFO (size_t, image->image_array_size);
     case CL_IMAGE_BUFFER:
-      POCL_RETURN_IMAGE_INFO (cl_mem, image->buffer);
+      POCL_RETURN_GETINFO (cl_mem, image->buffer);
     case CL_IMAGE_NUM_MIP_LEVELS:
-      POCL_RETURN_IMAGE_INFO (cl_uint, image->num_mip_levels);
+      POCL_RETURN_GETINFO (cl_uint, image->num_mip_levels);
     case CL_IMAGE_NUM_SAMPLES:
-      POCL_RETURN_IMAGE_INFO (cl_uint, image->num_samples);
+      POCL_RETURN_GETINFO (cl_uint, image->num_samples);
     default:
       return CL_INVALID_VALUE;
     }

--- a/lib/CL/clGetKernelArgInfo.c
+++ b/lib/CL/clGetKernelArgInfo.c
@@ -21,35 +21,7 @@
    THE SOFTWARE.
 */
 
-#include "pocl_cl.h"
-#include <string.h>
-
-
-
-#define POCL_RETURN_KERNEL_INFO(__TYPE__, __VALUE__)                    \
-  {                                                                     \
-    size_t const value_size = sizeof(__TYPE__);                         \
-    if (param_value) {                                                  \
-      if (param_value_size < value_size) return CL_INVALID_VALUE;       \
-      *(__TYPE__*)param_value = __VALUE__;                              \
-    }                                                                   \
-    if (param_value_size_ret)                                           \
-      *param_value_size_ret = value_size;                               \
-    return CL_SUCCESS;                                                  \
-  }
-
-#define POCL_RETURN_KERNEL_INFO_STR(__STR__)                        \
-  {                                                                 \
-    size_t const value_size = strlen(__STR__) + 1;                  \
-    if (param_value) {                                              \
-      if (param_value_size < value_size) return CL_INVALID_VALUE;   \
-      memcpy(param_value, __STR__, value_size);                     \
-    }                                                               \
-    if (param_value_size_ret)                                       \
-      *param_value_size_ret = value_size;                           \
-    return CL_SUCCESS;                                              \
-  }                                                                 \
-
+#include "pocl_util.h"
 
 
 CL_API_ENTRY cl_int CL_API_CALL
@@ -70,23 +42,23 @@ POname(clGetKernelArgInfo)(cl_kernel      kernel ,
     case CL_KERNEL_ARG_ADDRESS_QUALIFIER:
       if (!(kernel->has_arg_metadata & POCL_HAS_KERNEL_ARG_ADDRESS_QUALIFIER))
         return CL_KERNEL_ARG_INFO_NOT_AVAILABLE;
-      POCL_RETURN_KERNEL_INFO(cl_kernel_arg_address_qualifier, arg->address_qualifier);
+      POCL_RETURN_GETINFO(cl_kernel_arg_address_qualifier, arg->address_qualifier);
     case CL_KERNEL_ARG_ACCESS_QUALIFIER:
       if (!(kernel->has_arg_metadata & POCL_HAS_KERNEL_ARG_ACCESS_QUALIFIER))
         return CL_KERNEL_ARG_INFO_NOT_AVAILABLE;
-      POCL_RETURN_KERNEL_INFO(cl_kernel_arg_access_qualifier, arg->access_qualifier);
+      POCL_RETURN_GETINFO(cl_kernel_arg_access_qualifier, arg->access_qualifier);
     case CL_KERNEL_ARG_TYPE_NAME:
       if (!(kernel->has_arg_metadata & POCL_HAS_KERNEL_ARG_TYPE_NAME))
         return CL_KERNEL_ARG_INFO_NOT_AVAILABLE;
-      POCL_RETURN_KERNEL_INFO_STR(arg->type_name);
+      POCL_RETURN_GETINFO_STR(arg->type_name);
     case CL_KERNEL_ARG_TYPE_QUALIFIER:
       if (!(kernel->has_arg_metadata & POCL_HAS_KERNEL_ARG_TYPE_QUALIFIER))
         return CL_KERNEL_ARG_INFO_NOT_AVAILABLE;
-      POCL_RETURN_KERNEL_INFO(cl_kernel_arg_type_qualifier, arg->type_qualifier);
+      POCL_RETURN_GETINFO(cl_kernel_arg_type_qualifier, arg->type_qualifier);
     case CL_KERNEL_ARG_NAME:
       if (!(kernel->has_arg_metadata & POCL_HAS_KERNEL_ARG_NAME))
         return CL_KERNEL_ARG_INFO_NOT_AVAILABLE;
-      POCL_RETURN_KERNEL_INFO_STR(arg->name);
+      POCL_RETURN_GETINFO_STR(arg->name);
   }
   return CL_INVALID_VALUE;
 }

--- a/lib/CL/clGetKernelInfo.c
+++ b/lib/CL/clGetKernelInfo.c
@@ -21,34 +21,8 @@
    THE SOFTWARE.
 */
 
-#include "pocl_cl.h"
-#include <string.h>
+#include "pocl_util.h"
 
-
-
-#define POCL_RETURN_KERNEL_INFO(__TYPE__, __VALUE__)                    \
-  {                                                                     \
-    size_t const value_size = sizeof(__TYPE__);                         \
-    if (param_value) {                                                  \
-      if (param_value_size < value_size) return CL_INVALID_VALUE;       \
-      *(__TYPE__*)param_value = __VALUE__;                              \
-    }                                                                   \
-    if (param_value_size_ret)                                           \
-      *param_value_size_ret = value_size;                               \
-    return CL_SUCCESS;                                                  \
-  }
-
-#define POCL_RETURN_KERNEL_INFO_STR(__STR__)                        \
-  {                                                                 \
-    size_t const value_size = strlen(__STR__) + 1;                  \
-    if (param_value) {                                              \
-      if (param_value_size < value_size) return CL_INVALID_VALUE;   \
-      memcpy(param_value, __STR__, value_size);                     \
-    }                                                               \
-    if (param_value_size_ret)                                       \
-      *param_value_size_ret = value_size;                           \
-    return CL_SUCCESS;                                              \
-  }                                                                 \
 
 
 
@@ -63,15 +37,15 @@ POname(clGetKernelInfo)(cl_kernel      kernel ,
     return CL_INVALID_KERNEL;
   switch (param_name) {
   case CL_KERNEL_FUNCTION_NAME:
-    POCL_RETURN_KERNEL_INFO_STR(kernel->name);
+    POCL_RETURN_GETINFO_STR(kernel->name);
   case CL_KERNEL_NUM_ARGS:
-    POCL_RETURN_KERNEL_INFO(cl_uint, kernel->num_args);
+    POCL_RETURN_GETINFO(cl_uint, kernel->num_args);
   case CL_KERNEL_REFERENCE_COUNT:
-    POCL_RETURN_KERNEL_INFO(cl_uint, kernel->pocl_refcount);
+    POCL_RETURN_GETINFO(cl_uint, kernel->pocl_refcount);
   case CL_KERNEL_CONTEXT:
-    POCL_RETURN_KERNEL_INFO(cl_context, kernel->context);
+    POCL_RETURN_GETINFO(cl_context, kernel->context);
   case CL_KERNEL_PROGRAM:
-    POCL_RETURN_KERNEL_INFO(cl_program, kernel->program);
+    POCL_RETURN_GETINFO(cl_program, kernel->program);
   }
   return CL_INVALID_VALUE;
 }

--- a/lib/CL/clGetKernelWorkGroupInfo.c
+++ b/lib/CL/clGetKernelWorkGroupInfo.c
@@ -4,21 +4,7 @@
 
 
 #include "devices/devices.h"
-#include "pocl_cl.h"
 #include "pocl_util.h"
-
-#define POCL_RETURN_KERNEL_WG_INFO(__TYPE__, __VALUE__)                \
-  {                                                                 \
-    size_t const value_size = sizeof(__TYPE__);                     \
-    if (param_value)                                                \
-      {                                                             \
-        if (param_value_size < value_size) return CL_INVALID_VALUE; \
-        *(__TYPE__*)param_value = __VALUE__;                        \
-      }                                                             \
-    if (param_value_size_ret)                                       \
-      *param_value_size_ret = value_size;                           \
-    return CL_SUCCESS;                                              \
-  } 
 
 
 extern CL_API_ENTRY cl_int CL_API_CALL
@@ -71,7 +57,7 @@ POname(clGetKernelWorkGroupInfo)
     }
       
     case CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE:
-      POCL_RETURN_KERNEL_WG_INFO(size_t, device->preferred_wg_size_multiple);
+      POCL_RETURN_GETINFO(size_t, device->preferred_wg_size_multiple);
       
     case CL_KERNEL_LOCAL_MEM_SIZE:
     {
@@ -91,7 +77,7 @@ POname(clGetKernelWorkGroupInfo)
 #if 0
       printf("### local memory usage %d\n", local_size);
 #endif
-      POCL_RETURN_KERNEL_WG_INFO(cl_ulong, local_size);
+      POCL_RETURN_GETINFO(cl_ulong, local_size);
     }
       
     case CL_KERNEL_PRIVATE_MEM_SIZE:

--- a/lib/CL/clGetMemObjectInfo.c
+++ b/lib/CL/clGetMemObjectInfo.c
@@ -21,21 +21,7 @@
    THE SOFTWARE.
 */
 
-#include "pocl_cl.h"
-
-
-
-#define POCL_RETURN_MEM_INFO(__TYPE__, __VALUE__)                       \
-  {                                                                     \
-    size_t const value_size = sizeof(__TYPE__);                         \
-    if (param_value) {                                                  \
-      if (param_value_size < value_size) return CL_INVALID_VALUE;       \
-      *(__TYPE__*)param_value = __VALUE__;                              \
-    }                                                                   \
-    if (param_value_size_ret)                                           \
-      *param_value_size_ret = value_size;                               \
-    return CL_SUCCESS;                                                  \
-  }
+#include "pocl_util.h"
 
 
 
@@ -50,24 +36,24 @@ POname(clGetMemObjectInfo)(cl_mem      memobj ,
     return CL_INVALID_MEM_OBJECT;
   switch (param_name) {
   case CL_MEM_TYPE:
-    POCL_RETURN_MEM_INFO (cl_mem_object_type, memobj->type);
+    POCL_RETURN_GETINFO (cl_mem_object_type, memobj->type);
   case CL_MEM_FLAGS:
-    POCL_RETURN_MEM_INFO (cl_mem_flags, memobj->flags);
+    POCL_RETURN_GETINFO (cl_mem_flags, memobj->flags);
   case CL_MEM_SIZE:
-    POCL_RETURN_MEM_INFO (size_t, memobj->size);
+    POCL_RETURN_GETINFO (size_t, memobj->size);
   case CL_MEM_HOST_PTR:
-    POCL_RETURN_MEM_INFO (void *, memobj->mem_host_ptr);
+    POCL_RETURN_GETINFO (void *, memobj->mem_host_ptr);
   case CL_MEM_MAP_COUNT:
-    POCL_RETURN_MEM_INFO (cl_uint, memobj->map_count);
+    POCL_RETURN_GETINFO (cl_uint, memobj->map_count);
   case CL_MEM_REFERENCE_COUNT:
-    POCL_RETURN_MEM_INFO (cl_uint, memobj->pocl_refcount);
+    POCL_RETURN_GETINFO (cl_uint, memobj->pocl_refcount);
   case CL_MEM_CONTEXT:
-    POCL_RETURN_MEM_INFO (cl_context, memobj->context);
+    POCL_RETURN_GETINFO (cl_context, memobj->context);
   case CL_MEM_ASSOCIATED_MEMOBJECT:
-    POCL_RETURN_MEM_INFO (cl_mem, memobj->parent);
+    POCL_RETURN_GETINFO (cl_mem, memobj->parent);
   case CL_MEM_OFFSET:
     if (memobj->parent == NULL)
-      POCL_RETURN_MEM_INFO (size_t, 0);
+      POCL_RETURN_GETINFO (size_t, 0);
 
     POCL_ABORT_UNIMPLEMENTED();
   }

--- a/lib/CL/clGetPlatformInfo.c
+++ b/lib/CL/clGetPlatformInfo.c
@@ -21,22 +21,8 @@
    THE SOFTWARE.
 */
 
-#include <string.h>
-#include "pocl_cl.h"
 #include "pocl_util.h"
 
-#define POCL_RETURN_PLATFORM_INFO_STR(__STR__)                        \
-  {                                                                 \
-    size_t const value_size = strlen(__STR__) + 1;                  \
-    if (param_value)                                                \
-      {                                                             \
-        if (param_value_size < value_size) return CL_INVALID_VALUE; \
-        memcpy(param_value, __STR__, value_size);                   \
-      }                                                             \
-    if (param_value_size_ret)                                       \
-      *param_value_size_ret = value_size;                           \
-    return CL_SUCCESS;                                              \
-  }                                                                 \
     
 CL_API_ENTRY cl_int CL_API_CALL 
 POname(clGetPlatformInfo)(cl_platform_id   platform,
@@ -62,28 +48,28 @@ POname(clGetPlatformInfo)(cl_platform_id   platform,
     case CL_PLATFORM_PROFILE:
       // TODO: figure this out depending on the native execution host.
       // assume FULL_PROFILE for now.
-      POCL_RETURN_PLATFORM_INFO_STR("FULL_PROFILE");
+      POCL_RETURN_GETINFO_STR("FULL_PROFILE");
 
     case CL_PLATFORM_VERSION:
-      POCL_RETURN_PLATFORM_INFO_STR("OpenCL 1.2 pocl " PACKAGE_VERSION);
+      POCL_RETURN_GETINFO_STR("OpenCL 1.2 pocl " PACKAGE_VERSION);
 
     case CL_PLATFORM_NAME:
-      POCL_RETURN_PLATFORM_INFO_STR("Portable Computing Language");
+      POCL_RETURN_GETINFO_STR("Portable Computing Language");
 
     case CL_PLATFORM_VENDOR:
-      POCL_RETURN_PLATFORM_INFO_STR("The pocl project");
+      POCL_RETURN_GETINFO_STR("The pocl project");
 
     case CL_PLATFORM_EXTENSIONS:
       // TODO: do we want to list all suppoted extensions *here*, or in some header?.
       // TODO: yes, it is better here: available through ICD Loader and headers can be the ones from Khronos
 #ifdef BUILD_ICD
-      POCL_RETURN_PLATFORM_INFO_STR("cl_khr_icd");
+      POCL_RETURN_GETINFO_STR("cl_khr_icd");
 #else
-      POCL_RETURN_PLATFORM_INFO_STR("");
+      POCL_RETURN_GETINFO_STR("");
 #endif
 
     case CL_PLATFORM_ICD_SUFFIX_KHR:
-      POCL_RETURN_PLATFORM_INFO_STR("POCL");
+      POCL_RETURN_GETINFO_STR("POCL");
 
     default: 
       return CL_INVALID_VALUE;

--- a/lib/CL/clGetProgramBuildInfo.c
+++ b/lib/CL/clGetProgramBuildInfo.c
@@ -21,8 +21,7 @@
    THE SOFTWARE.
 */
 
-#include "pocl_cl.h"
-#include <string.h>
+#include "pocl_util.h"
 
 CL_API_ENTRY cl_int CL_API_CALL
 POname(clGetProgramBuildInfo)(cl_program            program,
@@ -46,41 +45,19 @@ POname(clGetProgramBuildInfo)(cl_program            program,
   switch (param_name) {
   case CL_PROGRAM_BUILD_STATUS:
     {
-      size_t const value_size = strlen(retval) + 1;
-      if (param_value)
-      {
-        if (param_value_size < value_size) return CL_INVALID_VALUE;
-        memcpy(param_value, retval, value_size);
-      }
-      if (param_value_size_ret)
-        *param_value_size_ret = value_size;
-
+      POCL_RETURN_GETINFO_STR(retval);
       return CL_SUCCESS;
     }
     
   case CL_PROGRAM_BUILD_OPTIONS:
     {
-      size_t const value_size = strlen(retval) + 1;
-      if (param_value)
-      {
-        if (param_value_size < value_size) return CL_INVALID_VALUE;
-        memcpy(param_value, retval, value_size);
-      }
-      if (param_value_size_ret)
-        *param_value_size_ret = value_size;
+      POCL_RETURN_GETINFO_STR(retval);
       return CL_SUCCESS;
     }
     
   case CL_PROGRAM_BUILD_LOG:
     {
-      size_t const value_size = strlen(retval) + 1;
-      if (param_value)
-      {
-        if (param_value_size < value_size) return CL_INVALID_VALUE;
-        memcpy(param_value, retval, value_size);
-      }
-      if (param_value_size_ret)
-        *param_value_size_ret = value_size;
+      POCL_RETURN_GETINFO_STR(retval);
       return CL_SUCCESS;
     }
   }

--- a/lib/CL/clGetProgramInfo.c
+++ b/lib/CL/clGetProgramInfo.c
@@ -21,10 +21,8 @@
    THE SOFTWARE.
 */
 
-#include "pocl_cl.h"
 #include "pocl_llvm.h"
 #include "pocl_util.h"
-#include <string.h>
 
 CL_API_ENTRY cl_int CL_API_CALL
 POname(clGetProgramInfo)(cl_program program,
@@ -38,10 +36,8 @@ POname(clGetProgramInfo)(cl_program program,
   {
   case CL_PROGRAM_REFERENCE_COUNT:
     POCL_RETURN_GETINFO(cl_uint, (cl_uint)program->pocl_refcount);
-    break;
   case CL_PROGRAM_CONTEXT:
     POCL_RETURN_GETINFO(cl_context, program->context);
-    break;
 
   case CL_PROGRAM_SOURCE:
     {
@@ -49,31 +45,17 @@ POname(clGetProgramInfo)(cl_program program,
       if (source == NULL)
         source = "";
 
-      size_t const value_size = strlen(source) + 1;
-      if (param_value)
-      {
-        if (param_value_size < value_size) return CL_INVALID_VALUE;
-        memcpy(param_value, source, value_size);
-      }
-      if (param_value_size_ret)
-        *param_value_size_ret = value_size;
-      return CL_SUCCESS;
+      POCL_RETURN_GETINFO_STR(source);
     }
     
   case CL_PROGRAM_BINARY_SIZES:
     {
       size_t const value_size = sizeof(size_t) * program->num_devices;
       if (param_value)
-      {
         pocl_llvm_update_binaries (program);
-        if (param_value_size < value_size) return CL_INVALID_VALUE;
-        memcpy(param_value, program->binary_sizes, value_size);
-      }
-      if (param_value_size_ret)
-        *param_value_size_ret = value_size;
-      return CL_SUCCESS;
+      POCL_RETURN_GETINFO_SIZE(value_size, program->binary_sizes);
     }
-    
+
   case CL_PROGRAM_BINARIES:
     {
       size_t const value_size = sizeof(unsigned char *) * program->num_devices;
@@ -92,17 +74,7 @@ POname(clGetProgramInfo)(cl_program program,
       return CL_SUCCESS;
     }
   case CL_PROGRAM_NUM_DEVICES:
-    {
-      size_t const value_size = sizeof(cl_uint);
-      if (param_value)
-      {
-        if (param_value_size < value_size) return CL_INVALID_VALUE;
-        *(size_t *) param_value = program->num_devices;
-      }
-      if (param_value_size_ret)
-        *param_value_size_ret = value_size;
-      return CL_SUCCESS;
-    }
+    POCL_RETURN_GETINFO(cl_uint, program->num_devices);
 
   case CL_PROGRAM_DEVICES:
     {


### PR DESCRIPTION
... for returning information in clGet*Info calls.

There are now 3 GETINFO macros in pocl_util.h, for type+value, size+pointer, and strings.

cmake & autotools tests passed, clinfo output seems to be correct.
