### PR TITLE
Don't pass an enum value as a bool.

### DIFF
--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -1451,7 +1451,7 @@ pocl_llvm_codegen(cl_kernel kernel,
     // TODO: better error check
     formatted_raw_ostream FOS(outfile.os());
     llvm::MCContext *mcc;
-    if(target->addPassesToEmitMC(PM, mcc, FOS, llvm::TargetMachine::CGFT_ObjectFile))
+    if(target->addPassesToEmitMC(PM, mcc, FOS))
         return 1;
 
     PM.run(*input);


### PR DESCRIPTION
Probably left over from changing addPassesToEmitFile to
addPassesToEmitMC. Won't change behaviour as CGFT_ObjectFile is 1 and
default value of the DisableVerify argument is true.

See http://llvm.org/doxygen/classllvm_1_1TargetMachine.html#a3d780c056467479af56e78d2adb6a200.