### PR TITLE
Initialize and use device’s dev_id

### DIFF
--- a/lib/CL/clEnqueueReadBuffer.c
+++ b/lib/CL/clEnqueueReadBuffer.c
@@ -64,13 +64,6 @@ POname(clEnqueueReadBuffer)(cl_command_queue command_queue,
 
   device = command_queue->device;
 
-  for (i = 0; i < command_queue->context->num_devices; ++i)
-    {
-        if (command_queue->context->devices[i] == device)
-            break;
-    }
-  assert(i < command_queue->context->num_devices);
-  
   errcode = pocl_create_command (&cmd, command_queue, CL_COMMAND_READ_BUFFER, 
                                  event, num_events_in_wait_list, 
                                  event_wait_list);

--- a/lib/CL/clEnqueueWriteBuffer.c
+++ b/lib/CL/clEnqueueWriteBuffer.c
@@ -79,7 +79,8 @@ POname(clEnqueueWriteBuffer)(cl_command_queue command_queue,
     return errcode;
   
   cmd->command.write.host_ptr = ptr;
-  cmd->command.write.device_ptr = buffer->device_ptrs[i].mem_ptr+offset;
+  cmd->command.write.device_ptr =
+    buffer->device_ptrs[device->dev_id].mem_ptr+offset;
   cmd->command.write.cb = cb;
   cmd->command.write.buffer = buffer;
   POname(clRetainMemObject) (buffer);

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -450,7 +450,6 @@ pocl_basic_run
   struct data *d;
   const char *module_fn;
   char workgroup_string[WORKGROUP_STRING_LENGTH];
-  unsigned device;
   struct pocl_argument *al;
   size_t x, y, z;
   unsigned i;
@@ -461,17 +460,6 @@ pocl_basic_run
   d = (struct data *) data;
 
   d->current_kernel = kernel;
-
-  /* Find which device number within the context correspond
-     to current device.  */
-  for (i = 0; i < kernel->context->num_devices; ++i)
-    {
-      if (kernel->context->devices[i]->data == data)
-        {
-          device = i;
-          break;
-        }
-    }
 
   void *arguments[kernel->num_args + kernel->num_locals];
 
@@ -498,12 +486,12 @@ pocl_basic_run
               *(void **)arguments[i] = NULL;
             }
           else
-            arguments[i] = &((*(cl_mem *) (al->value))->device_ptrs[device].mem_ptr);
+            arguments[i] = &((*(cl_mem *) (al->value))->device_ptrs[cmd->device->dev_id].mem_ptr);
         }
       else if (kernel->arg_info[i].type == POCL_ARG_TYPE_IMAGE)
         {
           dev_image_t di;
-          fill_dev_image_t (&di, al, device);
+          fill_dev_image_t (&di, al, cmd->device);
 
           void* devptr = pocl_basic_malloc (data, 0, sizeof(dev_image_t), NULL);
           arguments[i] = malloc (sizeof (void *));

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -117,10 +117,10 @@ llvm_codegen (const char* tmpdir, cl_kernel kernel, cl_device_id device) {
  * from given kernel image argument
  */
 void fill_dev_image_t (dev_image_t* di, struct pocl_argument* parg, 
-                       cl_int device)
+                       cl_device_id device)
 {
   cl_mem mem = *(cl_mem *)parg->value;
-  di->data = (mem->device_ptrs[device].mem_ptr);  
+  di->data = (mem->device_ptrs[device->dev_id].mem_ptr);
   di->width = mem->image_width;
   di->height = mem->image_height;
   di->depth = mem->image_depth;

--- a/lib/CL/devices/common.h
+++ b/lib/CL/devices/common.h
@@ -78,7 +78,7 @@ const char* llvm_codegen (const char* tmpdir,
                           cl_device_id device);
 
 void fill_dev_image_t (dev_image_t* di, struct pocl_argument* parg, 
-                       cl_int device);
+                       cl_device_id device);
 
 void* pocl_memalign_alloc(size_t align_width, size_t size);
 

--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -215,6 +215,7 @@ pocl_init_devices()
       for (j = 0; j < device_count[i]; ++j)
         {
           pocl_devices[dev_index].ops = &pocl_device_ops[i];
+          pocl_devices[dev_index].dev_id = dev_index;
           /* The default value for the global memory space identifier is
              the same as the device id. The device instance can then override 
              it to point to some other device's global memory id in case of


### PR DESCRIPTION
As far as I see device_ptrs should be accessed by dev_id too. See commit message.
