### PR TITLE
Corrected WORDS_BIGENDIAN for cmake build.

### DIFF
--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -137,7 +137,7 @@
 
 
 /* Defined on big endian systems */
-#cmakedefine WORDS_BIGENDIAN
+#define WORDS_BIGENDIAN @WORDS_BIGENDIAN@
 
 /* Disable cl_khr_int64 when a clang bug is present */
 #cmakedefine _CL_DISABLE_LONG


### PR DESCRIPTION
It should be 1 on a big endian target but was actually empty.