### PR TITLE
Protect half and double versions with the respective #ifdefs in kernel-vecmathlib.h

### DIFF
--- a/lib/kernel/vecmathlib-pocl/generate-files.py
+++ b/lib/kernel/vecmathlib-pocl/generate-files.py
@@ -590,7 +590,7 @@ def output_directfunc_direct(func, vectype):
         groups())
     size = 1 if sizename=="" else int(sizename)
     funcargstr = ", ".join(map(lambda (n, arg):
-                                   "%s x%d" % (mktype(arg, vectype), n),
+                               "%s x%d" % (mktype(arg, vectype), n),
                                zip(range(0, 100), args)))
     funcretstr = mktype(ret, vectype)
     decl("%s %s(%s)" % (funcretstr, prefixed(name), funcargstr))
@@ -648,9 +648,11 @@ def output_vmlfunc(func):
     out("// %s: %s -> %s" % (name, args, ret))
     for basetype in ["half", "float", "double"]:
         if basetype=="half":
+            decl("#ifdef cl_khr_fp16")
             out("")
             out("#ifdef cl_khr_fp16")
-        if basetype=="double":
+        elif basetype=="double":
+            decl("#ifdef cl_khr_fp64")
             out("")
             out("#ifdef cl_khr_fp64")
         for size in [1, 2, 3, 4, 8, 16]:
@@ -692,9 +694,11 @@ def output_vmlfunc(func):
                 output_vmlfunc_split(func, vectype)
             out("#endif")
         if basetype=="half":
+            decl("#endif // #ifdef cl_khr_fp16")
             out("")
             out("#endif // #ifdef cl_khr_fp16")
-        if basetype=="double":
+        elif basetype=="double":
+            decl("#endif // #ifdef cl_khr_fp64")
             out("")
             out("#endif // #ifdef cl_khr_fp64")
     out_close()
@@ -748,9 +752,11 @@ def output_directfunc(func):
             basetype!="float"):
             continue
         if basetype=="half":
+            decl("#ifdef cl_khr_fp16")
             out("")
             out("#ifdef cl_khr_fp16")
-        if basetype=="double":
+        elif basetype=="double":
+            decl("#ifdef cl_khr_fp64")
             out("")
             out("#ifdef cl_khr_fp64")
         for size in [1, 2, 3, 4, 8, 16]:
@@ -766,9 +772,11 @@ def output_directfunc(func):
                 out("// %s: VF=%s" % (name, vectype))
                 output_directfunc_direct(func, vectype)
         if basetype=="half":
+            decl("#endif // #ifdef cl_khr_fp16")
             out("")
             out("#endif // #ifdef cl_khr_fp16")
-        if basetype=="double":
+        elif basetype=="double":
+            decl("#endif // #ifdef cl_khr_fp64")
             out("")
             out("#endif // #ifdef cl_khr_fp64")
     out_close()

--- a/lib/kernel/vecmathlib-pocl/kernel-vecmathlib.h
+++ b/lib/kernel/vecmathlib-pocl/kernel-vecmathlib.h
@@ -5,6 +5,7 @@
 // acos: ['VF'] -> VF
 #undef acos
 #define acos _cl_acos
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_acos(half x0);
 __attribute__((__overloadable__)) half _cl_acos(half x0);
 __attribute__((__overloadable__)) half _cl_acos(half x0);
