### PR TITLE
Another round of static fixes

### DIFF
--- a/lib/CL/clCreateContextFromType.c
+++ b/lib/CL/clCreateContextFromType.c
@@ -44,6 +44,8 @@ POname(clCreateContextFromType)(const cl_context_properties *properties,
   int i;
   cl_device_id device_ptr;
 
+  POCL_GOTO_ERROR_COND((pfn_notify == NULL && user_data != NULL), CL_INVALID_VALUE);
+
   /* initialize libtool here, LT will be needed when loading the kernels */     
   lt_dlinit();
   pocl_init_devices();
@@ -54,8 +56,6 @@ POname(clCreateContextFromType)(const cl_context_properties *properties,
     errcode = CL_OUT_OF_HOST_MEMORY;
     goto ERROR;
   }
-
-  POCL_GOTO_ERROR_COND((pfn_notify == NULL && user_data != NULL), CL_INVALID_VALUE);
 
   POCL_INIT_OBJECT(context);
   context->valid = 0;

--- a/lib/CL/clCreateUserEvent.c
+++ b/lib/CL/clCreateUserEvent.c
@@ -4,23 +4,25 @@
 
 CL_API_ENTRY cl_event CL_API_CALL
 POname(clCreateUserEvent)(cl_context     context ,
-                  cl_int *       errcode_ret ) CL_API_SUFFIX__VERSION_1_1 
+                  cl_int *       errcode_ret ) CL_API_SUFFIX__VERSION_1_1
 {
-  int error; 
-  
-  cl_event event;
-  error = pocl_create_event (&event, 0, CL_COMMAND_USER);
+  int error;
+  cl_event event = NULL;
 
-  event->status = CL_QUEUED;
+  error = pocl_create_event (&event, NULL, CL_COMMAND_USER);
 
   if (error != CL_SUCCESS)
     {
-      if (errcode_ret)
-        *errcode_ret = error;
-
-      return NULL;
+      POCL_MEM_FREE(event);
     }
-  
+  else
+    {
+      event->status = CL_SUBMITTED;
+    }
+
+  if (errcode_ret)
+    *errcode_ret = error;
+
   return event;
 }
 POsym(clCreateUserEvent)

--- a/lib/CL/clCreateUserEvent.c
+++ b/lib/CL/clCreateUserEvent.c
@@ -9,7 +9,7 @@ POname(clCreateUserEvent)(cl_context     context ,
   int error;
   cl_event event = NULL;
 
-  error = pocl_create_event (&event, NULL, CL_COMMAND_USER);
+  error = pocl_create_event (&event, context, NULL, CL_COMMAND_USER);
 
   if (error != CL_SUCCESS)
     {

--- a/lib/CL/clEnqueueCopyBufferRect.c
+++ b/lib/CL/clEnqueueCopyBufferRect.c
@@ -121,8 +121,8 @@ POname(clEnqueueCopyBufferRect)(cl_command_queue command_queue,
       POname(clRetainMemObject) (dst_buffer);
       POname(clFinish)(command_queue);
     }
-  POCL_UPDATE_EVENT_SUBMITTED(event, command_queue);
-  POCL_UPDATE_EVENT_RUNNING(event, command_queue);
+  POCL_UPDATE_EVENT_SUBMITTED(event);
+  POCL_UPDATE_EVENT_RUNNING(event);
 
   /* TODO: offset computation doesn't work in case the ptr is not 
      a direct pointer */
@@ -133,7 +133,7 @@ POname(clEnqueueCopyBufferRect)(cl_command_queue command_queue,
                        src_row_pitch, src_slice_pitch,
                        dst_row_pitch, dst_slice_pitch);
 
-  POCL_UPDATE_EVENT_COMPLETE(event, command_queue);
+  POCL_UPDATE_EVENT_COMPLETE(event);
 
   POname(clReleaseMemObject) (src_buffer);
   POname(clReleaseMemObject) (dst_buffer);

--- a/lib/CL/clEnqueueCopyBufferToImage.c
+++ b/lib/CL/clEnqueueCopyBufferToImage.c
@@ -71,7 +71,7 @@ CL_API_SUFFIX__VERSION_1_0
                                       region, 0, 0, temp+src_offset);
     
   POCL_MEM_FREE(temp);
-  POCL_UPDATE_EVENT_COMPLETE(event, command_queue);
+  POCL_UPDATE_EVENT_COMPLETE(event);
   return ret_code;
 }
 POsym(clEnqueueCopyBufferToImage) 

