### PR TITLE
Two more tests

### DIFF
--- a/tests/runtime/Makefile.am
+++ b/tests/runtime/Makefile.am
@@ -23,6 +23,7 @@
 # THE SOFTWARE.
 
 noinst_PROGRAMS= test_clFinish test_clGetDeviceInfo test_clGetEventInfo \
+	test_read-copy-write-buffer \
 	test_clCreateProgramWithBinary test_clGetSupportedImageFormats \
 	test_clSetEventCallback test_clEnqueueNativeKernel test_clBuildProgram \
 	test_link_error \

--- a/tests/runtime/Makefile.am
+++ b/tests/runtime/Makefile.am
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 
 noinst_PROGRAMS= test_clFinish test_clGetDeviceInfo test_clGetEventInfo \
-	test_read-copy-write-buffer \
+	test_read-copy-write-buffer test_event_cycle \
 	test_clCreateProgramWithBinary test_clGetSupportedImageFormats \
 	test_clSetEventCallback test_clEnqueueNativeKernel test_clBuildProgram \
 	test_link_error \

--- a/tests/runtime/test_event_cycle.c
+++ b/tests/runtime/test_event_cycle.c
@@ -1,0 +1,152 @@
+/* Test that recycling wait lists doesn't lead to lockups
+
+   Copyright (C) 2015 Giuseppe Bilotta <giuseppe.bilotta@gmail.com>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <string.h>
+#include <unistd.h>
+#include <signal.h>
+#include <CL/cl.h>
+
+#define MAX_PLATFORMS 32
+#define MAX_DEVICES   32
+
+void timeout(int signum)
+{
+  exit(EXIT_FAILURE);
+}
+
+int
+main(void)
+{
+  cl_int err;
+  cl_platform_id platforms[MAX_PLATFORMS];
+  cl_uint nplatforms;
+  cl_device_id devices[MAX_DEVICES];
+  cl_uint ndevices;
+  cl_uint i, j;
+
+  /* set up a signal handler for ALRM that will kill
+   * the program with EXIT_FAILURE on timeout
+   */
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_handler = timeout;
+  sigaction(SIGALRM, &sa, NULL);
+
+  err = clGetPlatformIDs(MAX_PLATFORMS, platforms, &nplatforms);
+  if (err != CL_SUCCESS)
+    return EXIT_FAILURE;
+
+  for (i = 0; i < nplatforms; i++)
+  {
+    err = clGetDeviceIDs(platforms[i], CL_DEVICE_TYPE_ALL, MAX_DEVICES,
+      devices, &ndevices);
+    if (err != CL_SUCCESS)
+      return EXIT_FAILURE;
+
+    for (j = 0; j < ndevices; j++)
+    {
+      cl_context context = clCreateContext(NULL, 1, &devices[j], NULL, NULL, &err);
+      if (err != CL_SUCCESS)
+        return EXIT_FAILURE;
+      cl_command_queue queue = clCreateCommandQueue(context, devices[j], 0, &err);
+      if (err != CL_SUCCESS)
+        return EXIT_FAILURE;
+
+      cl_ulong alloc;
+#define MAXALLOC (128*1024U*1024U)
+
+      if (clGetDeviceInfo(devices[j], CL_DEVICE_MAX_MEM_ALLOC_SIZE,
+          sizeof(alloc), &alloc, NULL) != CL_SUCCESS)
+        return EXIT_FAILURE;
+
+      while (alloc > MAXALLOC)
+        alloc /= 2;
+
+      const size_t buf_size = alloc;
+
+      cl_int *host_buf1 = malloc(buf_size);
+      if (host_buf1 == NULL)
+        return EXIT_FAILURE;
+      cl_int *host_buf2 = malloc(buf_size);
+      if (host_buf2 == NULL)
+        return EXIT_FAILURE;
+
+      memset(host_buf1, 1, buf_size);
+      memset(host_buf2, 2, buf_size);
+
+      cl_mem buf1 = clCreateBuffer(context, CL_MEM_READ_WRITE, buf_size, NULL, &err);
+      if (err != CL_SUCCESS)
+        return EXIT_FAILURE;
+      cl_mem buf2 = clCreateBuffer(context, CL_MEM_READ_WRITE, buf_size, NULL, &err);
+      if (err != CL_SUCCESS)
+        return EXIT_FAILURE;
+
+      cl_event buf1_event, bufcp_event, buf2_event;
+
+      /* we test if recycling the wait list leads to neverending loops */
+      cl_event wait_list[1];
+
+      /* Note that this must be CL_TRUE because to trigger the bug the next
+       * command must have a completed event in the waiting lists */
+      if (clEnqueueWriteBuffer(queue, buf1, CL_TRUE, 0, buf_size, host_buf1,
+	  0, NULL, &buf1_event) != CL_SUCCESS)
+        return EXIT_FAILURE;
+
+      *wait_list = buf1_event;
+
+      if (clEnqueueCopyBuffer(queue, buf1, buf2, 0, 0, buf_size,
+	  1, wait_list, &bufcp_event) != CL_SUCCESS)
+        return EXIT_FAILURE;
+
+      *wait_list = bufcp_event;
+
+      if (clEnqueueReadBuffer(queue, buf2, CL_FALSE, 0, buf_size, host_buf2,
+	  1, wait_list, &buf2_event) != CL_SUCCESS)
+        return EXIT_FAILURE;
+
+      /* timeout after 30 seconds: if we're not done by then, timeout() will be
+       * invoked and terminate the program with an EXIT_FAILURE */
+      alarm(30);
+
+      if (clFinish(queue) != CL_SUCCESS)
+        return EXIT_FAILURE;
+
+      if (memcmp(host_buf2, host_buf1, buf_size) != 0)
+        return EXIT_FAILURE;
+
+      free(host_buf2);
+      free(host_buf1);
+      clReleaseEvent(buf2_event);
+      clReleaseEvent(bufcp_event);
+      clReleaseEvent(buf1_event);
+      clReleaseMemObject(buf2);
+      clReleaseMemObject(buf1);
+      clReleaseCommandQueue(queue);
+    }
+  }
+  return EXIT_SUCCESS;
+}
+

