### PR TITLE
Fix for AMD APP SDK MatrixMulImage test

### DIFF
--- a/tests/testsuite-amd.at
+++ b/tests/testsuite-amd.at
@@ -183,11 +183,9 @@ AT_CHECK_UNQUOTED([make test_MatrixMultiplication -sC $abs_top_builddir/examples
 AT_CLEANUP
 
 POAT_AMDSDK_SETUP([matrixmulimage])
-# pocl error: encountered unimplemented part of the OpenCL specs in clCreateImage2D.c:119
-AT_XFAIL_IF(true)
 AT_CHECK_UNQUOTED([make test_MatrixMulImage -sC $abs_top_builddir/examples/AMD | grep Passed], 0, 
 [Passed!
-])
+], ignore)
 AT_CLEANUP
 
 POAT_AMDSDK_SETUP([matrixtranspose])

--- a/tests/testsuite-amdsdk2_9.at
+++ b/tests/testsuite-amdsdk2_9.at
@@ -344,8 +344,6 @@ AT_CHECK_UNQUOTED([make test_MatrixMulDouble -sC $abs_top_builddir/examples/AMDS
 AT_CLEANUP
 
 POAT_AMDSDK_SETUP([matrixmulimage])
-# pocl error: encountered unimplemented part of the OpenCL specs in clCreateImage2D.c:119
-#AT_XFAIL_IF(true)
 AT_CHECK_UNQUOTED([make test_MatrixMulImage -sC $abs_top_builddir/examples/AMDSDK2.9 | grep Passed], 0, 
 [Passed!
 ], ignore)


### PR DESCRIPTION
Test is now identical with AMD SDK 2.9 test.
