### PR TITLE
Image fix for llvm32

### DIFF
--- a/include/_kernel_c.h
+++ b/include/_kernel_c.h
@@ -164,15 +164,16 @@ typedef int sampler_t;
  * (e.g. get_image_dim returns an int2 for 2D images and arrays,
  *  but an int4 for 3D images) we want each image type to
  * point to a different type which is actually always the same.
- * We do this by making it pointer to an anonymous struct
- * whose only element is a dev_image_t
+ * We do this by making it pointer to structs whose only element is a
+ * dev_image_t. The structs are not anonymous to allow identification
+ * by name.
  */
-typedef struct { dev_image_t base; }* image2d_t;
-typedef struct { dev_image_t base; }* image3d_t;
-typedef struct { dev_image_t base; }* image1d_t;
-typedef struct { dev_image_t base; }* image1d_buffer_t;
-typedef struct { dev_image_t base; }* image2d_array_t;
-typedef struct { dev_image_t base; }* image1d_array_t;
+typedef struct _pocl_image2d_t { dev_image_t base; }* image2d_t;
+typedef struct _pocl_image3d_t { dev_image_t base; }* image3d_t;
+typedef struct _pocl_image1d_t { dev_image_t base; }* image1d_t;
+typedef struct _pocl_image1d_buffer_t { dev_image_t base; }* image1d_buffer_t;
+typedef struct _pocl_image2d_array_t { dev_image_t base; }* image2d_array_t;
+typedef struct _pocl_image1d_array_t { dev_image_t base; }* image1d_array_t;
 #endif
 
 

--- a/lib/llvmopencl/GenerateHeader.cc
+++ b/lib/llvmopencl/GenerateHeader.cc
@@ -243,27 +243,22 @@ GenerateHeader::ProcessPointers(Function *F,
       is_pointer[i] = false;
       is_local[i] = false;
     }
-    
+
     if (t->isPointerTy()) {
-      if (t->getPointerElementType()->isStructTy()) {
-        string name = t->getPointerElementType()->getStructName().str();
-        if (name == "opencl.image2d_t" || name == "opencl.image3d_t" || 
-            name == "opencl.image1d_t" || name == "struct.dev_image_t") {
-          is_image[i] = true;
-          is_pointer[i] = false;
-          is_local[i] = false;
-        }
-        if (name == "opencl.sampler_t_") {
-          is_sampler[i] = true;
-          is_pointer[i] = false;
-          is_local[i] = false;
-        }
+      if (is_image_type(*t)) {
+        is_image[i] = true;
+        is_pointer[i] = false;
+        is_local[i] = false;
+      } else if (is_sampler_type(*t)) {
+        is_sampler[i] = true;
+        is_pointer[i] = false;
+        is_local[i] = false;
       }
     }
-    
+
     ++i;
   }
-    
+
   out << "#define _" << F->getName() << "_ARG_IS_POINTER {";
   if (num_args != 0) {
     out << is_pointer[0];

--- a/lib/llvmopencl/LLVMUtils.h
+++ b/lib/llvmopencl/LLVMUtils.h
@@ -65,8 +65,8 @@ is_image_type(const llvm::Type& t)
 {
   if (t.isPointerTy() && t.getPointerElementType()->isStructTy()) {
     llvm::StringRef name = t.getPointerElementType()->getStructName().str();
-    if (name.startswith("opencl.image2d_t") || name.startswith("opencl.image3d_t") || 
-        name.startswith("opencl.image1d_t") || name.startswith("struct.dev_image_t"))
+    if (name.startswith("opencl.image2d_t") || name.startswith("opencl.image3d_t") ||
+        name.startswith("opencl.image1d_t") || name.startswith("struct._pocl_image"))
       return true;
   }
   return false;


### PR DESCRIPTION
This is a (tentative) fix to restore image support in LLVM 3.2 which I broke in the `get_image_dim()` implementation. I don't have LLVM 3.2 around, so I can't test if it actually does, but at least it doesn't break anything in later versions.