### PR TITLE
Link failures

### DIFF
--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -44,7 +44,7 @@
 #define max(a,b) (((a) > (b)) ? (a) : (b))
 
 #define COMMAND_LENGTH 2048
-#define WORKGROUP_STRING_LENGTH 128
+#define WORKGROUP_STRING_LENGTH 1024
 
 struct data {
   /* Currently loaded kernel. */
@@ -816,7 +816,7 @@ void check_compiler_cache (_cl_command_node *cmd)
       abort();
     }
   snprintf (workgroup_string, WORKGROUP_STRING_LENGTH,
-            "_%s_workgroup", cmd->command.run.kernel->function_name);
+            "_pocl_launcher_%s_workgroup", cmd->command.run.kernel->function_name);
   cmd->command.run.wg = ci->wg = 
     (pocl_workgroup) lt_dlsym (dlhandle, workgroup_string);
 

--- a/lib/CL/devices/cellspu/cellspu.c
+++ b/lib/CL/devices/cellspu/cellspu.c
@@ -37,7 +37,7 @@
 #define max(a,b) (((a) > (b)) ? (a) : (b))
 
 #define COMMAND_LENGTH 2048
-#define WORKGROUP_STRING_LENGTH 128
+#define WORKGROUP_STRING_LENGTH 1024
 
 //#define DEBUG_CELLSPU_DRIVER
 
@@ -268,7 +268,7 @@ pocl_cellspu_run
   // SPU image.
   // TODO: figure out which function to call given what conditions
   snprintf (workgroup_string, WORKGROUP_STRING_LENGTH,
-            "_%s_workgroup_fast", kernel->function_name);
+            "_pocl_launcher_%s_workgroup_fast", kernel->function_name);
 
 
   if ( access (module, F_OK) != 0)

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -80,7 +80,7 @@
 #endif
 
 #define COMMAND_LENGTH 2048
-#define WORKGROUP_STRING_LENGTH 256
+#define WORKGROUP_STRING_LENGTH 1024
 
 /* The name of the environment variable used to force a certain max thread count
    for the thread execution. */

--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -53,7 +53,7 @@
 using namespace TTAMachine;
 
 #define COMMAND_LENGTH 256
-#define WORKGROUP_STRING_LENGTH 128
+#define WORKGROUP_STRING_LENGTH 1024
 #define max(a,b) (((a) > (b)) ? (a) : (b))
 
 #define ALIGNMENT (max(ALIGNOF_FLOAT16, ALIGNOF_DOUBLE16))

--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -820,9 +820,9 @@ int pocl_llvm_get_kernel_metadata(cl_program program,
       fprintf(kobj_c, "\n #include <pocl_device.h>\n");
 
       fprintf(kobj_c,
-        "void _%s_workgroup(void** args, struct pocl_context*);\n", kernel_name);
+        "void _pocl_launcher_%s_workgroup(void** args, struct pocl_context*);\n", kernel_name);
       fprintf(kobj_c,
-        "void _%s_workgroup_fast(void** args, struct pocl_context*);\n", kernel_name);
+        "void _pocl_launcher_%s_workgroup_fast(void** args, struct pocl_context*);\n", kernel_name);
 
       fprintf(kobj_c,
         "__attribute__((address_space(3))) __kernel_metadata _%s_md = {\n", kernel_name);
@@ -845,7 +845,7 @@ int pocl_llvm_get_kernel_metadata(cl_program program,
       fprintf( kobj_c,"     _%s_ARG_IS_IMAGE,\n",    kernel_name  );
       fprintf( kobj_c,"     _%s_ARG_IS_SAMPLER,\n",  kernel_name  );
 #endif
-      fprintf( kobj_c,"     _%s_workgroup_fast\n",   kernel_name  );
+      fprintf( kobj_c,"     _pocl_launcher_%s_workgroup_fast\n",   kernel_name  );
       fprintf( kobj_c," };\n");
       fclose(kobj_c);
    }

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -255,7 +255,7 @@ createLauncher(Module &M, Function *F)
 
   Function *L = Function::Create(ft,
 				 Function::ExternalLinkage,
-				 "_" + funcName,
+				 "_pocl_launcher_" + funcName,
 				 &M);
 
   SmallVector<Value *, 8> arguments;

--- a/scripts/pocl-kernel.in
+++ b/scripts/pocl-kernel.in
@@ -96,8 +96,8 @@ cat >> ${output_file}.kernel_obj.c <<EOF
 
 #include <pocl_device.h>
 
