### PR TITLE
Memory access violation fixes

### DIFF
--- a/lib/CL/clEnqueueFillImage.c
+++ b/lib/CL/clEnqueueFillImage.c
@@ -131,7 +131,6 @@ CL_API_SUFFIX__VERSION_1_2
   
  ERROR_CLEAN:
   POCL_MEM_FREE(supported_image_formats);
-  POCL_MEM_FREE(*event);
   POCL_MEM_FREE(fill_pixel);
   return errcode;
 }

--- a/lib/CL/clEnqueueMarkerWithWaitList.c
+++ b/lib/CL/clEnqueueMarkerWithWaitList.c
@@ -34,10 +34,10 @@ POname(clEnqueueMarkerWithWaitList) (cl_command_queue   command_queue,
 CL_API_SUFFIX__VERSION_1_2
 {
   int errcode;
-  _cl_command_node *cmd;
-  
+  _cl_command_node *cmd = NULL;
+
   POCL_RETURN_ERROR_COND((command_queue == NULL), CL_INVALID_COMMAND_QUEUE);
-  
+
   errcode = pocl_create_command (&cmd, command_queue, CL_COMMAND_MARKER, 
                                  event, num_events_in_wait_list, 
                                  event_wait_list);
@@ -46,11 +46,10 @@ CL_API_SUFFIX__VERSION_1_2
 
   cmd->command.marker.data = command_queue->device->data;
   pocl_command_enqueue (command_queue, cmd);
-  
+
   return CL_SUCCESS;
 
  ERROR:
-  POCL_MEM_FREE(event);
   POCL_MEM_FREE(cmd);
   return errcode;
 

--- a/lib/CL/clEnqueueReadImage.c
+++ b/lib/CL/clEnqueueReadImage.c
@@ -41,7 +41,7 @@ POname(clEnqueueReadImage)(cl_command_queue     command_queue,
 CL_API_SUFFIX__VERSION_1_0 
 {
   cl_int errcode;
-  _cl_command_node *cmd;
+  _cl_command_node *cmd = NULL;
 
   POCL_RETURN_ERROR_COND((command_queue == NULL), CL_INVALID_COMMAND_QUEUE);
 
@@ -76,8 +76,8 @@ CL_API_SUFFIX__VERSION_1_0
                                 event_wait_list);
   if (errcode != CL_SUCCESS)
     {
-      if (event)
-        POCL_MEM_FREE(*event);
+      POCL_MEM_FREE(cmd);
+      return errcode;
     }
 
   cmd->command.rw_image.device_ptr = 

--- a/lib/CL/clEnqueueUnmapMemObject.c
+++ b/lib/CL/clEnqueueUnmapMemObject.c
@@ -38,7 +38,7 @@ POname(clEnqueueUnmapMemObject)(cl_command_queue command_queue,
   cl_device_id device_id;
   unsigned i;
   mem_mapping_t *mapping = NULL;
-  _cl_command_node *cmd;
+  _cl_command_node *cmd = NULL;
 
   POCL_RETURN_ERROR_COND((memobj == NULL), CL_INVALID_MEM_OBJECT);
 
@@ -73,13 +73,13 @@ POname(clEnqueueUnmapMemObject)(cl_command_queue command_queue,
 
   assert(i < command_queue->context->num_devices);
 
-  errcode = pocl_create_command (&cmd, command_queue, 
-                                 CL_COMMAND_UNMAP_MEM_OBJECT, 
-                                 event, num_events_in_wait_list, 
+  errcode = pocl_create_command (&cmd, command_queue,
+                                 CL_COMMAND_UNMAP_MEM_OBJECT,
+                                 event, num_events_in_wait_list,
                                  event_wait_list);
   if (errcode != CL_SUCCESS)
     goto ERROR;
-  
+
   cmd->command.unmap.data = command_queue->device->data;
   cmd->command.unmap.memobj = memobj;
   cmd->command.unmap.mapping = mapping;
@@ -87,8 +87,7 @@ POname(clEnqueueUnmapMemObject)(cl_command_queue command_queue,
 
   return CL_SUCCESS;
 
- ERROR:
-  POCL_MEM_FREE(*event);
+ERROR:
   POCL_MEM_FREE(cmd);
   return errcode;
 }

--- a/lib/CL/clEnqueueWriteImage.c
+++ b/lib/CL/clEnqueueWriteImage.c
@@ -49,8 +49,6 @@ POname(clEnqueueWriteImage)(cl_command_queue    command_queue,
                                 event_wait_list);
   if (errcode != CL_SUCCESS)
     {
-      if (event)
-        POCL_MEM_FREE(*event);
       return errcode;
     }  
 

--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -944,7 +944,7 @@ static void InitializeLLVM() {
  * should be optimized using it.
  */
 static PassManager& kernel_compiler_passes
-(cl_device_id device, std::string module_data_layout)
+(cl_device_id device, const std::string& module_data_layout)
 {
   static std::map<cl_device_id, PassManager*> kernel_compiler_passes;
 

--- a/lib/llvmopencl/ParallelRegion.cc
+++ b/lib/llvmopencl/ParallelRegion.cc
@@ -674,7 +674,7 @@ ParallelRegion::LocalIDXLoad()
 
 void
 ParallelRegion::InjectPrintF
-(llvm::Instruction *before, std::string formatStr, 
+(llvm::Instruction *before, const std::string& formatStr,
  std::vector<Value*>& params)
 {
   IRBuilder<> builder(before);

--- a/lib/llvmopencl/ParallelRegion.h
+++ b/lib/llvmopencl/ParallelRegion.h
@@ -96,7 +96,7 @@ class Kernel;
     void InjectVariablePrintouts();
 
     void InjectPrintF
-        (llvm::Instruction *before, std::string formatStr, 
+        (llvm::Instruction *before, const std::string& formatStr,
          std::vector<llvm::Value*>& params);
 
     static ParallelRegion *

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -29,7 +29,7 @@ set(PROGRAMS_TO_BUILD test_clFinish test_clGetDeviceInfo test_clGetEventInfo
   test_clSetEventCallback test_clEnqueueNativeKernel test_clBuildProgram
   test_clCreateKernelsInProgram test_clCreateKernel test_clGetKernelArgInfo
   test_version test_kernel_cache_includes test_event_cycle test_link_error
-  test_read-copy-write-buffer test_clCreateSubDevices)
+  test_read-copy-write-buffer test_clCreateSubDevices test_event_free)
 
 #EXTRA_DIST= \
 # test_kernel_src_in_pwd.h \

--- a/tests/runtime/Makefile.am
+++ b/tests/runtime/Makefile.am
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 
 noinst_PROGRAMS= test_clFinish test_clGetDeviceInfo test_clGetEventInfo \
-	test_read-copy-write-buffer test_event_cycle \
+	test_read-copy-write-buffer test_event_cycle test_event_free \
 	test_clCreateProgramWithBinary test_clGetSupportedImageFormats \
 	test_clSetEventCallback test_clEnqueueNativeKernel test_clBuildProgram \
 	test_link_error test_kernel_cache_includes \

--- a/tests/runtime/test_event_free.c
+++ b/tests/runtime/test_event_free.c
@@ -1,0 +1,91 @@
+/* Test that the associated event to a failing command isn't unduly freed
+
+   Copyright (C) 2015 Giuseppe Bilotta <giuseppe.bilotta@gmail.com>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <CL/cl.h>
+#include "poclu.h"
+#include "pocl_tests.h"
+
+int main(int argc, char **argv)
+{
+  cl_int err;
+  cl_context ctx;
+  cl_command_queue queue;
+  cl_device_id did;
+
+  poclu_get_any_device(&ctx, &did, &queue);
+  TEST_ASSERT(ctx);
+  TEST_ASSERT(did);
+  TEST_ASSERT(queue);
+
+  const size_t buf_size = sizeof(cl_int);
+  cl_mem buf = clCreateBuffer(ctx, CL_MEM_READ_WRITE, buf_size, NULL, &err);
+
+  /* An invalid waiting list (e.g. a null event in it) should make
+   * associated commands fail without segfaults and without touching any associated
+   * event. Test that this is indeed the case.
+   */
+
+  cl_int *host_ptr = NULL;
+
+  /* Test with map_event = NULL */
+  cl_event no_event = NULL, map_event = NULL;
+  host_ptr = clEnqueueMapBuffer(queue, buf, CL_TRUE, CL_MAP_READ, 0, buf_size,
+    1, &no_event, &map_event, &err);
+  TEST_ASSERT(err == CL_INVALID_EVENT_WAIT_LIST);
+  TEST_ASSERT(map_event == NULL); /* should not have been touched */
+
+  host_ptr = clEnqueueMapBuffer(queue, buf, CL_TRUE, CL_MAP_READ, 0, buf_size,
+    0, NULL, NULL, &err);
+  CHECK_OPENCL_ERROR_IN("map buffer");
+  err = clEnqueueUnmapMemObject(queue, buf, host_ptr, 1, &no_event, &map_event);
+  TEST_ASSERT(err == CL_INVALID_EVENT_WAIT_LIST);
+  TEST_ASSERT(map_event == NULL); /* should not have been touched */
+  err = clEnqueueUnmapMemObject(queue, buf, host_ptr, 0, NULL, NULL);
+  CHECK_OPENCL_ERROR_IN("unmap buffer");
+  host_ptr = NULL;
+
+  /* Test with map_event != NULL but invalid */
+  map_event = (cl_event)1;
+  host_ptr = clEnqueueMapBuffer(queue, buf, CL_TRUE, CL_MAP_READ, 0, buf_size,
+    1, &no_event, &map_event, &err);
+  TEST_ASSERT(err == CL_INVALID_EVENT_WAIT_LIST);
+  TEST_ASSERT(map_event == (cl_event)1); /* should not have been touched */
+
+  host_ptr = clEnqueueMapBuffer(queue, buf, CL_TRUE, CL_MAP_READ, 0, buf_size,
+    0, NULL, NULL, &err);
+  CHECK_OPENCL_ERROR_IN("map buffer");
+  err = clEnqueueUnmapMemObject(queue, buf, host_ptr, 1, &no_event, &map_event);
+  TEST_ASSERT(err == CL_INVALID_EVENT_WAIT_LIST);
+  TEST_ASSERT(map_event == (cl_event)1); /* should not have been touched */
+  err = clEnqueueUnmapMemObject(queue, buf, host_ptr, 0, NULL, NULL);
+  CHECK_OPENCL_ERROR_IN("unmap buffer");
+  host_ptr = NULL;
+
+  return EXIT_SUCCESS;
+
+}
+
+

--- a/tests/runtime/test_event_free.c
+++ b/tests/runtime/test_event_free.c
@@ -196,6 +196,16 @@ int main(int argc, char **argv)
 
   }
 
+  err = clEnqueueMarkerWithWaitList(queue, 1, &no_event, NULL);
+  TEST_ASSERT(err == CL_INVALID_EVENT_WAIT_LIST);
+  for (i = 0; i < 2; ++i) {
+    cl_event initial_value = initial_values[i];
+    map_event = initial_value;
+    err = clEnqueueMarkerWithWaitList(queue, 1, &no_event, &map_event);
+    TEST_ASSERT(err == CL_INVALID_EVENT_WAIT_LIST);
+    TEST_ASSERT(map_event == initial_value);
+  }
+
   return EXIT_SUCCESS;
 
 }

--- a/tests/runtime/test_event_free.c
+++ b/tests/runtime/test_event_free.c
@@ -50,19 +50,29 @@ int main(int argc, char **argv)
 
   cl_int *host_ptr = NULL;
 
-  /* Test with map_event = NULL */
   cl_event no_event = NULL, map_event = NULL;
+  host_ptr = clEnqueueMapBuffer(queue, buf, CL_TRUE, CL_MAP_READ, 0, buf_size,
+    1, &no_event, NULL, &err);
+  TEST_ASSERT(err == CL_INVALID_EVENT_WAIT_LIST);
+
+  /* Test with map_event = NULL */
   host_ptr = clEnqueueMapBuffer(queue, buf, CL_TRUE, CL_MAP_READ, 0, buf_size,
     1, &no_event, &map_event, &err);
   TEST_ASSERT(err == CL_INVALID_EVENT_WAIT_LIST);
   TEST_ASSERT(map_event == NULL); /* should not have been touched */
 
+  /* Now do an actual mapping to test the unmapping */
   host_ptr = clEnqueueMapBuffer(queue, buf, CL_TRUE, CL_MAP_READ, 0, buf_size,
     0, NULL, NULL, &err);
   CHECK_OPENCL_ERROR_IN("map buffer");
+
+  err = clEnqueueUnmapMemObject(queue, buf, host_ptr, 1, &no_event, NULL);
+  TEST_ASSERT(err == CL_INVALID_EVENT_WAIT_LIST);
   err = clEnqueueUnmapMemObject(queue, buf, host_ptr, 1, &no_event, &map_event);
   TEST_ASSERT(err == CL_INVALID_EVENT_WAIT_LIST);
   TEST_ASSERT(map_event == NULL); /* should not have been touched */
+
+  /* Actually unmap */
   err = clEnqueueUnmapMemObject(queue, buf, host_ptr, 0, NULL, NULL);
   CHECK_OPENCL_ERROR_IN("unmap buffer");
   host_ptr = NULL;
@@ -77,9 +87,11 @@ int main(int argc, char **argv)
   host_ptr = clEnqueueMapBuffer(queue, buf, CL_TRUE, CL_MAP_READ, 0, buf_size,
     0, NULL, NULL, &err);
   CHECK_OPENCL_ERROR_IN("map buffer");
+
   err = clEnqueueUnmapMemObject(queue, buf, host_ptr, 1, &no_event, &map_event);
   TEST_ASSERT(err == CL_INVALID_EVENT_WAIT_LIST);
   TEST_ASSERT(map_event == (cl_event)1); /* should not have been touched */
+
   err = clEnqueueUnmapMemObject(queue, buf, host_ptr, 0, NULL, NULL);
   CHECK_OPENCL_ERROR_IN("unmap buffer");
   host_ptr = NULL;

--- a/tests/runtime/test_read-copy-write-buffer.c
+++ b/tests/runtime/test_read-copy-write-buffer.c
@@ -51,6 +51,10 @@ main(void)
     if (err != CL_SUCCESS)
       return EXIT_FAILURE;
 
+    /* Only test the devices we actually have room for */
+    if (ndevices > MAX_DEVICES)
+      ndevices = MAX_DEVICES;
+
     for (j = 0; j < ndevices; j++)
     {
       cl_context context = clCreateContext(NULL, 1, &devices[j], NULL, NULL, &err);

--- a/tests/testsuite-runtime.at
+++ b/tests/testsuite-runtime.at
@@ -26,6 +26,11 @@ AT_KEYWORDS([runtime])
 AT_CHECK([$abs_top_builddir/tests/runtime/test_event_cycle])
 AT_CLEANUP
 
+AT_SETUP([event freeing])
+AT_KEYWORDS([runtime])
+AT_CHECK([$abs_top_builddir/tests/runtime/test_event_free])
+AT_CLEANUP
+
 AT_SETUP([clCreateProgramWithBinary])
 AT_KEYWORDS([runtime])
 AT_CHECK([$abs_top_builddir/tests/runtime/test_clCreateProgramWithBinary])


### PR DESCRIPTION
This is a second round of fixes that are determined by more-or-less static analysis (where 'static' refers to my own eyes this time). I got interested in this round of fixes when I noticed a double-free when I happened to use an invalid event in a waitlist, so I went through all the clEnqueue* that seemed to be affected by similar issues, wrote tests triggering the relevant errors (mostly segmentation faults) and fixed those that I found.