### PR TITLE
[cmake] Make it possible to override CL_DISABLE_HALF.

### DIFF
--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -650,9 +650,7 @@ set_cache_var(CL_DISABLE_LONG "Disable cl_khr_int64 because of buggy llvm")
 
 ####################################################################
 
-setup_cache_var_name(CL_DISABLE_HALF "CL_DISABLE_HALF-${LLVM_HOST_TARGET}-${CLANG}")
-
-if(NOT DEFINED ${CACHE_VAR_NAME})
+if(NOT DEFINED ${CL_DISABLE_HALF})
   set(CL_DISABLE_HALF 0)
   # TODO -march=CPU flags !
   custom_try_compile_c_cxx("${CLANG}" "c" "__fp16 callfp16(__fp16 a) { return a * (__fp16)1.8; };" "__fp16 x=callfp16((__fp16)argc);" RESV -c ${CLANG_TARGET_OPTION}${LLC_TRIPLE} ${CLANG_MARCH_FLAG}${LLC_HOST_CPU})
@@ -661,4 +659,4 @@ if(NOT DEFINED ${CACHE_VAR_NAME})
   endif()
 endif()
 
-set_cache_var(CL_DISABLE_HALF "Disable cl_khr_fp16 because fp16 is not supported")
+set(CL_DISABLE_HALF "${CL_DISABLE_HALF}" CACHE BOOL "Disable cl_khr_fp16 because fp16 is not supported")


### PR DESCRIPTION
I suspect the check is currently wrong. It seems to be checking whether C
allows half precision types in arguments and returns. On Mips, this is not
currently allowed. However, I suspect OpenCL allows this regardless of
target. Regardless of the truth of the matter, we should be able to forcefully
enable half precision types in pocl.

This patch removes the unconventional caching mechanism for
CL_DISABLE_HALF in favour of cmake's usual method which allows the user
to specify it with -DCL_DISABLE_HALF=ON/OFF.