### PR TITLE
Various corrections to build on OS X

### DIFF
--- a/include/CL/cl_platform.h
+++ b/include/CL/cl_platform.h
@@ -213,16 +213,16 @@ typedef double                  cl_double;
 /* scalar types  */
 typedef int8_t          cl_char;
 typedef uint8_t         cl_uchar;
-typedef int16_t         cl_short    __attribute__((aligned(2)));
-typedef uint16_t        cl_ushort   __attribute__((aligned(2)));
-typedef int32_t         cl_int      __attribute__((aligned(4)));
-typedef uint32_t        cl_uint     __attribute__((aligned(4)));
-typedef int64_t         cl_long     __attribute__((aligned(8)));
-typedef uint64_t        cl_ulong    __attribute__((aligned(8)));
+typedef int16_t         cl_short    __attribute__((__aligned__(2)));
+typedef uint16_t        cl_ushort   __attribute__((__aligned__(2)));
+typedef int32_t         cl_int      __attribute__((__aligned__(4)));
+typedef uint32_t        cl_uint     __attribute__((__aligned__(4)));
+typedef int64_t         cl_long     __attribute__((__aligned__(8)));
+typedef uint64_t        cl_ulong    __attribute__((__aligned__(8)));
 
-typedef uint16_t        cl_half     __attribute__((aligned(2)));
-typedef float           cl_float    __attribute__((aligned(4)));
-typedef double          cl_double   __attribute__((aligned(8)));
+typedef uint16_t        cl_half     __attribute__((__aligned__(2)));
+typedef float           cl_float    __attribute__((__aligned__(4)));
+typedef double          cl_double   __attribute__((__aligned__(8)));
 
 /* Macro names and corresponding values defined by OpenCL */
 #define CL_CHAR_BIT         8
@@ -453,7 +453,7 @@ typedef unsigned int cl_GLenum;
 
 /* Define alignment keys */
 #if defined( __GNUC__ )
-    #define CL_ALIGNED(_x)          __attribute__ ((aligned(_x)))
+    #define CL_ALIGNED(_x)          __attribute__ ((__aligned__(_x)))
 #elif defined( _WIN32) && (_MSC_VER)
     /* Alignment keys neutered on windows because MSVC can't swallow function arguments with alignment requirements     */
     /* http://msdn.microsoft.com/en-us/library/373ak2y1%28VS.71%29.aspx                                                 */

--- a/lib/CL/Makefile.am
+++ b/lib/CL/Makefile.am
@@ -208,7 +208,5 @@ BUILT_SOURCES = kernellib_hash.h
 FORCE:
 
 kernellib_hash.h: FORCE
-	echo -n "#define POCL_KERNELLIB_SHA1 \"" > kernellib_hash.new
-	echo -n `sha1sum ../../include/_kernel.h ../../include/_kernel_c.h ../../include/pocl_types.h ../../include/pocl_features.h ../kernel/*.cl ../kernel/*.c ../kernel/vecmathlib-pocl/*.cl ../kernel/vecmathlib-pocl/*.cc | sha1sum -` >>kernellib_hash.new
-	echo "\"" >> kernellib_hash.new
+	echo '#define POCL_KERNELLIB_SHA1 "'`sha1sum ../../include/_kernel.h ../../include/_kernel_c.h ../../include/pocl_types.h ../../include/pocl_features.h ../kernel/*.cl ../kernel/*.c ../kernel/vecmathlib-pocl/*.cl ../kernel/vecmathlib-pocl/*.cc | sha1sum -`'"' > kernellib_hash.new
 	cmp kernellib_hash.new kernellib_hash.h || mv kernellib_hash.new kernellib_hash.h

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -128,6 +128,10 @@ pocl_lock_t ta_pool_lock;
 static size_t get_max_thread_count();
 static void * workgroup_thread (void *p);
 
+/* TODO: Declare this in a header file */
+void
+pocl_basic_set_buffer_image_limits(cl_device_id device);
+
 static void pocl_init_thread_argument_manager (void)
 {
   if (!argument_pool_initialized)

--- a/lib/CL/pocl_cache.c
+++ b/lib/CL/pocl_cache.c
@@ -24,6 +24,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "config.h"
 #include "kernellib_hash.h"
@@ -31,6 +32,7 @@
 #include "pocl_hash.h"
 #include "pocl_cache.h"
 #include "pocl_file_util.h"
+#include "pocl_llvm.h"
 
 #include "pocl_cl.h"
 #include "pocl_runtime_config.h"

--- a/lib/CL/pocl_queue_util.c
+++ b/lib/CL/pocl_queue_util.c
@@ -29,7 +29,6 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <malloc.h>
 #include "pocl_debug.h"
 #include "pocl_queue_util.h"
 

--- a/lib/llvmopencl/LLVMFileUtils.cc
+++ b/lib/llvmopencl/LLVMFileUtils.cc
@@ -235,7 +235,7 @@ int pocl_write_file(const char *path, const char* content,
     RETURN_IF_ERRNO;
 
     if (write(fd, content, (ssize_t)count) < (ssize_t)count)
-        return (-errno || -1);
+        return errno ? -errno : -1;
 
     return (close(fd) ? (-errno) : 0);
 }

--- a/tests/runtime/test_event_cycle.c
+++ b/tests/runtime/test_event_cycle.c
@@ -23,13 +23,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 #include <unistd.h>
 #include <signal.h>
 #include <CL/cl.h>
 
 #include "pocl_tests.h"
+#include "poclu.h"
 
 #define MAX_PLATFORMS 32
 #define MAX_DEVICES   32

--- a/tests/runtime/test_read-copy-write-buffer.c
+++ b/tests/runtime/test_read-copy-write-buffer.c
@@ -23,7 +23,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <string.h>
 #include <CL/cl.h>
 


### PR DESCRIPTION
This branch contains various small corrections to make pocl build on OS X, and to avoid compiler warnings.