--- a/lib/CL/clEnqueueMapImage.c
+++ b/lib/CL/clEnqueueMapImage.c
@@ -118,7 +118,7 @@ CL_API_SUFFIX__VERSION_1_0
                               origin, origin, region,
                               image->image_row_pitch, image->image_slice_pitch,
                               image->image_row_pitch, image->image_slice_pitch);
-      POCL_UPDATE_EVENT_COMPLETE(&event, command_queue);
+      POCL_UPDATE_EVENT_COMPLETE(&event);
     }
   else
     {

--- a/lib/CL/clEnqueueReadBufferRect.c
+++ b/lib/CL/clEnqueueReadBufferRect.c
@@ -107,8 +107,8 @@ POname(clEnqueueReadBufferRect)(cl_command_queue command_queue,
       POname(clRetainMemObject) (buffer);
       POname(clFinish)(command_queue);
     }
-  POCL_UPDATE_EVENT_SUBMITTED(event, command_queue);
-  POCL_UPDATE_EVENT_RUNNING(event, command_queue);
+  POCL_UPDATE_EVENT_SUBMITTED(event);
+  POCL_UPDATE_EVENT_RUNNING(event);
 
   /* TODO: offset computation doesn't work in case the ptr is not 
      a direct pointer */
@@ -118,7 +118,7 @@ POname(clEnqueueReadBufferRect)(cl_command_queue command_queue,
                     buffer_row_pitch, buffer_slice_pitch,
                     host_row_pitch, host_slice_pitch);
 
-  POCL_UPDATE_EVENT_COMPLETE(event, command_queue);
+  POCL_UPDATE_EVENT_COMPLETE(event);
 
   POname(clReleaseMemObject) (buffer);
 

--- a/lib/CL/clEnqueueWriteBufferRect.c
+++ b/lib/CL/clEnqueueWriteBufferRect.c
@@ -108,7 +108,7 @@ POname(clEnqueueWriteBufferRect)(cl_command_queue command_queue,
       POname(clFinish)(command_queue);
     }
 
-  POCL_UPDATE_EVENT_RUNNING(event, command_queue);
+  POCL_UPDATE_EVENT_RUNNING(event);
 
   /* TODO: offset computation doesn't work in case the ptr is not 
      a direct pointer */
@@ -118,7 +118,7 @@ POname(clEnqueueWriteBufferRect)(cl_command_queue command_queue,
                            buffer_row_pitch, buffer_slice_pitch,
                            host_row_pitch, host_slice_pitch);
 
-  POCL_UPDATE_EVENT_COMPLETE(event, command_queue);
+  POCL_UPDATE_EVENT_COMPLETE(event);
 
   POname(clReleaseMemObject) (buffer);
 

--- a/lib/CL/clGetEventInfo.c
+++ b/lib/CL/clGetEventInfo.c
@@ -21,7 +21,7 @@ CL_API_SUFFIX__VERSION_1_0
     case CL_EVENT_REFERENCE_COUNT:
       POCL_RETURN_GETINFO(cl_uint, event->pocl_refcount);
     case CL_EVENT_CONTEXT:
-      POCL_RETURN_GETINFO(cl_context, event->queue->context);
+      POCL_RETURN_GETINFO(cl_context, event->context);
     default:
       break;
     }

--- a/lib/CL/clReleaseEvent.c
+++ b/lib/CL/clReleaseEvent.c
@@ -30,13 +30,15 @@ POname(clReleaseEvent)(cl_event event) CL_API_SUFFIX__VERSION_1_0
   int new_refcount;
   POCL_RETURN_ERROR_COND((event == NULL), CL_INVALID_EVENT);
 
