### PR TITLE
Update test to use cl2.hpp

### DIFF
--- a/tests/regression/test_issue_231.cpp
+++ b/tests/regression/test_issue_231.cpp
@@ -2,8 +2,10 @@
 // Used to cause an LLVM crash with Haswell/Broadwell.
 // See https://github.com/pocl/pocl/issues/231
 
-#define __CL_ENABLE_EXCEPTIONS
-#include <CL/cl.hpp>
+#define CL_HPP_ENABLE_EXCEPTIONS
+#define CL_HPP_MINIMUM_OPENCL_VERSION 120
+#define CL_HPP_TARGET_OPENCL_VERSION 120
+#include <CL/cl2.hpp>
 #include <iostream>
 
 using namespace std;
@@ -80,7 +82,7 @@ int main(int argc, char *argv[])
   cl::CommandQueue queue = cl::CommandQueue::getDefault();
   cl::Program program(SOURCE, true);
 
-  auto kernel = cl::make_kernel<cl::Buffer, cl::Buffer, cl::Buffer, cl_int, cl_int, cl::Buffer>(program, "scan_scan_intervals_lev1");
+  auto kernel = cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer, cl_int, cl_int, cl::Buffer>(program, "scan_scan_intervals_lev1");
 
   cl_int i;
   cl::Buffer buffer;


### PR DESCRIPTION
A regression test added recently uses the old `cl.hpp` header, which requires OpenGL headers. This is just a minor update to use `cl2.hpp` instead, which matches the other C++ tests and removes the OpenGL dependency.
