### PR TITLE
Clip max_work_item_sizes to max_work_group_size

### DIFF
--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -221,9 +221,7 @@ pocl_basic_init_device_infos(struct _cl_device_id* dev)
   dev->vendor_id = 0;
   dev->max_compute_units = 0;
   dev->max_work_item_dimensions = 3;
-  dev->max_work_item_sizes[0] = SIZE_MAX;
-  dev->max_work_item_sizes[1] = SIZE_MAX;
-  dev->max_work_item_sizes[2] = SIZE_MAX;
+
   /*
     The hard restriction will be the context data which is
     stored in stack that can be as small as 8K in Linux.
@@ -231,7 +229,9 @@ pocl_basic_init_device_infos(struct _cl_device_id* dev)
     the SIMD lanes times the vector units, but not more than
     that to avoid stack overflow and cache trashing.
   */
-  dev->max_work_group_size = 1024*4;
+  dev->max_work_item_sizes[0] = dev->max_work_item_sizes[1] =
+	  dev->max_work_item_sizes[2] = dev->max_work_group_size = 1024*4;
+
   dev->preferred_wg_size_multiple = 8;
   dev->preferred_vector_width_char = POCL_DEVICES_PREFERRED_VECTOR_WIDTH_CHAR;
   dev->preferred_vector_width_short = POCL_DEVICES_PREFERRED_VECTOR_WIDTH_SHORT;

--- a/lib/CL/devices/cellspu/cellspu.c
+++ b/lib/CL/devices/cellspu/cellspu.c
@@ -86,10 +86,8 @@ pocl_cellspu_init_device_infos(struct _cl_device_id* dev)
   dev->type = CL_DEVICE_TYPE_ACCELERATOR;
   dev->max_compute_units = 1;
   dev->max_work_item_dimensions = 3;
-  dev->max_work_item_sizes[0] = CL_INT_MAX;
-  dev->max_work_item_sizes[1] = CL_INT_MAX;
-  dev->max_work_item_sizes[2] = CL_INT_MAX;
-  dev->max_work_group_size = 1024;
+  dev->max_work_item_sizes[0] = dev->max_work_item_sizes[1] =
+	  dev->max_work_item_sizes[2] = dev->max_work_group_size = 8192;
   dev->preferred_wg_size_multiple = 8;
   dev->preferred_vector_width_char = POCL_DEVICES_PREFERRED_VECTOR_WIDTH_CHAR;
   dev->preferred_vector_width_short = POCL_DEVICES_PREFERRED_VECTOR_WIDTH_SHORT;

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -199,9 +199,8 @@ pocl_pthread_init_device_infos(struct _cl_device_id* dev)
   pocl_basic_init_device_infos(dev);
 
   dev->type = CL_DEVICE_TYPE_CPU;
-  dev->max_work_item_sizes[0] = SIZE_MAX;
-  dev->max_work_item_sizes[1] = SIZE_MAX;
-  dev->max_work_item_sizes[2] = SIZE_MAX;
+  dev->max_work_item_sizes[0] = dev->max_work_item_sizes[1] =
+	  dev->max_work_item_sizes[2] = dev->max_work_group_size;
 
 }
 

--- a/lib/CL/devices/tce/ttasim/ttasim.cc
+++ b/lib/CL/devices/tce/ttasim/ttasim.cc
@@ -66,8 +66,6 @@
 
 using namespace TTAMachine;
 
-size_t pocl_ttasim_max_work_item_sizes[] = {CL_INT_MAX, CL_INT_MAX, CL_INT_MAX};
-
 static void *pocl_ttasim_thread (void *p);
 
 void
@@ -102,10 +100,8 @@ pocl_ttasim_init_device_infos(struct _cl_device_id* dev)
   dev->type = CL_DEVICE_TYPE_GPU;
   dev->max_compute_units = 1;
   dev->max_work_item_dimensions = 3;
-  dev->max_work_item_sizes[0] = CL_INT_MAX;
-  dev->max_work_item_sizes[1] = CL_INT_MAX;
-  dev->max_work_item_sizes[2] = CL_INT_MAX;
-  dev->max_work_group_size = 8192;
+  dev->max_work_item_sizes[0] = dev->max_work_item_sizes[1] =
+	  dev->max_work_item_sizes[2] = dev->max_work_group_size = 8192;
   dev->preferred_wg_size_multiple = 8;
   dev->preferred_vector_width_char = POCL_DEVICES_PREFERRED_VECTOR_WIDTH_CHAR;
   dev->preferred_vector_width_short = POCL_DEVICES_PREFERRED_VECTOR_WIDTH_SHORT;


### PR DESCRIPTION
CL_DEVICE_MAX_WORK_ITEM_SIZES is an array describing the maximum
number of work-items that can be indexed in a given dimension in a
work-group (not globally), so it doesn't make any sense for it to be
larger than CL_DEVICE_MAX_WORK_GROUP_SIZE, which is the overall limit
in the number of work-items in a work-group.

Just as well, since we don't have hardware work-item indices (which is
the case on GPUs instead) it also doesn't make any sense for any of the
values to be _less_ than the maximum work-group size (i.e. there's no
reason to not allow 1×1×MAX as well as MAX×1×1 and 1×MAX×1), so just
set each element of max_work_item_sizes to the value of
max_work_group_size.

Signed-off-by: Giuseppe Bilotta <giuseppe.bilotta@gmail.com>