-  POCL_RETURN_ERROR_COND((event->queue == NULL), CL_INVALID_EVENT);
+  POCL_RETURN_ERROR_COND((event->context == NULL), CL_INVALID_EVENT);
 
   POCL_RELEASE_OBJECT (event, new_refcount);
 
   if (new_refcount == 0)
     {
-      POname(clReleaseCommandQueue) (event->queue);
+      POname(clReleaseContext) (event->context);
+      if (event->queue)
+        POname(clReleaseCommandQueue) (event->queue);
       pocl_mem_manager_free_event (event);
     }
 

--- a/lib/CL/clSetUserEventStatus.c
+++ b/lib/CL/clSetUserEventStatus.c
@@ -3,11 +3,18 @@ CL_API_ENTRY cl_int CL_API_CALL
 POname(clSetUserEventStatus)(cl_event    event ,
                      cl_int      execution_status ) CL_API_SUFFIX__VERSION_1_1
 {
-  if(event == NULL)
+  /* Must be a valid user event */
+  if (event == NULL || event->command_type != CL_COMMAND_USER)
     return CL_INVALID_EVENT;
+  /* Can only be set to CL_COMPLETE (0) or negative values */
+  if (execution_status > CL_COMPLETE)
+    return CL_INVALID_VALUE;
+  /* Can only be done once */
+  if (event->status <= CL_COMPLETE)
+    return CL_INVALID_OPERATION;
 
   event->status = execution_status;
-  
+
   return CL_SUCCESS;
 }
 POsym(clSetUserEventStatus)

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -547,50 +547,54 @@ struct _cl_sampler {
   cl_filter_mode      filter_mode;
 };
 
-#define POCL_UPDATE_EVENT_QUEUED(__event, __cq)                         \
+#define POCL_UPDATE_EVENT_QUEUED(__event)                               \
   do {                                                                  \
     if ((__event) != NULL && (*(__event)) != NULL)                      \
       {                                                                 \
+        cl_command_queue __cq = (*(__event))->queue;                    \
         (*(__event))->status = CL_QUEUED;                               \
-        if ((__cq)->properties & CL_QUEUE_PROFILING_ENABLE)             \
+        if (__cq && __cq->properties & CL_QUEUE_PROFILING_ENABLE)       \
           (*(__event))->time_queue =                                    \
-            (__cq)->device->ops->get_timer_value((__cq)->device->data);      \
+            __cq->device->ops->get_timer_value(__cq->device->data);     \
       }                                                                 \
   } while (0)                                                           \
 
-#define POCL_UPDATE_EVENT_SUBMITTED(__event, __cq)                      \
+#define POCL_UPDATE_EVENT_SUBMITTED(__event)                            \
   do {                                                                  \
     if ((__event) != NULL && (*(__event)) != NULL)                      \
       {                                                                 \
         assert((*(__event))->status == CL_QUEUED);                      \
         (*(__event))->status = CL_SUBMITTED;                            \
-        if ((__cq)->properties & CL_QUEUE_PROFILING_ENABLE)             \
+        cl_command_queue __cq = (*(__event))->queue;                    \
+        if (__cq && __cq->properties & CL_QUEUE_PROFILING_ENABLE)       \
           (*(__event))->time_submit =                                   \
-            (__cq)->device->ops->get_timer_value((__cq)->device->data);      \
+            __cq->device->ops->get_timer_value(__cq->device->data);     \
       }                                                                 \
   } while (0)                                                           \
 
