### PR TITLE
Implement get_image_dim

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,10 @@ OpenCL Runtime/Platform API support
 -Transferred buffer read/write/copy offset calculation to device driver side.
  - these driver api functions have changed; got offset as a new argument.
 
+OpenCL C Builtin Function Implementations
+-----------------------------------------
+- Implemented get_image_dim()
+
 0.11 unreleased
 ===============
 

--- a/include/_kernel_c.h
+++ b/include/_kernel_c.h
@@ -159,12 +159,20 @@ typedef ulong ulong16 __attribute__((__ext_vector_type__(16)));
    by the frontend. */
 #if !defined(_CL_HAS_IMAGE_ACCESS)
 typedef int sampler_t;
-typedef struct dev_image_t* image2d_t;
-typedef struct dev_image_t* image3d_t;
-typedef struct dev_image_t* image1d_t;
-typedef struct dev_image_t* image1d_buffer_t;
-typedef struct dev_image_t* image2d_array_t;
-typedef struct dev_image_t* image1d_array_t;
+
+/* Since some built-ins have different return types
+ * (e.g. get_image_dim returns an int2 for 2D images and arrays,
+ *  but an int4 for 3D images) we want each image type to
+ * point to a different type which is actually always the same.
+ * We do this by making it pointer to an anonymous struct
+ * whose only element is a dev_image_t
+ */
+typedef struct { dev_image_t base; }* image2d_t;
+typedef struct { dev_image_t base; }* image3d_t;
+typedef struct { dev_image_t base; }* image1d_t;
+typedef struct { dev_image_t base; }* image1d_buffer_t;
+typedef struct { dev_image_t base; }* image2d_array_t;
+typedef struct { dev_image_t base; }* image1d_array_t;
 #endif
 
 
@@ -298,4 +306,9 @@ int _CL_OVERLOADABLE get_image_height (image3d_t image);
 int _CL_OVERLOADABLE get_image_depth (image1d_t image);
 int _CL_OVERLOADABLE get_image_depth (image2d_t image);
 int _CL_OVERLOADABLE get_image_depth (image3d_t image);
+
+int2 _CL_OVERLOADABLE get_image_dim (image2d_t image);
+int2 _CL_OVERLOADABLE get_image_dim (image2d_array_t image);
+int4 _CL_OVERLOADABLE get_image_dim (image3d_t image);
+
 #endif

--- a/lib/kernel/CMakeLists.txt
+++ b/lib/kernel/CMakeLists.txt
@@ -84,6 +84,7 @@ get_group_id.c
 get_image_depth.cl
 get_image_height.cl
 get_image_width.cl
+get_image_dim.cl
 get_local_id.c
 get_local_size.c
 get_num_groups.c

--- a/lib/kernel/get_image_dim.cl
+++ b/lib/kernel/get_image_dim.cl
@@ -1,0 +1,54 @@
+/* OpenCL built-in library: get_image_dim()
+
+   Copyright (c) 2013-2014 Ville Korhonen, Pekka Jääskeläinen
+                           Tampere University of Technology
+   Copyright (c) 2015      Giuseppe Bilotta
+   
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+   
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+   
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+#include "templates.h"
+
+#if (__clang_major__ == 3) && (__clang_minor__ >= 5)
+// Clang 3.5 crashes in case trying to cast to the private pointer,
+// adding the global qualifier fixes it. Clang 3.4 crashes if it's
+// there. The issue is in SROA.
+#define ADDRESS_SPACE global
+#else
+#define ADDRESS_SPACE
+#endif
+
+int2 _CL_OVERLOADABLE get_image_dim(image2d_t image)
+{
+  ADDRESS_SPACE dev_image_t* img = *(ADDRESS_SPACE dev_image_t**)&image;
+  return (int2)(img->width, img->height);
+}
+
+int2 _CL_OVERLOADABLE get_image_dim(image2d_array_t image)
+{
+  ADDRESS_SPACE dev_image_t* img = *(ADDRESS_SPACE dev_image_t**)&image;
+  return (int2)(img->width, img->height);
+}
+
+int4 _CL_OVERLOADABLE get_image_dim(image3d_t image)
+{
+  ADDRESS_SPACE dev_image_t* img = *(ADDRESS_SPACE dev_image_t**)&image;
+  return (int4)(img->width, img->height, img->depth, 0);
+}
+

--- a/lib/kernel/sources.mk
+++ b/lib/kernel/sources.mk
@@ -85,6 +85,7 @@ LKERNEL_SRCS_DEFAULT =				\
 	get_image_depth.cl			\
 	get_image_height.cl			\
 	get_image_width.cl			\
+	get_image_dim.cl			\
 	get_local_id.c				\
 	get_local_size.c			\
 	get_num_groups.c			\

--- a/tests/kernel/image_query_funcs.c
+++ b/tests/kernel/image_query_funcs.c
@@ -31,16 +31,23 @@ int main(int argc, char **argv)
   /* image parameters */
   cl_uchar4 *imageData;
   cl_image_format image_format;