@@ -22,6 +23,7 @@ __attribute__((__overloadable__)) half8 _cl_acos(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_acos(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_acos(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_acos(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_acos(float x0);
 __attribute__((__overloadable__)) float _cl_acos(float x0);
 __attribute__((__overloadable__)) float _cl_acos(float x0);
@@ -39,6 +41,7 @@ __attribute__((__overloadable__)) float8 _cl_acos(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_acos(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_acos(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_acos(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_acos(double x0);
 __attribute__((__overloadable__)) double _cl_acos(double x0);
 __attribute__((__overloadable__)) double _cl_acos(double x0);
@@ -56,10 +59,12 @@ __attribute__((__overloadable__)) double8 _cl_acos(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_acos(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_acos(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_acos(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // acosh: ['VF'] -> VF
 #undef acosh
 #define acosh _cl_acosh
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_acosh(half x0);
 __attribute__((__overloadable__)) half _cl_acosh(half x0);
 __attribute__((__overloadable__)) half _cl_acosh(half x0);
@@ -77,6 +82,7 @@ __attribute__((__overloadable__)) half8 _cl_acosh(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_acosh(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_acosh(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_acosh(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_acosh(float x0);
 __attribute__((__overloadable__)) float _cl_acosh(float x0);
 __attribute__((__overloadable__)) float _cl_acosh(float x0);
@@ -94,6 +100,7 @@ __attribute__((__overloadable__)) float8 _cl_acosh(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_acosh(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_acosh(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_acosh(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_acosh(double x0);
 __attribute__((__overloadable__)) double _cl_acosh(double x0);
 __attribute__((__overloadable__)) double _cl_acosh(double x0);
@@ -111,10 +118,12 @@ __attribute__((__overloadable__)) double8 _cl_acosh(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_acosh(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_acosh(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_acosh(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // asin: ['VF'] -> VF
 #undef asin
 #define asin _cl_asin
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_asin(half x0);
 __attribute__((__overloadable__)) half _cl_asin(half x0);
 __attribute__((__overloadable__)) half _cl_asin(half x0);
@@ -132,6 +141,7 @@ __attribute__((__overloadable__)) half8 _cl_asin(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_asin(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_asin(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_asin(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_asin(float x0);
 __attribute__((__overloadable__)) float _cl_asin(float x0);
 __attribute__((__overloadable__)) float _cl_asin(float x0);
@@ -149,6 +159,7 @@ __attribute__((__overloadable__)) float8 _cl_asin(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_asin(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_asin(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_asin(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_asin(double x0);
 __attribute__((__overloadable__)) double _cl_asin(double x0);
 __attribute__((__overloadable__)) double _cl_asin(double x0);
@@ -166,10 +177,12 @@ __attribute__((__overloadable__)) double8 _cl_asin(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_asin(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_asin(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_asin(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // asinh: ['VF'] -> VF
 #undef asinh
 #define asinh _cl_asinh
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_asinh(half x0);
 __attribute__((__overloadable__)) half _cl_asinh(half x0);
 __attribute__((__overloadable__)) half _cl_asinh(half x0);
@@ -187,6 +200,7 @@ __attribute__((__overloadable__)) half8 _cl_asinh(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_asinh(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_asinh(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_asinh(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_asinh(float x0);
 __attribute__((__overloadable__)) float _cl_asinh(float x0);
 __attribute__((__overloadable__)) float _cl_asinh(float x0);
@@ -204,6 +218,7 @@ __attribute__((__overloadable__)) float8 _cl_asinh(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_asinh(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_asinh(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_asinh(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_asinh(double x0);
 __attribute__((__overloadable__)) double _cl_asinh(double x0);
 __attribute__((__overloadable__)) double _cl_asinh(double x0);
@@ -221,10 +236,12 @@ __attribute__((__overloadable__)) double8 _cl_asinh(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_asinh(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_asinh(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_asinh(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // atan: ['VF'] -> VF
 #undef atan
 #define atan _cl_atan
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_atan(half x0);
 __attribute__((__overloadable__)) half _cl_atan(half x0);
 __attribute__((__overloadable__)) half _cl_atan(half x0);
@@ -242,6 +259,7 @@ __attribute__((__overloadable__)) half8 _cl_atan(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_atan(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_atan(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_atan(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_atan(float x0);
 __attribute__((__overloadable__)) float _cl_atan(float x0);
 __attribute__((__overloadable__)) float _cl_atan(float x0);
@@ -259,6 +277,7 @@ __attribute__((__overloadable__)) float8 _cl_atan(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_atan(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_atan(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_atan(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_atan(double x0);
 __attribute__((__overloadable__)) double _cl_atan(double x0);
 __attribute__((__overloadable__)) double _cl_atan(double x0);
@@ -276,10 +295,12 @@ __attribute__((__overloadable__)) double8 _cl_atan(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_atan(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_atan(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_atan(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // atanh: ['VF'] -> VF
 #undef atanh
 #define atanh _cl_atanh
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_atanh(half x0);
 __attribute__((__overloadable__)) half _cl_atanh(half x0);
 __attribute__((__overloadable__)) half _cl_atanh(half x0);
@@ -297,6 +318,7 @@ __attribute__((__overloadable__)) half8 _cl_atanh(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_atanh(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_atanh(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_atanh(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_atanh(float x0);
 __attribute__((__overloadable__)) float _cl_atanh(float x0);
 __attribute__((__overloadable__)) float _cl_atanh(float x0);
@@ -314,6 +336,7 @@ __attribute__((__overloadable__)) float8 _cl_atanh(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_atanh(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_atanh(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_atanh(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_atanh(double x0);
 __attribute__((__overloadable__)) double _cl_atanh(double x0);
 __attribute__((__overloadable__)) double _cl_atanh(double x0);
@@ -331,10 +354,12 @@ __attribute__((__overloadable__)) double8 _cl_atanh(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_atanh(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_atanh(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_atanh(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // cbrt: ['VF'] -> VF
 #undef cbrt
 #define cbrt _cl_cbrt
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_cbrt(half x0);
 __attribute__((__overloadable__)) half _cl_cbrt(half x0);
 __attribute__((__overloadable__)) half _cl_cbrt(half x0);
@@ -352,6 +377,7 @@ __attribute__((__overloadable__)) half8 _cl_cbrt(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_cbrt(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_cbrt(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_cbrt(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_cbrt(float x0);
 __attribute__((__overloadable__)) float _cl_cbrt(float x0);
 __attribute__((__overloadable__)) float _cl_cbrt(float x0);
@@ -369,6 +395,7 @@ __attribute__((__overloadable__)) float8 _cl_cbrt(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_cbrt(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_cbrt(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_cbrt(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_cbrt(double x0);
 __attribute__((__overloadable__)) double _cl_cbrt(double x0);
 __attribute__((__overloadable__)) double _cl_cbrt(double x0);
@@ -386,10 +413,12 @@ __attribute__((__overloadable__)) double8 _cl_cbrt(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_cbrt(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_cbrt(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_cbrt(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // ceil: ['VF'] -> VF
 #undef ceil
 #define ceil _cl_ceil
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_ceil(half x0);
 __attribute__((__overloadable__)) half _cl_ceil(half x0);
 __attribute__((__overloadable__)) half _cl_ceil(half x0);
@@ -407,6 +436,7 @@ __attribute__((__overloadable__)) half8 _cl_ceil(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_ceil(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_ceil(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_ceil(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_ceil(float x0);
 __attribute__((__overloadable__)) float _cl_ceil(float x0);
 __attribute__((__overloadable__)) float _cl_ceil(float x0);
@@ -424,6 +454,7 @@ __attribute__((__overloadable__)) float8 _cl_ceil(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_ceil(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_ceil(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_ceil(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_ceil(double x0);
 __attribute__((__overloadable__)) double _cl_ceil(double x0);
 __attribute__((__overloadable__)) double _cl_ceil(double x0);
@@ -441,10 +472,12 @@ __attribute__((__overloadable__)) double8 _cl_ceil(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_ceil(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_ceil(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_ceil(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // copysign: ['VF', 'VF'] -> VF
 #undef copysign
 #define copysign _cl_copysign
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_copysign(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_copysign(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_copysign(half x0, half x1);
@@ -462,6 +495,7 @@ __attribute__((__overloadable__)) half8 _cl_copysign(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half8 _cl_copysign(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_copysign(half16 x0, half16 x1);
 __attribute__((__overloadable__)) half16 _cl_copysign(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_copysign(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_copysign(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_copysign(float x0, float x1);
@@ -479,6 +513,7 @@ __attribute__((__overloadable__)) float8 _cl_copysign(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float8 _cl_copysign(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_copysign(float16 x0, float16 x1);
 __attribute__((__overloadable__)) float16 _cl_copysign(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_copysign(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_copysign(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_copysign(double x0, double x1);
@@ -496,10 +531,12 @@ __attribute__((__overloadable__)) double8 _cl_copysign(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double8 _cl_copysign(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_copysign(double16 x0, double16 x1);
 __attribute__((__overloadable__)) double16 _cl_copysign(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // cos: ['VF'] -> VF
 #undef cos
 #define cos _cl_cos
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_cos(half x0);
 __attribute__((__overloadable__)) half _cl_cos(half x0);
 __attribute__((__overloadable__)) half _cl_cos(half x0);
@@ -517,6 +554,7 @@ __attribute__((__overloadable__)) half8 _cl_cos(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_cos(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_cos(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_cos(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_cos(float x0);
 __attribute__((__overloadable__)) float _cl_cos(float x0);
 __attribute__((__overloadable__)) float _cl_cos(float x0);
@@ -534,6 +572,7 @@ __attribute__((__overloadable__)) float8 _cl_cos(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_cos(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_cos(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_cos(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_cos(double x0);
 __attribute__((__overloadable__)) double _cl_cos(double x0);
 __attribute__((__overloadable__)) double _cl_cos(double x0);
@@ -551,10 +590,12 @@ __attribute__((__overloadable__)) double8 _cl_cos(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_cos(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_cos(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_cos(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // cosh: ['VF'] -> VF
 #undef cosh
 #define cosh _cl_cosh
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_cosh(half x0);
 __attribute__((__overloadable__)) half _cl_cosh(half x0);
 __attribute__((__overloadable__)) half _cl_cosh(half x0);
@@ -572,6 +613,7 @@ __attribute__((__overloadable__)) half8 _cl_cosh(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_cosh(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_cosh(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_cosh(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_cosh(float x0);
 __attribute__((__overloadable__)) float _cl_cosh(float x0);
 __attribute__((__overloadable__)) float _cl_cosh(float x0);
@@ -589,6 +631,7 @@ __attribute__((__overloadable__)) float8 _cl_cosh(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_cosh(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_cosh(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_cosh(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_cosh(double x0);
 __attribute__((__overloadable__)) double _cl_cosh(double x0);
 __attribute__((__overloadable__)) double _cl_cosh(double x0);
@@ -606,10 +649,12 @@ __attribute__((__overloadable__)) double8 _cl_cosh(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_cosh(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_cosh(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_cosh(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // exp: ['VF'] -> VF
 #undef exp
 #define exp _cl_exp
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_exp(half x0);
 __attribute__((__overloadable__)) half _cl_exp(half x0);
 __attribute__((__overloadable__)) half _cl_exp(half x0);
@@ -627,6 +672,7 @@ __attribute__((__overloadable__)) half8 _cl_exp(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_exp(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_exp(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_exp(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_exp(float x0);
 __attribute__((__overloadable__)) float _cl_exp(float x0);
 __attribute__((__overloadable__)) float _cl_exp(float x0);
@@ -644,6 +690,7 @@ __attribute__((__overloadable__)) float8 _cl_exp(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_exp(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_exp(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_exp(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_exp(double x0);
 __attribute__((__overloadable__)) double _cl_exp(double x0);
 __attribute__((__overloadable__)) double _cl_exp(double x0);
@@ -661,10 +708,12 @@ __attribute__((__overloadable__)) double8 _cl_exp(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_exp(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_exp(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_exp(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // exp2: ['VF'] -> VF
 #undef exp2
 #define exp2 _cl_exp2
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_exp2(half x0);
 __attribute__((__overloadable__)) half _cl_exp2(half x0);
 __attribute__((__overloadable__)) half _cl_exp2(half x0);
@@ -682,6 +731,7 @@ __attribute__((__overloadable__)) half8 _cl_exp2(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_exp2(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_exp2(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_exp2(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_exp2(float x0);
 __attribute__((__overloadable__)) float _cl_exp2(float x0);
 __attribute__((__overloadable__)) float _cl_exp2(float x0);
@@ -699,6 +749,7 @@ __attribute__((__overloadable__)) float8 _cl_exp2(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_exp2(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_exp2(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_exp2(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_exp2(double x0);
 __attribute__((__overloadable__)) double _cl_exp2(double x0);
 __attribute__((__overloadable__)) double _cl_exp2(double x0);
@@ -716,10 +767,12 @@ __attribute__((__overloadable__)) double8 _cl_exp2(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_exp2(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_exp2(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_exp2(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // exp10: ['VF'] -> VF
 #undef exp10
 #define exp10 _cl_exp10
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_exp10(half x0);
 __attribute__((__overloadable__)) half _cl_exp10(half x0);
 __attribute__((__overloadable__)) half _cl_exp10(half x0);
@@ -737,6 +790,7 @@ __attribute__((__overloadable__)) half8 _cl_exp10(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_exp10(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_exp10(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_exp10(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_exp10(float x0);
 __attribute__((__overloadable__)) float _cl_exp10(float x0);
 __attribute__((__overloadable__)) float _cl_exp10(float x0);
@@ -754,6 +808,7 @@ __attribute__((__overloadable__)) float8 _cl_exp10(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_exp10(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_exp10(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_exp10(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_exp10(double x0);
 __attribute__((__overloadable__)) double _cl_exp10(double x0);
 __attribute__((__overloadable__)) double _cl_exp10(double x0);
@@ -771,10 +826,12 @@ __attribute__((__overloadable__)) double8 _cl_exp10(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_exp10(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_exp10(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_exp10(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // expm1: ['VF'] -> VF
 #undef expm1
 #define expm1 _cl_expm1
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_expm1(half x0);
 __attribute__((__overloadable__)) half _cl_expm1(half x0);
 __attribute__((__overloadable__)) half _cl_expm1(half x0);
@@ -792,6 +849,7 @@ __attribute__((__overloadable__)) half8 _cl_expm1(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_expm1(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_expm1(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_expm1(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_expm1(float x0);
 __attribute__((__overloadable__)) float _cl_expm1(float x0);
 __attribute__((__overloadable__)) float _cl_expm1(float x0);
@@ -809,6 +867,7 @@ __attribute__((__overloadable__)) float8 _cl_expm1(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_expm1(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_expm1(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_expm1(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_expm1(double x0);
 __attribute__((__overloadable__)) double _cl_expm1(double x0);
 __attribute__((__overloadable__)) double _cl_expm1(double x0);
@@ -826,10 +885,12 @@ __attribute__((__overloadable__)) double8 _cl_expm1(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_expm1(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_expm1(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_expm1(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // fabs: ['VF'] -> VF
 #undef fabs
 #define fabs _cl_fabs
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_fabs(half x0);
 __attribute__((__overloadable__)) half _cl_fabs(half x0);
 __attribute__((__overloadable__)) half _cl_fabs(half x0);
@@ -847,6 +908,7 @@ __attribute__((__overloadable__)) half8 _cl_fabs(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_fabs(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_fabs(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_fabs(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_fabs(float x0);
 __attribute__((__overloadable__)) float _cl_fabs(float x0);
 __attribute__((__overloadable__)) float _cl_fabs(float x0);
@@ -864,6 +926,7 @@ __attribute__((__overloadable__)) float8 _cl_fabs(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_fabs(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_fabs(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_fabs(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_fabs(double x0);
 __attribute__((__overloadable__)) double _cl_fabs(double x0);
 __attribute__((__overloadable__)) double _cl_fabs(double x0);
@@ -881,10 +944,12 @@ __attribute__((__overloadable__)) double8 _cl_fabs(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_fabs(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_fabs(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_fabs(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // fdim: ['VF', 'VF'] -> VF
 #undef fdim
 #define fdim _cl_fdim
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_fdim(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_fdim(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_fdim(half x0, half x1);
@@ -902,6 +967,7 @@ __attribute__((__overloadable__)) half8 _cl_fdim(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half8 _cl_fdim(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_fdim(half16 x0, half16 x1);
 __attribute__((__overloadable__)) half16 _cl_fdim(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_fdim(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_fdim(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_fdim(float x0, float x1);
@@ -919,6 +985,7 @@ __attribute__((__overloadable__)) float8 _cl_fdim(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float8 _cl_fdim(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_fdim(float16 x0, float16 x1);
 __attribute__((__overloadable__)) float16 _cl_fdim(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_fdim(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_fdim(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_fdim(double x0, double x1);
@@ -936,10 +1003,12 @@ __attribute__((__overloadable__)) double8 _cl_fdim(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double8 _cl_fdim(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_fdim(double16 x0, double16 x1);
 __attribute__((__overloadable__)) double16 _cl_fdim(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // floor: ['VF'] -> VF
 #undef floor
 #define floor _cl_floor
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_floor(half x0);
 __attribute__((__overloadable__)) half _cl_floor(half x0);
 __attribute__((__overloadable__)) half _cl_floor(half x0);
@@ -957,6 +1026,7 @@ __attribute__((__overloadable__)) half8 _cl_floor(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_floor(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_floor(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_floor(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_floor(float x0);
 __attribute__((__overloadable__)) float _cl_floor(float x0);
 __attribute__((__overloadable__)) float _cl_floor(float x0);
@@ -974,6 +1044,7 @@ __attribute__((__overloadable__)) float8 _cl_floor(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_floor(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_floor(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_floor(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_floor(double x0);
 __attribute__((__overloadable__)) double _cl_floor(double x0);
 __attribute__((__overloadable__)) double _cl_floor(double x0);
@@ -991,10 +1062,12 @@ __attribute__((__overloadable__)) double8 _cl_floor(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_floor(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_floor(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_floor(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // fma: ['VF', 'VF', 'VF'] -> VF
 #undef fma
 #define fma _cl_fma
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_fma(half x0, half x1, half x2);
 __attribute__((__overloadable__)) half _cl_fma(half x0, half x1, half x2);
 __attribute__((__overloadable__)) half _cl_fma(half x0, half x1, half x2);
@@ -1012,6 +1085,7 @@ __attribute__((__overloadable__)) half8 _cl_fma(half8 x0, half8 x1, half8 x2);
 __attribute__((__overloadable__)) half8 _cl_fma(half8 x0, half8 x1, half8 x2);
 __attribute__((__overloadable__)) half16 _cl_fma(half16 x0, half16 x1, half16 x2);
 __attribute__((__overloadable__)) half16 _cl_fma(half16 x0, half16 x1, half16 x2);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_fma(float x0, float x1, float x2);
 __attribute__((__overloadable__)) float _cl_fma(float x0, float x1, float x2);
 __attribute__((__overloadable__)) float _cl_fma(float x0, float x1, float x2);
@@ -1029,6 +1103,7 @@ __attribute__((__overloadable__)) float8 _cl_fma(float8 x0, float8 x1, float8 x2
 __attribute__((__overloadable__)) float8 _cl_fma(float8 x0, float8 x1, float8 x2);
 __attribute__((__overloadable__)) float16 _cl_fma(float16 x0, float16 x1, float16 x2);
 __attribute__((__overloadable__)) float16 _cl_fma(float16 x0, float16 x1, float16 x2);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_fma(double x0, double x1, double x2);
 __attribute__((__overloadable__)) double _cl_fma(double x0, double x1, double x2);
 __attribute__((__overloadable__)) double _cl_fma(double x0, double x1, double x2);
@@ -1046,10 +1121,12 @@ __attribute__((__overloadable__)) double8 _cl_fma(double8 x0, double8 x1, double
 __attribute__((__overloadable__)) double8 _cl_fma(double8 x0, double8 x1, double8 x2);
 __attribute__((__overloadable__)) double16 _cl_fma(double16 x0, double16 x1, double16 x2);
 __attribute__((__overloadable__)) double16 _cl_fma(double16 x0, double16 x1, double16 x2);
+#endif // #ifdef cl_khr_fp64
 
 // fmax: ['VF', 'VF'] -> VF
 #undef fmax
 #define fmax _cl_fmax
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_fmax(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_fmax(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_fmax(half x0, half x1);
@@ -1067,6 +1144,7 @@ __attribute__((__overloadable__)) half8 _cl_fmax(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half8 _cl_fmax(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_fmax(half16 x0, half16 x1);
 __attribute__((__overloadable__)) half16 _cl_fmax(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_fmax(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_fmax(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_fmax(float x0, float x1);
@@ -1084,6 +1162,7 @@ __attribute__((__overloadable__)) float8 _cl_fmax(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float8 _cl_fmax(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_fmax(float16 x0, float16 x1);
 __attribute__((__overloadable__)) float16 _cl_fmax(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_fmax(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_fmax(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_fmax(double x0, double x1);
@@ -1101,10 +1180,12 @@ __attribute__((__overloadable__)) double8 _cl_fmax(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double8 _cl_fmax(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_fmax(double16 x0, double16 x1);
 __attribute__((__overloadable__)) double16 _cl_fmax(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // fmin: ['VF', 'VF'] -> VF
 #undef fmin
 #define fmin _cl_fmin
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_fmin(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_fmin(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_fmin(half x0, half x1);
@@ -1122,6 +1203,7 @@ __attribute__((__overloadable__)) half8 _cl_fmin(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half8 _cl_fmin(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_fmin(half16 x0, half16 x1);
 __attribute__((__overloadable__)) half16 _cl_fmin(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_fmin(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_fmin(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_fmin(float x0, float x1);
@@ -1139,6 +1221,7 @@ __attribute__((__overloadable__)) float8 _cl_fmin(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float8 _cl_fmin(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_fmin(float16 x0, float16 x1);
 __attribute__((__overloadable__)) float16 _cl_fmin(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_fmin(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_fmin(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_fmin(double x0, double x1);
@@ -1156,10 +1239,12 @@ __attribute__((__overloadable__)) double8 _cl_fmin(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double8 _cl_fmin(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_fmin(double16 x0, double16 x1);
 __attribute__((__overloadable__)) double16 _cl_fmin(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // fmod: ['VF', 'VF'] -> VF
 #undef fmod
 #define fmod _cl_fmod
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_fmod(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_fmod(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_fmod(half x0, half x1);
@@ -1177,6 +1262,7 @@ __attribute__((__overloadable__)) half8 _cl_fmod(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half8 _cl_fmod(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_fmod(half16 x0, half16 x1);
 __attribute__((__overloadable__)) half16 _cl_fmod(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_fmod(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_fmod(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_fmod(float x0, float x1);
@@ -1194,6 +1280,7 @@ __attribute__((__overloadable__)) float8 _cl_fmod(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float8 _cl_fmod(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_fmod(float16 x0, float16 x1);
 __attribute__((__overloadable__)) float16 _cl_fmod(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_fmod(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_fmod(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_fmod(double x0, double x1);
@@ -1211,10 +1298,12 @@ __attribute__((__overloadable__)) double8 _cl_fmod(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double8 _cl_fmod(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_fmod(double16 x0, double16 x1);
 __attribute__((__overloadable__)) double16 _cl_fmod(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // hypot: ['VF', 'VF'] -> VF
 #undef hypot
 #define hypot _cl_hypot
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_hypot(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_hypot(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_hypot(half x0, half x1);
@@ -1232,6 +1321,7 @@ __attribute__((__overloadable__)) half8 _cl_hypot(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half8 _cl_hypot(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_hypot(half16 x0, half16 x1);
 __attribute__((__overloadable__)) half16 _cl_hypot(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_hypot(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_hypot(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_hypot(float x0, float x1);
@@ -1249,6 +1339,7 @@ __attribute__((__overloadable__)) float8 _cl_hypot(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float8 _cl_hypot(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_hypot(float16 x0, float16 x1);
 __attribute__((__overloadable__)) float16 _cl_hypot(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_hypot(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_hypot(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_hypot(double x0, double x1);
@@ -1266,10 +1357,12 @@ __attribute__((__overloadable__)) double8 _cl_hypot(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double8 _cl_hypot(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_hypot(double16 x0, double16 x1);
 __attribute__((__overloadable__)) double16 _cl_hypot(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // ilogb_: ['VF'] -> VI
 #undef ilogb_
 #define ilogb_ _cl_ilogb_
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) extern "C" short _cl_ilogb_half(half x0);
 __attribute__((__overloadable__)) extern "C" short _cl_ilogb_half(half x0);
 __attribute__((__overloadable__)) extern "C" short _cl_ilogb_half(half x0);
@@ -1287,6 +1380,7 @@ __attribute__((__overloadable__)) extern "C" short8 _cl_ilogb_half8(half8 x0);
 __attribute__((__overloadable__)) extern "C" short8 _cl_ilogb_half8(half8 x0);
 __attribute__((__overloadable__)) extern "C" short16 _cl_ilogb_half16(half16 x0);
 __attribute__((__overloadable__)) extern "C" short16 _cl_ilogb_half16(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) extern "C" int _cl_ilogb_float(float x0);
 __attribute__((__overloadable__)) extern "C" int _cl_ilogb_float(float x0);
 __attribute__((__overloadable__)) extern "C" int _cl_ilogb_float(float x0);
@@ -1304,6 +1398,7 @@ __attribute__((__overloadable__)) extern "C" int8 _cl_ilogb_float8(float8 x0);
 __attribute__((__overloadable__)) extern "C" int8 _cl_ilogb_float8(float8 x0);
 __attribute__((__overloadable__)) extern "C" int16 _cl_ilogb_float16(float16 x0);
 __attribute__((__overloadable__)) extern "C" int16 _cl_ilogb_float16(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) extern "C" long _cl_ilogb_double(double x0);
 __attribute__((__overloadable__)) extern "C" long _cl_ilogb_double(double x0);
 __attribute__((__overloadable__)) extern "C" long _cl_ilogb_double(double x0);
@@ -1321,10 +1416,12 @@ __attribute__((__overloadable__)) extern "C" long8 _cl_ilogb_double8(double8 x0)
 __attribute__((__overloadable__)) extern "C" long8 _cl_ilogb_double8(double8 x0);
 __attribute__((__overloadable__)) extern "C" long16 _cl_ilogb_double16(double16 x0);
 __attribute__((__overloadable__)) extern "C" long16 _cl_ilogb_double16(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // ldexp_: ['VF', 'VI'] -> VF
 #undef ldexp_
 #define ldexp_ _cl_ldexp_
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) extern "C" half _cl_ldexp_half_short(half x0, short x1);
 __attribute__((__overloadable__)) extern "C" half _cl_ldexp_half_short(half x0, short x1);
 __attribute__((__overloadable__)) extern "C" half _cl_ldexp_half_short(half x0, short x1);
@@ -1342,6 +1439,7 @@ __attribute__((__overloadable__)) extern "C" half8 _cl_ldexp_half8_short8(half8 
 __attribute__((__overloadable__)) extern "C" half8 _cl_ldexp_half8_short8(half8 x0, short8 x1);
 __attribute__((__overloadable__)) extern "C" half16 _cl_ldexp_half16_short16(half16 x0, short16 x1);
 __attribute__((__overloadable__)) extern "C" half16 _cl_ldexp_half16_short16(half16 x0, short16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) extern "C" float _cl_ldexp_float_int(float x0, int x1);
 __attribute__((__overloadable__)) extern "C" float _cl_ldexp_float_int(float x0, int x1);
 __attribute__((__overloadable__)) extern "C" float _cl_ldexp_float_int(float x0, int x1);
@@ -1359,6 +1457,7 @@ __attribute__((__overloadable__)) extern "C" float8 _cl_ldexp_float8_int8(float8
 __attribute__((__overloadable__)) extern "C" float8 _cl_ldexp_float8_int8(float8 x0, int8 x1);
 __attribute__((__overloadable__)) extern "C" float16 _cl_ldexp_float16_int16(float16 x0, int16 x1);
 __attribute__((__overloadable__)) extern "C" float16 _cl_ldexp_float16_int16(float16 x0, int16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) extern "C" double _cl_ldexp_double_long(double x0, long x1);
 __attribute__((__overloadable__)) extern "C" double _cl_ldexp_double_long(double x0, long x1);
 __attribute__((__overloadable__)) extern "C" double _cl_ldexp_double_long(double x0, long x1);
@@ -1376,10 +1475,12 @@ __attribute__((__overloadable__)) extern "C" double8 _cl_ldexp_double8_long8(dou
 __attribute__((__overloadable__)) extern "C" double8 _cl_ldexp_double8_long8(double8 x0, long8 x1);
 __attribute__((__overloadable__)) extern "C" double16 _cl_ldexp_double16_long16(double16 x0, long16 x1);
 __attribute__((__overloadable__)) extern "C" double16 _cl_ldexp_double16_long16(double16 x0, long16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // ldexp_: ['VF', 'SI'] -> VF
 #undef ldexp_
 #define ldexp_ _cl_ldexp_
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) extern "C" half2 _cl_ldexp_half2_short(half2 x0, short x1);
 __attribute__((__overloadable__)) extern "C" half2 _cl_ldexp_half2_short(half2 x0, short x1);
 __attribute__((__overloadable__)) extern "C" half2 _cl_ldexp_half2_short(half2 x0, short x1);
@@ -1394,6 +1495,7 @@ __attribute__((__overloadable__)) extern "C" half8 _cl_ldexp_half8_short(half8 x
 __attribute__((__overloadable__)) extern "C" half8 _cl_ldexp_half8_short(half8 x0, short x1);
 __attribute__((__overloadable__)) extern "C" half16 _cl_ldexp_half16_short(half16 x0, short x1);
 __attribute__((__overloadable__)) extern "C" half16 _cl_ldexp_half16_short(half16 x0, short x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) extern "C" float2 _cl_ldexp_float2_int(float2 x0, int x1);
 __attribute__((__overloadable__)) extern "C" float2 _cl_ldexp_float2_int(float2 x0, int x1);
 __attribute__((__overloadable__)) extern "C" float2 _cl_ldexp_float2_int(float2 x0, int x1);
@@ -1408,6 +1510,7 @@ __attribute__((__overloadable__)) extern "C" float8 _cl_ldexp_float8_int(float8 
 __attribute__((__overloadable__)) extern "C" float8 _cl_ldexp_float8_int(float8 x0, int x1);
 __attribute__((__overloadable__)) extern "C" float16 _cl_ldexp_float16_int(float16 x0, int x1);
 __attribute__((__overloadable__)) extern "C" float16 _cl_ldexp_float16_int(float16 x0, int x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) extern "C" double2 _cl_ldexp_double2_long(double2 x0, long x1);
 __attribute__((__overloadable__)) extern "C" double2 _cl_ldexp_double2_long(double2 x0, long x1);
 __attribute__((__overloadable__)) extern "C" double2 _cl_ldexp_double2_long(double2 x0, long x1);
@@ -1422,10 +1525,12 @@ __attribute__((__overloadable__)) extern "C" double8 _cl_ldexp_double8_long(doub
 __attribute__((__overloadable__)) extern "C" double8 _cl_ldexp_double8_long(double8 x0, long x1);
 __attribute__((__overloadable__)) extern "C" double16 _cl_ldexp_double16_long(double16 x0, long x1);
 __attribute__((__overloadable__)) extern "C" double16 _cl_ldexp_double16_long(double16 x0, long x1);
+#endif // #ifdef cl_khr_fp64
 
 // log: ['VF'] -> VF
 #undef log
 #define log _cl_log
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_log(half x0);
 __attribute__((__overloadable__)) half _cl_log(half x0);
 __attribute__((__overloadable__)) half _cl_log(half x0);
@@ -1443,6 +1548,7 @@ __attribute__((__overloadable__)) half8 _cl_log(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_log(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_log(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_log(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_log(float x0);
 __attribute__((__overloadable__)) float _cl_log(float x0);
 __attribute__((__overloadable__)) float _cl_log(float x0);
@@ -1460,6 +1566,7 @@ __attribute__((__overloadable__)) float8 _cl_log(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_log(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_log(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_log(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_log(double x0);
 __attribute__((__overloadable__)) double _cl_log(double x0);
 __attribute__((__overloadable__)) double _cl_log(double x0);
@@ -1477,10 +1584,12 @@ __attribute__((__overloadable__)) double8 _cl_log(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_log(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_log(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_log(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // log2: ['VF'] -> VF
 #undef log2
 #define log2 _cl_log2
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_log2(half x0);
 __attribute__((__overloadable__)) half _cl_log2(half x0);
 __attribute__((__overloadable__)) half _cl_log2(half x0);
@@ -1498,6 +1607,7 @@ __attribute__((__overloadable__)) half8 _cl_log2(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_log2(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_log2(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_log2(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_log2(float x0);
 __attribute__((__overloadable__)) float _cl_log2(float x0);
 __attribute__((__overloadable__)) float _cl_log2(float x0);
@@ -1515,6 +1625,7 @@ __attribute__((__overloadable__)) float8 _cl_log2(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_log2(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_log2(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_log2(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_log2(double x0);
 __attribute__((__overloadable__)) double _cl_log2(double x0);
 __attribute__((__overloadable__)) double _cl_log2(double x0);
@@ -1532,10 +1643,12 @@ __attribute__((__overloadable__)) double8 _cl_log2(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_log2(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_log2(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_log2(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // log10: ['VF'] -> VF
 #undef log10
 #define log10 _cl_log10
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_log10(half x0);
 __attribute__((__overloadable__)) half _cl_log10(half x0);
 __attribute__((__overloadable__)) half _cl_log10(half x0);
@@ -1553,6 +1666,7 @@ __attribute__((__overloadable__)) half8 _cl_log10(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_log10(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_log10(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_log10(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_log10(float x0);
 __attribute__((__overloadable__)) float _cl_log10(float x0);
 __attribute__((__overloadable__)) float _cl_log10(float x0);
@@ -1570,6 +1684,7 @@ __attribute__((__overloadable__)) float8 _cl_log10(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_log10(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_log10(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_log10(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_log10(double x0);
 __attribute__((__overloadable__)) double _cl_log10(double x0);
 __attribute__((__overloadable__)) double _cl_log10(double x0);
@@ -1587,10 +1702,12 @@ __attribute__((__overloadable__)) double8 _cl_log10(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_log10(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_log10(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_log10(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // log1p: ['VF'] -> VF
 #undef log1p
 #define log1p _cl_log1p
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_log1p(half x0);
 __attribute__((__overloadable__)) half _cl_log1p(half x0);
 __attribute__((__overloadable__)) half _cl_log1p(half x0);
@@ -1608,6 +1725,7 @@ __attribute__((__overloadable__)) half8 _cl_log1p(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_log1p(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_log1p(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_log1p(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_log1p(float x0);
 __attribute__((__overloadable__)) float _cl_log1p(float x0);
 __attribute__((__overloadable__)) float _cl_log1p(float x0);
@@ -1625,6 +1743,7 @@ __attribute__((__overloadable__)) float8 _cl_log1p(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_log1p(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_log1p(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_log1p(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_log1p(double x0);
 __attribute__((__overloadable__)) double _cl_log1p(double x0);
 __attribute__((__overloadable__)) double _cl_log1p(double x0);
@@ -1642,10 +1761,12 @@ __attribute__((__overloadable__)) double8 _cl_log1p(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_log1p(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_log1p(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_log1p(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // pow: ['VF', 'VF'] -> VF
 #undef pow
 #define pow _cl_pow
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_pow(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_pow(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_pow(half x0, half x1);
@@ -1663,6 +1784,7 @@ __attribute__((__overloadable__)) half8 _cl_pow(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half8 _cl_pow(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_pow(half16 x0, half16 x1);
 __attribute__((__overloadable__)) half16 _cl_pow(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_pow(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_pow(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_pow(float x0, float x1);
@@ -1680,6 +1802,7 @@ __attribute__((__overloadable__)) float8 _cl_pow(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float8 _cl_pow(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_pow(float16 x0, float16 x1);
 __attribute__((__overloadable__)) float16 _cl_pow(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_pow(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_pow(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_pow(double x0, double x1);
@@ -1697,10 +1820,12 @@ __attribute__((__overloadable__)) double8 _cl_pow(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double8 _cl_pow(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_pow(double16 x0, double16 x1);
 __attribute__((__overloadable__)) double16 _cl_pow(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // remainder: ['VF', 'VF'] -> VF
 #undef remainder
 #define remainder _cl_remainder
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_remainder(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_remainder(half x0, half x1);
 __attribute__((__overloadable__)) half _cl_remainder(half x0, half x1);
@@ -1718,6 +1843,7 @@ __attribute__((__overloadable__)) half8 _cl_remainder(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half8 _cl_remainder(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_remainder(half16 x0, half16 x1);
 __attribute__((__overloadable__)) half16 _cl_remainder(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_remainder(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_remainder(float x0, float x1);
 __attribute__((__overloadable__)) float _cl_remainder(float x0, float x1);
@@ -1735,6 +1861,7 @@ __attribute__((__overloadable__)) float8 _cl_remainder(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float8 _cl_remainder(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_remainder(float16 x0, float16 x1);
 __attribute__((__overloadable__)) float16 _cl_remainder(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_remainder(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_remainder(double x0, double x1);
 __attribute__((__overloadable__)) double _cl_remainder(double x0, double x1);
@@ -1752,10 +1879,12 @@ __attribute__((__overloadable__)) double8 _cl_remainder(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double8 _cl_remainder(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_remainder(double16 x0, double16 x1);
 __attribute__((__overloadable__)) double16 _cl_remainder(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // rint: ['VF'] -> VF
 #undef rint
 #define rint _cl_rint
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_rint(half x0);
 __attribute__((__overloadable__)) half _cl_rint(half x0);
 __attribute__((__overloadable__)) half _cl_rint(half x0);
@@ -1773,6 +1902,7 @@ __attribute__((__overloadable__)) half8 _cl_rint(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_rint(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_rint(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_rint(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_rint(float x0);
 __attribute__((__overloadable__)) float _cl_rint(float x0);
 __attribute__((__overloadable__)) float _cl_rint(float x0);
@@ -1790,6 +1920,7 @@ __attribute__((__overloadable__)) float8 _cl_rint(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_rint(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_rint(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_rint(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_rint(double x0);
 __attribute__((__overloadable__)) double _cl_rint(double x0);
 __attribute__((__overloadable__)) double _cl_rint(double x0);
@@ -1807,10 +1938,12 @@ __attribute__((__overloadable__)) double8 _cl_rint(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_rint(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_rint(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_rint(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // round: ['VF'] -> VF
 #undef round
 #define round _cl_round
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_round(half x0);
 __attribute__((__overloadable__)) half _cl_round(half x0);
 __attribute__((__overloadable__)) half _cl_round(half x0);
@@ -1828,6 +1961,7 @@ __attribute__((__overloadable__)) half8 _cl_round(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_round(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_round(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_round(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_round(float x0);
 __attribute__((__overloadable__)) float _cl_round(float x0);
 __attribute__((__overloadable__)) float _cl_round(float x0);
@@ -1845,6 +1979,7 @@ __attribute__((__overloadable__)) float8 _cl_round(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_round(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_round(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_round(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_round(double x0);
 __attribute__((__overloadable__)) double _cl_round(double x0);
 __attribute__((__overloadable__)) double _cl_round(double x0);
@@ -1862,10 +1997,12 @@ __attribute__((__overloadable__)) double8 _cl_round(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_round(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_round(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_round(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // rsqrt: ['VF'] -> VF
 #undef rsqrt
 #define rsqrt _cl_rsqrt
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_rsqrt(half x0);
 __attribute__((__overloadable__)) half _cl_rsqrt(half x0);
 __attribute__((__overloadable__)) half _cl_rsqrt(half x0);
@@ -1883,6 +2020,7 @@ __attribute__((__overloadable__)) half8 _cl_rsqrt(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_rsqrt(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_rsqrt(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_rsqrt(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_rsqrt(float x0);
 __attribute__((__overloadable__)) float _cl_rsqrt(float x0);
 __attribute__((__overloadable__)) float _cl_rsqrt(float x0);
@@ -1900,6 +2038,7 @@ __attribute__((__overloadable__)) float8 _cl_rsqrt(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_rsqrt(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_rsqrt(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_rsqrt(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_rsqrt(double x0);
 __attribute__((__overloadable__)) double _cl_rsqrt(double x0);
 __attribute__((__overloadable__)) double _cl_rsqrt(double x0);
@@ -1917,10 +2056,12 @@ __attribute__((__overloadable__)) double8 _cl_rsqrt(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_rsqrt(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_rsqrt(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_rsqrt(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // sin: ['VF'] -> VF
 #undef sin
 #define sin _cl_sin
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_sin(half x0);
 __attribute__((__overloadable__)) half _cl_sin(half x0);
 __attribute__((__overloadable__)) half _cl_sin(half x0);
@@ -1938,6 +2079,7 @@ __attribute__((__overloadable__)) half8 _cl_sin(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_sin(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_sin(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_sin(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_sin(float x0);
 __attribute__((__overloadable__)) float _cl_sin(float x0);
 __attribute__((__overloadable__)) float _cl_sin(float x0);
@@ -1955,6 +2097,7 @@ __attribute__((__overloadable__)) float8 _cl_sin(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_sin(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_sin(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_sin(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_sin(double x0);
 __attribute__((__overloadable__)) double _cl_sin(double x0);
 __attribute__((__overloadable__)) double _cl_sin(double x0);
@@ -1972,10 +2115,12 @@ __attribute__((__overloadable__)) double8 _cl_sin(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_sin(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_sin(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_sin(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // sinh: ['VF'] -> VF
 #undef sinh
 #define sinh _cl_sinh
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_sinh(half x0);
 __attribute__((__overloadable__)) half _cl_sinh(half x0);
 __attribute__((__overloadable__)) half _cl_sinh(half x0);
@@ -1993,6 +2138,7 @@ __attribute__((__overloadable__)) half8 _cl_sinh(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_sinh(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_sinh(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_sinh(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_sinh(float x0);
 __attribute__((__overloadable__)) float _cl_sinh(float x0);
 __attribute__((__overloadable__)) float _cl_sinh(float x0);
@@ -2010,6 +2156,7 @@ __attribute__((__overloadable__)) float8 _cl_sinh(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_sinh(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_sinh(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_sinh(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_sinh(double x0);
 __attribute__((__overloadable__)) double _cl_sinh(double x0);
 __attribute__((__overloadable__)) double _cl_sinh(double x0);
@@ -2027,10 +2174,12 @@ __attribute__((__overloadable__)) double8 _cl_sinh(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_sinh(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_sinh(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_sinh(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // sqrt: ['VF'] -> VF
 #undef sqrt
 #define sqrt _cl_sqrt
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_sqrt(half x0);
 __attribute__((__overloadable__)) half _cl_sqrt(half x0);
 __attribute__((__overloadable__)) half _cl_sqrt(half x0);
@@ -2048,6 +2197,7 @@ __attribute__((__overloadable__)) half8 _cl_sqrt(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_sqrt(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_sqrt(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_sqrt(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_sqrt(float x0);
 __attribute__((__overloadable__)) float _cl_sqrt(float x0);
 __attribute__((__overloadable__)) float _cl_sqrt(float x0);
@@ -2065,6 +2215,7 @@ __attribute__((__overloadable__)) float8 _cl_sqrt(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_sqrt(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_sqrt(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_sqrt(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_sqrt(double x0);
 __attribute__((__overloadable__)) double _cl_sqrt(double x0);
 __attribute__((__overloadable__)) double _cl_sqrt(double x0);
@@ -2082,10 +2233,12 @@ __attribute__((__overloadable__)) double8 _cl_sqrt(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_sqrt(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_sqrt(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_sqrt(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // tan: ['VF'] -> VF
 #undef tan
 #define tan _cl_tan
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_tan(half x0);
 __attribute__((__overloadable__)) half _cl_tan(half x0);
 __attribute__((__overloadable__)) half _cl_tan(half x0);
@@ -2103,6 +2256,7 @@ __attribute__((__overloadable__)) half8 _cl_tan(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_tan(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_tan(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_tan(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_tan(float x0);
 __attribute__((__overloadable__)) float _cl_tan(float x0);
 __attribute__((__overloadable__)) float _cl_tan(float x0);
@@ -2120,6 +2274,7 @@ __attribute__((__overloadable__)) float8 _cl_tan(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_tan(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_tan(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_tan(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_tan(double x0);
 __attribute__((__overloadable__)) double _cl_tan(double x0);
 __attribute__((__overloadable__)) double _cl_tan(double x0);
@@ -2137,10 +2292,12 @@ __attribute__((__overloadable__)) double8 _cl_tan(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_tan(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_tan(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_tan(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // tanh: ['VF'] -> VF
 #undef tanh
 #define tanh _cl_tanh
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_tanh(half x0);
 __attribute__((__overloadable__)) half _cl_tanh(half x0);
 __attribute__((__overloadable__)) half _cl_tanh(half x0);
@@ -2158,6 +2315,7 @@ __attribute__((__overloadable__)) half8 _cl_tanh(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_tanh(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_tanh(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_tanh(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_tanh(float x0);
 __attribute__((__overloadable__)) float _cl_tanh(float x0);
 __attribute__((__overloadable__)) float _cl_tanh(float x0);
@@ -2175,6 +2333,7 @@ __attribute__((__overloadable__)) float8 _cl_tanh(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_tanh(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_tanh(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_tanh(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_tanh(double x0);
 __attribute__((__overloadable__)) double _cl_tanh(double x0);
 __attribute__((__overloadable__)) double _cl_tanh(double x0);
@@ -2192,10 +2351,12 @@ __attribute__((__overloadable__)) double8 _cl_tanh(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_tanh(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_tanh(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_tanh(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // trunc: ['VF'] -> VF
 #undef trunc
 #define trunc _cl_trunc
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_trunc(half x0);
 __attribute__((__overloadable__)) half _cl_trunc(half x0);
 __attribute__((__overloadable__)) half _cl_trunc(half x0);
@@ -2213,6 +2374,7 @@ __attribute__((__overloadable__)) half8 _cl_trunc(half8 x0);
 __attribute__((__overloadable__)) half8 _cl_trunc(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_trunc(half16 x0);
 __attribute__((__overloadable__)) half16 _cl_trunc(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_trunc(float x0);
 __attribute__((__overloadable__)) float _cl_trunc(float x0);
 __attribute__((__overloadable__)) float _cl_trunc(float x0);
@@ -2230,6 +2392,7 @@ __attribute__((__overloadable__)) float8 _cl_trunc(float8 x0);
 __attribute__((__overloadable__)) float8 _cl_trunc(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_trunc(float16 x0);
 __attribute__((__overloadable__)) float16 _cl_trunc(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_trunc(double x0);
 __attribute__((__overloadable__)) double _cl_trunc(double x0);
 __attribute__((__overloadable__)) double _cl_trunc(double x0);
@@ -2247,10 +2410,12 @@ __attribute__((__overloadable__)) double8 _cl_trunc(double8 x0);
 __attribute__((__overloadable__)) double8 _cl_trunc(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_trunc(double16 x0);
 __attribute__((__overloadable__)) double16 _cl_trunc(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // isfinite: ['VF'] -> VJ
 #undef isfinite
 #define isfinite _cl_isfinite
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isfinite(half x0);
 __attribute__((__overloadable__)) int _cl_isfinite(half x0);
 __attribute__((__overloadable__)) int _cl_isfinite(half x0);
@@ -2268,6 +2433,7 @@ __attribute__((__overloadable__)) short8 _cl_isfinite(half8 x0);
 __attribute__((__overloadable__)) short8 _cl_isfinite(half8 x0);
 __attribute__((__overloadable__)) short16 _cl_isfinite(half16 x0);
 __attribute__((__overloadable__)) short16 _cl_isfinite(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isfinite(float x0);
 __attribute__((__overloadable__)) int _cl_isfinite(float x0);
 __attribute__((__overloadable__)) int _cl_isfinite(float x0);
@@ -2285,6 +2451,7 @@ __attribute__((__overloadable__)) int8 _cl_isfinite(float8 x0);
 __attribute__((__overloadable__)) int8 _cl_isfinite(float8 x0);
 __attribute__((__overloadable__)) int16 _cl_isfinite(float16 x0);
 __attribute__((__overloadable__)) int16 _cl_isfinite(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_isfinite(double x0);
 __attribute__((__overloadable__)) int _cl_isfinite(double x0);
 __attribute__((__overloadable__)) int _cl_isfinite(double x0);
@@ -2302,10 +2469,12 @@ __attribute__((__overloadable__)) long8 _cl_isfinite(double8 x0);
 __attribute__((__overloadable__)) long8 _cl_isfinite(double8 x0);
 __attribute__((__overloadable__)) long16 _cl_isfinite(double16 x0);
 __attribute__((__overloadable__)) long16 _cl_isfinite(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // isinf: ['VF'] -> VJ
 #undef isinf
 #define isinf _cl_isinf
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isinf(half x0);
 __attribute__((__overloadable__)) int _cl_isinf(half x0);
 __attribute__((__overloadable__)) int _cl_isinf(half x0);
@@ -2323,6 +2492,7 @@ __attribute__((__overloadable__)) short8 _cl_isinf(half8 x0);
 __attribute__((__overloadable__)) short8 _cl_isinf(half8 x0);
 __attribute__((__overloadable__)) short16 _cl_isinf(half16 x0);
 __attribute__((__overloadable__)) short16 _cl_isinf(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isinf(float x0);
 __attribute__((__overloadable__)) int _cl_isinf(float x0);
 __attribute__((__overloadable__)) int _cl_isinf(float x0);
@@ -2340,6 +2510,7 @@ __attribute__((__overloadable__)) int8 _cl_isinf(float8 x0);
 __attribute__((__overloadable__)) int8 _cl_isinf(float8 x0);
 __attribute__((__overloadable__)) int16 _cl_isinf(float16 x0);
 __attribute__((__overloadable__)) int16 _cl_isinf(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_isinf(double x0);
 __attribute__((__overloadable__)) int _cl_isinf(double x0);
 __attribute__((__overloadable__)) int _cl_isinf(double x0);
@@ -2357,10 +2528,12 @@ __attribute__((__overloadable__)) long8 _cl_isinf(double8 x0);
 __attribute__((__overloadable__)) long8 _cl_isinf(double8 x0);
 __attribute__((__overloadable__)) long16 _cl_isinf(double16 x0);
 __attribute__((__overloadable__)) long16 _cl_isinf(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // isnan: ['VF'] -> VJ
 #undef isnan
 #define isnan _cl_isnan
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isnan(half x0);
 __attribute__((__overloadable__)) int _cl_isnan(half x0);
 __attribute__((__overloadable__)) int _cl_isnan(half x0);
@@ -2378,6 +2551,7 @@ __attribute__((__overloadable__)) short8 _cl_isnan(half8 x0);
 __attribute__((__overloadable__)) short8 _cl_isnan(half8 x0);
 __attribute__((__overloadable__)) short16 _cl_isnan(half16 x0);
 __attribute__((__overloadable__)) short16 _cl_isnan(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isnan(float x0);
 __attribute__((__overloadable__)) int _cl_isnan(float x0);
 __attribute__((__overloadable__)) int _cl_isnan(float x0);
@@ -2395,6 +2569,7 @@ __attribute__((__overloadable__)) int8 _cl_isnan(float8 x0);
 __attribute__((__overloadable__)) int8 _cl_isnan(float8 x0);
 __attribute__((__overloadable__)) int16 _cl_isnan(float16 x0);
 __attribute__((__overloadable__)) int16 _cl_isnan(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_isnan(double x0);
 __attribute__((__overloadable__)) int _cl_isnan(double x0);
 __attribute__((__overloadable__)) int _cl_isnan(double x0);
@@ -2412,10 +2587,12 @@ __attribute__((__overloadable__)) long8 _cl_isnan(double8 x0);
 __attribute__((__overloadable__)) long8 _cl_isnan(double8 x0);
 __attribute__((__overloadable__)) long16 _cl_isnan(double16 x0);
 __attribute__((__overloadable__)) long16 _cl_isnan(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // isnormal: ['VF'] -> VJ
 #undef isnormal
 #define isnormal _cl_isnormal
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isnormal(half x0);
 __attribute__((__overloadable__)) int _cl_isnormal(half x0);
 __attribute__((__overloadable__)) int _cl_isnormal(half x0);
@@ -2433,6 +2610,7 @@ __attribute__((__overloadable__)) short8 _cl_isnormal(half8 x0);
 __attribute__((__overloadable__)) short8 _cl_isnormal(half8 x0);
 __attribute__((__overloadable__)) short16 _cl_isnormal(half16 x0);
 __attribute__((__overloadable__)) short16 _cl_isnormal(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isnormal(float x0);
 __attribute__((__overloadable__)) int _cl_isnormal(float x0);
 __attribute__((__overloadable__)) int _cl_isnormal(float x0);
@@ -2450,6 +2628,7 @@ __attribute__((__overloadable__)) int8 _cl_isnormal(float8 x0);
 __attribute__((__overloadable__)) int8 _cl_isnormal(float8 x0);
 __attribute__((__overloadable__)) int16 _cl_isnormal(float16 x0);
 __attribute__((__overloadable__)) int16 _cl_isnormal(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_isnormal(double x0);
 __attribute__((__overloadable__)) int _cl_isnormal(double x0);
 __attribute__((__overloadable__)) int _cl_isnormal(double x0);
@@ -2467,10 +2646,12 @@ __attribute__((__overloadable__)) long8 _cl_isnormal(double8 x0);
 __attribute__((__overloadable__)) long8 _cl_isnormal(double8 x0);
 __attribute__((__overloadable__)) long16 _cl_isnormal(double16 x0);
 __attribute__((__overloadable__)) long16 _cl_isnormal(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // signbit: ['VF'] -> VJ
 #undef signbit
 #define signbit _cl_signbit
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_signbit(half x0);
 __attribute__((__overloadable__)) int _cl_signbit(half x0);
 __attribute__((__overloadable__)) int _cl_signbit(half x0);
@@ -2488,6 +2669,7 @@ __attribute__((__overloadable__)) short8 _cl_signbit(half8 x0);
 __attribute__((__overloadable__)) short8 _cl_signbit(half8 x0);
 __attribute__((__overloadable__)) short16 _cl_signbit(half16 x0);
 __attribute__((__overloadable__)) short16 _cl_signbit(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_signbit(float x0);
 __attribute__((__overloadable__)) int _cl_signbit(float x0);
 __attribute__((__overloadable__)) int _cl_signbit(float x0);
@@ -2505,6 +2687,7 @@ __attribute__((__overloadable__)) int8 _cl_signbit(float8 x0);
 __attribute__((__overloadable__)) int8 _cl_signbit(float8 x0);
 __attribute__((__overloadable__)) int16 _cl_signbit(float16 x0);
 __attribute__((__overloadable__)) int16 _cl_signbit(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_signbit(double x0);
 __attribute__((__overloadable__)) int _cl_signbit(double x0);
 __attribute__((__overloadable__)) int _cl_signbit(double x0);
@@ -2522,180 +2705,214 @@ __attribute__((__overloadable__)) long8 _cl_signbit(double8 x0);
 __attribute__((__overloadable__)) long8 _cl_signbit(double8 x0);
 __attribute__((__overloadable__)) long16 _cl_signbit(double16 x0);
 __attribute__((__overloadable__)) long16 _cl_signbit(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // acospi: ['VF'] -> VF
 #undef acospi
 #define acospi _cl_acospi
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_acospi(half x0);
 __attribute__((__overloadable__)) half2 _cl_acospi(half2 x0);
 __attribute__((__overloadable__)) half3 _cl_acospi(half3 x0);
 __attribute__((__overloadable__)) half4 _cl_acospi(half4 x0);
 __attribute__((__overloadable__)) half8 _cl_acospi(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_acospi(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_acospi(float x0);
 __attribute__((__overloadable__)) float2 _cl_acospi(float2 x0);
 __attribute__((__overloadable__)) float3 _cl_acospi(float3 x0);
 __attribute__((__overloadable__)) float4 _cl_acospi(float4 x0);
 __attribute__((__overloadable__)) float8 _cl_acospi(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_acospi(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_acospi(double x0);
 __attribute__((__overloadable__)) double2 _cl_acospi(double2 x0);
 __attribute__((__overloadable__)) double3 _cl_acospi(double3 x0);
 __attribute__((__overloadable__)) double4 _cl_acospi(double4 x0);
 __attribute__((__overloadable__)) double8 _cl_acospi(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_acospi(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // asinpi: ['VF'] -> VF
 #undef asinpi
 #define asinpi _cl_asinpi
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_asinpi(half x0);
 __attribute__((__overloadable__)) half2 _cl_asinpi(half2 x0);
 __attribute__((__overloadable__)) half3 _cl_asinpi(half3 x0);
 __attribute__((__overloadable__)) half4 _cl_asinpi(half4 x0);
 __attribute__((__overloadable__)) half8 _cl_asinpi(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_asinpi(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_asinpi(float x0);
 __attribute__((__overloadable__)) float2 _cl_asinpi(float2 x0);
 __attribute__((__overloadable__)) float3 _cl_asinpi(float3 x0);
 __attribute__((__overloadable__)) float4 _cl_asinpi(float4 x0);
 __attribute__((__overloadable__)) float8 _cl_asinpi(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_asinpi(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_asinpi(double x0);
 __attribute__((__overloadable__)) double2 _cl_asinpi(double2 x0);
 __attribute__((__overloadable__)) double3 _cl_asinpi(double3 x0);
 __attribute__((__overloadable__)) double4 _cl_asinpi(double4 x0);
 __attribute__((__overloadable__)) double8 _cl_asinpi(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_asinpi(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // atanpi: ['VF'] -> VF
 #undef atanpi
 #define atanpi _cl_atanpi
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_atanpi(half x0);
 __attribute__((__overloadable__)) half2 _cl_atanpi(half2 x0);
 __attribute__((__overloadable__)) half3 _cl_atanpi(half3 x0);
 __attribute__((__overloadable__)) half4 _cl_atanpi(half4 x0);
 __attribute__((__overloadable__)) half8 _cl_atanpi(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_atanpi(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_atanpi(float x0);
 __attribute__((__overloadable__)) float2 _cl_atanpi(float2 x0);
 __attribute__((__overloadable__)) float3 _cl_atanpi(float3 x0);
 __attribute__((__overloadable__)) float4 _cl_atanpi(float4 x0);
 __attribute__((__overloadable__)) float8 _cl_atanpi(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_atanpi(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_atanpi(double x0);
 __attribute__((__overloadable__)) double2 _cl_atanpi(double2 x0);
 __attribute__((__overloadable__)) double3 _cl_atanpi(double3 x0);
 __attribute__((__overloadable__)) double4 _cl_atanpi(double4 x0);
 __attribute__((__overloadable__)) double8 _cl_atanpi(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_atanpi(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // atan2: ['VF', 'VF'] -> VF
 #undef atan2
 #define atan2 _cl_atan2
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_atan2(half x0, half x1);
 __attribute__((__overloadable__)) half2 _cl_atan2(half2 x0, half2 x1);
 __attribute__((__overloadable__)) half3 _cl_atan2(half3 x0, half3 x1);
 __attribute__((__overloadable__)) half4 _cl_atan2(half4 x0, half4 x1);
 __attribute__((__overloadable__)) half8 _cl_atan2(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_atan2(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_atan2(float x0, float x1);
 __attribute__((__overloadable__)) float2 _cl_atan2(float2 x0, float2 x1);
 __attribute__((__overloadable__)) float3 _cl_atan2(float3 x0, float3 x1);
 __attribute__((__overloadable__)) float4 _cl_atan2(float4 x0, float4 x1);
 __attribute__((__overloadable__)) float8 _cl_atan2(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_atan2(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_atan2(double x0, double x1);
 __attribute__((__overloadable__)) double2 _cl_atan2(double2 x0, double2 x1);
 __attribute__((__overloadable__)) double3 _cl_atan2(double3 x0, double3 x1);
 __attribute__((__overloadable__)) double4 _cl_atan2(double4 x0, double4 x1);
 __attribute__((__overloadable__)) double8 _cl_atan2(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_atan2(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // atan2pi: ['VF', 'VF'] -> VF
 #undef atan2pi
 #define atan2pi _cl_atan2pi
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_atan2pi(half x0, half x1);
 __attribute__((__overloadable__)) half2 _cl_atan2pi(half2 x0, half2 x1);
 __attribute__((__overloadable__)) half3 _cl_atan2pi(half3 x0, half3 x1);
 __attribute__((__overloadable__)) half4 _cl_atan2pi(half4 x0, half4 x1);
 __attribute__((__overloadable__)) half8 _cl_atan2pi(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_atan2pi(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_atan2pi(float x0, float x1);
 __attribute__((__overloadable__)) float2 _cl_atan2pi(float2 x0, float2 x1);
 __attribute__((__overloadable__)) float3 _cl_atan2pi(float3 x0, float3 x1);
 __attribute__((__overloadable__)) float4 _cl_atan2pi(float4 x0, float4 x1);
 __attribute__((__overloadable__)) float8 _cl_atan2pi(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_atan2pi(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_atan2pi(double x0, double x1);
 __attribute__((__overloadable__)) double2 _cl_atan2pi(double2 x0, double2 x1);
 __attribute__((__overloadable__)) double3 _cl_atan2pi(double3 x0, double3 x1);
 __attribute__((__overloadable__)) double4 _cl_atan2pi(double4 x0, double4 x1);
 __attribute__((__overloadable__)) double8 _cl_atan2pi(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_atan2pi(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // cospi: ['VF'] -> VF
 #undef cospi
 #define cospi _cl_cospi
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_cospi(half x0);
 __attribute__((__overloadable__)) half2 _cl_cospi(half2 x0);
 __attribute__((__overloadable__)) half3 _cl_cospi(half3 x0);
 __attribute__((__overloadable__)) half4 _cl_cospi(half4 x0);
 __attribute__((__overloadable__)) half8 _cl_cospi(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_cospi(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_cospi(float x0);
 __attribute__((__overloadable__)) float2 _cl_cospi(float2 x0);
 __attribute__((__overloadable__)) float3 _cl_cospi(float3 x0);
 __attribute__((__overloadable__)) float4 _cl_cospi(float4 x0);
 __attribute__((__overloadable__)) float8 _cl_cospi(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_cospi(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_cospi(double x0);
 __attribute__((__overloadable__)) double2 _cl_cospi(double2 x0);
 __attribute__((__overloadable__)) double3 _cl_cospi(double3 x0);
 __attribute__((__overloadable__)) double4 _cl_cospi(double4 x0);
 __attribute__((__overloadable__)) double8 _cl_cospi(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_cospi(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // fmax: ['VF', 'SF'] -> VF
 #undef fmax
 #define fmax _cl_fmax
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half2 _cl_fmax(half2 x0, half x1);
 __attribute__((__overloadable__)) half3 _cl_fmax(half3 x0, half x1);
 __attribute__((__overloadable__)) half4 _cl_fmax(half4 x0, half x1);
 __attribute__((__overloadable__)) half8 _cl_fmax(half8 x0, half x1);
 __attribute__((__overloadable__)) half16 _cl_fmax(half16 x0, half x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float2 _cl_fmax(float2 x0, float x1);
 __attribute__((__overloadable__)) float3 _cl_fmax(float3 x0, float x1);
 __attribute__((__overloadable__)) float4 _cl_fmax(float4 x0, float x1);
 __attribute__((__overloadable__)) float8 _cl_fmax(float8 x0, float x1);
 __attribute__((__overloadable__)) float16 _cl_fmax(float16 x0, float x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double2 _cl_fmax(double2 x0, double x1);
 __attribute__((__overloadable__)) double3 _cl_fmax(double3 x0, double x1);
 __attribute__((__overloadable__)) double4 _cl_fmax(double4 x0, double x1);
 __attribute__((__overloadable__)) double8 _cl_fmax(double8 x0, double x1);
 __attribute__((__overloadable__)) double16 _cl_fmax(double16 x0, double x1);
+#endif // #ifdef cl_khr_fp64
 
 // fmin: ['VF', 'SF'] -> VF
 #undef fmin
 #define fmin _cl_fmin
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half2 _cl_fmin(half2 x0, half x1);
 __attribute__((__overloadable__)) half3 _cl_fmin(half3 x0, half x1);
 __attribute__((__overloadable__)) half4 _cl_fmin(half4 x0, half x1);
 __attribute__((__overloadable__)) half8 _cl_fmin(half8 x0, half x1);
 __attribute__((__overloadable__)) half16 _cl_fmin(half16 x0, half x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float2 _cl_fmin(float2 x0, float x1);
 __attribute__((__overloadable__)) float3 _cl_fmin(float3 x0, float x1);
 __attribute__((__overloadable__)) float4 _cl_fmin(float4 x0, float x1);
 __attribute__((__overloadable__)) float8 _cl_fmin(float8 x0, float x1);
 __attribute__((__overloadable__)) float16 _cl_fmin(float16 x0, float x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double2 _cl_fmin(double2 x0, double x1);
 __attribute__((__overloadable__)) double3 _cl_fmin(double3 x0, double x1);
 __attribute__((__overloadable__)) double4 _cl_fmin(double4 x0, double x1);
 __attribute__((__overloadable__)) double8 _cl_fmin(double8 x0, double x1);
 __attribute__((__overloadable__)) double16 _cl_fmin(double16 x0, double x1);
+#endif // #ifdef cl_khr_fp64
 
 // fract: ['VF', 'PVF'] -> VF
 #undef fract
 #define fract _cl_fract
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_fract(half x0, global half* x1);
 __attribute__((__overloadable__)) half _cl_fract(half x0, local half* x1);
 __attribute__((__overloadable__)) half _cl_fract(half x0, private half* x1);
@@ -2714,6 +2931,7 @@ __attribute__((__overloadable__)) half8 _cl_fract(half8 x0, private half8* x1);
 __attribute__((__overloadable__)) half16 _cl_fract(half16 x0, global half16* x1);
 __attribute__((__overloadable__)) half16 _cl_fract(half16 x0, local half16* x1);
 __attribute__((__overloadable__)) half16 _cl_fract(half16 x0, private half16* x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_fract(float x0, global float* x1);
 __attribute__((__overloadable__)) float _cl_fract(float x0, local float* x1);
 __attribute__((__overloadable__)) float _cl_fract(float x0, private float* x1);
@@ -2732,6 +2950,7 @@ __attribute__((__overloadable__)) float8 _cl_fract(float8 x0, private float8* x1
 __attribute__((__overloadable__)) float16 _cl_fract(float16 x0, global float16* x1);
 __attribute__((__overloadable__)) float16 _cl_fract(float16 x0, local float16* x1);
 __attribute__((__overloadable__)) float16 _cl_fract(float16 x0, private float16* x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_fract(double x0, global double* x1);
 __attribute__((__overloadable__)) double _cl_fract(double x0, local double* x1);
 __attribute__((__overloadable__)) double _cl_fract(double x0, private double* x1);
@@ -2750,10 +2969,12 @@ __attribute__((__overloadable__)) double8 _cl_fract(double8 x0, private double8*
 __attribute__((__overloadable__)) double16 _cl_fract(double16 x0, global double16* x1);
 __attribute__((__overloadable__)) double16 _cl_fract(double16 x0, local double16* x1);
 __attribute__((__overloadable__)) double16 _cl_fract(double16 x0, private double16* x1);
+#endif // #ifdef cl_khr_fp64
 
 // frexp: ['VF', 'PVK'] -> VF
 #undef frexp
 #define frexp _cl_frexp
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_frexp(half x0, global int* x1);
 __attribute__((__overloadable__)) half _cl_frexp(half x0, local int* x1);
 __attribute__((__overloadable__)) half _cl_frexp(half x0, private int* x1);
@@ -2772,6 +2993,7 @@ __attribute__((__overloadable__)) half8 _cl_frexp(half8 x0, private int8* x1);
 __attribute__((__overloadable__)) half16 _cl_frexp(half16 x0, global int16* x1);
 __attribute__((__overloadable__)) half16 _cl_frexp(half16 x0, local int16* x1);
 __attribute__((__overloadable__)) half16 _cl_frexp(half16 x0, private int16* x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_frexp(float x0, global int* x1);
 __attribute__((__overloadable__)) float _cl_frexp(float x0, local int* x1);
 __attribute__((__overloadable__)) float _cl_frexp(float x0, private int* x1);
@@ -2790,6 +3012,7 @@ __attribute__((__overloadable__)) float8 _cl_frexp(float8 x0, private int8* x1);
 __attribute__((__overloadable__)) float16 _cl_frexp(float16 x0, global int16* x1);
 __attribute__((__overloadable__)) float16 _cl_frexp(float16 x0, local int16* x1);
 __attribute__((__overloadable__)) float16 _cl_frexp(float16 x0, private int16* x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_frexp(double x0, global int* x1);
 __attribute__((__overloadable__)) double _cl_frexp(double x0, local int* x1);
 __attribute__((__overloadable__)) double _cl_frexp(double x0, private int* x1);
@@ -2808,161 +3031,191 @@ __attribute__((__overloadable__)) double8 _cl_frexp(double8 x0, private int8* x1
 __attribute__((__overloadable__)) double16 _cl_frexp(double16 x0, global int16* x1);
 __attribute__((__overloadable__)) double16 _cl_frexp(double16 x0, local int16* x1);
 __attribute__((__overloadable__)) double16 _cl_frexp(double16 x0, private int16* x1);
+#endif // #ifdef cl_khr_fp64
 
 // ilogb: ['VF'] -> VK
 #undef ilogb
 #define ilogb _cl_ilogb
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_ilogb(half x0);
 __attribute__((__overloadable__)) int2 _cl_ilogb(half2 x0);
 __attribute__((__overloadable__)) int3 _cl_ilogb(half3 x0);
 __attribute__((__overloadable__)) int4 _cl_ilogb(half4 x0);
 __attribute__((__overloadable__)) int8 _cl_ilogb(half8 x0);
 __attribute__((__overloadable__)) int16 _cl_ilogb(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_ilogb(float x0);
 __attribute__((__overloadable__)) int2 _cl_ilogb(float2 x0);
 __attribute__((__overloadable__)) int3 _cl_ilogb(float3 x0);
 __attribute__((__overloadable__)) int4 _cl_ilogb(float4 x0);
 __attribute__((__overloadable__)) int8 _cl_ilogb(float8 x0);
 __attribute__((__overloadable__)) int16 _cl_ilogb(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_ilogb(double x0);
 __attribute__((__overloadable__)) int2 _cl_ilogb(double2 x0);
 __attribute__((__overloadable__)) int3 _cl_ilogb(double3 x0);
 __attribute__((__overloadable__)) int4 _cl_ilogb(double4 x0);
 __attribute__((__overloadable__)) int8 _cl_ilogb(double8 x0);
 __attribute__((__overloadable__)) int16 _cl_ilogb(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // ldexp: ['VF', 'VK'] -> VF
 #undef ldexp
 #define ldexp _cl_ldexp
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_ldexp(half x0, int x1);
 __attribute__((__overloadable__)) half2 _cl_ldexp(half2 x0, int2 x1);
 __attribute__((__overloadable__)) half3 _cl_ldexp(half3 x0, int3 x1);
 __attribute__((__overloadable__)) half4 _cl_ldexp(half4 x0, int4 x1);
 __attribute__((__overloadable__)) half8 _cl_ldexp(half8 x0, int8 x1);
 __attribute__((__overloadable__)) half16 _cl_ldexp(half16 x0, int16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_ldexp(float x0, int x1);
 __attribute__((__overloadable__)) float2 _cl_ldexp(float2 x0, int2 x1);
 __attribute__((__overloadable__)) float3 _cl_ldexp(float3 x0, int3 x1);
 __attribute__((__overloadable__)) float4 _cl_ldexp(float4 x0, int4 x1);
 __attribute__((__overloadable__)) float8 _cl_ldexp(float8 x0, int8 x1);
 __attribute__((__overloadable__)) float16 _cl_ldexp(float16 x0, int16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_ldexp(double x0, int x1);
 __attribute__((__overloadable__)) double2 _cl_ldexp(double2 x0, int2 x1);
 __attribute__((__overloadable__)) double3 _cl_ldexp(double3 x0, int3 x1);
 __attribute__((__overloadable__)) double4 _cl_ldexp(double4 x0, int4 x1);
 __attribute__((__overloadable__)) double8 _cl_ldexp(double8 x0, int8 x1);
 __attribute__((__overloadable__)) double16 _cl_ldexp(double16 x0, int16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // ldexp: ['VF', 'SK'] -> VF
 #undef ldexp
 #define ldexp _cl_ldexp
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half2 _cl_ldexp(half2 x0, int x1);
 __attribute__((__overloadable__)) half3 _cl_ldexp(half3 x0, int x1);
 __attribute__((__overloadable__)) half4 _cl_ldexp(half4 x0, int x1);
 __attribute__((__overloadable__)) half8 _cl_ldexp(half8 x0, int x1);
 __attribute__((__overloadable__)) half16 _cl_ldexp(half16 x0, int x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float2 _cl_ldexp(float2 x0, int x1);
 __attribute__((__overloadable__)) float3 _cl_ldexp(float3 x0, int x1);
 __attribute__((__overloadable__)) float4 _cl_ldexp(float4 x0, int x1);
 __attribute__((__overloadable__)) float8 _cl_ldexp(float8 x0, int x1);
 __attribute__((__overloadable__)) float16 _cl_ldexp(float16 x0, int x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double2 _cl_ldexp(double2 x0, int x1);
 __attribute__((__overloadable__)) double3 _cl_ldexp(double3 x0, int x1);
 __attribute__((__overloadable__)) double4 _cl_ldexp(double4 x0, int x1);
 __attribute__((__overloadable__)) double8 _cl_ldexp(double8 x0, int x1);
 __attribute__((__overloadable__)) double16 _cl_ldexp(double16 x0, int x1);
+#endif // #ifdef cl_khr_fp64
 
 // logb: ['VF'] -> VF
 #undef logb
 #define logb _cl_logb
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_logb(half x0);
 __attribute__((__overloadable__)) half2 _cl_logb(half2 x0);
 __attribute__((__overloadable__)) half3 _cl_logb(half3 x0);
 __attribute__((__overloadable__)) half4 _cl_logb(half4 x0);
 __attribute__((__overloadable__)) half8 _cl_logb(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_logb(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_logb(float x0);
 __attribute__((__overloadable__)) float2 _cl_logb(float2 x0);
 __attribute__((__overloadable__)) float3 _cl_logb(float3 x0);
 __attribute__((__overloadable__)) float4 _cl_logb(float4 x0);
 __attribute__((__overloadable__)) float8 _cl_logb(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_logb(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_logb(double x0);
 __attribute__((__overloadable__)) double2 _cl_logb(double2 x0);
 __attribute__((__overloadable__)) double3 _cl_logb(double3 x0);
 __attribute__((__overloadable__)) double4 _cl_logb(double4 x0);
 __attribute__((__overloadable__)) double8 _cl_logb(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_logb(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // mad: ['VF', 'VF', 'VF'] -> VF
 #undef mad
 #define mad _cl_mad
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_mad(half x0, half x1, half x2);
 __attribute__((__overloadable__)) half2 _cl_mad(half2 x0, half2 x1, half2 x2);
 __attribute__((__overloadable__)) half3 _cl_mad(half3 x0, half3 x1, half3 x2);
 __attribute__((__overloadable__)) half4 _cl_mad(half4 x0, half4 x1, half4 x2);
 __attribute__((__overloadable__)) half8 _cl_mad(half8 x0, half8 x1, half8 x2);
 __attribute__((__overloadable__)) half16 _cl_mad(half16 x0, half16 x1, half16 x2);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_mad(float x0, float x1, float x2);
 __attribute__((__overloadable__)) float2 _cl_mad(float2 x0, float2 x1, float2 x2);
 __attribute__((__overloadable__)) float3 _cl_mad(float3 x0, float3 x1, float3 x2);
 __attribute__((__overloadable__)) float4 _cl_mad(float4 x0, float4 x1, float4 x2);
 __attribute__((__overloadable__)) float8 _cl_mad(float8 x0, float8 x1, float8 x2);
 __attribute__((__overloadable__)) float16 _cl_mad(float16 x0, float16 x1, float16 x2);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_mad(double x0, double x1, double x2);
 __attribute__((__overloadable__)) double2 _cl_mad(double2 x0, double2 x1, double2 x2);
 __attribute__((__overloadable__)) double3 _cl_mad(double3 x0, double3 x1, double3 x2);
 __attribute__((__overloadable__)) double4 _cl_mad(double4 x0, double4 x1, double4 x2);
 __attribute__((__overloadable__)) double8 _cl_mad(double8 x0, double8 x1, double8 x2);
 __attribute__((__overloadable__)) double16 _cl_mad(double16 x0, double16 x1, double16 x2);
+#endif // #ifdef cl_khr_fp64
 
 // maxmag: ['VF', 'VF'] -> VF
 #undef maxmag
 #define maxmag _cl_maxmag
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_maxmag(half x0, half x1);
 __attribute__((__overloadable__)) half2 _cl_maxmag(half2 x0, half2 x1);
 __attribute__((__overloadable__)) half3 _cl_maxmag(half3 x0, half3 x1);
 __attribute__((__overloadable__)) half4 _cl_maxmag(half4 x0, half4 x1);
 __attribute__((__overloadable__)) half8 _cl_maxmag(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_maxmag(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_maxmag(float x0, float x1);
 __attribute__((__overloadable__)) float2 _cl_maxmag(float2 x0, float2 x1);
 __attribute__((__overloadable__)) float3 _cl_maxmag(float3 x0, float3 x1);
 __attribute__((__overloadable__)) float4 _cl_maxmag(float4 x0, float4 x1);
 __attribute__((__overloadable__)) float8 _cl_maxmag(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_maxmag(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_maxmag(double x0, double x1);
 __attribute__((__overloadable__)) double2 _cl_maxmag(double2 x0, double2 x1);
 __attribute__((__overloadable__)) double3 _cl_maxmag(double3 x0, double3 x1);
 __attribute__((__overloadable__)) double4 _cl_maxmag(double4 x0, double4 x1);
 __attribute__((__overloadable__)) double8 _cl_maxmag(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_maxmag(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // minmag: ['VF', 'VF'] -> VF
 #undef minmag
 #define minmag _cl_minmag
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_minmag(half x0, half x1);
 __attribute__((__overloadable__)) half2 _cl_minmag(half2 x0, half2 x1);
 __attribute__((__overloadable__)) half3 _cl_minmag(half3 x0, half3 x1);
 __attribute__((__overloadable__)) half4 _cl_minmag(half4 x0, half4 x1);
 __attribute__((__overloadable__)) half8 _cl_minmag(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_minmag(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_minmag(float x0, float x1);
 __attribute__((__overloadable__)) float2 _cl_minmag(float2 x0, float2 x1);
 __attribute__((__overloadable__)) float3 _cl_minmag(float3 x0, float3 x1);
 __attribute__((__overloadable__)) float4 _cl_minmag(float4 x0, float4 x1);
 __attribute__((__overloadable__)) float8 _cl_minmag(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_minmag(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_minmag(double x0, double x1);
 __attribute__((__overloadable__)) double2 _cl_minmag(double2 x0, double2 x1);
 __attribute__((__overloadable__)) double3 _cl_minmag(double3 x0, double3 x1);
 __attribute__((__overloadable__)) double4 _cl_minmag(double4 x0, double4 x1);
 __attribute__((__overloadable__)) double8 _cl_minmag(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_minmag(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // modf: ['VF', 'PVF'] -> VF
 #undef modf
 #define modf _cl_modf
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_modf(half x0, global half* x1);
 __attribute__((__overloadable__)) half _cl_modf(half x0, local half* x1);
 __attribute__((__overloadable__)) half _cl_modf(half x0, private half* x1);
@@ -2981,6 +3234,7 @@ __attribute__((__overloadable__)) half8 _cl_modf(half8 x0, private half8* x1);
 __attribute__((__overloadable__)) half16 _cl_modf(half16 x0, global half16* x1);
 __attribute__((__overloadable__)) half16 _cl_modf(half16 x0, local half16* x1);
 __attribute__((__overloadable__)) half16 _cl_modf(half16 x0, private half16* x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_modf(float x0, global float* x1);
 __attribute__((__overloadable__)) float _cl_modf(float x0, local float* x1);
 __attribute__((__overloadable__)) float _cl_modf(float x0, private float* x1);
@@ -2999,6 +3253,7 @@ __attribute__((__overloadable__)) float8 _cl_modf(float8 x0, private float8* x1)
 __attribute__((__overloadable__)) float16 _cl_modf(float16 x0, global float16* x1);
 __attribute__((__overloadable__)) float16 _cl_modf(float16 x0, local float16* x1);
 __attribute__((__overloadable__)) float16 _cl_modf(float16 x0, private float16* x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_modf(double x0, global double* x1);
 __attribute__((__overloadable__)) double _cl_modf(double x0, local double* x1);
 __attribute__((__overloadable__)) double _cl_modf(double x0, private double* x1);
@@ -3017,76 +3272,90 @@ __attribute__((__overloadable__)) double8 _cl_modf(double8 x0, private double8* 
 __attribute__((__overloadable__)) double16 _cl_modf(double16 x0, global double16* x1);
 __attribute__((__overloadable__)) double16 _cl_modf(double16 x0, local double16* x1);
 __attribute__((__overloadable__)) double16 _cl_modf(double16 x0, private double16* x1);
+#endif // #ifdef cl_khr_fp64
 
 // nan: ['VU'] -> VF
 #undef nan
 #define nan _cl_nan
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_nan(ushort x0);
 __attribute__((__overloadable__)) half2 _cl_nan(ushort2 x0);
 __attribute__((__overloadable__)) half3 _cl_nan(ushort3 x0);
 __attribute__((__overloadable__)) half4 _cl_nan(ushort4 x0);
 __attribute__((__overloadable__)) half8 _cl_nan(ushort8 x0);
 __attribute__((__overloadable__)) half16 _cl_nan(ushort16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_nan(uint x0);
 __attribute__((__overloadable__)) float2 _cl_nan(uint2 x0);
 __attribute__((__overloadable__)) float3 _cl_nan(uint3 x0);
 __attribute__((__overloadable__)) float4 _cl_nan(uint4 x0);
 __attribute__((__overloadable__)) float8 _cl_nan(uint8 x0);
 __attribute__((__overloadable__)) float16 _cl_nan(uint16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_nan(ulong x0);
 __attribute__((__overloadable__)) double2 _cl_nan(ulong2 x0);
 __attribute__((__overloadable__)) double3 _cl_nan(ulong3 x0);
 __attribute__((__overloadable__)) double4 _cl_nan(ulong4 x0);
 __attribute__((__overloadable__)) double8 _cl_nan(ulong8 x0);
 __attribute__((__overloadable__)) double16 _cl_nan(ulong16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // pown: ['VF', 'VK'] -> VF
 #undef pown
 #define pown _cl_pown
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_pown(half x0, int x1);
 __attribute__((__overloadable__)) half2 _cl_pown(half2 x0, int2 x1);
 __attribute__((__overloadable__)) half3 _cl_pown(half3 x0, int3 x1);
 __attribute__((__overloadable__)) half4 _cl_pown(half4 x0, int4 x1);
 __attribute__((__overloadable__)) half8 _cl_pown(half8 x0, int8 x1);
 __attribute__((__overloadable__)) half16 _cl_pown(half16 x0, int16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_pown(float x0, int x1);
 __attribute__((__overloadable__)) float2 _cl_pown(float2 x0, int2 x1);
 __attribute__((__overloadable__)) float3 _cl_pown(float3 x0, int3 x1);
 __attribute__((__overloadable__)) float4 _cl_pown(float4 x0, int4 x1);
 __attribute__((__overloadable__)) float8 _cl_pown(float8 x0, int8 x1);
 __attribute__((__overloadable__)) float16 _cl_pown(float16 x0, int16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_pown(double x0, int x1);
 __attribute__((__overloadable__)) double2 _cl_pown(double2 x0, int2 x1);
 __attribute__((__overloadable__)) double3 _cl_pown(double3 x0, int3 x1);
 __attribute__((__overloadable__)) double4 _cl_pown(double4 x0, int4 x1);
 __attribute__((__overloadable__)) double8 _cl_pown(double8 x0, int8 x1);
 __attribute__((__overloadable__)) double16 _cl_pown(double16 x0, int16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // powr: ['VF', 'VF'] -> VF
 #undef powr
 #define powr _cl_powr
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_powr(half x0, half x1);
 __attribute__((__overloadable__)) half2 _cl_powr(half2 x0, half2 x1);
 __attribute__((__overloadable__)) half3 _cl_powr(half3 x0, half3 x1);
 __attribute__((__overloadable__)) half4 _cl_powr(half4 x0, half4 x1);
 __attribute__((__overloadable__)) half8 _cl_powr(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_powr(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_powr(float x0, float x1);
 __attribute__((__overloadable__)) float2 _cl_powr(float2 x0, float2 x1);
 __attribute__((__overloadable__)) float3 _cl_powr(float3 x0, float3 x1);
 __attribute__((__overloadable__)) float4 _cl_powr(float4 x0, float4 x1);
 __attribute__((__overloadable__)) float8 _cl_powr(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_powr(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_powr(double x0, double x1);
 __attribute__((__overloadable__)) double2 _cl_powr(double2 x0, double2 x1);
 __attribute__((__overloadable__)) double3 _cl_powr(double3 x0, double3 x1);
 __attribute__((__overloadable__)) double4 _cl_powr(double4 x0, double4 x1);
 __attribute__((__overloadable__)) double8 _cl_powr(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_powr(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // remquo: ['VF', 'VF', 'PVK'] -> VF
 #undef remquo
 #define remquo _cl_remquo
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_remquo(half x0, half x1, global int* x2);
 __attribute__((__overloadable__)) half _cl_remquo(half x0, half x1, local int* x2);
 __attribute__((__overloadable__)) half _cl_remquo(half x0, half x1, private int* x2);
@@ -3105,6 +3374,7 @@ __attribute__((__overloadable__)) half8 _cl_remquo(half8 x0, half8 x1, private i
 __attribute__((__overloadable__)) half16 _cl_remquo(half16 x0, half16 x1, global int16* x2);
 __attribute__((__overloadable__)) half16 _cl_remquo(half16 x0, half16 x1, local int16* x2);
 __attribute__((__overloadable__)) half16 _cl_remquo(half16 x0, half16 x1, private int16* x2);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_remquo(float x0, float x1, global int* x2);
 __attribute__((__overloadable__)) float _cl_remquo(float x0, float x1, local int* x2);
 __attribute__((__overloadable__)) float _cl_remquo(float x0, float x1, private int* x2);
@@ -3123,6 +3393,7 @@ __attribute__((__overloadable__)) float8 _cl_remquo(float8 x0, float8 x1, privat
 __attribute__((__overloadable__)) float16 _cl_remquo(float16 x0, float16 x1, global int16* x2);
 __attribute__((__overloadable__)) float16 _cl_remquo(float16 x0, float16 x1, local int16* x2);
 __attribute__((__overloadable__)) float16 _cl_remquo(float16 x0, float16 x1, private int16* x2);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_remquo(double x0, double x1, global int* x2);
 __attribute__((__overloadable__)) double _cl_remquo(double x0, double x1, local int* x2);
 __attribute__((__overloadable__)) double _cl_remquo(double x0, double x1, private int* x2);
@@ -3141,32 +3412,38 @@ __attribute__((__overloadable__)) double8 _cl_remquo(double8 x0, double8 x1, pri
 __attribute__((__overloadable__)) double16 _cl_remquo(double16 x0, double16 x1, global int16* x2);
 __attribute__((__overloadable__)) double16 _cl_remquo(double16 x0, double16 x1, local int16* x2);
 __attribute__((__overloadable__)) double16 _cl_remquo(double16 x0, double16 x1, private int16* x2);
+#endif // #ifdef cl_khr_fp64
 
 // rootn: ['VF', 'VK'] -> VF
 #undef rootn
 #define rootn _cl_rootn
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_rootn(half x0, int x1);
 __attribute__((__overloadable__)) half2 _cl_rootn(half2 x0, int2 x1);
 __attribute__((__overloadable__)) half3 _cl_rootn(half3 x0, int3 x1);
 __attribute__((__overloadable__)) half4 _cl_rootn(half4 x0, int4 x1);
 __attribute__((__overloadable__)) half8 _cl_rootn(half8 x0, int8 x1);
 __attribute__((__overloadable__)) half16 _cl_rootn(half16 x0, int16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_rootn(float x0, int x1);
 __attribute__((__overloadable__)) float2 _cl_rootn(float2 x0, int2 x1);
 __attribute__((__overloadable__)) float3 _cl_rootn(float3 x0, int3 x1);
 __attribute__((__overloadable__)) float4 _cl_rootn(float4 x0, int4 x1);
 __attribute__((__overloadable__)) float8 _cl_rootn(float8 x0, int8 x1);
 __attribute__((__overloadable__)) float16 _cl_rootn(float16 x0, int16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_rootn(double x0, int x1);
 __attribute__((__overloadable__)) double2 _cl_rootn(double2 x0, int2 x1);
 __attribute__((__overloadable__)) double3 _cl_rootn(double3 x0, int3 x1);
 __attribute__((__overloadable__)) double4 _cl_rootn(double4 x0, int4 x1);
 __attribute__((__overloadable__)) double8 _cl_rootn(double8 x0, int8 x1);
 __attribute__((__overloadable__)) double16 _cl_rootn(double16 x0, int16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // sincos: ['VF', 'PVF'] -> VF
 #undef sincos
 #define sincos _cl_sincos
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_sincos(half x0, global half* x1);
 __attribute__((__overloadable__)) half _cl_sincos(half x0, local half* x1);
 __attribute__((__overloadable__)) half _cl_sincos(half x0, private half* x1);
@@ -3185,6 +3462,7 @@ __attribute__((__overloadable__)) half8 _cl_sincos(half8 x0, private half8* x1);
 __attribute__((__overloadable__)) half16 _cl_sincos(half16 x0, global half16* x1);
 __attribute__((__overloadable__)) half16 _cl_sincos(half16 x0, local half16* x1);
 __attribute__((__overloadable__)) half16 _cl_sincos(half16 x0, private half16* x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_sincos(float x0, global float* x1);
 __attribute__((__overloadable__)) float _cl_sincos(float x0, local float* x1);
 __attribute__((__overloadable__)) float _cl_sincos(float x0, private float* x1);
@@ -3203,6 +3481,7 @@ __attribute__((__overloadable__)) float8 _cl_sincos(float8 x0, private float8* x
 __attribute__((__overloadable__)) float16 _cl_sincos(float16 x0, global float16* x1);
 __attribute__((__overloadable__)) float16 _cl_sincos(float16 x0, local float16* x1);
 __attribute__((__overloadable__)) float16 _cl_sincos(float16 x0, private float16* x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_sincos(double x0, global double* x1);
 __attribute__((__overloadable__)) double _cl_sincos(double x0, local double* x1);
 __attribute__((__overloadable__)) double _cl_sincos(double x0, private double* x1);
@@ -3221,50 +3500,59 @@ __attribute__((__overloadable__)) double8 _cl_sincos(double8 x0, private double8
 __attribute__((__overloadable__)) double16 _cl_sincos(double16 x0, global double16* x1);
 __attribute__((__overloadable__)) double16 _cl_sincos(double16 x0, local double16* x1);
 __attribute__((__overloadable__)) double16 _cl_sincos(double16 x0, private double16* x1);
+#endif // #ifdef cl_khr_fp64
 
 // sinpi: ['VF'] -> VF
 #undef sinpi
 #define sinpi _cl_sinpi
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_sinpi(half x0);
 __attribute__((__overloadable__)) half2 _cl_sinpi(half2 x0);
 __attribute__((__overloadable__)) half3 _cl_sinpi(half3 x0);
 __attribute__((__overloadable__)) half4 _cl_sinpi(half4 x0);
 __attribute__((__overloadable__)) half8 _cl_sinpi(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_sinpi(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_sinpi(float x0);
 __attribute__((__overloadable__)) float2 _cl_sinpi(float2 x0);
 __attribute__((__overloadable__)) float3 _cl_sinpi(float3 x0);
 __attribute__((__overloadable__)) float4 _cl_sinpi(float4 x0);
 __attribute__((__overloadable__)) float8 _cl_sinpi(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_sinpi(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_sinpi(double x0);
 __attribute__((__overloadable__)) double2 _cl_sinpi(double2 x0);
 __attribute__((__overloadable__)) double3 _cl_sinpi(double3 x0);
 __attribute__((__overloadable__)) double4 _cl_sinpi(double4 x0);
 __attribute__((__overloadable__)) double8 _cl_sinpi(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_sinpi(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // tanpi: ['VF'] -> VF
 #undef tanpi
 #define tanpi _cl_tanpi
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_tanpi(half x0);
 __attribute__((__overloadable__)) half2 _cl_tanpi(half2 x0);
 __attribute__((__overloadable__)) half3 _cl_tanpi(half3 x0);
 __attribute__((__overloadable__)) half4 _cl_tanpi(half4 x0);
 __attribute__((__overloadable__)) half8 _cl_tanpi(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_tanpi(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_tanpi(float x0);
 __attribute__((__overloadable__)) float2 _cl_tanpi(float2 x0);
 __attribute__((__overloadable__)) float3 _cl_tanpi(float3 x0);
 __attribute__((__overloadable__)) float4 _cl_tanpi(float4 x0);
 __attribute__((__overloadable__)) float8 _cl_tanpi(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_tanpi(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_tanpi(double x0);
 __attribute__((__overloadable__)) double2 _cl_tanpi(double2 x0);
 __attribute__((__overloadable__)) double3 _cl_tanpi(double3 x0);
 __attribute__((__overloadable__)) double4 _cl_tanpi(double4 x0);
 __attribute__((__overloadable__)) double8 _cl_tanpi(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_tanpi(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // half_cos: ['VF'] -> VF
 #undef half_cos
@@ -3549,511 +3837,607 @@ __attribute__((__overloadable__)) float16 _cl_native_tan(float16 x0);
 // clamp: ['VF', 'VF', 'VF'] -> VF
 #undef clamp
 #define clamp _cl_clamp
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_clamp(half x0, half x1, half x2);
 __attribute__((__overloadable__)) half2 _cl_clamp(half2 x0, half2 x1, half2 x2);
 __attribute__((__overloadable__)) half3 _cl_clamp(half3 x0, half3 x1, half3 x2);
 __attribute__((__overloadable__)) half4 _cl_clamp(half4 x0, half4 x1, half4 x2);
 __attribute__((__overloadable__)) half8 _cl_clamp(half8 x0, half8 x1, half8 x2);
 __attribute__((__overloadable__)) half16 _cl_clamp(half16 x0, half16 x1, half16 x2);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_clamp(float x0, float x1, float x2);
 __attribute__((__overloadable__)) float2 _cl_clamp(float2 x0, float2 x1, float2 x2);
 __attribute__((__overloadable__)) float3 _cl_clamp(float3 x0, float3 x1, float3 x2);
 __attribute__((__overloadable__)) float4 _cl_clamp(float4 x0, float4 x1, float4 x2);
 __attribute__((__overloadable__)) float8 _cl_clamp(float8 x0, float8 x1, float8 x2);
 __attribute__((__overloadable__)) float16 _cl_clamp(float16 x0, float16 x1, float16 x2);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_clamp(double x0, double x1, double x2);
 __attribute__((__overloadable__)) double2 _cl_clamp(double2 x0, double2 x1, double2 x2);
 __attribute__((__overloadable__)) double3 _cl_clamp(double3 x0, double3 x1, double3 x2);
 __attribute__((__overloadable__)) double4 _cl_clamp(double4 x0, double4 x1, double4 x2);
 __attribute__((__overloadable__)) double8 _cl_clamp(double8 x0, double8 x1, double8 x2);
 __attribute__((__overloadable__)) double16 _cl_clamp(double16 x0, double16 x1, double16 x2);
+#endif // #ifdef cl_khr_fp64
 
 // clamp: ['VF', 'SF', 'SF'] -> VF
 #undef clamp
 #define clamp _cl_clamp
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half2 _cl_clamp(half2 x0, half x1, half x2);
 __attribute__((__overloadable__)) half3 _cl_clamp(half3 x0, half x1, half x2);
 __attribute__((__overloadable__)) half4 _cl_clamp(half4 x0, half x1, half x2);
 __attribute__((__overloadable__)) half8 _cl_clamp(half8 x0, half x1, half x2);
 __attribute__((__overloadable__)) half16 _cl_clamp(half16 x0, half x1, half x2);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float2 _cl_clamp(float2 x0, float x1, float x2);
 __attribute__((__overloadable__)) float3 _cl_clamp(float3 x0, float x1, float x2);
 __attribute__((__overloadable__)) float4 _cl_clamp(float4 x0, float x1, float x2);
 __attribute__((__overloadable__)) float8 _cl_clamp(float8 x0, float x1, float x2);
 __attribute__((__overloadable__)) float16 _cl_clamp(float16 x0, float x1, float x2);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double2 _cl_clamp(double2 x0, double x1, double x2);
 __attribute__((__overloadable__)) double3 _cl_clamp(double3 x0, double x1, double x2);
 __attribute__((__overloadable__)) double4 _cl_clamp(double4 x0, double x1, double x2);
 __attribute__((__overloadable__)) double8 _cl_clamp(double8 x0, double x1, double x2);
 __attribute__((__overloadable__)) double16 _cl_clamp(double16 x0, double x1, double x2);
+#endif // #ifdef cl_khr_fp64
 
 // degrees: ['VF'] -> VF
 #undef degrees
 #define degrees _cl_degrees
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_degrees(half x0);
 __attribute__((__overloadable__)) half2 _cl_degrees(half2 x0);
 __attribute__((__overloadable__)) half3 _cl_degrees(half3 x0);
 __attribute__((__overloadable__)) half4 _cl_degrees(half4 x0);
 __attribute__((__overloadable__)) half8 _cl_degrees(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_degrees(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_degrees(float x0);
 __attribute__((__overloadable__)) float2 _cl_degrees(float2 x0);
 __attribute__((__overloadable__)) float3 _cl_degrees(float3 x0);
 __attribute__((__overloadable__)) float4 _cl_degrees(float4 x0);
 __attribute__((__overloadable__)) float8 _cl_degrees(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_degrees(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_degrees(double x0);
 __attribute__((__overloadable__)) double2 _cl_degrees(double2 x0);
 __attribute__((__overloadable__)) double3 _cl_degrees(double3 x0);
 __attribute__((__overloadable__)) double4 _cl_degrees(double4 x0);
 __attribute__((__overloadable__)) double8 _cl_degrees(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_degrees(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // max: ['VF', 'VF'] -> VF
 #undef max
 #define max _cl_max
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_max(half x0, half x1);
 __attribute__((__overloadable__)) half2 _cl_max(half2 x0, half2 x1);
 __attribute__((__overloadable__)) half3 _cl_max(half3 x0, half3 x1);
 __attribute__((__overloadable__)) half4 _cl_max(half4 x0, half4 x1);
 __attribute__((__overloadable__)) half8 _cl_max(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_max(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_max(float x0, float x1);
 __attribute__((__overloadable__)) float2 _cl_max(float2 x0, float2 x1);
 __attribute__((__overloadable__)) float3 _cl_max(float3 x0, float3 x1);
 __attribute__((__overloadable__)) float4 _cl_max(float4 x0, float4 x1);
 __attribute__((__overloadable__)) float8 _cl_max(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_max(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_max(double x0, double x1);
 __attribute__((__overloadable__)) double2 _cl_max(double2 x0, double2 x1);
 __attribute__((__overloadable__)) double3 _cl_max(double3 x0, double3 x1);
 __attribute__((__overloadable__)) double4 _cl_max(double4 x0, double4 x1);
 __attribute__((__overloadable__)) double8 _cl_max(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_max(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // max: ['VF', 'SF'] -> VF
 #undef max
 #define max _cl_max
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half2 _cl_max(half2 x0, half x1);
 __attribute__((__overloadable__)) half3 _cl_max(half3 x0, half x1);
 __attribute__((__overloadable__)) half4 _cl_max(half4 x0, half x1);
 __attribute__((__overloadable__)) half8 _cl_max(half8 x0, half x1);
 __attribute__((__overloadable__)) half16 _cl_max(half16 x0, half x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float2 _cl_max(float2 x0, float x1);
 __attribute__((__overloadable__)) float3 _cl_max(float3 x0, float x1);
 __attribute__((__overloadable__)) float4 _cl_max(float4 x0, float x1);
 __attribute__((__overloadable__)) float8 _cl_max(float8 x0, float x1);
 __attribute__((__overloadable__)) float16 _cl_max(float16 x0, float x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double2 _cl_max(double2 x0, double x1);
 __attribute__((__overloadable__)) double3 _cl_max(double3 x0, double x1);
 __attribute__((__overloadable__)) double4 _cl_max(double4 x0, double x1);
 __attribute__((__overloadable__)) double8 _cl_max(double8 x0, double x1);
 __attribute__((__overloadable__)) double16 _cl_max(double16 x0, double x1);
+#endif // #ifdef cl_khr_fp64
 
 // min: ['VF', 'VF'] -> VF
 #undef min
 #define min _cl_min
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_min(half x0, half x1);
 __attribute__((__overloadable__)) half2 _cl_min(half2 x0, half2 x1);
 __attribute__((__overloadable__)) half3 _cl_min(half3 x0, half3 x1);
 __attribute__((__overloadable__)) half4 _cl_min(half4 x0, half4 x1);
 __attribute__((__overloadable__)) half8 _cl_min(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_min(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_min(float x0, float x1);
 __attribute__((__overloadable__)) float2 _cl_min(float2 x0, float2 x1);
 __attribute__((__overloadable__)) float3 _cl_min(float3 x0, float3 x1);
 __attribute__((__overloadable__)) float4 _cl_min(float4 x0, float4 x1);
 __attribute__((__overloadable__)) float8 _cl_min(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_min(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_min(double x0, double x1);
 __attribute__((__overloadable__)) double2 _cl_min(double2 x0, double2 x1);
 __attribute__((__overloadable__)) double3 _cl_min(double3 x0, double3 x1);
 __attribute__((__overloadable__)) double4 _cl_min(double4 x0, double4 x1);
 __attribute__((__overloadable__)) double8 _cl_min(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_min(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // min: ['VF', 'SF'] -> VF
 #undef min
 #define min _cl_min
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half2 _cl_min(half2 x0, half x1);
 __attribute__((__overloadable__)) half3 _cl_min(half3 x0, half x1);
 __attribute__((__overloadable__)) half4 _cl_min(half4 x0, half x1);
 __attribute__((__overloadable__)) half8 _cl_min(half8 x0, half x1);
 __attribute__((__overloadable__)) half16 _cl_min(half16 x0, half x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float2 _cl_min(float2 x0, float x1);
 __attribute__((__overloadable__)) float3 _cl_min(float3 x0, float x1);
 __attribute__((__overloadable__)) float4 _cl_min(float4 x0, float x1);
 __attribute__((__overloadable__)) float8 _cl_min(float8 x0, float x1);
 __attribute__((__overloadable__)) float16 _cl_min(float16 x0, float x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double2 _cl_min(double2 x0, double x1);
 __attribute__((__overloadable__)) double3 _cl_min(double3 x0, double x1);
 __attribute__((__overloadable__)) double4 _cl_min(double4 x0, double x1);
 __attribute__((__overloadable__)) double8 _cl_min(double8 x0, double x1);
 __attribute__((__overloadable__)) double16 _cl_min(double16 x0, double x1);
+#endif // #ifdef cl_khr_fp64
 
 // mix: ['VF', 'VF', 'VF'] -> VF
 #undef mix
 #define mix _cl_mix
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_mix(half x0, half x1, half x2);
 __attribute__((__overloadable__)) half2 _cl_mix(half2 x0, half2 x1, half2 x2);
 __attribute__((__overloadable__)) half3 _cl_mix(half3 x0, half3 x1, half3 x2);
 __attribute__((__overloadable__)) half4 _cl_mix(half4 x0, half4 x1, half4 x2);
 __attribute__((__overloadable__)) half8 _cl_mix(half8 x0, half8 x1, half8 x2);
 __attribute__((__overloadable__)) half16 _cl_mix(half16 x0, half16 x1, half16 x2);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_mix(float x0, float x1, float x2);
 __attribute__((__overloadable__)) float2 _cl_mix(float2 x0, float2 x1, float2 x2);
 __attribute__((__overloadable__)) float3 _cl_mix(float3 x0, float3 x1, float3 x2);
 __attribute__((__overloadable__)) float4 _cl_mix(float4 x0, float4 x1, float4 x2);
 __attribute__((__overloadable__)) float8 _cl_mix(float8 x0, float8 x1, float8 x2);
 __attribute__((__overloadable__)) float16 _cl_mix(float16 x0, float16 x1, float16 x2);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_mix(double x0, double x1, double x2);
 __attribute__((__overloadable__)) double2 _cl_mix(double2 x0, double2 x1, double2 x2);
 __attribute__((__overloadable__)) double3 _cl_mix(double3 x0, double3 x1, double3 x2);
 __attribute__((__overloadable__)) double4 _cl_mix(double4 x0, double4 x1, double4 x2);
 __attribute__((__overloadable__)) double8 _cl_mix(double8 x0, double8 x1, double8 x2);
 __attribute__((__overloadable__)) double16 _cl_mix(double16 x0, double16 x1, double16 x2);
+#endif // #ifdef cl_khr_fp64
 
 // mix: ['VF', 'VF', 'SF'] -> VF
 #undef mix
 #define mix _cl_mix
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half2 _cl_mix(half2 x0, half2 x1, half x2);
 __attribute__((__overloadable__)) half3 _cl_mix(half3 x0, half3 x1, half x2);
 __attribute__((__overloadable__)) half4 _cl_mix(half4 x0, half4 x1, half x2);
 __attribute__((__overloadable__)) half8 _cl_mix(half8 x0, half8 x1, half x2);
 __attribute__((__overloadable__)) half16 _cl_mix(half16 x0, half16 x1, half x2);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float2 _cl_mix(float2 x0, float2 x1, float x2);
 __attribute__((__overloadable__)) float3 _cl_mix(float3 x0, float3 x1, float x2);
 __attribute__((__overloadable__)) float4 _cl_mix(float4 x0, float4 x1, float x2);
 __attribute__((__overloadable__)) float8 _cl_mix(float8 x0, float8 x1, float x2);
 __attribute__((__overloadable__)) float16 _cl_mix(float16 x0, float16 x1, float x2);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double2 _cl_mix(double2 x0, double2 x1, double x2);
 __attribute__((__overloadable__)) double3 _cl_mix(double3 x0, double3 x1, double x2);
 __attribute__((__overloadable__)) double4 _cl_mix(double4 x0, double4 x1, double x2);
 __attribute__((__overloadable__)) double8 _cl_mix(double8 x0, double8 x1, double x2);
 __attribute__((__overloadable__)) double16 _cl_mix(double16 x0, double16 x1, double x2);
+#endif // #ifdef cl_khr_fp64
 
 // radians: ['VF'] -> VF
 #undef radians
 #define radians _cl_radians
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_radians(half x0);
 __attribute__((__overloadable__)) half2 _cl_radians(half2 x0);
 __attribute__((__overloadable__)) half3 _cl_radians(half3 x0);
 __attribute__((__overloadable__)) half4 _cl_radians(half4 x0);
 __attribute__((__overloadable__)) half8 _cl_radians(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_radians(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_radians(float x0);
 __attribute__((__overloadable__)) float2 _cl_radians(float2 x0);
 __attribute__((__overloadable__)) float3 _cl_radians(float3 x0);
 __attribute__((__overloadable__)) float4 _cl_radians(float4 x0);
 __attribute__((__overloadable__)) float8 _cl_radians(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_radians(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_radians(double x0);
 __attribute__((__overloadable__)) double2 _cl_radians(double2 x0);
 __attribute__((__overloadable__)) double3 _cl_radians(double3 x0);
 __attribute__((__overloadable__)) double4 _cl_radians(double4 x0);
 __attribute__((__overloadable__)) double8 _cl_radians(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_radians(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // step: ['VF', 'VF'] -> VF
 #undef step
 #define step _cl_step
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_step(half x0, half x1);
 __attribute__((__overloadable__)) half2 _cl_step(half2 x0, half2 x1);
 __attribute__((__overloadable__)) half3 _cl_step(half3 x0, half3 x1);
 __attribute__((__overloadable__)) half4 _cl_step(half4 x0, half4 x1);
 __attribute__((__overloadable__)) half8 _cl_step(half8 x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_step(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_step(float x0, float x1);
 __attribute__((__overloadable__)) float2 _cl_step(float2 x0, float2 x1);
 __attribute__((__overloadable__)) float3 _cl_step(float3 x0, float3 x1);
 __attribute__((__overloadable__)) float4 _cl_step(float4 x0, float4 x1);
 __attribute__((__overloadable__)) float8 _cl_step(float8 x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_step(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_step(double x0, double x1);
 __attribute__((__overloadable__)) double2 _cl_step(double2 x0, double2 x1);
 __attribute__((__overloadable__)) double3 _cl_step(double3 x0, double3 x1);
 __attribute__((__overloadable__)) double4 _cl_step(double4 x0, double4 x1);
 __attribute__((__overloadable__)) double8 _cl_step(double8 x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_step(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // step: ['SF', 'VF'] -> VF
 #undef step
 #define step _cl_step
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half2 _cl_step(half x0, half2 x1);
 __attribute__((__overloadable__)) half3 _cl_step(half x0, half3 x1);
 __attribute__((__overloadable__)) half4 _cl_step(half x0, half4 x1);
 __attribute__((__overloadable__)) half8 _cl_step(half x0, half8 x1);
 __attribute__((__overloadable__)) half16 _cl_step(half x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float2 _cl_step(float x0, float2 x1);
 __attribute__((__overloadable__)) float3 _cl_step(float x0, float3 x1);
 __attribute__((__overloadable__)) float4 _cl_step(float x0, float4 x1);
 __attribute__((__overloadable__)) float8 _cl_step(float x0, float8 x1);
 __attribute__((__overloadable__)) float16 _cl_step(float x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double2 _cl_step(double x0, double2 x1);
 __attribute__((__overloadable__)) double3 _cl_step(double x0, double3 x1);
 __attribute__((__overloadable__)) double4 _cl_step(double x0, double4 x1);
 __attribute__((__overloadable__)) double8 _cl_step(double x0, double8 x1);
 __attribute__((__overloadable__)) double16 _cl_step(double x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // smoothstep: ['VF', 'VF', 'VF'] -> VF
 #undef smoothstep
 #define smoothstep _cl_smoothstep
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_smoothstep(half x0, half x1, half x2);
 __attribute__((__overloadable__)) half2 _cl_smoothstep(half2 x0, half2 x1, half2 x2);
 __attribute__((__overloadable__)) half3 _cl_smoothstep(half3 x0, half3 x1, half3 x2);
 __attribute__((__overloadable__)) half4 _cl_smoothstep(half4 x0, half4 x1, half4 x2);
 __attribute__((__overloadable__)) half8 _cl_smoothstep(half8 x0, half8 x1, half8 x2);
 __attribute__((__overloadable__)) half16 _cl_smoothstep(half16 x0, half16 x1, half16 x2);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_smoothstep(float x0, float x1, float x2);
 __attribute__((__overloadable__)) float2 _cl_smoothstep(float2 x0, float2 x1, float2 x2);
 __attribute__((__overloadable__)) float3 _cl_smoothstep(float3 x0, float3 x1, float3 x2);
 __attribute__((__overloadable__)) float4 _cl_smoothstep(float4 x0, float4 x1, float4 x2);
 __attribute__((__overloadable__)) float8 _cl_smoothstep(float8 x0, float8 x1, float8 x2);
 __attribute__((__overloadable__)) float16 _cl_smoothstep(float16 x0, float16 x1, float16 x2);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_smoothstep(double x0, double x1, double x2);
 __attribute__((__overloadable__)) double2 _cl_smoothstep(double2 x0, double2 x1, double2 x2);
 __attribute__((__overloadable__)) double3 _cl_smoothstep(double3 x0, double3 x1, double3 x2);
 __attribute__((__overloadable__)) double4 _cl_smoothstep(double4 x0, double4 x1, double4 x2);
 __attribute__((__overloadable__)) double8 _cl_smoothstep(double8 x0, double8 x1, double8 x2);
 __attribute__((__overloadable__)) double16 _cl_smoothstep(double16 x0, double16 x1, double16 x2);
+#endif // #ifdef cl_khr_fp64
 
 // smoothstep: ['SF', 'SF', 'VF'] -> VF
 #undef smoothstep
 #define smoothstep _cl_smoothstep
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half2 _cl_smoothstep(half x0, half x1, half2 x2);
 __attribute__((__overloadable__)) half3 _cl_smoothstep(half x0, half x1, half3 x2);
 __attribute__((__overloadable__)) half4 _cl_smoothstep(half x0, half x1, half4 x2);
 __attribute__((__overloadable__)) half8 _cl_smoothstep(half x0, half x1, half8 x2);
 __attribute__((__overloadable__)) half16 _cl_smoothstep(half x0, half x1, half16 x2);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float2 _cl_smoothstep(float x0, float x1, float2 x2);
 __attribute__((__overloadable__)) float3 _cl_smoothstep(float x0, float x1, float3 x2);
 __attribute__((__overloadable__)) float4 _cl_smoothstep(float x0, float x1, float4 x2);
 __attribute__((__overloadable__)) float8 _cl_smoothstep(float x0, float x1, float8 x2);
 __attribute__((__overloadable__)) float16 _cl_smoothstep(float x0, float x1, float16 x2);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double2 _cl_smoothstep(double x0, double x1, double2 x2);
 __attribute__((__overloadable__)) double3 _cl_smoothstep(double x0, double x1, double3 x2);
 __attribute__((__overloadable__)) double4 _cl_smoothstep(double x0, double x1, double4 x2);
 __attribute__((__overloadable__)) double8 _cl_smoothstep(double x0, double x1, double8 x2);
 __attribute__((__overloadable__)) double16 _cl_smoothstep(double x0, double x1, double16 x2);
+#endif // #ifdef cl_khr_fp64
 
 // sign: ['VF'] -> VF
 #undef sign
 #define sign _cl_sign
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) half _cl_sign(half x0);
 __attribute__((__overloadable__)) half2 _cl_sign(half2 x0);
 __attribute__((__overloadable__)) half3 _cl_sign(half3 x0);
 __attribute__((__overloadable__)) half4 _cl_sign(half4 x0);
 __attribute__((__overloadable__)) half8 _cl_sign(half8 x0);
 __attribute__((__overloadable__)) half16 _cl_sign(half16 x0);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) float _cl_sign(float x0);
 __attribute__((__overloadable__)) float2 _cl_sign(float2 x0);
 __attribute__((__overloadable__)) float3 _cl_sign(float3 x0);
 __attribute__((__overloadable__)) float4 _cl_sign(float4 x0);
 __attribute__((__overloadable__)) float8 _cl_sign(float8 x0);
 __attribute__((__overloadable__)) float16 _cl_sign(float16 x0);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) double _cl_sign(double x0);
 __attribute__((__overloadable__)) double2 _cl_sign(double2 x0);
 __attribute__((__overloadable__)) double3 _cl_sign(double3 x0);
 __attribute__((__overloadable__)) double4 _cl_sign(double4 x0);
 __attribute__((__overloadable__)) double8 _cl_sign(double8 x0);
 __attribute__((__overloadable__)) double16 _cl_sign(double16 x0);
+#endif // #ifdef cl_khr_fp64
 
 // isequal: ['VF', 'VF'] -> VJ
 #undef isequal
 #define isequal _cl_isequal
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isequal(half x0, half x1);
 __attribute__((__overloadable__)) short2 _cl_isequal(half2 x0, half2 x1);
 __attribute__((__overloadable__)) short3 _cl_isequal(half3 x0, half3 x1);
 __attribute__((__overloadable__)) short4 _cl_isequal(half4 x0, half4 x1);
 __attribute__((__overloadable__)) short8 _cl_isequal(half8 x0, half8 x1);
 __attribute__((__overloadable__)) short16 _cl_isequal(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isequal(float x0, float x1);
 __attribute__((__overloadable__)) int2 _cl_isequal(float2 x0, float2 x1);
 __attribute__((__overloadable__)) int3 _cl_isequal(float3 x0, float3 x1);
 __attribute__((__overloadable__)) int4 _cl_isequal(float4 x0, float4 x1);
 __attribute__((__overloadable__)) int8 _cl_isequal(float8 x0, float8 x1);
 __attribute__((__overloadable__)) int16 _cl_isequal(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_isequal(double x0, double x1);
 __attribute__((__overloadable__)) long2 _cl_isequal(double2 x0, double2 x1);
 __attribute__((__overloadable__)) long3 _cl_isequal(double3 x0, double3 x1);
 __attribute__((__overloadable__)) long4 _cl_isequal(double4 x0, double4 x1);
 __attribute__((__overloadable__)) long8 _cl_isequal(double8 x0, double8 x1);
 __attribute__((__overloadable__)) long16 _cl_isequal(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // isnotequal: ['VF', 'VF'] -> VJ
 #undef isnotequal
 #define isnotequal _cl_isnotequal
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isnotequal(half x0, half x1);
 __attribute__((__overloadable__)) short2 _cl_isnotequal(half2 x0, half2 x1);
 __attribute__((__overloadable__)) short3 _cl_isnotequal(half3 x0, half3 x1);
 __attribute__((__overloadable__)) short4 _cl_isnotequal(half4 x0, half4 x1);
 __attribute__((__overloadable__)) short8 _cl_isnotequal(half8 x0, half8 x1);
 __attribute__((__overloadable__)) short16 _cl_isnotequal(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isnotequal(float x0, float x1);
 __attribute__((__overloadable__)) int2 _cl_isnotequal(float2 x0, float2 x1);
 __attribute__((__overloadable__)) int3 _cl_isnotequal(float3 x0, float3 x1);
 __attribute__((__overloadable__)) int4 _cl_isnotequal(float4 x0, float4 x1);
 __attribute__((__overloadable__)) int8 _cl_isnotequal(float8 x0, float8 x1);
 __attribute__((__overloadable__)) int16 _cl_isnotequal(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_isnotequal(double x0, double x1);
 __attribute__((__overloadable__)) long2 _cl_isnotequal(double2 x0, double2 x1);
 __attribute__((__overloadable__)) long3 _cl_isnotequal(double3 x0, double3 x1);
 __attribute__((__overloadable__)) long4 _cl_isnotequal(double4 x0, double4 x1);
 __attribute__((__overloadable__)) long8 _cl_isnotequal(double8 x0, double8 x1);
 __attribute__((__overloadable__)) long16 _cl_isnotequal(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // isgreater: ['VF', 'VF'] -> VJ
 #undef isgreater
 #define isgreater _cl_isgreater
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isgreater(half x0, half x1);
 __attribute__((__overloadable__)) short2 _cl_isgreater(half2 x0, half2 x1);
 __attribute__((__overloadable__)) short3 _cl_isgreater(half3 x0, half3 x1);
 __attribute__((__overloadable__)) short4 _cl_isgreater(half4 x0, half4 x1);
 __attribute__((__overloadable__)) short8 _cl_isgreater(half8 x0, half8 x1);
 __attribute__((__overloadable__)) short16 _cl_isgreater(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isgreater(float x0, float x1);
 __attribute__((__overloadable__)) int2 _cl_isgreater(float2 x0, float2 x1);
 __attribute__((__overloadable__)) int3 _cl_isgreater(float3 x0, float3 x1);
 __attribute__((__overloadable__)) int4 _cl_isgreater(float4 x0, float4 x1);
 __attribute__((__overloadable__)) int8 _cl_isgreater(float8 x0, float8 x1);
 __attribute__((__overloadable__)) int16 _cl_isgreater(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_isgreater(double x0, double x1);
 __attribute__((__overloadable__)) long2 _cl_isgreater(double2 x0, double2 x1);
 __attribute__((__overloadable__)) long3 _cl_isgreater(double3 x0, double3 x1);
 __attribute__((__overloadable__)) long4 _cl_isgreater(double4 x0, double4 x1);
 __attribute__((__overloadable__)) long8 _cl_isgreater(double8 x0, double8 x1);
 __attribute__((__overloadable__)) long16 _cl_isgreater(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // isgreaterequal: ['VF', 'VF'] -> VJ
 #undef isgreaterequal
 #define isgreaterequal _cl_isgreaterequal
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isgreaterequal(half x0, half x1);
 __attribute__((__overloadable__)) short2 _cl_isgreaterequal(half2 x0, half2 x1);
 __attribute__((__overloadable__)) short3 _cl_isgreaterequal(half3 x0, half3 x1);
 __attribute__((__overloadable__)) short4 _cl_isgreaterequal(half4 x0, half4 x1);
 __attribute__((__overloadable__)) short8 _cl_isgreaterequal(half8 x0, half8 x1);
 __attribute__((__overloadable__)) short16 _cl_isgreaterequal(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isgreaterequal(float x0, float x1);
 __attribute__((__overloadable__)) int2 _cl_isgreaterequal(float2 x0, float2 x1);
 __attribute__((__overloadable__)) int3 _cl_isgreaterequal(float3 x0, float3 x1);
 __attribute__((__overloadable__)) int4 _cl_isgreaterequal(float4 x0, float4 x1);
 __attribute__((__overloadable__)) int8 _cl_isgreaterequal(float8 x0, float8 x1);
 __attribute__((__overloadable__)) int16 _cl_isgreaterequal(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_isgreaterequal(double x0, double x1);
 __attribute__((__overloadable__)) long2 _cl_isgreaterequal(double2 x0, double2 x1);
 __attribute__((__overloadable__)) long3 _cl_isgreaterequal(double3 x0, double3 x1);
 __attribute__((__overloadable__)) long4 _cl_isgreaterequal(double4 x0, double4 x1);
 __attribute__((__overloadable__)) long8 _cl_isgreaterequal(double8 x0, double8 x1);
 __attribute__((__overloadable__)) long16 _cl_isgreaterequal(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // isless: ['VF', 'VF'] -> VJ
 #undef isless
 #define isless _cl_isless
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isless(half x0, half x1);
 __attribute__((__overloadable__)) short2 _cl_isless(half2 x0, half2 x1);
 __attribute__((__overloadable__)) short3 _cl_isless(half3 x0, half3 x1);
 __attribute__((__overloadable__)) short4 _cl_isless(half4 x0, half4 x1);
 __attribute__((__overloadable__)) short8 _cl_isless(half8 x0, half8 x1);
 __attribute__((__overloadable__)) short16 _cl_isless(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isless(float x0, float x1);
 __attribute__((__overloadable__)) int2 _cl_isless(float2 x0, float2 x1);
 __attribute__((__overloadable__)) int3 _cl_isless(float3 x0, float3 x1);
 __attribute__((__overloadable__)) int4 _cl_isless(float4 x0, float4 x1);
 __attribute__((__overloadable__)) int8 _cl_isless(float8 x0, float8 x1);
 __attribute__((__overloadable__)) int16 _cl_isless(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_isless(double x0, double x1);
 __attribute__((__overloadable__)) long2 _cl_isless(double2 x0, double2 x1);
 __attribute__((__overloadable__)) long3 _cl_isless(double3 x0, double3 x1);
 __attribute__((__overloadable__)) long4 _cl_isless(double4 x0, double4 x1);
 __attribute__((__overloadable__)) long8 _cl_isless(double8 x0, double8 x1);
 __attribute__((__overloadable__)) long16 _cl_isless(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // islessequal: ['VF', 'VF'] -> VJ
 #undef islessequal
 #define islessequal _cl_islessequal
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_islessequal(half x0, half x1);
 __attribute__((__overloadable__)) short2 _cl_islessequal(half2 x0, half2 x1);
 __attribute__((__overloadable__)) short3 _cl_islessequal(half3 x0, half3 x1);
 __attribute__((__overloadable__)) short4 _cl_islessequal(half4 x0, half4 x1);
 __attribute__((__overloadable__)) short8 _cl_islessequal(half8 x0, half8 x1);
 __attribute__((__overloadable__)) short16 _cl_islessequal(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_islessequal(float x0, float x1);
 __attribute__((__overloadable__)) int2 _cl_islessequal(float2 x0, float2 x1);
 __attribute__((__overloadable__)) int3 _cl_islessequal(float3 x0, float3 x1);
 __attribute__((__overloadable__)) int4 _cl_islessequal(float4 x0, float4 x1);
 __attribute__((__overloadable__)) int8 _cl_islessequal(float8 x0, float8 x1);
 __attribute__((__overloadable__)) int16 _cl_islessequal(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_islessequal(double x0, double x1);
 __attribute__((__overloadable__)) long2 _cl_islessequal(double2 x0, double2 x1);
 __attribute__((__overloadable__)) long3 _cl_islessequal(double3 x0, double3 x1);
 __attribute__((__overloadable__)) long4 _cl_islessequal(double4 x0, double4 x1);
 __attribute__((__overloadable__)) long8 _cl_islessequal(double8 x0, double8 x1);
 __attribute__((__overloadable__)) long16 _cl_islessequal(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // islessgreater: ['VF', 'VF'] -> VJ
 #undef islessgreater
 #define islessgreater _cl_islessgreater
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_islessgreater(half x0, half x1);
 __attribute__((__overloadable__)) short2 _cl_islessgreater(half2 x0, half2 x1);
 __attribute__((__overloadable__)) short3 _cl_islessgreater(half3 x0, half3 x1);
 __attribute__((__overloadable__)) short4 _cl_islessgreater(half4 x0, half4 x1);
 __attribute__((__overloadable__)) short8 _cl_islessgreater(half8 x0, half8 x1);
 __attribute__((__overloadable__)) short16 _cl_islessgreater(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_islessgreater(float x0, float x1);
 __attribute__((__overloadable__)) int2 _cl_islessgreater(float2 x0, float2 x1);
 __attribute__((__overloadable__)) int3 _cl_islessgreater(float3 x0, float3 x1);
 __attribute__((__overloadable__)) int4 _cl_islessgreater(float4 x0, float4 x1);
 __attribute__((__overloadable__)) int8 _cl_islessgreater(float8 x0, float8 x1);
 __attribute__((__overloadable__)) int16 _cl_islessgreater(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_islessgreater(double x0, double x1);
 __attribute__((__overloadable__)) long2 _cl_islessgreater(double2 x0, double2 x1);
 __attribute__((__overloadable__)) long3 _cl_islessgreater(double3 x0, double3 x1);
 __attribute__((__overloadable__)) long4 _cl_islessgreater(double4 x0, double4 x1);
 __attribute__((__overloadable__)) long8 _cl_islessgreater(double8 x0, double8 x1);
 __attribute__((__overloadable__)) long16 _cl_islessgreater(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // isordered: ['VF', 'VF'] -> VJ
 #undef isordered
 #define isordered _cl_isordered
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isordered(half x0, half x1);
 __attribute__((__overloadable__)) short2 _cl_isordered(half2 x0, half2 x1);
 __attribute__((__overloadable__)) short3 _cl_isordered(half3 x0, half3 x1);
 __attribute__((__overloadable__)) short4 _cl_isordered(half4 x0, half4 x1);
 __attribute__((__overloadable__)) short8 _cl_isordered(half8 x0, half8 x1);
 __attribute__((__overloadable__)) short16 _cl_isordered(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isordered(float x0, float x1);
 __attribute__((__overloadable__)) int2 _cl_isordered(float2 x0, float2 x1);
 __attribute__((__overloadable__)) int3 _cl_isordered(float3 x0, float3 x1);
 __attribute__((__overloadable__)) int4 _cl_isordered(float4 x0, float4 x1);
 __attribute__((__overloadable__)) int8 _cl_isordered(float8 x0, float8 x1);
 __attribute__((__overloadable__)) int16 _cl_isordered(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_isordered(double x0, double x1);
 __attribute__((__overloadable__)) long2 _cl_isordered(double2 x0, double2 x1);
 __attribute__((__overloadable__)) long3 _cl_isordered(double3 x0, double3 x1);
 __attribute__((__overloadable__)) long4 _cl_isordered(double4 x0, double4 x1);
 __attribute__((__overloadable__)) long8 _cl_isordered(double8 x0, double8 x1);
 __attribute__((__overloadable__)) long16 _cl_isordered(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 // isunordered: ['VF', 'VF'] -> VJ
 #undef isunordered
 #define isunordered _cl_isunordered
+#ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isunordered(half x0, half x1);
 __attribute__((__overloadable__)) short2 _cl_isunordered(half2 x0, half2 x1);
 __attribute__((__overloadable__)) short3 _cl_isunordered(half3 x0, half3 x1);
 __attribute__((__overloadable__)) short4 _cl_isunordered(half4 x0, half4 x1);
 __attribute__((__overloadable__)) short8 _cl_isunordered(half8 x0, half8 x1);
 __attribute__((__overloadable__)) short16 _cl_isunordered(half16 x0, half16 x1);
+#endif // #ifdef cl_khr_fp16
 __attribute__((__overloadable__)) int _cl_isunordered(float x0, float x1);
 __attribute__((__overloadable__)) int2 _cl_isunordered(float2 x0, float2 x1);
 __attribute__((__overloadable__)) int3 _cl_isunordered(float3 x0, float3 x1);
 __attribute__((__overloadable__)) int4 _cl_isunordered(float4 x0, float4 x1);
 __attribute__((__overloadable__)) int8 _cl_isunordered(float8 x0, float8 x1);
 __attribute__((__overloadable__)) int16 _cl_isunordered(float16 x0, float16 x1);
+#ifdef cl_khr_fp64
 __attribute__((__overloadable__)) int _cl_isunordered(double x0, double x1);
 __attribute__((__overloadable__)) long2 _cl_isunordered(double2 x0, double2 x1);
 __attribute__((__overloadable__)) long3 _cl_isunordered(double3 x0, double3 x1);
 __attribute__((__overloadable__)) long4 _cl_isunordered(double4 x0, double4 x1);
 __attribute__((__overloadable__)) long8 _cl_isunordered(double8 x0, double8 x1);
 __attribute__((__overloadable__)) long16 _cl_isunordered(double16 x0, double16 x1);
+#endif // #ifdef cl_khr_fp64
 
 #endif // #ifndef KERNEL_VECMATHLIB_H


### PR DESCRIPTION
This should not lead to any user-visible changes since `kernel-vecmathlib.h` is not used anywhere yet.

In principle, this file could be included from `_kernel.h` instead of most of the #define-based declarations.