-#define POCL_UPDATE_EVENT_RUNNING(__event, __cq)                        \
+#define POCL_UPDATE_EVENT_RUNNING(__event)                              \
   do {                                                                  \
     if (__event != NULL && (*(__event)) != NULL)                        \
       {                                                                 \
         assert((*(__event))->status == CL_SUBMITTED);                   \
         (*(__event))->status = CL_RUNNING;                              \
-        if ((__cq)->properties & CL_QUEUE_PROFILING_ENABLE)             \
+        cl_command_queue __cq = (*(__event))->queue;                    \
+        if (__cq && __cq->properties & CL_QUEUE_PROFILING_ENABLE)       \
           (*(__event))->time_start =                                    \
-            (__cq)->device->ops->get_timer_value((__cq)->device->data);      \
+            __cq->device->ops->get_timer_value(__cq->device->data);     \
       }                                                                 \
   } while (0)                                                           \
 
-#define POCL_UPDATE_EVENT_COMPLETE(__event, __cq)                       \
+#define POCL_UPDATE_EVENT_COMPLETE(__event)                             \
   do {                                                                  \
     if ((__event) != NULL && (*(__event)) != NULL)                      \
       {                                                                 \
         assert((*(__event))->status == CL_RUNNING);                     \
         (*(__event))->status = CL_COMPLETE;                             \
-        if ((__cq)->properties & CL_QUEUE_PROFILING_ENABLE)             \
+        cl_command_queue __cq = (*(__event))->queue;                    \
+        if (__cq && __cq->properties & CL_QUEUE_PROFILING_ENABLE)       \
           (*(__event))->time_end =                                      \
-            (__cq)->device->ops->get_timer_value((__cq)->device->data);      \
+            __cq->device->ops->get_timer_value(__cq->device->data);     \
       }                                                                 \
   } while (0)                                                           \
 

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -518,6 +518,7 @@ typedef struct _cl_event _cl_event;
 struct _cl_event {
   POCL_ICD_OBJECT
   POCL_OBJECT;
+  cl_context context;
   cl_command_queue queue;
   cl_command_type command_type;
 

--- a/lib/CL/pocl_hash.c
+++ b/lib/CL/pocl_hash.c
@@ -155,6 +155,7 @@ static void SHA1_Transform(uint32_t state[5], const uint8_t buffer[64])
 
     /* Wipe variables */
     a = b = c = d = e = 0;
+    (void)a; /* avoid dead store */
 }
 
 
@@ -215,6 +216,7 @@ void pocl_SHA1_Final(SHA1_CTX* context, uint8_t digest[SHA1_DIGEST_SIZE])
 
     /* Wipe variables */
     i = 0;
