### PR TITLE
Preprocess errors resiliency

### DIFF
--- a/include/pocl_cache.h
+++ b/include/pocl_cache.h
@@ -43,7 +43,7 @@ void pocl_cache_init_topdir();
 
 int
 pocl_cache_create_program_cachedir(cl_program program, unsigned device_i,
-                                   char* preprocessed_source, size_t source_len,
+                                   const char* preprocessed_source, size_t source_len,
                                    char *program_bc_path, void **cache_lock);
 
 void pocl_cache_cleanup_cachedir(cl_program program);

--- a/lib/CL/clCreateProgramWithSource.c
+++ b/lib/CL/clCreateProgramWithSource.c
@@ -34,14 +34,14 @@ POname(clCreateProgramWithSource)(cl_context context,
                           cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0
 {
   cl_program program = NULL;
-  size_t size;
-  char *source;
+  size_t size = 0;
+  char *source = NULL;
   unsigned i;
   int errcode;
 
   POCL_GOTO_ERROR_COND((count == 0), CL_INVALID_VALUE);
 
-  program = (cl_program) malloc(sizeof(struct _cl_program));
+  program = (cl_program) calloc(1, sizeof(struct _cl_program));
   if (program == NULL)
   {
     errcode = CL_OUT_OF_HOST_MEMORY;
@@ -50,7 +50,6 @@ POname(clCreateProgramWithSource)(cl_context context,
 
   POCL_INIT_OBJECT(program);
 
-  size = 0;
   for (i = 0; i < count; ++i)
     {
       POCL_GOTO_ERROR_ON((strings[i] == NULL), CL_INVALID_VALUE,
@@ -63,7 +62,7 @@ POname(clCreateProgramWithSource)(cl_context context,
       else
         size += lengths[i];
     }
-  
+
   source = (char *) malloc(size + 1);
   if (source == NULL)
   {
@@ -124,6 +123,14 @@ POname(clCreateProgramWithSource)(cl_context context,
   return program;
 
 ERROR:
+  if (program) {
+    POCL_MEM_FREE(program->build_hash);
+    POCL_MEM_FREE(program->llvm_irs);
+    POCL_MEM_FREE(program->build_log);
+    POCL_MEM_FREE(program->binaries);
+    POCL_MEM_FREE(program->binary_sizes);
+    POCL_MEM_FREE(program->source);
+  }
   POCL_MEM_FREE(program);
   if(errcode_ret)
   {

--- a/lib/CL/clGetProgramBuildInfo.c
+++ b/lib/CL/clGetProgramBuildInfo.c
@@ -68,7 +68,11 @@ POname(clGetProgramBuildInfo)(cl_program            program,
       size_t const value_size = strlen(build_log) + 1;
       if (param_value)
       {
-        if (param_value_size < value_size) return CL_INVALID_VALUE;
+        if (param_value_size < value_size)
+        {
+            POCL_MEM_FREE(build_log);
+            return CL_INVALID_VALUE;
+        }
         memcpy(param_value, build_log, value_size);
       }
       POCL_MEM_FREE(build_log);

--- a/lib/CL/clReleaseProgram.c
+++ b/lib/CL/clReleaseProgram.c
@@ -65,13 +65,15 @@ POname(clReleaseProgram)(cl_program program) CL_API_SUFFIX__VERSION_1_0
       POCL_MEM_FREE(program->source);
 
       POCL_MEM_FREE(program->binary_sizes);
-      for (i = 0; i < program->num_devices; ++i)
+      if (program->binaries)
+        for (i = 0; i < program->num_devices; ++i)
           POCL_MEM_FREE(program->binaries[i]);
       POCL_MEM_FREE(program->binaries);
 
       pocl_cache_cleanup_cachedir(program);
 
-      for (i = 0; i < program->num_devices; ++i)
+      if (program->build_log)
+        for (i = 0; i < program->num_devices; ++i)
           POCL_MEM_FREE(program->build_log[i]);
       POCL_MEM_FREE(program->build_log);
 

--- a/lib/CL/pocl_cache.c
+++ b/lib/CL/pocl_cache.c
@@ -217,8 +217,6 @@ char* pocl_cache_read_buildlog(cl_program program,
     uint64_t filesize;
     if (pocl_read_file(buildlog_path, &res, &filesize))
         return NULL;
-
-    res[filesize]='0';
     return res;
 }
 

--- a/lib/CL/pocl_llvm.h
+++ b/lib/CL/pocl_llvm.h
@@ -66,6 +66,11 @@ int pocl_llvm_generate_workgroup_function
 );
 
 /**
+ * Free the LLVM IR of a program for a given device
+ */
+void pocl_free_llvm_irs(cl_program program, int device_i);
+
+/**
  * Update the program->binaries[] representation of the kernels
  * from the program->llvm_irs[] representation.
  * Also updates the 'program.bc' file in the POCL_TEMP_DIR cache.

--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -385,7 +385,7 @@ int pocl_llvm_build_program(cl_program program,
   bool success = true;
   clang::FrontendAction *action2 = NULL;
   action2 = new clang::PrintPreprocessedAction();
-  success |= CI.ExecuteAction(*action2);
+  success = CI.ExecuteAction(*action2);
   if(!success)
     return CL_BUILD_PROGRAM_FAILURE;
 
@@ -435,7 +435,7 @@ int pocl_llvm_build_program(cl_program program,
 
   clang::CodeGenAction *action = NULL;
   action = new clang::EmitLLVMOnlyAction(GlobalContext());
-  success |= CI.ExecuteAction(*action);
+  success = CI.ExecuteAction(*action);
 
   SourceManager &source_manager = CI.getSourceManager();
   for (TextDiagnosticBuffer::const_iterator i = diagsBuffer->err_begin(),

--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -176,7 +176,10 @@ static void get_build_log(cl_program program,
                          unsigned device_i,
                          std::stringstream &ss_build_log,
                          clang::TextDiagnosticBuffer *diagsBuffer,
-                         const SourceManager &sm) {
+                         const SourceManager &sm)
+{
+    static const bool show_log = pocl_get_bool_option("POCL_VERBOSE", 0) ||
+      pocl_get_bool_option("POCL_DEBUG", 0);
 
     for (TextDiagnosticBuffer::const_iterator i = diagsBuffer->err_begin(),
          e = diagsBuffer->err_end(); i != e; ++i)
@@ -195,7 +198,8 @@ static void get_build_log(cl_program program,
                                   ss_build_log.str().c_str(),
                                   ss_build_log.str().size());
 
-    std::cerr << ss_build_log.str();
+    if (show_log)
+      std::cerr << ss_build_log.str();
 
 }
 

--- a/tests/runtime/test_clBuildProgram.c
+++ b/tests/runtime/test_clBuildProgram.c
@@ -35,15 +35,15 @@
 
 /* A dummy kernel that just includes another kernel. To test the #include and
    -I */
-char kernel[] = 
+static const char kernel[] =
   "#include \"test_kernel_src_in_another_dir.h\"\n"
   "#include \"test_kernel_src_in_pwd.h\"\n";
 
-char invalid_kernel[] =
+static const char invalid_kernel[] =
   "kernel void test_kernel(constant int a, j) { return 3; }\n";
 
 /* kernel can have any name, except main() starting from OpenCL 2.0 */
-char valid_kernel[] =
+static const char valid_kernel[] =
   "kernel void init(global int *arg) { return; }\n";
 
 int
@@ -69,7 +69,7 @@ main(void){
   CHECK_OPENCL_ERROR_IN("clCreateContext");
 
   size_t kernel_size = strlen(kernel);
-  char* kernel_buffer = kernel;
+  const char* kernel_buffer = kernel;
 
   program = clCreateProgramWithSource(context, 1, (const char**)&kernel_buffer, 
                                      &kernel_size, &err);

--- a/tests/runtime/test_clBuildProgram.c
+++ b/tests/runtime/test_clBuildProgram.c
@@ -115,6 +115,19 @@ main(void){
   err = clBuildProgram(program, num_devices, devices, NULL, NULL, NULL);
   TEST_ASSERT(err == CL_BUILD_PROGRAM_FAILURE);
 
+  for (i = 0; i < num_devices; ++i) {
+	  size_t log_size = 0;
+	  err = clGetProgramBuildInfo(program, devices[i], CL_PROGRAM_BUILD_LOG,
+		  0, NULL, &log_size);
+	  CHECK_OPENCL_ERROR_IN("get build log size");
+	  char *log = malloc(log_size);
+	  err = clGetProgramBuildInfo(program, devices[i], CL_PROGRAM_BUILD_LOG,
+		  log_size, log, NULL);
+	  CHECK_OPENCL_ERROR_IN("get build log");
+	  log[log_size] = '\0';
+	  fprintf(stderr, "preprocess failure log[%u]: %s\n", i, log);
+  }
+
   err = clReleaseProgram(program);
   CHECK_OPENCL_ERROR_IN("clReleaseProgram");
 


### PR DESCRIPTION
This patchset should significantly improve error handling during early program builds (e.g. during preprocessing), avoid segmentation faults and properly reporting errors.