-  cl_image_desc image_desc;
+  cl_image_desc image2_desc, image3_desc;
 
   
 
   printf("Running test %s...\n", name);
-  memset(&image_desc, 0, sizeof(cl_image_desc));
-  image_desc.image_type = CL_MEM_OBJECT_IMAGE3D;
-  image_desc.image_width = 2;
-  image_desc.image_height = 4;
-  image_desc.image_depth = 8;
+
+  memset(&image2_desc, 0, sizeof(cl_image_desc));
+  image2_desc.image_type = CL_MEM_OBJECT_IMAGE2D;
+  image2_desc.image_width = 2;
+  image2_desc.image_height = 4;
+
+  memset(&image3_desc, 0, sizeof(cl_image_desc));
+  image3_desc.image_type = CL_MEM_OBJECT_IMAGE3D;
+  image3_desc.image_width = 2;
+  image3_desc.image_height = 4;
+  image3_desc.image_depth = 8;
+
   image_format.image_channel_order = CL_RGBA;
   image_format.image_channel_data_type = CL_UNSIGNED_INT8;
   imageData = (cl_uchar4*)malloc (4 * 4 * sizeof(cl_uchar4));
@@ -120,11 +127,19 @@ int main(int argc, char **argv)
 
   /* Create image */
 
-  cl_mem image = clCreateImage (context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
-                                &image_format, &image_desc, imageData, &result);
+  cl_mem image2 = clCreateImage (context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
+                                &image_format, &image2_desc, imageData, &result);
   if (result != CL_SUCCESS)
     {
-      puts("image creation failed\n");
+      puts("image2 creation failed\n");
+      goto error;
+    }
+
+  cl_mem image3 = clCreateImage (context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
+                                &image_format, &image3_desc, imageData, &result);
+  if (result != CL_SUCCESS)
+    {
+      puts("image3 creation failed\n");
       goto error;
     }
 
@@ -153,10 +168,17 @@ int main(int argc, char **argv)
       goto error;
     }
 
-   result = clSetKernelArg( kernel, 0, sizeof(cl_mem), &image);
+   result = clSetKernelArg( kernel, 0, sizeof(cl_mem), &image2);
    if (result)
      {
-       puts("clSetKernelArg failed\n");
+       puts("clSetKernelArg 0 failed\n");
+       goto error;
+     }
+
+   result = clSetKernelArg( kernel, 1, sizeof(cl_mem), &image3);
+   if (result)
+     {
+       puts("clSetKernelArg 1 failed\n");
        goto error;
      }
 

--- a/tests/kernel/test_image_query_funcs.cl
+++ b/tests/kernel/test_image_query_funcs.cl
@@ -1,12 +1,13 @@
 
 
-kernel 
-void test_image_query_funcs(__read_only image3d_t image)
+kernel
+void test_image_query_funcs(__read_only image2d_t image2, __read_only image3d_t image3)
 {
-  int h = get_image_height (image);
-  int w = get_image_width (image);
-  int d = get_image_depth (image);
-  
+  int h = get_image_height (image3);
+  int w = get_image_width (image3);
+  int d = get_image_depth (image3);
+  int4 dim4 = get_image_dim (image3);
+
   if (h != 4)
     printf("get_image_height failed expected 4, got %d\n", h);
 
@@ -14,6 +15,24 @@ void test_image_query_funcs(__read_only image3d_t image)
     printf("get_image_width failed expected 2, got %d\n", w);
 
   if (d != 8)
-    printf("get_image_width failed expected 8, got %d\n", d);  
+    printf("get_image_width failed expected 8, got %d\n", d);
+
+  if (dim4.x != w || dim4.y != h || dim4.z != d || dim4.w != 0)
+    printf("get_image_dim failed expected (%d,%d,%d,0), got %v4d\n",
+      w, h, d, dim4);
+
+  h = get_image_height (image2);
+  w = get_image_width (image2);
+  int2 dim2 = get_image_dim (image2);
+
+  if (h != 4)
+    printf("get_image_height failed expected 4, got %d\n", h);
+
+  if (w != 2)
+    printf("get_image_width failed expected 2, got %d\n", w);
+
+  if (dim2.x != w || dim2.y != h)
+    printf("get_image_dim failed expected (%d,%d), got %v2d\n",
+      w, h, dim2);
 
 }


### PR DESCRIPTION
This implements get_image_dim for 2D images and arrays, and for 3D images.

This should fix issue #55.

(Note that the issue also mentions some write image functions in a later comment. This is not addressed here.)