+    (void)i; /* avoid dead store */
     memset(context->buffer, 0, 64);
     memset(context->state, 0, 20);
     memset(context->count, 0, 8);

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -239,15 +239,19 @@ cl_int pocl_create_command (_cl_command_node **cmd,
   if (*cmd == NULL)
     return CL_OUT_OF_HOST_MEMORY;
 
-  event_wl = (cl_event*)malloc((num_events + add_prev_command)*sizeof(cl_event));
-  if (event_wl == NULL)
-    return CL_OUT_OF_HOST_MEMORY;
+  if (num_events || add_prev_command)
+    {
+      event_wl = (cl_event*)malloc((num_events + add_prev_command)*sizeof(cl_event));
+      if (event_wl == NULL)
+        return CL_OUT_OF_HOST_MEMORY;
+    }
 
   /* if user does not provide event pointer, create event anyway */
   event = &((*cmd)->event);
   err = pocl_create_event(event, command_queue->context, command_queue, command_type);
   if (err != CL_SUCCESS)
     {
+      POCL_MEM_FREE(event_wl);
       POCL_MEM_FREE(*cmd);
       return err;
     }
@@ -271,10 +275,12 @@ cl_int pocl_create_command (_cl_command_node **cmd,
       //printf("create_command: prev_com=%d prev_com->event = %d \n",prev_command, prev_command->event);
       event_wl[i] = prev_command->event;
     }
+#if 0
   for (i = 0; i < num_events + add_prev_command; ++i)
     {
-      //printf("create-command: event_wl[%i]=%d\n", i, event_wl[i]);
+      printf("create-command: event_wl[%i]=%p\n", i, event_wl[i]);
     }
+#endif
   (*cmd)->event_wait_list = event_wl;
   (*cmd)->num_events_in_wait_list = num_events + add_prev_command;
   (*cmd)->type = command_type;

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -290,7 +290,7 @@ void pocl_command_enqueue (cl_command_queue command_queue,
   if (pocl_is_option_set("POCL_IMPLICIT_FINISH"))
     POclFinish (command_queue);
   #endif
-  POCL_UPDATE_EVENT_QUEUED (&node->event, command_queue);
+  POCL_UPDATE_EVENT_QUEUED (&node->event);
 
 }
 

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -60,7 +60,8 @@ void pocl_aligned_free(void* ptr);
 #endif
 
 /* Function for creating events */
-cl_int pocl_create_event (cl_event *event, cl_command_queue command_queue,
+cl_int pocl_create_event (cl_event *event, cl_context context,
+                          cl_command_queue command_queue,
                           cl_command_type command_type);
 
 cl_int pocl_create_command (_cl_command_node **cmd,

--- a/tests/kernel/image_query_funcs.c
+++ b/tests/kernel/image_query_funcs.c
@@ -220,12 +220,15 @@ error:
     {
       free(source);
     }
-  if (filename) 
+  if (filename)
     {
       free(filename);
     }
+  if (imageData)
+    {
+      free(imageData);
+    }
 
-  
   if (retval) 
     {
       printf("FAIL\n");

--- a/tests/kernel/sampler_address_clamp.c
+++ b/tests/kernel/sampler_address_clamp.c
@@ -197,12 +197,16 @@ error:
     {
       free(source);
     }
-  if (filename) 
+  if (filename)
     {
       free(filename);
     }
+  if (imageData)
+    {
+      free(imageData);
+    }
 
-  
+
   if (retval) 
     {
       printf("FAIL\n");

--- a/tests/regression/test_barrier_before_return.cpp
+++ b/tests/regression/test_barrier_before_return.cpp
@@ -134,20 +134,21 @@ main(void)
                 ok = false;
             }
         }
-        if (ok) 
-          return EXIT_SUCCESS;
-        else
-          return EXIT_FAILURE;
 
         // Finally release our hold on accessing the memory
         queue.enqueueUnmapMemObject(
             cBuffer,
             (void *) output);
- 
+
         // There is no need to perform a finish on the final unmap
         // or release any objects as this all happens implicitly with
         // the C++ Wrapper API.
-    } 
+
+        if (ok)
+          return EXIT_SUCCESS;
+        else
+          return EXIT_FAILURE;
+    }
     catch (cl::Error err) {
          std::cerr
              << "ERROR: "

--- a/tests/regression/test_barrier_between_for_loops.cpp
+++ b/tests/regression/test_barrier_between_for_loops.cpp
@@ -172,20 +172,22 @@ main(void)
                 ok = false;
             }
         }
-        if (ok) 
-            return EXIT_SUCCESS; 
-        else
-            return EXIT_FAILURE;
 
         // Finally release our hold on accessing the memory
         queue.enqueueUnmapMemObject(
             cBuffer,
             (void *) output);
- 
+
         // There is no need to perform a finish on the final unmap
         // or release any objects as this all happens implicitly with
         // the C++ Wrapper API.
-    } 
+	//
+
+        if (ok)
+            return EXIT_SUCCESS;
+        else
+            return EXIT_FAILURE;
+    }
     catch (cl::Error err) {
          std::cerr
              << "ERROR: "

--- a/tests/regression/test_early_return.cpp
+++ b/tests/regression/test_early_return.cpp
@@ -130,20 +130,21 @@ main(void)
                 ok = false;
             }
         }
-        if (ok) 
-            return EXIT_SUCCESS; 
-        else 
-            return EXIT_FAILURE;
 
         // Finally release our hold on accessing the memory
         queue.enqueueUnmapMemObject(
             cBuffer,
             (void *) output);
- 
+
         // There is no need to perform a finish on the final unmap
         // or release any objects as this all happens implicitly with
         // the C++ Wrapper API.