-void _${kernel}_workgroup(void** args, struct pocl_context*);
-void _${kernel}_workgroup_fast(void** args, struct pocl_context*);
+void _pocl_launcher_${kernel}_workgroup(void** args, struct pocl_context*);
+void _pocl_launcher_${kernel}_workgroup_fast(void** args, struct pocl_context*);
 
 __attribute__((address_space(3))) __kernel_metadata _${kernel}_md = {
     "${kernel}", /* name */

--- a/tests/runtime/Makefile.am
+++ b/tests/runtime/Makefile.am
@@ -25,6 +25,7 @@
 noinst_PROGRAMS= test_clFinish test_clGetDeviceInfo test_clGetEventInfo \
 	test_clCreateProgramWithBinary test_clGetSupportedImageFormats \
 	test_clSetEventCallback test_clEnqueueNativeKernel test_clBuildProgram \
+	test_link_error \
 	test_clCreateKernelsInProgram test_clCreateKernel test_version \
 	test_clGetKernelArgInfo
 

--- a/tests/runtime/test_link_error.c
+++ b/tests/runtime/test_link_error.c
@@ -1,0 +1,75 @@
+/* Test that link errors are caught at clBuildProgram time
+
+   Copyright (c) 2015 Giuseppe Bilotta
+                      Kalray
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <CL/cl.h>
+#include <poclu.h>
+#include "pocl_tests.h"
+
+#define MAX_PLATFORMS 32
+#define MAX_DEVICES   32
+#define MAX_BINARIES  32
+
+/* A program that fails to link */
+char program_src[] =
+  "void test_func();\n" /* declared but not defined */
+  "kernel void test_kernel(global int *a) { test_func(); }\n";
+
+int
+main(void){
+  cl_int err;
+  cl_platform_id platforms[MAX_PLATFORMS];
+  cl_uint nplatforms;
+  cl_device_id devices[MAX_DEVICES + 1]; // + 1 for duplicate test
+  cl_uint num_devices;
+  cl_uint i;
+  cl_program program = NULL;
+  cl_program program_with_binary = NULL;
+  err = clGetPlatformIDs(MAX_PLATFORMS, platforms, &nplatforms);
+  CHECK_OPENCL_ERROR_IN("clGetPlatformIDs");
+  if (!nplatforms)
+    return EXIT_FAILURE;
+
+  err = clGetDeviceIDs(platforms[0], CL_DEVICE_TYPE_ALL, MAX_DEVICES,
+		       devices, &num_devices);  
+  CHECK_OPENCL_ERROR_IN("clGetDeviceIDs");
+
+  cl_context context = clCreateContext(NULL, num_devices, devices, NULL, NULL, &err);
+  CHECK_OPENCL_ERROR_IN("clCreateContext");
+
+  size_t program_size = strlen(program_src);
+  char* program_buffer = program_src;
+
+  program = clCreateProgramWithSource(context, 1, (const char**)&program_buffer, 
+                                     &program_size, &err);
+  //clCreateProgramWithSource for the program with #include failed
+  CHECK_OPENCL_ERROR_IN("clCreateProgramWithSource");
+
+  err = clBuildProgram(program, num_devices, devices, NULL, NULL, NULL);
+  TEST_ASSERT(err == CL_BUILD_PROGRAM_FAILURE);
+
+  return EXIT_SUCCESS;
+}

--- a/tests/testsuite-runtime.at
+++ b/tests/testsuite-runtime.at
@@ -27,6 +27,13 @@ AT_KEYWORDS([runtime])
 AT_CHECK([cd $abs_top_srcdir/tests/runtime/; $abs_top_builddir/tests/runtime/test_clBuildProgram], 0, ignore, ignore)
 AT_CLEANUP
 
+AT_SETUP([clBuildProgram link error])
+AT_XFAIL_IF(true)
+AT_KEYWORDS([runtime])
+AT_CHECK([$abs_top_builddir/tests/runtime/test_link_error])
+AT_CLEANUP
+
+
 AT_SETUP([clFinish])
 AT_KEYWORDS([runtime])
 AT_CHECK_UNQUOTED([$abs_top_builddir/tests/runtime/test_clFinish | grep "ABABC"], 0, [ABABC


### PR DESCRIPTION
While testing some simple programs in a course I'm running I discovered an interesting issue with pocl: if a kernel called 'init' is present, the program will fail to launch due to a link error in the device code. However, the link error doesn't actually happen when building the program, but when kernels are actually invoked.

This patch series thereby tests for two issues:

1. a spec violation, by which link failures are not reported from within clBuildProgram(), even though they should (instead, they are reported further on when the kernels are actually linked at launch time);
2. the actual 'init' bug, which is caused by the kernel launcher name mangling prepending a '_' to the kernel name, causing the '_init' symbol to be double-defined;

The last patch actually fixes the second bug, by changing the mangling scheme into something more sophisticated.

Note that with this patchset the clBuildProgram test will fail due to the delayed linking behavior in current pocl.