--- a/tests/runtime/test_read-copy-write-buffer.c
+++ b/tests/runtime/test_read-copy-write-buffer.c
@@ -1,0 +1,119 @@
+/* Test clEnqueue{Write,Copy,Read}Buffer
+
+   Copyright (C) 2015 Giuseppe Bilotta <giuseppe.bilotta@gmail.com>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <malloc.h>
+#include <string.h>
+#include <CL/cl.h>
+
+#define MAX_PLATFORMS 32
+#define MAX_DEVICES   32
+
+int
+main(void)
+{
+  cl_int err;
+  cl_platform_id platforms[MAX_PLATFORMS];
+  cl_uint nplatforms;
+  cl_device_id devices[MAX_DEVICES];
+  cl_uint ndevices;
+  cl_uint i, j;
+
+  err = clGetPlatformIDs(MAX_PLATFORMS, platforms, &nplatforms);
+  if (err != CL_SUCCESS)
+    return EXIT_FAILURE;
+
+  for (i = 0; i < nplatforms; i++)
+  {
+    err = clGetDeviceIDs(platforms[i], CL_DEVICE_TYPE_ALL, MAX_DEVICES,
+      devices, &ndevices);
+    if (err != CL_SUCCESS)
+      return EXIT_FAILURE;
+
+    for (j = 0; j < ndevices; j++)
+    {
+      cl_context context = clCreateContext(NULL, 1, &devices[j], NULL, NULL, &err);
+      if (err != CL_SUCCESS)
+        return EXIT_FAILURE;
+      cl_command_queue queue = clCreateCommandQueue(context, devices[j], 0, &err);
+      if (err != CL_SUCCESS)
+        return EXIT_FAILURE;
+
+      cl_ulong alloc;
+#define MAXALLOC (1024U*1024U)
+
+      if (clGetDeviceInfo(devices[j], CL_DEVICE_MAX_MEM_ALLOC_SIZE,
+          sizeof(alloc), &alloc, NULL) != CL_SUCCESS)
+        return EXIT_FAILURE;
+
+      while (alloc > MAXALLOC)
+        alloc /= 2;
+
+      const size_t buf_size = (alloc/sizeof(cl_int))*sizeof(cl_int);
+
+      cl_int *host_buf1 = malloc(buf_size);
+      if (host_buf1 == NULL)
+        return EXIT_FAILURE;
+      cl_int *host_buf2 = malloc(buf_size);
+      if (host_buf2 == NULL)
+        return EXIT_FAILURE;
+
+      memset(host_buf1, 1, buf_size);
+      memset(host_buf2, 2, buf_size);
+
+      cl_mem buf1 = clCreateBuffer(context, CL_MEM_READ_WRITE, buf_size, NULL, &err);
+      if (err != CL_SUCCESS)
+        return EXIT_FAILURE;
+      cl_mem buf2 = clCreateBuffer(context, CL_MEM_READ_WRITE, buf_size, NULL, &err);
+      if (err != CL_SUCCESS)
+        return EXIT_FAILURE;
+
+      if (clEnqueueWriteBuffer(queue, buf1, CL_TRUE, 0, buf_size, host_buf1,
+	  0, NULL, NULL) != CL_SUCCESS)
+        return EXIT_FAILURE;
+
+      if (clEnqueueCopyBuffer(queue, buf1, buf2, 0, 0, buf_size,
+	  0, NULL, NULL) != CL_SUCCESS)
+        return EXIT_FAILURE;
+
+      if (clEnqueueReadBuffer(queue, buf2, CL_TRUE, 0, buf_size, host_buf2,
+	  0, NULL, NULL) != CL_SUCCESS)
+        return EXIT_FAILURE;
+
+      if (clFinish(queue) != CL_SUCCESS)
+        return EXIT_FAILURE;
+
+      if (memcmp(host_buf2, host_buf1, buf_size) != 0)
+        return EXIT_FAILURE;
+
+      free(host_buf2);
+      free(host_buf1);
+      clReleaseMemObject(buf2);
+      clReleaseMemObject(buf1);
+      clReleaseCommandQueue(queue);
+    }
+  }
+  return EXIT_SUCCESS;
+}
+

--- a/tests/testsuite-runtime.at
+++ b/tests/testsuite-runtime.at
@@ -21,6 +21,11 @@ AT_KEYWORDS([runtime])
 AT_CHECK([$abs_top_builddir/tests/runtime/test_read-copy-write-buffer])
 AT_CLEANUP
 
+AT_SETUP([event cycle])
+AT_KEYWORDS([runtime])
+AT_CHECK([$abs_top_builddir/tests/runtime/test_event_cycle])
+AT_CLEANUP
+
 AT_SETUP([clCreateProgramWithBinary])
 AT_KEYWORDS([runtime])
 AT_CHECK([$abs_top_builddir/tests/runtime/test_clCreateProgramWithBinary])

--- a/tests/testsuite-runtime.at
+++ b/tests/testsuite-runtime.at
@@ -16,6 +16,11 @@ AT_KEYWORDS([runtime])
 AT_CHECK([$abs_top_builddir/tests/runtime/test_clGetEventInfo])
 AT_CLEANUP
 
+AT_SETUP([read/copy/write buffer])
+AT_KEYWORDS([runtime])
+AT_CHECK([$abs_top_builddir/tests/runtime/test_read-copy-write-buffer])
+AT_CLEANUP
+
 AT_SETUP([clCreateProgramWithBinary])
 AT_KEYWORDS([runtime])
 AT_CHECK([$abs_top_builddir/tests/runtime/test_clCreateProgramWithBinary])


### PR DESCRIPTION
This patchset adds two small tests:

* the first is a simple test for reading, copying and writing buffers (nothing special, passes as-is);
* the second is a test for the “neverending loop” that was fixed by the (merged) pull requesnt #172 (I tested it without those patches and it fails as expected, after a 30s timeout, it passes with the latest master).