-    } 
+
+        if (ok)
+            return EXIT_SUCCESS;
+        else
+            return EXIT_FAILURE;
+    }
     catch (cl::Error err) {
          std::cerr
              << "ERROR: "

--- a/tests/regression/test_for_with_var_iteration_count.cpp
+++ b/tests/regression/test_for_with_var_iteration_count.cpp
@@ -139,20 +139,21 @@ main(void)
                 ok = false;
             }
         }
-        if (ok) 
-          return EXIT_SUCCESS;
-        else
-          return EXIT_FAILURE;
 
         // Finally release our hold on accessing the memory
         queue.enqueueUnmapMemObject(
             cBuffer,
             (void *) output);
- 
+
         // There is no need to perform a finish on the final unmap
         // or release any objects as this all happens implicitly with
         // the C++ Wrapper API.
-    } 
+
+        if (ok)
+          return EXIT_SUCCESS;
+        else
+          return EXIT_FAILURE;
+    }
     catch (cl::Error err) {
          std::cerr
              << "ERROR: "

--- a/tests/regression/test_id_dependent_computation.cpp
+++ b/tests/regression/test_id_dependent_computation.cpp
@@ -142,7 +142,7 @@ main(void)
 
         bool ok = true;
         for (int i = 0; i < WORK_ITEMS; i++) {
-            int correct = i;
+            int correct;
             if (i == 1)
                 correct = 43;
             else 
@@ -154,20 +154,21 @@ main(void)
                 ok = false;
             }
         }
-        if (ok) 
-            return EXIT_SUCCESS;
-        else
-            return EXIT_FAILURE;
 
         // Finally release our hold on accessing the memory
         queue.enqueueUnmapMemObject(
             cBuffer,
             (void *) output);
- 
+
         // There is no need to perform a finish on the final unmap
         // or release any objects as this all happens implicitly with
         // the C++ Wrapper API.
-    } 
+
+        if (ok)
+            return EXIT_SUCCESS;
+        else
+            return EXIT_FAILURE;
+    }
     catch (cl::Error err) {
          std::cerr
              << "ERROR: "

--- a/tests/regression/test_loop_phi_replication.cpp
+++ b/tests/regression/test_loop_phi_replication.cpp
@@ -138,20 +138,21 @@ main(void)
                 ok = false;
             }
         }
-        if (ok) 
-            return EXIT_SUCCESS;
-        else
-            return EXIT_FAILURE;
 
         // Finally release our hold on accessing the memory
         queue.enqueueUnmapMemObject(
             cBuffer,
             (void *) output);
- 
+
         // There is no need to perform a finish on the final unmap
         // or release any objects as this all happens implicitly with
         // the C++ Wrapper API.
-    } 
+
+        if (ok)
+            return EXIT_SUCCESS;
+        else
+            return EXIT_FAILURE;
+    }
     catch (cl::Error err) {
          std::cerr
              << "ERROR: "

--- a/tests/regression/test_multi_level_loops_with_barriers.cpp
+++ b/tests/regression/test_multi_level_loops_with_barriers.cpp
@@ -148,20 +148,21 @@ main(void)
                 ok = false;
             }
         }
-        if (ok) 
-          return EXIT_SUCCESS; 
-        else
-          return EXIT_FAILURE;
 
         // Finally release our hold on accessing the memory
         queue.enqueueUnmapMemObject(
             cBuffer,
             (void *) output);
- 
+
         // There is no need to perform a finish on the final unmap
         // or release any objects as this all happens implicitly with
         // the C++ Wrapper API.
-    } 
+
+        if (ok)
+          return EXIT_SUCCESS;
+        else
+          return EXIT_FAILURE;
+    }
     catch (cl::Error err) {
          std::cerr
              << "ERROR: "

--- a/tests/regression/test_null_arg.cpp
+++ b/tests/regression/test_null_arg.cpp
@@ -124,20 +124,21 @@ main(void)
               ok = false;
         }
 
-        if (ok) 
-          return EXIT_SUCCESS;
-        else
-          return EXIT_FAILURE;
-
         // Finally release our hold on accessing the memory
         queue.enqueueUnmapMemObject(
             outBuffer,
             (void *) output);
