### PR TITLE
Fix devel-envs.sh for cmake.

### DIFF
--- a/doc/sphinx/source/development.rst
+++ b/doc/sphinx/source/development.rst
@@ -160,7 +160,9 @@ POCL_BUILDING setups the OCL_ICD_VENDORS path to point to the pocl in
 the build tree. This removes the need to install pocl to test the 
 built version. It should be executed in the source root::
 
-  . tools/scripts/devel-envs.sh
+  . tools/scripts/devel-envs.sh [cmake]
+
+The ``cmake`` argument is required when pocl is built with cmake.
 
 To test as much as possible link options, it is recommended to
 configure pocl two times and run "make check" with both. One should be

--- a/tools/scripts/devel-envs.sh
+++ b/tools/scripts/devel-envs.sh
@@ -1,3 +1,9 @@
+if [ "$1" = "cmake" ]; then
+  libs_subdir=.
+else
+  libs_subdir=.libs
+fi
+
 # source this while in the pocl build dir
 export POCL_BUILDING=1
 export OCL_ICD_VENDORS=$PWD/ocl-vendors
@@ -8,12 +14,12 @@ export OPENCL_VENDOR_PATH=$OCL_ICD_VENDORS
 #pocl test-cases don't link against pthreads, but libpocl does.
 #this confuses gdb, unless we preload libpthread
 #If libpocl is not built yet, this will fail...
-export LD_PRELOAD=$(ldd lib/CL/.libs/libpocl.so | grep pthread | cut -f 3 -d' ')
+export LD_PRELOAD=$(ldd lib/CL/$libs_subdir/libpocl.so | grep pthread | cut -f 3 -d' ')
 
 #make sure we use the new built pocl, not some installed version.
 #also, this is needed if the test binaries are run in gdb without the wrapper
 #shell script automake generates
-export LD_LIBRARY_PATH=$PWD/lib/CL/.libs:$PWD/lib/poclu/.libs/:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$PWD/lib/CL/$libs_subdir:$PWD/lib/poclu/$libs_subdir/:$LD_LIBRARY_PATH
 
 #sometimes useful variable when ICD fails (and we use ocl-icd)
 #export OCL_ICD_DEBUG=15


### PR DESCRIPTION
CMake builds don't have a .libs directory. This change adds an optional
'cmake' argument that causes the script to work for cmake builds.