### PR TITLE
Substitute spir-* triples for the default target triple so that Address Spaces are lowered correctly.

### DIFF
--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -675,6 +675,7 @@ int pocl_llvm_get_kernel_metadata(cl_program program,
       return 1;
     }
 
+  input->setTargetTriple(program->devices[device_i]->llvm_target_triplet);
 
 #ifdef DEBUG_POCL_LLVM_API        
   printf("### fetching kernel metadata for kernel %s program %p input llvm::Module %p\n",


### PR DESCRIPTION
The root of the problem is that the spir-* triple does not indicate the underlying
target architecture and the lowering of address spaces is therefore skipped
when the target is MIPS.

This fixes example1-spir32 for MIPS.