- 
+
         // There is no need to perform a finish on the final unmap
         // or release any objects as this all happens implicitly with
         // the C++ Wrapper API.
-    } 
+
+        if (ok)
+          return EXIT_SUCCESS;
+        else
+          return EXIT_FAILURE;
+
+    }
     catch (cl::Error err) {
          std::cerr
              << "ERROR: "

--- a/tests/regression/test_undominated_variable.cpp
+++ b/tests/regression/test_undominated_variable.cpp
@@ -141,20 +141,21 @@ main(void)
                 ok = false;
             }
         }
-        if (ok) 
-          return EXIT_SUCCESS;
-        else
-          return EXIT_FAILURE;
 
         // Finally release our hold on accessing the memory
         queue.enqueueUnmapMemObject(
             cBuffer,
             (void *) output);
- 
+
         // There is no need to perform a finish on the final unmap
         // or release any objects as this all happens implicitly with
         // the C++ Wrapper API.
-    } 
+
+        if (ok)
+          return EXIT_SUCCESS;
+        else
+          return EXIT_FAILURE;
+    }
     catch (cl::Error err) {
          std::cerr
              << "ERROR: "

--- a/tests/runtime/test_clCreateKernel.c
+++ b/tests/runtime/test_clCreateKernel.c
@@ -34,9 +34,11 @@ int main(int argc, char **argv)
 
   kernel = clCreateKernel(program, NULL, &err);
   TEST_ASSERT(err == CL_INVALID_VALUE);
+  TEST_ASSERT(kernel == NULL);
 
   kernel = clCreateKernel(program, "nonexistent_kernel", &err);
   TEST_ASSERT(err == CL_INVALID_KERNEL_NAME);
+  TEST_ASSERT(kernel == NULL);
 
   printf("OK\n");
 

--- a/tests/runtime/test_event_free.c
+++ b/tests/runtime/test_event_free.c
@@ -84,12 +84,14 @@ int main(int argc, char **argv)
   host_ptr = clEnqueueMapBuffer(queue, buf, CL_TRUE, CL_MAP_READ, 0, buf_size,
     1, &no_event, NULL, &err);
   TEST_ASSERT(err == CL_INVALID_EVENT_WAIT_LIST);
+  TEST_ASSERT(host_ptr == NULL);
 
   /* Test with map_event = NULL */
   cl_event map_event = NULL;
   host_ptr = clEnqueueMapBuffer(queue, buf, CL_TRUE, CL_MAP_READ, 0, buf_size,
     1, &no_event, &map_event, &err);
   TEST_ASSERT(err == CL_INVALID_EVENT_WAIT_LIST);
+  TEST_ASSERT(host_ptr == NULL);
   TEST_ASSERT(map_event == NULL); /* should not have been touched */
 
   /* Now do an actual mapping to test the unmapping */
@@ -113,6 +115,7 @@ int main(int argc, char **argv)
   host_ptr = clEnqueueMapBuffer(queue, buf, CL_TRUE, CL_MAP_READ, 0, buf_size,
     1, &no_event, &map_event, &err);
   TEST_ASSERT(err == CL_INVALID_EVENT_WAIT_LIST);
+  TEST_ASSERT(host_ptr == NULL);
   TEST_ASSERT(map_event == (cl_event)1); /* should not have been touched */
 
   host_ptr = clEnqueueMapBuffer(queue, buf, CL_TRUE, CL_MAP_READ, 0, buf_size,


### PR DESCRIPTION
Again, most are trivial issues detected by clang's scan-build. The only major changes are those pertaining to the general aspects of event handling, and specifically:

* the command queue is always taken from the event itself when updating its status, and it is checked for existance (since user events can have a NULL queue);
* user event handling is much closer to what is required by the specification (the only thing missing is terminating all commands that depend on a user event whose status is updated to a negative value indicating error —I'm thinking this should need a more general solution, but first I want to study the spec better to see what happens when to standard enqueued commands when any of their preceding commands fail.