### PR TITLE
Update cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,10 +22,6 @@ config/ltmain.sh
 config/missing
 configure
 examples/EinsteinToolkit/EinsteinToolkit
-examples/ViennaCL
-examples/AMD
-examples/AMDSDK2.9
-examples/piglit
 examples/example1/example1
 examples/example1-spir32/example1-spir32
 examples/example1-spir64/example1-spir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,41 +655,61 @@ set(OCL_KERNEL_TARGET_CPU "${LLC_HOST_CPU}") #The kernel target CPU variant.
 
 if(NOT DEFINED DEFAULT_ENABLE_TCE)
 
-  # THESE are only used in makefile.am & scripts/pocl*
-  set(TCE_TARGET_CLANG_FLAGS "" CACHE STRING "Extra parameters to Clang for TCE compilation.")
-
-  set(TCE_TARGET_LLC_FLAGS "" CACHE STRING "Extra parameters to LLVM's llc for TCE compilation.")
-
-  find_program(TCE_CONFIG NAMES "tce-config")
-  if(TCE_CONFIG)
-
-    find_program(TCECC NAMES "tcecc")
-    set(TCE_USABLE 1)
-
+  if (NOT WITH_TCE)
+    set(WITH_TCE ENV PATH)
   endif()
 
-  if(TCE_CONFIG AND TCECC AND TCE_USABLE)
+  # THESE are only used in makefile.am & scripts/pocl*
+  set(TCE_TARGET_CLANG_FLAGS "" CACHE STRING "Extra parameters to Clang for TCE compilation.")
+  set(TCE_TARGET_LLC_FLAGS "" CACHE STRING "Extra parameters to LLVM's llc for TCE compilation.")
 
-    execute_process(COMMAND "${TCE_CONFIG}" --libs OUTPUT_VARIABLE TCE_LIBS RESULT_VARIABLE RESV)
+  find_program(TCE_CONFIG NAMES "tce-config" HINTS ${WITH_TCE})
+  find_program(TCECC NAMES "tcecc" HINTS ${WITH_TCE})
+  find_program(TTASIM NAMES "ttasim" HINTS ${WITH_TCE})
+
+  if(TCE_CONFIG AND TCECC AND TTASIM)
+
+    message(STATUS "Found tcecc + tce-config + ttasim, testing setup")
+
+    execute_process(COMMAND "${TCE_CONFIG}" --libs OUTPUT_VARIABLE TCE_LIBS RESULT_VARIABLE RESV1)
+    execute_process(COMMAND "${TCE_CONFIG}" --includes OUTPUT_VARIABLE TCE_INCLUDES RESULT_VARIABLE RESV2)
+    execute_process(COMMAND "${TCE_CONFIG}" --version OUTPUT_VARIABLE TCE_VERSION RESULT_VARIABLE RESV3)
+    execute_process(COMMAND "${TCE_CONFIG}" --cxxflags OUTPUT_VARIABLE TCE_CXXFLAGS RESULT_VARIABLE RESV4)
+    execute_process(COMMAND "${TCE_CONFIG}" --prefix OUTPUT_VARIABLE TCE_PREFIX RESULT_VARIABLE RESV5)
+    execute_process(COMMAND "${TTASIM}" --help OUTPUT_VARIABLE TTASIM_HELP RESULT_VARIABLE RESV9)
+
+    if (RESV1 OR RESV2 OR RESV3 OR RESV4 OR RESV5)
+      message(FATAL_ERROR "tce-config: Nonzero exit status")
+    endif()
+    if (RESV9)
+      message(FATAL_ERROR "ttasim: Nonzero exit status")
+    endif()
+
     string(STRIP "${TCE_LIBS}" TCE_LIBS)
+    separate_arguments(TCE_LIBS)
+    string(STRIP "${TCE_INCLUDES}" TCE_INCLUDES)
+    separate_arguments(TCE_INCLUDES)
+    string(STRIP "${TCE_CXXFLAGS}" TCE_CXXFLAGS)
+    separate_arguments(TCE_CXXFLAGS)
+    string(STRIP "${TCE_VERSION}" TCE_VERSION)
+    string(STRIP "${TCE_PREFIX}" TCE_PREFIX)
+
     set(TCE_LIBS "${TCE_LIBS}" CACHE INTERNAL "tce-config --libs")
+    set(TCE_INCLUDES "${TCE_INCLUDES}" CACHE INTERNAL "tce-config --includes")
+    set(TCE_VERSION "${TCE_VERSION}" CACHE INTERNAL "tce-config --version")
+    set(TCE_CXXFLAGS "${TCE_CXXFLAGS}" CACHE INTERNAL "tce-config --cxxflags")
+    set(TCE_PREFIX "${TCE_PREFIX}" CACHE INTERNAL "tce-config --prefix")
+
     # TODO
     set(LD_FLAGS_BIN ${LD_FLAGS_BIN} ${TCE_LIBS})
 
-    execute_process(COMMAND "${TCE_CONFIG}" --includes OUTPUT_VARIABLE TCE_INCLUDES RESULT_VARIABLE RESV)
-    string(STRIP "${TCE_INCLUDES}" TCE_INCLUDES)
-    set(TCE_INCLUDES "${TCE_INCLUDES}" CACHE INTERNAL "tce-config --includes")
-
-    execute_process(COMMAND "${TCE_CONFIG}" --version OUTPUT_VARIABLE TCE_VERSION RESULT_VARIABLE RESV)
-    set(TCE_VERSION "${TCE_VERSION}" CACHE INTERNAL "tce-config --version")
-
     set(DEFAULT_ENABLE_TCE 1 CACHE INTERNAL "TCE available")
-
     if(TCE_VERSION MATCHES "trunk")
       set(DEFAULT_ENABLE_TCEMC 1 CACHE INTERNAL "TCEMC available")
     endif()
 
   else()
+    message(STATUS "Failed to find tcecc or tce-config, disabling TCE")
     set(DEFAULT_ENABLE_TCE 0 CACHE INTERNAL "TCE available")
     set(DEFAULT_ENABLE_TCEMC 0 CACHE INTERNAL "TCEMC available")
   endif()
@@ -707,6 +727,16 @@ if(ENABLE_TCE)
     set(ENABLE_TCEMC 1)
     set(OCL_DRIVERS "${OCL_DRIVERS} tcemc") # TCEMC is a "superset" of TCE (lp:tce) features.
   endif()
+  set(TCE_DEVICE_EXTENSIONS "cl_khr_byte_addressable_store cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_int64 cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_fp16")
+  set(TEMP_EXT "${TCE_DEVICE_EXTENSIONS}")
+  set(TCE_DEVICE_EXTENSION_DEFINES "")
+  separate_arguments(TEMP_EXT)
+  foreach(EXT ${TEMP_EXT})
+    set(TCE_DEVICE_EXTENSION_DEFINES "${TCE_DEVICE_EXTENSION_DEFINES} -D${EXT}")
+  endforeach()
+
+  set(TCE_DEVICE_CL_VERSION "120")
+
 else()
   set(ENABLE_TCEMC 0)
 endif()
@@ -1022,6 +1052,11 @@ MESSAGE(STATUS "OCL_KERNEL_TARGET_CPU: ${OCL_KERNEL_TARGET_CPU}")
 MESSAGE(STATUS "POCL_DEVICE_ADDRESS_BITS: ${POCL_DEVICE_ADDRESS_BITS}")
 MESSAGE(STATUS "TCE_TARGET_CLANG_FLAGS: ${TCE_TARGET_CLANG_FLAGS}")
 MESSAGE(STATUS "TCE_TARGET_LLC_FLAGS: ${TCE_TARGET_LLC_FLAGS}")
+MESSAGE(STATUS "TCE_CXXFLAGS: ${TCE_CXXFLAGS}")
+MESSAGE(STATUS "TCE_INCLUDES: ${TCE_INCLUDES}")
+MESSAGE(STATUS "TCE_LIBS: ${TCE_LIBS}")
+MESSAGE(STATUS "TCE_VERSION: ${TCE_VERSION}")
+MESSAGE(STATUS "TCE_PREFIX: ${TCE_PREFIX}")
 MESSAGE(STATUS "")
 MESSAGE(STATUS "----------- -------------------------------- --------")
 MESSAGE(STATUS "llvm libs libpocl will be linked to (POCL_LLVM_LIBS):")

--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -144,6 +144,7 @@ endif(WIN32)
 
 # required for sources..
 if(LLVM_VERSION MATCHES "3[.]([0-9]+)")
+  set(LLVM_MAJOR 3)
   string(STRIP "${CMAKE_MATCH_1}" LLVM_MINOR)
   message(STATUS "Minor llvm version: ${LLVM_MINOR}")
   if(LLVM_MINOR STREQUAL "6")

--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -126,6 +126,7 @@
 
 #cmakedefine TCE_AVAILABLE
 
+#define TCE_DEVICE_EXTENSIONS "@TCE_DEVICE_EXTENSIONS@"
 
 /* "Use vecmathlib if available for the target." */
 #cmakedefine USE_VECMATHLIB
@@ -146,3 +147,6 @@
 
 #define HOST_DEVICE_CL_VERSION_MAJOR 2
 #define HOST_DEVICE_CL_VERSION_MINOR 0
+
+#define TCE_DEVICE_CL_VERSION_MAJOR 1
+#define TCE_DEVICE_CL_VERSION_MINOR 2

--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -14,7 +14,9 @@
 /* "Build with ICD" */
 #cmakedefine BUILD_ICD
 
-#define LLVM_VERSION "@LLVM_VERSION@"
+#ifndef LLVM_VERSION
+#define LLVM_VERSION "@LLVM_VERSION_FULL@"
+#endif
 
 #define CLANG "@CLANG@"
 

--- a/examples/AMD/CMakeLists.txt
+++ b/examples/AMD/CMakeLists.txt
@@ -34,7 +34,8 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND X86_64)
   if(EXISTS "${AMD_APP_SDK_TGZ}")
 
     message(STATUS "Enabling testsuite ${TS_NAME}")
-    set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+    list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
+    set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
 
     ExternalProject_Add(
       ${TS_NAME}
@@ -46,6 +47,9 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND X86_64)
       BUILD_COMMAND "/bin/true"
       INSTALL_COMMAND "/bin/true"
     )
+
+    set_target_properties(${TS_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    add_dependencies(prepare_examples ${TS_NAME})
 
     set(AMD_SAMPLES
     AESEncryptDecrypt

--- a/examples/AMDSDK2.9/CMakeLists.txt
+++ b/examples/AMDSDK2.9/CMakeLists.txt
@@ -34,7 +34,8 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND X86_64)
   if(EXISTS "${AMD_APP_SDK_TGZ}")
 
     message(STATUS "Enabling testsuite ${TS_NAME}")
-    set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+    list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
+    set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
 
     ExternalProject_Add(
       ${TS_NAME}
@@ -46,6 +47,9 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND X86_64)
       BUILD_COMMAND "/bin/true"
       INSTALL_COMMAND "/bin/true"
     )
+
+    set_target_properties(${TS_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    add_dependencies(prepare_examples ${TS_NAME})
 
     set(AMD_SAMPLES
     BinarySearch

--- a/examples/AMDSDK3.0/CMakeLists.txt
+++ b/examples/AMDSDK3.0/CMakeLists.txt
@@ -34,7 +34,8 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND X86_64)
   if(EXISTS "${AMD_APP_SDK_TGZ}")
 
     message(STATUS "Enabling testsuite ${TS_NAME}")
-    set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+    list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
+    set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
 
     ExternalProject_Add(
       ${TS_NAME}
@@ -47,6 +48,9 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND X86_64)
       BUILD_COMMAND "/bin/true"
       INSTALL_COMMAND "/bin/true"
     )
+
+    set_target_properties(${TS_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+    add_dependencies(prepare_examples ${TS_NAME})
 
     set(AMD_SAMPLES
     AdvancedConvolution

--- a/examples/ASL/CMakeLists.txt
+++ b/examples/ASL/CMakeLists.txt
@@ -1,0 +1,188 @@
+#=============================================================================
+#   CMake build system files
+#
+#   Copyright (c) 2015 pocl developers
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#   THE SOFTWARE.
+#
+#=============================================================================
+
+set(TS_NAME "ASL")
+set(TS_BASEDIR "${TESTSUITE_BASEDIR}/${TS_NAME}")
+set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}-build")
+set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
+set(ASL_TGZ "${TS_SRCDIR}/v0.1.6.tar.gz")
+
+# find required libs - boost & vtk
+find_package(Boost 1.55)
+find_package(VTK)
+set(VTK_VER "${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}")
+
+if ((NOT "${CMAKE_VERSION}" VERSION_LESS "3.0.2")
+    AND VTK_FOUND AND (NOT VTK_VER VERSION_LESS "6.1")
+    AND Boost_FOUND AND (NOT Boost_VERSION VERSION_LESS "1.55"))
+
+  message(STATUS "Enabling testsuite ${TS_NAME}")
+  list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
+  set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
+
+  ExternalProject_Add(
+    ${TS_NAME}
+    PREFIX "${TS_BASEDIR}"
+    # GIT_REPOSITORY "https://github.com/AvtechScientific/ASL"
+    URL "https://github.com/AvtechScientific/ASL/archive/v0.1.6.tar.gz"
+    CMAKE_ARGS
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      -DWITH_API_DOC:BOOL=OFF
+      -DWITH_EXAMPLES:BOOL=ON
+      -DWITH_MATIO:BOOL=OFF
+      -DWITH_TESTS:BOOL=ON
+      "-DCMAKE_CXX_FLAGS_RELWITHDEBINFO=-O2 -g -DCL_USE_DEPRECATED_OPENCL_1_2_APIS -DCL_USE_DEPRECATED_OPENCL_1_1_APIS"
+      "-DCMAKE_C_FLAGS_RELWITHDEBINFO=-O2 -g -DCL_USE_DEPRECATED_OPENCL_1_2_APIS -DCL_USE_DEPRECATED_OPENCL_1_1_APIS"
+    INSTALL_COMMAND /bin/true
+  )
+
+  set_target_properties(${TS_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  add_dependencies(prepare_examples ${TS_NAME})
+
+  add_test(NAME ASL_testABDFormat
+           COMMAND "${TS_BUILDDIR}/test/testABD/testABDFormat")
+  add_test(NAME ASL_testVectorOfElements
+           COMMAND "${TS_BUILDDIR}/test/testACL/testVectorOfElements")
+  add_test(NAME ASL_testMatrixOfElements
+           COMMAND "${TS_BUILDDIR}/test/testACL/testMatrixOfElements")
+  add_test(NAME ASL_testKernel
+           COMMAND "${TS_BUILDDIR}/test/testACL/testKernel")
+  add_test(NAME ASL_testOperators
+           COMMAND "${TS_BUILDDIR}/test/testACL/testOperators")
+  add_test(NAME ASL_testKernelMerger
+           COMMAND "${TS_BUILDDIR}/test/testACL/testKernelMerger")
+  add_test(NAME ASL_testPrivateVar
+           COMMAND "${TS_BUILDDIR}/test/testACL/testPrivateVar")
+  add_test(NAME ASL_testASLData
+           COMMAND "${TS_BUILDDIR}/test/testMath/testASLData")
+  add_test(NAME ASL_testDistanceFunction
+           COMMAND "${TS_BUILDDIR}/test/testMath/testDistanceFunction")
+  add_test(NAME ASL_testReductionFunction
+           COMMAND "${TS_BUILDDIR}/test/testMath/testReductionFunction")
+
+
+  add_test(NAME ASL_example_bus_wind
+           COMMAND "${TS_BUILDDIR}/examples/flow/bus_wind/asl-bus_wind")
+  add_test(NAME ASL_example_compressor
+           COMMAND "${TS_BUILDDIR}/examples/flow/compressor/asl-compressor")
+  add_test(NAME ASL_example_flow
+           COMMAND "${TS_BUILDDIR}/examples/flow/flow/asl-flow")
+  add_test(NAME ASL_example_flow2
+           COMMAND "${TS_BUILDDIR}/examples/flow/flow2/asl-flow2")
+  add_test(NAME ASL_example_flow3
+           COMMAND "${TS_BUILDDIR}/examples/flow/flow3/asl-flow3")
+  add_test(NAME ASL_example_flowKDPGrowth
+           COMMAND "${TS_BUILDDIR}/examples/flow/flowKDPGrowth/asl-flowKDPGrowth")
+  add_test(NAME ASL_example_flowRotatingCylinders
+           COMMAND "${TS_BUILDDIR}/examples/flow/flowRotatingCylinders/asl-flowRotatingCylinders")
+  add_test(NAME ASL_example_locomotive
+           COMMAND "${TS_BUILDDIR}/examples/flow/locomotive/asl-locomotive")
+  add_test(NAME ASL_example_locomotive_laminar
+           COMMAND "${TS_BUILDDIR}/examples/flow/locomotive_laminar/asl-locomotive_laminar")
+  add_test(NAME ASL_example_locomotive_stability
+           COMMAND "${TS_BUILDDIR}/examples/flow/locomotive_stability/asl-locomotive_stability")
+  add_test(NAME ASL_example_multicomponent_flow
+           COMMAND "${TS_BUILDDIR}/examples/flow/multicomponent_flow/asl-multicomponent_flow")
+  add_test(NAME ASL_example_multiphase_flow
+           COMMAND "${TS_BUILDDIR}/examples/flow/multiphase_flow/asl-multiphase_flow")
+  add_test(NAME ASL_example_pitot_tube_ice
+           COMMAND "${TS_BUILDDIR}/examples/flow/pitot_tube_ice/asl-pitot_tube_ice")
+  add_test(NAME ASL_example_acousticWaves
+           COMMAND "${TS_BUILDDIR}/examples/elastic/acousticWaves/asl-acousticWaves")
+  add_test(NAME ASL_example_cubeGravity
+           COMMAND "${TS_BUILDDIR}/examples/elastic/cubeGravity/asl-cubeGravity")
+  add_test(NAME ASL_example_cubeIncompressibleGravity
+           COMMAND "${TS_BUILDDIR}/examples/elastic/cubeIncompressibleGravity/asl-cubeIncompressibleGravity")
+  add_test(NAME ASL_example_cubePoroelasticGravity
+           COMMAND "${TS_BUILDDIR}/examples/elastic/cubePoroelasticGravity/asl-cubePoroelasticGravity")
+  add_test(NAME ASL_example_poroelastic
+           COMMAND "${TS_BUILDDIR}/examples/elastic/poroelastic/asl-poroelastic")
+  add_test(NAME ASL_example_levelSetBasic
+           COMMAND "${TS_BUILDDIR}/examples/levelSet/levelSetBasic/asl-levelSetBasic")
+  add_test(NAME ASL_example_levelSetFacetedGrowth
+           COMMAND "${TS_BUILDDIR}/examples/levelSet/levelSetFacetedGrowth/asl-levelSetFacetedGrowth")
+  add_test(NAME ASL_example_levelSetNormalGrowth
+           COMMAND "${TS_BUILDDIR}/examples/levelSet/levelSetNormalGrowth/asl-levelSetNormalGrowth")
+  add_test(NAME ASL_example_jumpingBox
+           COMMAND "${TS_BUILDDIR}/examples/jumpingObjects/jumpingBox/asl-jumpingBox")
+  add_test(NAME ASL_example_surfaceFlux
+           COMMAND "${TS_BUILDDIR}/examples/heatTransfer/surfaceFlux/asl-surfaceFlux")
+  add_test(NAME ASL_example_testSMDiff
+           COMMAND "${TS_BUILDDIR}/examples/massTransferSM/testSMDiff/asl-testSMDiff")
+  add_test(NAME ASL_example_testSMDiff3C
+           COMMAND "${TS_BUILDDIR}/examples/massTransferSM/testSMDiff3C/asl-testSMDiff3C")
+  add_test(NAME ASL_example_testSMPhi
+           COMMAND "${TS_BUILDDIR}/examples/massTransferSM/testSMPhi/asl-testSMPhi")
+  add_test(NAME ASL_example_testSMPhiBV
+           COMMAND "${TS_BUILDDIR}/examples/massTransferSM/testSMPhiBV/asl-testSMPhiBV")
+
+
+  set_tests_properties(
+    ASL_testABDFormat
+    ASL_testVectorOfElements
+    ASL_testMatrixOfElements
+    ASL_testKernel
+    ASL_testOperators
+    ASL_testKernelMerger
+    ASL_testPrivateVar
+    ASL_testASLData
+    ASL_testDistanceFunction
+    ASL_testReductionFunction
+    ASL_example_bus_wind
+    ASL_example_compressor
+    ASL_example_flow
+    ASL_example_flow2
+    ASL_example_flow3
+    ASL_example_flowKDPGrowth
+    ASL_example_flowRotatingCylinders
+    ASL_example_locomotive
+    ASL_example_locomotive_laminar
+    ASL_example_locomotive_stability
+    ASL_example_multicomponent_flow
+    ASL_example_multiphase_flow
+    ASL_example_pitot_tube_ice
+    ASL_example_acousticWaves
+    ASL_example_cubeGravity
+    ASL_example_cubeIncompressibleGravity
+    ASL_example_cubePoroelasticGravity
+    ASL_example_poroelastic
+    ASL_example_levelSetBasic
+    ASL_example_levelSetFacetedGrowth
+    ASL_example_levelSetNormalGrowth
+    ASL_example_jumpingBox
+    ASL_example_surfaceFlux
+    ASL_example_testSMDiff
+    ASL_example_testSMDiff3C
+    ASL_example_testSMPhi
+    ASL_example_testSMPhiBV
+
+    PROPERTIES
+      LABELS "ASL")
+
+else()
+
+  message(STATUS "Disabling testsuite ${TS_NAME}, required files not found" )
+
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -31,6 +31,7 @@ add_subdirectory("example2a")
 add_subdirectory("standalone")
 add_subdirectory("scalarwave")
 add_subdirectory("trig")
+add_subdirectory("EinsteinToolkit")
 
 set(ALL_TESTSUITES "AMD;AMDSDK2.9;AMDSDK3.0;opencl-book-samples;Parboil;Piglit;Rodinia;VexCL;ViennaCL;Halide;OpenCV;CloverLeaf;hsa")
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -33,7 +33,12 @@ add_subdirectory("scalarwave")
 add_subdirectory("trig")
 add_subdirectory("EinsteinToolkit")
 
-set(ALL_TESTSUITES "AMD;AMDSDK2.9;AMDSDK3.0;opencl-book-samples;Parboil;piglit;Rodinia;VexCL;ViennaCL;Halide;IntelSVM;OpenCV;CloverLeaf;hsa")
+# TODO:   opencl-book-samples  PyOpenCL
+set(ALL_TESTSUITES
+    AMD AMDSDK2.9 AMDSDK3.0 ASL
+    CloverLeaf Halide IntelSVM OpenCV
+    Parboil piglit PyOpenCL
+    Rodinia VexCL ViennaCL)
 
 if("${ENABLE_TESTSUITES}" STREQUAL "all")
   set(ENABLE_TESTSUITES ${ALL_TESTSUITES})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -33,7 +33,7 @@ add_subdirectory("scalarwave")
 add_subdirectory("trig")
 add_subdirectory("EinsteinToolkit")
 
-set(ALL_TESTSUITES "AMD;AMDSDK2.9;AMDSDK3.0;opencl-book-samples;Parboil;Piglit;Rodinia;VexCL;ViennaCL;Halide;OpenCV;CloverLeaf;hsa")
+set(ALL_TESTSUITES "AMD;AMDSDK2.9;AMDSDK3.0;opencl-book-samples;Parboil;piglit;Rodinia;VexCL;ViennaCL;Halide;IntelSVM;OpenCV;CloverLeaf;hsa")
 
 if("${ENABLE_TESTSUITES}" STREQUAL "all")
   set(ENABLE_TESTSUITES ${ALL_TESTSUITES})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -45,6 +45,9 @@ include(ExternalProject)
 
 set(ACTUALLY_ENABLED_TESTSUITES "")
 
+# invoke this to build all examples
+add_custom_target(prepare_examples)
+
 if(ENABLE_TESTSUITES)
 
   if(NOT DEFINED TESTSUITE_BASEDIR)
@@ -70,7 +73,6 @@ if(ENABLE_TESTSUITES)
     if(ALL_TESTSUITES MATCHES ${TESTSUITE})
       if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${TESTSUITE}")
         add_subdirectory("${TESTSUITE}")
-        list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TESTSUITE}")
       else()
         message(FATAL_ERROR "Cannot find source dir for testsuite: ${TESTSUITE}")
       endif()

--- a/examples/CloverLeaf/CMakeLists.txt
+++ b/examples/CloverLeaf/CMakeLists.txt
@@ -29,7 +29,8 @@ set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}")
 set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
 
 message(STATUS "Enabling testsuite ${TS_NAME}")
-set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
+set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
 
 if(UNIX)
   pkg_check_modules(OPENMPI ompi)
@@ -63,6 +64,9 @@ if (MPI_F90 AND MPI_CC AND MPI_CXX AND MPI_LIB)
       "MPICXX_LIB=${MPI_LIB}"
     INSTALL_COMMAND "/bin/true"
   )
+
+  set_target_properties(${TS_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  add_dependencies(prepare_examples ${TS_NAME})
 
   add_test(NAME CloverLeaf
            COMMAND "${TS_BUILDDIR}/clover_leaf")

--- a/examples/CloverLeaf/CMakeLists.txt
+++ b/examples/CloverLeaf/CMakeLists.txt
@@ -1,0 +1,78 @@
+#=============================================================================
+#   CMake build system files
+#
+#   Copyright (c) 2015 pocl developers
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#   THE SOFTWARE.
+#
+#=============================================================================
+
+set(TS_NAME CloverLeaf)
+set(TS_BASEDIR "${TESTSUITE_BASEDIR}/${TS_NAME}")
+set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}")
+set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
+
+message(STATUS "Enabling testsuite ${TS_NAME}")
+set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+
+if(UNIX)
+  pkg_check_modules(OPENMPI ompi)
+  if (OPENMPI_FOUND)
+    set(EXTRA_LIB_HINTS "HINTS" "${OPENMPI_LIBRARY_DIRS}")
+  endif()
+endif()
+
+#You need to have "openmpi" and "gfortran" packages installed to build it.
+find_program(MPI_F90 mpif90)
+find_program(MPI_CC  mpicc)
+find_program(MPI_CXX  mpiCC)
+find_library(MPI_LIB mpi_cxx ${EXTRA_LIB_HINTS})
+
+if (MPI_F90 AND MPI_CC AND MPI_CXX AND MPI_LIB)
+
+  ExternalProject_Add(
+    ${TS_NAME}
+    PREFIX "${TS_BASEDIR}"
+    #DOWNLOAD_COMMAND "/bin/true"
+    GIT_REPOSITORY "https://github.com/UK-MAC/CloverLeaf_OpenCL.git"
+    GIT_TAG "Bristol"
+    CONFIGURE_COMMAND "/bin/true"
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND
+      make COMPILER=GNU
+      "C_OPTIONS=-g -I${CMAKE_SOURCE_DIR}/include -DCL_USE_DEPRECATED_OPENCL_1_2_APIS -DCL_USE_DEPRECATED_OPENCL_1_1_APIS"
+      "MPI_COMPILER=${MPI_F90}"
+      "C_MPI_COMPILER=${MPI_CC}"
+      "CXX_MPI_COMPILER=${MPI_CXX}"
+      "MPICXX_LIB=${MPI_LIB}"
+    INSTALL_COMMAND "/bin/true"
+  )
+
+  add_test(NAME CloverLeaf
+           COMMAND "${TS_BUILDDIR}/clover_leaf")
+
+  set_tests_properties(CloverLeaf
+    PROPERTIES
+      LABELS "CloverLeaf")
+
+else()
+
+  message(STATUS "Disabling testsuite ${TS_NAME}, required files not found" )
+
+endif()

--- a/examples/EinsteinToolkit/CMakeLists.txt
+++ b/examples/EinsteinToolkit/CMakeLists.txt
@@ -1,0 +1,46 @@
+#=============================================================================
+#   CMake build system files
+#
+#   Copyright (c) 2015 pocl developers
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#   THE SOFTWARE.
+#
+#=============================================================================
+
+#AM_CPPFLAGS = -I$(top_srcdir)/fix-include -I$(top_srcdir)/include -DSRCDIR='"$(abs_srcdir)"'
+add_definitions("-DSRCDIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"")
+
+# EinsteinToolkit_CFLAGS = @OPENCL_CFLAGS@
+#set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 ${OPENCL_CFLAGS}")
+add_compile_options(${OPENCL_CFLAGS} -std=c99)
+
+if (MSVC)
+  set_source_files_properties( EinsteinToolkit.c PROPERTIES LANGUAGE CXX )
+endif(MSVC)
+add_executable("EinsteinToolkit" EinsteinToolkit.c ML_BSSN_CL_RHS1.cl ML_BSSN_CL_RHS2.cl)
+
+# EinsteinToolkit_LDADD = @OPENCL_LIBS@ ../../lib/poclu/libpoclu.la
+target_link_libraries("EinsteinToolkit" ${POCLU_LINK_OPTIONS})
+
+add_test(NAME "EinsteinToolkit" COMMAND "EinsteinToolkit")
+
+set_tests_properties( "EinsteinToolkit"
+  PROPERTIES
+    LABELS "Einstein"
+    DEPENDS "pocl_version_check")

--- a/examples/Halide/CMakeLists.txt
+++ b/examples/Halide/CMakeLists.txt
@@ -1,0 +1,1063 @@
+#=============================================================================
+#   CMake build system files
+#
+#   Copyright (c) 2015 pocl developers
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#   THE SOFTWARE.
+#
+#=============================================================================
+
+set(TS_NAME Halide)
+set(TS_BASEDIR "${TESTSUITE_BASEDIR}/${TS_NAME}")
+set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}-build")
+set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
+
+message(STATUS "Enabling testsuite ${TS_NAME}")
+set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+
+ExternalProject_Add(
+  ${TS_NAME}
+  PREFIX "${TS_BASEDIR}"
+  #DOWNLOAD_COMMAND "/bin/true"
+  GIT_REPOSITORY "https://github.com/Halide/Halide.git"
+  #PATCH_COMMAND /bin/sh "${AMD_APP_SDK_TGZ}" --noexec --keep --target AMD-APP-SDK-3.0 &&
+  #     patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/amdsdk3_0.patch
+  CMAKE_ARGS
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    -DTARGET_ARM=OFF
+    -DTARGET_AARCH64=OFF
+    -DTARGET_MIPS=OFF
+    -DTARGET_METAL=OFF
+    -DTARGET_OPENCL=ON
+    -DTARGET_OPENGL=OFF
+    -DTARGET_OPENGLCOMPUTE=OFF
+    -DTARGET_PTX=OFF
+    -DTARGET_X86=ON
+  CMAKE_CACHE_ARGS
+    "-DLLVM_BIN:STRING=${LLVM_BINDIR}"
+    "-DLLVM_LIB:STRING=${LLVM_LIBDIR}"
+    "-DLLVM_INCLUDE:STRING=${LLVM_INCLUDEDIR}"
+    "-DLLVM_VERSION:STRING=${LLVM_MAJOR}${LLVM_MINOR}"
+  INSTALL_COMMAND "/bin/true"
+)
+
+# TODO Probably not tests
+# acquire_release.generator argvcall.generator cleanup_on_error.generator
+# embed_image.generator example.generator extended_buffer_t.generator
+# error_codes.generator gpu_object_lifetime.generator gpu_only.generator
+# mandelbrot.generator matlab.generator metadata_tester.generator
+# nested_externs.generator paramtest.generator pyramid.generator
+# runtime.generator tiled_blur.generator tiled_blur_blur.generator
+# user_context.generator user_context_insanity.generator
+
+
+
+add_test(NAME halide_bilateral_grid
+         COMMAND "${TS_BUILDDIR}/bin/bilateral_grid")
+add_test(NAME halide_bitcode2cpp
+         COMMAND "${TS_BUILDDIR}/bin/bitcode2cpp")
+add_test(NAME halide_blur_test
+         COMMAND "${TS_BUILDDIR}/bin/blur_test")
+add_test(NAME halide_build_halide_h
+         COMMAND "${TS_BUILDDIR}/bin/build_halide_h")
+add_test(NAME halide_camera_pipe
+         COMMAND "${TS_BUILDDIR}/bin/camera_pipe")
+add_test(NAME halide_correctness_argmax
+         COMMAND "${TS_BUILDDIR}/bin/correctness_argmax")
+add_test(NAME halide_correctness_assertion_failure_in_parallel_for
+         COMMAND "${TS_BUILDDIR}/bin/correctness_assertion_failure_in_parallel_for")
+add_test(NAME halide_correctness_autotune_bug
+         COMMAND "${TS_BUILDDIR}/bin/correctness_autotune_bug")
+add_test(NAME halide_correctness_autotune_bug_2
+         COMMAND "${TS_BUILDDIR}/bin/correctness_autotune_bug_2")
+add_test(NAME halide_correctness_autotune_bug_3
+         COMMAND "${TS_BUILDDIR}/bin/correctness_autotune_bug_3")
+add_test(NAME halide_correctness_autotune_bug_4
+         COMMAND "${TS_BUILDDIR}/bin/correctness_autotune_bug_4")
+add_test(NAME halide_correctness_autotune_bug_5
+         COMMAND "${TS_BUILDDIR}/bin/correctness_autotune_bug_5")
+add_test(NAME halide_correctness_bad_likely
+         COMMAND "${TS_BUILDDIR}/bin/correctness_bad_likely")
+add_test(NAME halide_correctness_bit_counting
+         COMMAND "${TS_BUILDDIR}/bin/correctness_bit_counting")
+add_test(NAME halide_correctness_bitwise_ops
+         COMMAND "${TS_BUILDDIR}/bin/correctness_bitwise_ops")
+add_test(NAME halide_correctness_bool_compute_root_vectorize
+         COMMAND "${TS_BUILDDIR}/bin/correctness_bool_compute_root_vectorize")
+add_test(NAME halide_correctness_bound
+         COMMAND "${TS_BUILDDIR}/bin/correctness_bound")
+add_test(NAME halide_correctness_boundary_conditions
+         COMMAND "${TS_BUILDDIR}/bin/correctness_boundary_conditions")
+add_test(NAME halide_correctness_bounds
+         COMMAND "${TS_BUILDDIR}/bin/correctness_bounds")
+add_test(NAME halide_correctness_bounds_inference
+         COMMAND "${TS_BUILDDIR}/bin/correctness_bounds_inference")
+add_test(NAME halide_correctness_bounds_inference_chunk
+         COMMAND "${TS_BUILDDIR}/bin/correctness_bounds_inference_chunk")
+add_test(NAME halide_correctness_bounds_inference_complex
+         COMMAND "${TS_BUILDDIR}/bin/correctness_bounds_inference_complex")
+add_test(NAME halide_correctness_bounds_of_abs
+         COMMAND "${TS_BUILDDIR}/bin/correctness_bounds_of_abs")
+add_test(NAME halide_correctness_bounds_of_cast
+         COMMAND "${TS_BUILDDIR}/bin/correctness_bounds_of_cast")
+add_test(NAME halide_correctness_bounds_of_func
+         COMMAND "${TS_BUILDDIR}/bin/correctness_bounds_of_func")
+add_test(NAME halide_correctness_bounds_of_monotonic_math
+         COMMAND "${TS_BUILDDIR}/bin/correctness_bounds_of_monotonic_math")
+add_test(NAME halide_correctness_bounds_query
+         COMMAND "${TS_BUILDDIR}/bin/correctness_bounds_query")
+add_test(NAME halide_correctness_buffer_t
+         COMMAND "${TS_BUILDDIR}/bin/correctness_buffer_t")
+add_test(NAME halide_correctness_cascaded_filters
+         COMMAND "${TS_BUILDDIR}/bin/correctness_cascaded_filters")
+add_test(NAME halide_correctness_cast
+         COMMAND "${TS_BUILDDIR}/bin/correctness_cast")
+add_test(NAME halide_correctness_cast_handle
+         COMMAND "${TS_BUILDDIR}/bin/correctness_cast_handle")
+add_test(NAME halide_correctness_c_function
+         COMMAND "${TS_BUILDDIR}/bin/correctness_c_function")
+add_test(NAME halide_correctness_chunk
+         COMMAND "${TS_BUILDDIR}/bin/correctness_chunk")
+add_test(NAME halide_correctness_chunk_sharing
+         COMMAND "${TS_BUILDDIR}/bin/correctness_chunk_sharing")
+add_test(NAME halide_correctness_circular_reference_leak
+         COMMAND "${TS_BUILDDIR}/bin/correctness_circular_reference_leak")
+add_test(NAME halide_correctness_code_explosion
+         COMMAND "${TS_BUILDDIR}/bin/correctness_code_explosion")
+add_test(NAME halide_correctness_compare_vars
+         COMMAND "${TS_BUILDDIR}/bin/correctness_compare_vars")
+add_test(NAME halide_correctness_compile_to
+         COMMAND "${TS_BUILDDIR}/bin/correctness_compile_to")
+add_test(NAME halide_correctness_compile_to_bitcode
+         COMMAND "${TS_BUILDDIR}/bin/correctness_compile_to_bitcode")
+add_test(NAME halide_correctness_compile_to_lowered_stmt
+         COMMAND "${TS_BUILDDIR}/bin/correctness_compile_to_lowered_stmt")
+add_test(NAME halide_correctness_compute_at_split_rvar
+         COMMAND "${TS_BUILDDIR}/bin/correctness_compute_at_split_rvar")
+add_test(NAME halide_correctness_computed_index
+         COMMAND "${TS_BUILDDIR}/bin/correctness_computed_index")
+add_test(NAME halide_correctness_compute_outermost
+         COMMAND "${TS_BUILDDIR}/bin/correctness_compute_outermost")
+add_test(NAME halide_correctness_constant_expr
+         COMMAND "${TS_BUILDDIR}/bin/correctness_constant_expr")
+add_test(NAME halide_correctness_constant_type
+         COMMAND "${TS_BUILDDIR}/bin/correctness_constant_type")
+add_test(NAME halide_correctness_constraints
+         COMMAND "${TS_BUILDDIR}/bin/correctness_constraints")
+add_test(NAME halide_correctness_convolution
+         COMMAND "${TS_BUILDDIR}/bin/correctness_convolution")
+add_test(NAME halide_correctness_convolution_multiple_kernels
+         COMMAND "${TS_BUILDDIR}/bin/correctness_convolution_multiple_kernels")
+add_test(NAME halide_correctness_cross_compilation
+         COMMAND "${TS_BUILDDIR}/bin/correctness_cross_compilation")
+add_test(NAME halide_correctness_custom_allocator
+         COMMAND "${TS_BUILDDIR}/bin/correctness_custom_allocator")
+add_test(NAME halide_correctness_custom_error_reporter
+         COMMAND "${TS_BUILDDIR}/bin/correctness_custom_error_reporter")
+add_test(NAME halide_correctness_custom_lowering_pass
+         COMMAND "${TS_BUILDDIR}/bin/correctness_custom_lowering_pass")
+add_test(NAME halide_correctness_debug_to_file
+         COMMAND "${TS_BUILDDIR}/bin/correctness_debug_to_file")
+add_test(NAME halide_correctness_deinterleave4
+         COMMAND "${TS_BUILDDIR}/bin/correctness_deinterleave4")
+add_test(NAME halide_correctness_div_mod
+         COMMAND "${TS_BUILDDIR}/bin/correctness_div_mod")
+add_test(NAME halide_correctness_dynamic_reduction_bounds
+         COMMAND "${TS_BUILDDIR}/bin/correctness_dynamic_reduction_bounds")
+add_test(NAME halide_correctness_erf
+         COMMAND "${TS_BUILDDIR}/bin/correctness_erf")
+add_test(NAME halide_correctness_exception
+         COMMAND "${TS_BUILDDIR}/bin/correctness_exception")
+add_test(NAME halide_correctness_explicit_inline_reductions
+         COMMAND "${TS_BUILDDIR}/bin/correctness_explicit_inline_reductions")
+add_test(NAME halide_correctness_extern_bounds_inference
+         COMMAND "${TS_BUILDDIR}/bin/correctness_extern_bounds_inference")
+add_test(NAME halide_correctness_extern_consumer
+         COMMAND "${TS_BUILDDIR}/bin/correctness_extern_consumer")
+add_test(NAME halide_correctness_extern_error
+         COMMAND "${TS_BUILDDIR}/bin/correctness_extern_error")
+add_test(NAME halide_correctness_extern_output_expansion
+         COMMAND "${TS_BUILDDIR}/bin/correctness_extern_output_expansion")
+add_test(NAME halide_correctness_extern_producer
+         COMMAND "${TS_BUILDDIR}/bin/correctness_extern_producer")
+add_test(NAME halide_correctness_extern_sort
+         COMMAND "${TS_BUILDDIR}/bin/correctness_extern_sort")
+add_test(NAME halide_correctness_extern_stage
+         COMMAND "${TS_BUILDDIR}/bin/correctness_extern_stage")
+add_test(NAME halide_correctness_fibonacci
+         COMMAND "${TS_BUILDDIR}/bin/correctness_fibonacci")
+add_test(NAME halide_correctness_float16_t_comparison
+         COMMAND "${TS_BUILDDIR}/bin/correctness_float16_t_comparison")
+add_test(NAME halide_correctness_float16_t_constants
+         COMMAND "${TS_BUILDDIR}/bin/correctness_float16_t_constants")
+add_test(NAME halide_correctness_float16_t_image_type
+         COMMAND "${TS_BUILDDIR}/bin/correctness_float16_t_image_type")
+add_test(NAME halide_correctness_float16_t_implicit_upcast
+         COMMAND "${TS_BUILDDIR}/bin/correctness_float16_t_implicit_upcast")
+add_test(NAME halide_correctness_float16_t_realize_constant
+         COMMAND "${TS_BUILDDIR}/bin/correctness_float16_t_realize_constant")
+add_test(NAME halide_correctness_func_lifetime
+         COMMAND "${TS_BUILDDIR}/bin/correctness_func_lifetime")
+add_test(NAME halide_correctness_func_lifetime_2
+         COMMAND "${TS_BUILDDIR}/bin/correctness_func_lifetime_2")
+add_test(NAME halide_correctness_fuse
+         COMMAND "${TS_BUILDDIR}/bin/correctness_fuse")
+add_test(NAME halide_correctness_fused_where_inner_extent_is_zero
+         COMMAND "${TS_BUILDDIR}/bin/correctness_fused_where_inner_extent_is_zero")
+add_test(NAME halide_correctness_fuzz_simplify
+         COMMAND "${TS_BUILDDIR}/bin/correctness_fuzz_simplify")
+add_test(NAME halide_correctness_gameoflife
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gameoflife")
+add_test(NAME halide_correctness_gpu_data_flows
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_data_flows")
+add_test(NAME halide_correctness_gpu_dynamic_shared
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_dynamic_shared")
+add_test(NAME halide_correctness_gpu_free_sync
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_free_sync")
+add_test(NAME halide_correctness_gpu_large_alloc
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_large_alloc")
+add_test(NAME halide_correctness_gpu_mixed_dimensionality
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_mixed_dimensionality")
+add_test(NAME halide_correctness_gpu_mixed_shared_mem_types
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_mixed_shared_mem_types")
+add_test(NAME halide_correctness_gpu_multi_device
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_multi_device")
+add_test(NAME halide_correctness_gpu_multi_kernel
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_multi_kernel")
+add_test(NAME halide_correctness_gpu_non_contiguous_copy
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_non_contiguous_copy")
+add_test(NAME halide_correctness_gpu_object_lifetime
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_object_lifetime")
+add_test(NAME halide_correctness_gpu_specialize
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_specialize")
+add_test(NAME halide_correctness_gpu_sum_scan
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_sum_scan")
+add_test(NAME halide_correctness_gpu_thread_barrier
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_thread_barrier")
+add_test(NAME halide_correctness_gpu_transpose
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_transpose")
+add_test(NAME halide_correctness_gpu_vectorize_div_mod
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_vectorize_div_mod")
+add_test(NAME halide_correctness_gpu_vectorized_shared_memory
+         COMMAND "${TS_BUILDDIR}/bin/correctness_gpu_vectorized_shared_memory")
+add_test(NAME halide_correctness_handle
+         COMMAND "${TS_BUILDDIR}/bin/correctness_handle")
+add_test(NAME halide_correctness_heap_cleanup
+         COMMAND "${TS_BUILDDIR}/bin/correctness_heap_cleanup")
+add_test(NAME halide_correctness_hello_gpu
+         COMMAND "${TS_BUILDDIR}/bin/correctness_hello_gpu")
+add_test(NAME halide_correctness_histogram
+         COMMAND "${TS_BUILDDIR}/bin/correctness_histogram")
+add_test(NAME halide_correctness_histogram_equalize
+         COMMAND "${TS_BUILDDIR}/bin/correctness_histogram_equalize")
+add_test(NAME halide_correctness_image_of_lists
+         COMMAND "${TS_BUILDDIR}/bin/correctness_image_of_lists")
+add_test(NAME halide_correctness_implicit_args
+         COMMAND "${TS_BUILDDIR}/bin/correctness_implicit_args")
+add_test(NAME halide_correctness_infer_arguments
+         COMMAND "${TS_BUILDDIR}/bin/correctness_infer_arguments")
+add_test(NAME halide_correctness_inline_reduction
+         COMMAND "${TS_BUILDDIR}/bin/correctness_inline_reduction")
+add_test(NAME halide_correctness_in_place
+         COMMAND "${TS_BUILDDIR}/bin/correctness_in_place")
+add_test(NAME halide_correctness_input_image_bounds_check
+         COMMAND "${TS_BUILDDIR}/bin/correctness_input_image_bounds_check")
+add_test(NAME halide_correctness_input_larger_than_two_gigs
+         COMMAND "${TS_BUILDDIR}/bin/correctness_input_larger_than_two_gigs")
+add_test(NAME halide_correctness_integer_powers
+         COMMAND "${TS_BUILDDIR}/bin/correctness_integer_powers")
+add_test(NAME halide_correctness_interleave
+         COMMAND "${TS_BUILDDIR}/bin/correctness_interleave")
+add_test(NAME halide_correctness_introspection
+         COMMAND "${TS_BUILDDIR}/bin/correctness_introspection")
+add_test(NAME halide_correctness_inverse
+         COMMAND "${TS_BUILDDIR}/bin/correctness_inverse")
+add_test(NAME halide_correctness_isnan
+         COMMAND "${TS_BUILDDIR}/bin/correctness_isnan")
+add_test(NAME halide_correctness_iterate_over_circle
+         COMMAND "${TS_BUILDDIR}/bin/correctness_iterate_over_circle")
+add_test(NAME halide_correctness_lambda
+         COMMAND "${TS_BUILDDIR}/bin/correctness_lambda")
+add_test(NAME halide_correctness_lazy_convolution
+         COMMAND "${TS_BUILDDIR}/bin/correctness_lazy_convolution")
+add_test(NAME halide_correctness_legal_race_condition
+         COMMAND "${TS_BUILDDIR}/bin/correctness_legal_race_condition")
+add_test(NAME halide_correctness_lerp
+         COMMAND "${TS_BUILDDIR}/bin/correctness_lerp")
+add_test(NAME halide_correctness_likely
+         COMMAND "${TS_BUILDDIR}/bin/correctness_likely")
+add_test(NAME halide_correctness_logical
+         COMMAND "${TS_BUILDDIR}/bin/correctness_logical")
+add_test(NAME halide_correctness_loop_invariant_extern_calls
+         COMMAND "${TS_BUILDDIR}/bin/correctness_loop_invariant_extern_calls")
+add_test(NAME halide_correctness_make_struct
+         COMMAND "${TS_BUILDDIR}/bin/correctness_make_struct")
+add_test(NAME halide_correctness_many_dimensions
+         COMMAND "${TS_BUILDDIR}/bin/correctness_many_dimensions")
+add_test(NAME halide_correctness_many_small_extern_stages
+         COMMAND "${TS_BUILDDIR}/bin/correctness_many_small_extern_stages")
+add_test(NAME halide_correctness_many_updates
+         COMMAND "${TS_BUILDDIR}/bin/correctness_many_updates")
+add_test(NAME halide_correctness_math
+         COMMAND "${TS_BUILDDIR}/bin/correctness_math")
+add_test(NAME halide_correctness_memoize
+         COMMAND "${TS_BUILDDIR}/bin/correctness_memoize")
+add_test(NAME halide_correctness_min_extent
+         COMMAND "${TS_BUILDDIR}/bin/correctness_min_extent")
+add_test(NAME halide_correctness_mod
+         COMMAND "${TS_BUILDDIR}/bin/correctness_mod")
+add_test(NAME halide_correctness_multi_output_pipeline_with_bad_sizes
+         COMMAND "${TS_BUILDDIR}/bin/correctness_multi_output_pipeline_with_bad_sizes")
+add_test(NAME halide_correctness_multipass_constraints
+         COMMAND "${TS_BUILDDIR}/bin/correctness_multipass_constraints")
+add_test(NAME halide_correctness_multi_pass_reduction
+         COMMAND "${TS_BUILDDIR}/bin/correctness_multi_pass_reduction")
+add_test(NAME halide_correctness_multiple_outputs
+         COMMAND "${TS_BUILDDIR}/bin/correctness_multiple_outputs")
+add_test(NAME halide_correctness_multi_way_select
+         COMMAND "${TS_BUILDDIR}/bin/correctness_multi_way_select")
+add_test(NAME halide_correctness_named_updates
+         COMMAND "${TS_BUILDDIR}/bin/correctness_named_updates")
+add_test(NAME halide_correctness_newtons_method
+         COMMAND "${TS_BUILDDIR}/bin/correctness_newtons_method")
+add_test(NAME halide_correctness_obscure_image_references
+         COMMAND "${TS_BUILDDIR}/bin/correctness_obscure_image_references")
+add_test(NAME halide_correctness_oddly_sized_output
+         COMMAND "${TS_BUILDDIR}/bin/correctness_oddly_sized_output")
+add_test(NAME halide_correctness_out_of_memory
+         COMMAND "${TS_BUILDDIR}/bin/correctness_out_of_memory")
+add_test(NAME halide_correctness_output_larger_than_two_gigs
+         COMMAND "${TS_BUILDDIR}/bin/correctness_output_larger_than_two_gigs")
+add_test(NAME halide_correctness_parallel
+         COMMAND "${TS_BUILDDIR}/bin/correctness_parallel")
+add_test(NAME halide_correctness_parallel_alloc
+         COMMAND "${TS_BUILDDIR}/bin/correctness_parallel_alloc")
+add_test(NAME halide_correctness_parallel_gpu_nested
+         COMMAND "${TS_BUILDDIR}/bin/correctness_parallel_gpu_nested")
+add_test(NAME halide_correctness_parallel_nested
+         COMMAND "${TS_BUILDDIR}/bin/correctness_parallel_nested")
+add_test(NAME halide_correctness_parallel_reductions
+         COMMAND "${TS_BUILDDIR}/bin/correctness_parallel_reductions")
+add_test(NAME halide_correctness_parallel_rvar
+         COMMAND "${TS_BUILDDIR}/bin/correctness_parallel_rvar")
+add_test(NAME halide_correctness_param
+         COMMAND "${TS_BUILDDIR}/bin/correctness_param")
+add_test(NAME halide_correctness_parameter_constraints
+         COMMAND "${TS_BUILDDIR}/bin/correctness_parameter_constraints")
+add_test(NAME halide_correctness_partial_application
+         COMMAND "${TS_BUILDDIR}/bin/correctness_partial_application")
+add_test(NAME halide_correctness_partition_loops_bug
+         COMMAND "${TS_BUILDDIR}/bin/correctness_partition_loops_bug")
+add_test(NAME halide_correctness_pipeline_set_jit_externs_func
+         COMMAND "${TS_BUILDDIR}/bin/correctness_pipeline_set_jit_externs_func")
+add_test(NAME halide_correctness_print
+         COMMAND "${TS_BUILDDIR}/bin/correctness_print")
+add_test(NAME halide_correctness_process_some_tiles
+         COMMAND "${TS_BUILDDIR}/bin/correctness_process_some_tiles")
+add_test(NAME halide_correctness_random
+         COMMAND "${TS_BUILDDIR}/bin/correctness_random")
+add_test(NAME halide_correctness_realize_larger_than_two_gigs
+         COMMAND "${TS_BUILDDIR}/bin/correctness_realize_larger_than_two_gigs")
+add_test(NAME halide_correctness_realize_over_shifted_domain
+         COMMAND "${TS_BUILDDIR}/bin/correctness_realize_over_shifted_domain")
+add_test(NAME halide_correctness_reduction_chain
+         COMMAND "${TS_BUILDDIR}/bin/correctness_reduction_chain")
+add_test(NAME halide_correctness_reduction_schedule
+         COMMAND "${TS_BUILDDIR}/bin/correctness_reduction_schedule")
+add_test(NAME halide_correctness_reduction_subregion
+         COMMAND "${TS_BUILDDIR}/bin/correctness_reduction_subregion")
+add_test(NAME halide_correctness_reorder_rvars
+         COMMAND "${TS_BUILDDIR}/bin/correctness_reorder_rvars")
+add_test(NAME halide_correctness_reorder_storage
+         COMMAND "${TS_BUILDDIR}/bin/correctness_reorder_storage")
+add_test(NAME halide_correctness_reschedule
+         COMMAND "${TS_BUILDDIR}/bin/correctness_reschedule")
+add_test(NAME halide_correctness_reuse_stack_alloc
+         COMMAND "${TS_BUILDDIR}/bin/correctness_reuse_stack_alloc")
+add_test(NAME halide_correctness_round
+         COMMAND "${TS_BUILDDIR}/bin/correctness_round")
+add_test(NAME halide_correctness_runtime_float16_t_upcast
+         COMMAND "${TS_BUILDDIR}/bin/correctness_runtime_float16_t_upcast")
+add_test(NAME halide_correctness_scatter
+         COMMAND "${TS_BUILDDIR}/bin/correctness_scatter")
+add_test(NAME halide_correctness_shared_self_references
+         COMMAND "${TS_BUILDDIR}/bin/correctness_shared_self_references")
+add_test(NAME halide_correctness_shifted_image
+         COMMAND "${TS_BUILDDIR}/bin/correctness_shifted_image")
+add_test(NAME halide_correctness_side_effects
+         COMMAND "${TS_BUILDDIR}/bin/correctness_side_effects")
+add_test(NAME halide_correctness_simd_op_check
+         COMMAND "${TS_BUILDDIR}/bin/correctness_simd_op_check")
+add_test(NAME halide_correctness_simplified_away_embedded_image
+         COMMAND "${TS_BUILDDIR}/bin/correctness_simplified_away_embedded_image")
+add_test(NAME halide_correctness_skip_stages
+         COMMAND "${TS_BUILDDIR}/bin/correctness_skip_stages")
+add_test(NAME halide_correctness_skip_stages_external_array_functions
+         COMMAND "${TS_BUILDDIR}/bin/correctness_skip_stages_external_array_functions")
+add_test(NAME halide_correctness_sliding_backwards
+         COMMAND "${TS_BUILDDIR}/bin/correctness_sliding_backwards")
+add_test(NAME halide_correctness_sliding_reduction
+         COMMAND "${TS_BUILDDIR}/bin/correctness_sliding_reduction")
+add_test(NAME halide_correctness_sliding_window
+         COMMAND "${TS_BUILDDIR}/bin/correctness_sliding_window")
+add_test(NAME halide_correctness_sort_exprs
+         COMMAND "${TS_BUILDDIR}/bin/correctness_sort_exprs")
+add_test(NAME halide_correctness_specialize
+         COMMAND "${TS_BUILDDIR}/bin/correctness_specialize")
+add_test(NAME halide_correctness_specialize_to_gpu
+         COMMAND "${TS_BUILDDIR}/bin/correctness_specialize_to_gpu")
+add_test(NAME halide_correctness_split_fuse_rvar
+         COMMAND "${TS_BUILDDIR}/bin/correctness_split_fuse_rvar")
+add_test(NAME halide_correctness_split_reuse_inner_name_bug
+         COMMAND "${TS_BUILDDIR}/bin/correctness_split_reuse_inner_name_bug")
+add_test(NAME halide_correctness_split_store_compute
+         COMMAND "${TS_BUILDDIR}/bin/correctness_split_store_compute")
+add_test(NAME halide_correctness_stack_allocations
+         COMMAND "${TS_BUILDDIR}/bin/correctness_stack_allocations")
+add_test(NAME halide_correctness_stmt_to_html
+         COMMAND "${TS_BUILDDIR}/bin/correctness_stmt_to_html")
+add_test(NAME halide_correctness_storage_folding
+         COMMAND "${TS_BUILDDIR}/bin/correctness_storage_folding")
+add_test(NAME halide_correctness_stream_compaction
+         COMMAND "${TS_BUILDDIR}/bin/correctness_stream_compaction")
+add_test(NAME halide_correctness_strided_load
+         COMMAND "${TS_BUILDDIR}/bin/correctness_strided_load")
+add_test(NAME halide_correctness_target
+         COMMAND "${TS_BUILDDIR}/bin/correctness_target")
+add_test(NAME halide_correctness_tracing
+         COMMAND "${TS_BUILDDIR}/bin/correctness_tracing")
+add_test(NAME halide_correctness_tracing_bounds
+         COMMAND "${TS_BUILDDIR}/bin/correctness_tracing_bounds")
+add_test(NAME halide_correctness_tracing_stack
+         COMMAND "${TS_BUILDDIR}/bin/correctness_tracing_stack")
+add_test(NAME halide_correctness_transitive_bounds
+         COMMAND "${TS_BUILDDIR}/bin/correctness_transitive_bounds")
+add_test(NAME halide_correctness_tuple_reduction
+         COMMAND "${TS_BUILDDIR}/bin/correctness_tuple_reduction")
+add_test(NAME halide_correctness_two_vector_args
+         COMMAND "${TS_BUILDDIR}/bin/correctness_two_vector_args")
+add_test(NAME halide_correctness_undef
+         COMMAND "${TS_BUILDDIR}/bin/correctness_undef")
+add_test(NAME halide_correctness_uninitialized_read
+         COMMAND "${TS_BUILDDIR}/bin/correctness_uninitialized_read")
+add_test(NAME halide_correctness_unique_func_image
+         COMMAND "${TS_BUILDDIR}/bin/correctness_unique_func_image")
+add_test(NAME halide_correctness_unrolled_reduction
+         COMMAND "${TS_BUILDDIR}/bin/correctness_unrolled_reduction")
+add_test(NAME halide_correctness_update_chunk
+         COMMAND "${TS_BUILDDIR}/bin/correctness_update_chunk")
+add_test(NAME halide_correctness_vector_bounds_inference
+         COMMAND "${TS_BUILDDIR}/bin/correctness_vector_bounds_inference")
+add_test(NAME halide_correctness_vector_cast
+         COMMAND "${TS_BUILDDIR}/bin/correctness_vector_cast")
+add_test(NAME halide_correctness_vector_extern
+         COMMAND "${TS_BUILDDIR}/bin/correctness_vector_extern")
+add_test(NAME halide_correctness_vectorized_initialization
+         COMMAND "${TS_BUILDDIR}/bin/correctness_vectorized_initialization")
+add_test(NAME halide_correctness_vectorized_reduction_bug
+         COMMAND "${TS_BUILDDIR}/bin/correctness_vectorized_reduction_bug")
+add_test(NAME halide_correctness_vectorize_mixed_widths
+         COMMAND "${TS_BUILDDIR}/bin/correctness_vectorize_mixed_widths")
+add_test(NAME halide_correctness_vector_math
+         COMMAND "${TS_BUILDDIR}/bin/correctness_vector_math")
+add_test(NAME halide_error_ambiguous_inline_reductions
+         COMMAND "${TS_BUILDDIR}/bin/error_ambiguous_inline_reductions")
+add_test(NAME halide_error_bad_bound
+         COMMAND "${TS_BUILDDIR}/bin/error_bad_bound")
+add_test(NAME halide_error_bad_compute_at
+         COMMAND "${TS_BUILDDIR}/bin/error_bad_compute_at")
+add_test(NAME halide_error_bad_const_cast
+         COMMAND "${TS_BUILDDIR}/bin/error_bad_const_cast")
+add_test(NAME halide_error_bad_rvar_order
+         COMMAND "${TS_BUILDDIR}/bin/error_bad_rvar_order")
+add_test(NAME halide_error_bad_schedule
+         COMMAND "${TS_BUILDDIR}/bin/error_bad_schedule")
+add_test(NAME halide_error_bad_store_at
+         COMMAND "${TS_BUILDDIR}/bin/error_bad_store_at")
+add_test(NAME halide_error_buffer_larger_than_two_gigs
+         COMMAND "${TS_BUILDDIR}/bin/error_buffer_larger_than_two_gigs")
+add_test(NAME halide_error_constrain_wrong_output_buffer
+         COMMAND "${TS_BUILDDIR}/bin/error_constrain_wrong_output_buffer")
+add_test(NAME halide_error_define_after_realize
+         COMMAND "${TS_BUILDDIR}/bin/error_define_after_realize")
+add_test(NAME halide_error_define_after_use
+         COMMAND "${TS_BUILDDIR}/bin/error_define_after_use")
+add_test(NAME halide_error_expanding_reduction
+         COMMAND "${TS_BUILDDIR}/bin/error_expanding_reduction")
+add_test(NAME halide_error_five_d_gpu_buffer
+         COMMAND "${TS_BUILDDIR}/bin/error_five_d_gpu_buffer")
+add_test(NAME halide_error_float16_t_implicit_downcast
+         COMMAND "${TS_BUILDDIR}/bin/error_float16_t_implicit_downcast")
+add_test(NAME halide_error_float16_t_overflow
+         COMMAND "${TS_BUILDDIR}/bin/error_float16_t_overflow")
+add_test(NAME halide_error_float16_t_overflow_int_conv
+         COMMAND "${TS_BUILDDIR}/bin/error_float16_t_overflow_int_conv")
+add_test(NAME halide_error_float_arg
+         COMMAND "${TS_BUILDDIR}/bin/error_float_arg")
+add_test(NAME halide_error_impossible_constraints
+         COMMAND "${TS_BUILDDIR}/bin/error_impossible_constraints")
+add_test(NAME halide_error_lerp_float_weight_out_of_range
+         COMMAND "${TS_BUILDDIR}/bin/error_lerp_float_weight_out_of_range")
+add_test(NAME halide_error_lerp_mismatch
+         COMMAND "${TS_BUILDDIR}/bin/error_lerp_mismatch")
+add_test(NAME halide_error_lerp_signed_weight
+         COMMAND "${TS_BUILDDIR}/bin/error_lerp_signed_weight")
+add_test(NAME halide_error_memoize_different_compute_store
+         COMMAND "${TS_BUILDDIR}/bin/error_memoize_different_compute_store")
+add_test(NAME halide_error_missing_args
+         COMMAND "${TS_BUILDDIR}/bin/error_missing_args")
+add_test(NAME halide_error_modulo_constant_zero
+         COMMAND "${TS_BUILDDIR}/bin/error_modulo_constant_zero")
+add_test(NAME halide_error_nonexistent_update_stage
+         COMMAND "${TS_BUILDDIR}/bin/error_nonexistent_update_stage")
+add_test(NAME halide_error_old_implicit_args
+         COMMAND "${TS_BUILDDIR}/bin/error_old_implicit_args")
+add_test(NAME halide_error_pointer_arithmetic
+         COMMAND "${TS_BUILDDIR}/bin/error_pointer_arithmetic")
+add_test(NAME halide_error_race_condition
+         COMMAND "${TS_BUILDDIR}/bin/error_race_condition")
+add_test(NAME halide_error_realize_constantly_larger_than_two_gigs
+         COMMAND "${TS_BUILDDIR}/bin/error_realize_constantly_larger_than_two_gigs")
+add_test(NAME halide_error_reduction_bounds
+         COMMAND "${TS_BUILDDIR}/bin/error_reduction_bounds")
+add_test(NAME halide_error_reduction_type_mismatch
+         COMMAND "${TS_BUILDDIR}/bin/error_reduction_type_mismatch")
+add_test(NAME halide_error_reused_args
+         COMMAND "${TS_BUILDDIR}/bin/error_reused_args")
+add_test(NAME halide_error_reuse_var_in_schedule
+         COMMAND "${TS_BUILDDIR}/bin/error_reuse_var_in_schedule")
+add_test(NAME halide_error_thread_id_outside_block_id
+         COMMAND "${TS_BUILDDIR}/bin/error_thread_id_outside_block_id")
+add_test(NAME halide_error_too_many_args
+         COMMAND "${TS_BUILDDIR}/bin/error_too_many_args")
+add_test(NAME halide_error_unbounded_input
+         COMMAND "${TS_BUILDDIR}/bin/error_unbounded_input")
+add_test(NAME halide_error_unbounded_output
+         COMMAND "${TS_BUILDDIR}/bin/error_unbounded_output")
+add_test(NAME halide_error_undefined_rdom_dimension
+         COMMAND "${TS_BUILDDIR}/bin/error_undefined_rdom_dimension")
+add_test(NAME halide_error_vectorize_dynamic
+         COMMAND "${TS_BUILDDIR}/bin/error_vectorize_dynamic")
+add_test(NAME halide_error_vectorize_too_little
+         COMMAND "${TS_BUILDDIR}/bin/error_vectorize_too_little")
+add_test(NAME halide_error_vectorize_too_much
+         COMMAND "${TS_BUILDDIR}/bin/error_vectorize_too_much")
+add_test(NAME halide_error_wrong_type
+         COMMAND "${TS_BUILDDIR}/bin/error_wrong_type")
+add_test(NAME halide_filter
+         COMMAND "${TS_BUILDDIR}/bin/filter")
+add_test(NAME halide_generator_aot_acquire_release
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_acquire_release")
+add_test(NAME halide_generator_aot_argvcall
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_argvcall")
+add_test(NAME halide_generator_aot_cleanup_on_error
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_cleanup_on_error")
+add_test(NAME halide_generator_aot_embed_image
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_embed_image")
+add_test(NAME halide_generator_aot_error_codes
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_error_codes")
+add_test(NAME halide_generator_aot_example
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_example")
+add_test(NAME halide_generator_aot_extended_buffer_t
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_extended_buffer_t")
+add_test(NAME halide_generator_aot_gpu_object_lifetime
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_gpu_object_lifetime")
+add_test(NAME halide_generator_aot_gpu_only
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_gpu_only")
+add_test(NAME halide_generator_aot_mandelbrot
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_mandelbrot")
+add_test(NAME halide_generator_aot_matlab
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_matlab")
+add_test(NAME halide_generator_aot_metadata_tester
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_metadata_tester")
+add_test(NAME halide_generator_aot_nested_externs
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_nested_externs")
+add_test(NAME halide_generator_aot_pyramid
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_pyramid")
+add_test(NAME halide_generator_aot_tiled_blur
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_tiled_blur")
+add_test(NAME halide_generator_aot_tiled_blur_interleaved
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_tiled_blur_interleaved")
+add_test(NAME halide_generator_aot_user_context
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_user_context")
+add_test(NAME halide_generator_aot_user_context_insanity
+         COMMAND "${TS_BUILDDIR}/bin/generator_aot_user_context_insanity")
+add_test(NAME halide_generator_jit_example
+         COMMAND "${TS_BUILDDIR}/bin/generator_jit_example")
+add_test(NAME halide_generator_jit_paramtest
+         COMMAND "${TS_BUILDDIR}/bin/generator_jit_paramtest")
+add_test(NAME halide_glsl_halide_blur
+         COMMAND "${TS_BUILDDIR}/bin/glsl_halide_blur")
+add_test(NAME halide_glsl_halide_ycc
+         COMMAND "${TS_BUILDDIR}/bin/glsl_halide_ycc")
+add_test(NAME halide_halide_blur
+         COMMAND "${TS_BUILDDIR}/bin/halide_blur")
+add_test(NAME halide_HalideTraceViz
+         COMMAND "${TS_BUILDDIR}/bin/HalideTraceViz")
+add_test(NAME halide_lesson_01_basics
+         COMMAND "${TS_BUILDDIR}/bin/lesson_01_basics")
+add_test(NAME halide_lesson_02_input_image
+         COMMAND "${TS_BUILDDIR}/bin/lesson_02_input_image")
+add_test(NAME halide_lesson_03_debugging_1
+         COMMAND "${TS_BUILDDIR}/bin/lesson_03_debugging_1")
+add_test(NAME halide_lesson_04_debugging_2
+         COMMAND "${TS_BUILDDIR}/bin/lesson_04_debugging_2")
+add_test(NAME halide_lesson_05_scheduling_1
+         COMMAND "${TS_BUILDDIR}/bin/lesson_05_scheduling_1")
+add_test(NAME halide_lesson_06_realizing_over_shifted_domains
+         COMMAND "${TS_BUILDDIR}/bin/lesson_06_realizing_over_shifted_domains")
+add_test(NAME halide_lesson_07_multi_stage_pipelines
+         COMMAND "${TS_BUILDDIR}/bin/lesson_07_multi_stage_pipelines")
+add_test(NAME halide_lesson_08_scheduling_2
+         COMMAND "${TS_BUILDDIR}/bin/lesson_08_scheduling_2")
+add_test(NAME halide_lesson_09_update_definitions
+         COMMAND "${TS_BUILDDIR}/bin/lesson_09_update_definitions")
+add_test(NAME halide_lesson_10_aot_compilation_generate
+         COMMAND "${TS_BUILDDIR}/bin/lesson_10_aot_compilation_generate")
+add_test(NAME halide_lesson_10_aot_compilation_run
+         COMMAND "${TS_BUILDDIR}/bin/lesson_10_aot_compilation_run")
+add_test(NAME halide_lesson_11_cross_compilation
+         COMMAND "${TS_BUILDDIR}/bin/lesson_11_cross_compilation")
+add_test(NAME halide_lesson_12_using_the_gpu
+         COMMAND "${TS_BUILDDIR}/bin/lesson_12_using_the_gpu")
+add_test(NAME halide_lesson_13_tuples
+         COMMAND "${TS_BUILDDIR}/bin/lesson_13_tuples")
+add_test(NAME halide_lesson_14_types
+         COMMAND "${TS_BUILDDIR}/bin/lesson_14_types")
+add_test(NAME halide_ll_process
+         COMMAND "${TS_BUILDDIR}/bin/ll_process")
+add_test(NAME halide_local_laplacian_gen
+         COMMAND "${TS_BUILDDIR}/bin/local_laplacian_gen")
+add_test(NAME halide_opengl_copy_pixels
+         COMMAND "${TS_BUILDDIR}/bin/opengl_copy_pixels")
+add_test(NAME halide_opengl_copy_to_device
+         COMMAND "${TS_BUILDDIR}/bin/opengl_copy_to_device")
+add_test(NAME halide_opengl_copy_to_host
+         COMMAND "${TS_BUILDDIR}/bin/opengl_copy_to_host")
+add_test(NAME halide_opengl_float_texture
+         COMMAND "${TS_BUILDDIR}/bin/opengl_float_texture")
+add_test(NAME halide_opengl_internal
+         COMMAND "${TS_BUILDDIR}/bin/opengl_internal")
+add_test(NAME halide_opengl_lut
+         COMMAND "${TS_BUILDDIR}/bin/opengl_lut")
+add_test(NAME halide_opengl_produce
+         COMMAND "${TS_BUILDDIR}/bin/opengl_produce")
+add_test(NAME halide_opengl_select
+         COMMAND "${TS_BUILDDIR}/bin/opengl_select")
+add_test(NAME halide_opengl_set_pixels
+         COMMAND "${TS_BUILDDIR}/bin/opengl_set_pixels")
+add_test(NAME halide_opengl_shifted_domains
+         COMMAND "${TS_BUILDDIR}/bin/opengl_shifted_domains")
+add_test(NAME halide_opengl_special_funcs
+         COMMAND "${TS_BUILDDIR}/bin/opengl_special_funcs")
+add_test(NAME halide_opengl_test
+         COMMAND "${TS_BUILDDIR}/bin/opengl_test")
+add_test(NAME halide_opengl_varying
+         COMMAND "${TS_BUILDDIR}/bin/opengl_varying")
+add_test(NAME halide_performance_block_transpose
+         COMMAND "${TS_BUILDDIR}/bin/performance_block_transpose")
+add_test(NAME halide_performance_boundary_conditions
+         COMMAND "${TS_BUILDDIR}/bin/performance_boundary_conditions")
+add_test(NAME halide_performance_clamped_vector_load
+         COMMAND "${TS_BUILDDIR}/bin/performance_clamped_vector_load")
+add_test(NAME halide_performance_const_division
+         COMMAND "${TS_BUILDDIR}/bin/performance_const_division")
+add_test(NAME halide_performance_fast_inverse
+         COMMAND "${TS_BUILDDIR}/bin/performance_fast_inverse")
+add_test(NAME halide_performance_fast_pow
+         COMMAND "${TS_BUILDDIR}/bin/performance_fast_pow")
+add_test(NAME halide_performance_inner_loop_parallel
+         COMMAND "${TS_BUILDDIR}/bin/performance_inner_loop_parallel")
+add_test(NAME halide_performance_jit_stress
+         COMMAND "${TS_BUILDDIR}/bin/performance_jit_stress")
+add_test(NAME halide_performance_matrix_multiplication
+         COMMAND "${TS_BUILDDIR}/bin/performance_matrix_multiplication")
+add_test(NAME halide_performance_memcpy
+         COMMAND "${TS_BUILDDIR}/bin/performance_memcpy")
+add_test(NAME halide_performance_packed_planar_fusion
+         COMMAND "${TS_BUILDDIR}/bin/performance_packed_planar_fusion")
+add_test(NAME halide_performance_parallel_performance
+         COMMAND "${TS_BUILDDIR}/bin/performance_parallel_performance")
+add_test(NAME halide_performance_profiler
+         COMMAND "${TS_BUILDDIR}/bin/performance_profiler")
+add_test(NAME halide_performance_rgb_interleaved
+         COMMAND "${TS_BUILDDIR}/bin/performance_rgb_interleaved")
+add_test(NAME halide_performance_sort
+         COMMAND "${TS_BUILDDIR}/bin/performance_sort")
+add_test(NAME halide_performance_vectorize
+         COMMAND "${TS_BUILDDIR}/bin/performance_vectorize")
+add_test(NAME halide_pipeline
+         COMMAND "${TS_BUILDDIR}/bin/pipeline")
+add_test(NAME halide_process
+         COMMAND "${TS_BUILDDIR}/bin/process")
+add_test(NAME halide_renderscript_aot_copy
+         COMMAND "${TS_BUILDDIR}/bin/renderscript_aot_copy")
+add_test(NAME halide_renderscript_aot_copy_error
+         COMMAND "${TS_BUILDDIR}/bin/renderscript_aot_copy_error")
+add_test(NAME halide_renderscript_jit_copy
+         COMMAND "${TS_BUILDDIR}/bin/renderscript_jit_copy")
+add_test(NAME halide_run_c_backend_and_native
+         COMMAND "${TS_BUILDDIR}/bin/run_c_backend_and_native")
+add_test(NAME halide_test_internal
+         COMMAND "${TS_BUILDDIR}/bin/test_internal")
+add_test(NAME halide_warning_double_vectorize
+         COMMAND "${TS_BUILDDIR}/bin/warning_double_vectorize")
+add_test(NAME halide_warning_float16_t_underflow
+         COMMAND "${TS_BUILDDIR}/bin/warning_float16_t_underflow")
+add_test(NAME halide_warning_hidden_pure_definition
+         COMMAND "${TS_BUILDDIR}/bin/warning_hidden_pure_definition")
+add_test(NAME halide_warning_parallel_size_one
+         COMMAND "${TS_BUILDDIR}/bin/warning_parallel_size_one")
+add_test(NAME halide_warning_vectorize_size_one
+         COMMAND "${TS_BUILDDIR}/bin/warning_vectorize_size_one")
+
+
+
+set_tests_properties(
+  halide_bilateral_grid
+  halide_bitcode2cpp
+  halide_blur_test
+  halide_build_halide_h
+  halide_camera_pipe
+  halide_correctness_argmax
+  halide_correctness_assertion_failure_in_parallel_for
+  halide_correctness_autotune_bug
+  halide_correctness_autotune_bug_2
+  halide_correctness_autotune_bug_3
+  halide_correctness_autotune_bug_4
+  halide_correctness_autotune_bug_5
+  halide_correctness_bad_likely
+  halide_correctness_bit_counting
+  halide_correctness_bitwise_ops
+  halide_correctness_bool_compute_root_vectorize
+  halide_correctness_bound
+  halide_correctness_boundary_conditions
+  halide_correctness_bounds
+  halide_correctness_bounds_inference
+  halide_correctness_bounds_inference_chunk
+  halide_correctness_bounds_inference_complex
+  halide_correctness_bounds_of_abs
+  halide_correctness_bounds_of_cast
+  halide_correctness_bounds_of_func
+  halide_correctness_bounds_of_monotonic_math
+  halide_correctness_bounds_query
+  halide_correctness_buffer_t
+  halide_correctness_cascaded_filters
+  halide_correctness_cast
+  halide_correctness_cast_handle
+  halide_correctness_c_function
+  halide_correctness_chunk
+  halide_correctness_chunk_sharing
+  halide_correctness_circular_reference_leak
+  halide_correctness_code_explosion
+  halide_correctness_compare_vars
+  halide_correctness_compile_to
+  halide_correctness_compile_to_bitcode
+  halide_correctness_compile_to_lowered_stmt
+  halide_correctness_compute_at_split_rvar
+  halide_correctness_computed_index
+  halide_correctness_compute_outermost
+  halide_correctness_constant_expr
+  halide_correctness_constant_type
+  halide_correctness_constraints
+  halide_correctness_convolution
+  halide_correctness_convolution_multiple_kernels
+  halide_correctness_cross_compilation
+  halide_correctness_custom_allocator
+  halide_correctness_custom_error_reporter
+  halide_correctness_custom_lowering_pass
+  halide_correctness_debug_to_file
+  halide_correctness_deinterleave4
+  halide_correctness_div_mod
+  halide_correctness_dynamic_reduction_bounds
+  halide_correctness_erf
+  halide_correctness_exception
+  halide_correctness_explicit_inline_reductions
+  halide_correctness_extern_bounds_inference
+  halide_correctness_extern_consumer
+  halide_correctness_extern_error
+  halide_correctness_extern_output_expansion
+  halide_correctness_extern_producer
+  halide_correctness_extern_sort
+  halide_correctness_extern_stage
+  halide_correctness_fibonacci
+  halide_correctness_float16_t_comparison
+  halide_correctness_float16_t_constants
+  halide_correctness_float16_t_image_type
+  halide_correctness_float16_t_implicit_upcast
+  halide_correctness_float16_t_realize_constant
+  halide_correctness_func_lifetime
+  halide_correctness_func_lifetime_2
+  halide_correctness_fuse
+  halide_correctness_fused_where_inner_extent_is_zero
+  halide_correctness_fuzz_simplify
+  halide_correctness_gameoflife
+  halide_correctness_gpu_data_flows
+  halide_correctness_gpu_dynamic_shared
+  halide_correctness_gpu_free_sync
+  halide_correctness_gpu_large_alloc
+  halide_correctness_gpu_mixed_dimensionality
+  halide_correctness_gpu_mixed_shared_mem_types
+  halide_correctness_gpu_multi_device
+  halide_correctness_gpu_multi_kernel
+  halide_correctness_gpu_non_contiguous_copy
+  halide_correctness_gpu_object_lifetime
+  halide_correctness_gpu_specialize
+  halide_correctness_gpu_sum_scan
+  halide_correctness_gpu_thread_barrier
+  halide_correctness_gpu_transpose
+  halide_correctness_gpu_vectorize_div_mod
+  halide_correctness_gpu_vectorized_shared_memory
+  halide_correctness_handle
+  halide_correctness_heap_cleanup
+  halide_correctness_hello_gpu
+  halide_correctness_histogram
+  halide_correctness_histogram_equalize
+  halide_correctness_image_of_lists
+  halide_correctness_implicit_args
+  halide_correctness_infer_arguments
+  halide_correctness_inline_reduction
+  halide_correctness_in_place
+  halide_correctness_input_image_bounds_check
+  halide_correctness_input_larger_than_two_gigs
+  halide_correctness_integer_powers
+  halide_correctness_interleave
+  halide_correctness_introspection
+  halide_correctness_inverse
+  halide_correctness_isnan
+  halide_correctness_iterate_over_circle
+  halide_correctness_lambda
+  halide_correctness_lazy_convolution
+  halide_correctness_legal_race_condition
+  halide_correctness_lerp
+  halide_correctness_likely
+  halide_correctness_logical
+  halide_correctness_loop_invariant_extern_calls
+  halide_correctness_make_struct
+  halide_correctness_many_dimensions
+  halide_correctness_many_small_extern_stages
+  halide_correctness_many_updates
+  halide_correctness_math
+  halide_correctness_memoize
+  halide_correctness_min_extent
+  halide_correctness_mod
+  halide_correctness_multi_output_pipeline_with_bad_sizes
+  halide_correctness_multipass_constraints
+  halide_correctness_multi_pass_reduction
+  halide_correctness_multiple_outputs
+  halide_correctness_multi_way_select
+  halide_correctness_named_updates
+  halide_correctness_newtons_method
+  halide_correctness_obscure_image_references
+  halide_correctness_oddly_sized_output
+  halide_correctness_out_of_memory
+  halide_correctness_output_larger_than_two_gigs
+  halide_correctness_parallel
+  halide_correctness_parallel_alloc
+  halide_correctness_parallel_gpu_nested
+  halide_correctness_parallel_nested
+  halide_correctness_parallel_reductions
+  halide_correctness_parallel_rvar
+  halide_correctness_param
+  halide_correctness_parameter_constraints
+  halide_correctness_partial_application
+  halide_correctness_partition_loops_bug
+  halide_correctness_pipeline_set_jit_externs_func
+  halide_correctness_print
+  halide_correctness_process_some_tiles
+  halide_correctness_random
+  halide_correctness_realize_larger_than_two_gigs
+  halide_correctness_realize_over_shifted_domain
+  halide_correctness_reduction_chain
+  halide_correctness_reduction_schedule
+  halide_correctness_reduction_subregion
+  halide_correctness_reorder_rvars
+  halide_correctness_reorder_storage
+  halide_correctness_reschedule
+  halide_correctness_reuse_stack_alloc
+  halide_correctness_round
+  halide_correctness_runtime_float16_t_upcast
+  halide_correctness_scatter
+  halide_correctness_shared_self_references
+  halide_correctness_shifted_image
+  halide_correctness_side_effects
+  halide_correctness_simd_op_check
+  halide_correctness_simplified_away_embedded_image
+  halide_correctness_skip_stages
+  halide_correctness_skip_stages_external_array_functions
+  halide_correctness_sliding_backwards
+  halide_correctness_sliding_reduction
+  halide_correctness_sliding_window
+  halide_correctness_sort_exprs
+  halide_correctness_specialize
+  halide_correctness_specialize_to_gpu
+  halide_correctness_split_fuse_rvar
+  halide_correctness_split_reuse_inner_name_bug
+  halide_correctness_split_store_compute
+  halide_correctness_stack_allocations
+  halide_correctness_stmt_to_html
+  halide_correctness_storage_folding
+  halide_correctness_stream_compaction
+  halide_correctness_strided_load
+  halide_correctness_target
+  halide_correctness_tracing
+  halide_correctness_tracing_bounds
+  halide_correctness_tracing_stack
+  halide_correctness_transitive_bounds
+  halide_correctness_tuple_reduction
+  halide_correctness_two_vector_args
+  halide_correctness_undef
+  halide_correctness_uninitialized_read
+  halide_correctness_unique_func_image
+  halide_correctness_unrolled_reduction
+  halide_correctness_update_chunk
+  halide_correctness_vector_bounds_inference
+  halide_correctness_vector_cast
+  halide_correctness_vector_extern
+  halide_correctness_vectorized_initialization
+  halide_correctness_vectorized_reduction_bug
+  halide_correctness_vectorize_mixed_widths
+  halide_correctness_vector_math
+  halide_error_ambiguous_inline_reductions
+  halide_error_bad_bound
+  halide_error_bad_compute_at
+  halide_error_bad_const_cast
+  halide_error_bad_rvar_order
+  halide_error_bad_schedule
+  halide_error_bad_store_at
+  halide_error_buffer_larger_than_two_gigs
+  halide_error_constrain_wrong_output_buffer
+  halide_error_define_after_realize
+  halide_error_define_after_use
+  halide_error_expanding_reduction
+  halide_error_five_d_gpu_buffer
+  halide_error_float16_t_implicit_downcast
+  halide_error_float16_t_overflow
+  halide_error_float16_t_overflow_int_conv
+  halide_error_float_arg
+  halide_error_impossible_constraints
+  halide_error_lerp_float_weight_out_of_range
+  halide_error_lerp_mismatch
+  halide_error_lerp_signed_weight
+  halide_error_memoize_different_compute_store
+  halide_error_missing_args
+  halide_error_modulo_constant_zero
+  halide_error_nonexistent_update_stage
+  halide_error_old_implicit_args
+  halide_error_pointer_arithmetic
+  halide_error_race_condition
+  halide_error_realize_constantly_larger_than_two_gigs
+  halide_error_reduction_bounds
+  halide_error_reduction_type_mismatch
+  halide_error_reused_args
+  halide_error_reuse_var_in_schedule
+  halide_error_thread_id_outside_block_id
+  halide_error_too_many_args
+  halide_error_unbounded_input
+  halide_error_unbounded_output
+  halide_error_undefined_rdom_dimension
+  halide_error_vectorize_dynamic
+  halide_error_vectorize_too_little
+  halide_error_vectorize_too_much
+  halide_error_wrong_type
+  halide_filter
+  halide_generator_aot_acquire_release
+  halide_generator_aot_argvcall
+  halide_generator_aot_cleanup_on_error
+  halide_generator_aot_embed_image
+  halide_generator_aot_error_codes
+  halide_generator_aot_example
+  halide_generator_aot_extended_buffer_t
+  halide_generator_aot_gpu_object_lifetime
+  halide_generator_aot_gpu_only
+  halide_generator_aot_mandelbrot
+  halide_generator_aot_matlab
+  halide_generator_aot_metadata_tester
+  halide_generator_aot_nested_externs
+  halide_generator_aot_pyramid
+  halide_generator_aot_tiled_blur
+  halide_generator_aot_tiled_blur_interleaved
+  halide_generator_aot_user_context
+  halide_generator_aot_user_context_insanity
+  halide_generator_jit_example
+  halide_generator_jit_paramtest
+  halide_glsl_halide_blur
+  halide_glsl_halide_ycc
+  halide_halide_blur
+  halide_HalideTraceViz
+  halide_lesson_01_basics
+  halide_lesson_02_input_image
+  halide_lesson_03_debugging_1
+  halide_lesson_04_debugging_2
+  halide_lesson_05_scheduling_1
+  halide_lesson_06_realizing_over_shifted_domains
+  halide_lesson_07_multi_stage_pipelines
+  halide_lesson_08_scheduling_2
+  halide_lesson_09_update_definitions
+  halide_lesson_10_aot_compilation_generate
+  halide_lesson_10_aot_compilation_run
+  halide_lesson_11_cross_compilation
+  halide_lesson_12_using_the_gpu
+  halide_lesson_13_tuples
+  halide_lesson_14_types
+  halide_ll_process
+  halide_local_laplacian_gen
+  halide_opengl_copy_pixels
+  halide_opengl_copy_to_device
+  halide_opengl_copy_to_host
+  halide_opengl_float_texture
+  halide_opengl_internal
+  halide_opengl_lut
+  halide_opengl_produce
+  halide_opengl_select
+  halide_opengl_set_pixels
+  halide_opengl_shifted_domains
+  halide_opengl_special_funcs
+  halide_opengl_test
+  halide_opengl_varying
+  halide_performance_block_transpose
+  halide_performance_boundary_conditions
+  halide_performance_clamped_vector_load
+  halide_performance_const_division
+  halide_performance_fast_inverse
+  halide_performance_fast_pow
+  halide_performance_inner_loop_parallel
+  halide_performance_jit_stress
+  halide_performance_matrix_multiplication
+  halide_performance_memcpy
+  halide_performance_packed_planar_fusion
+  halide_performance_parallel_performance
+  halide_performance_profiler
+  halide_performance_rgb_interleaved
+  halide_performance_sort
+  halide_performance_vectorize
+  halide_pipeline
+  halide_process
+  halide_renderscript_aot_copy
+  halide_renderscript_aot_copy_error
+  halide_renderscript_jit_copy
+  halide_run_c_backend_and_native
+  halide_test_internal
+  halide_warning_double_vectorize
+  halide_warning_float16_t_underflow
+  halide_warning_hidden_pure_definition
+  halide_warning_parallel_size_one
+  halide_warning_vectorize_size_one
+  PROPERTIES
+    LABELS "Halide")

--- a/examples/Halide/CMakeLists.txt
+++ b/examples/Halide/CMakeLists.txt
@@ -29,7 +29,8 @@ set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}-build")
 set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
 
 message(STATUS "Enabling testsuite ${TS_NAME}")
-set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
+set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
 
 ExternalProject_Add(
   ${TS_NAME}
@@ -56,6 +57,9 @@ ExternalProject_Add(
     "-DLLVM_VERSION:STRING=${LLVM_MAJOR}${LLVM_MINOR}"
   INSTALL_COMMAND "/bin/true"
 )
+
+set_target_properties(${TS_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+add_dependencies(prepare_examples ${TS_NAME})
 
 # TODO Probably not tests
 # acquire_release.generator argvcall.generator cleanup_on_error.generator

--- a/examples/IntelSVM/CMakeLists.txt
+++ b/examples/IntelSVM/CMakeLists.txt
@@ -31,7 +31,8 @@ set(INTEL_ZIP "${TS_SRCDIR}/intel_ocl_svm_basic_win.zip")
 
 if (EXISTS "${INTEL_ZIP}")
   message(STATUS "Enabling testsuite ${TS_NAME}")
-  set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+  list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
+  set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
 
   ExternalProject_Add(
     ${TS_NAME}
@@ -46,6 +47,9 @@ if (EXISTS "${INTEL_ZIP}")
       -DOPENCL_LIBRARIES:STRING=OpenCL
     INSTALL_COMMAND "/bin/true"
   )
+
+  set_target_properties(${TS_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  add_dependencies(prepare_examples ${TS_NAME})
 
   add_test(NAME intel_svm_coarse
     COMMAND "${TS_BUILDDIR}/coarse")

--- a/examples/IntelSVM/CMakeLists.txt
+++ b/examples/IntelSVM/CMakeLists.txt
@@ -1,0 +1,62 @@
+#=============================================================================
+#   CMake build system files
+#
+#   Copyright (c) 2015 pocl developers
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#   THE SOFTWARE.
+#
+#=============================================================================
+
+set(TS_NAME IntelSVM)
+set(TS_BASEDIR "${TESTSUITE_BASEDIR}/${TS_NAME}")
+set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}-build")
+set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
+set(INTEL_ZIP "${TS_SRCDIR}/intel_ocl_svm_basic_win.zip")
+
+if (EXISTS "${INTEL_ZIP}")
+  message(STATUS "Enabling testsuite ${TS_NAME}")
+  set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+
+  ExternalProject_Add(
+    ${TS_NAME}
+    PREFIX "${TS_BASEDIR}"
+    DOWNLOAD_COMMAND /bin/true
+    PATCH_COMMAND pwd && unzip "${INTEL_ZIP}" &&
+      cp "${CMAKE_CURRENT_SOURCE_DIR}/intelsvm_CMakeLists.txt" ./CMakeLists.txt &&
+      patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/intelsvm.patch
+    CMAKE_ARGS
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      "-DCMAKE_CXX_FLAGS_RELWITHDEBINFO=-O2 -g -DCL_USE_DEPRECATED_OPENCL_1_2_APIS"
+      -DOPENCL_LIBRARIES:STRING=OpenCL
+    INSTALL_COMMAND "/bin/true"
+  )
+
+  add_test(NAME intel_svm_coarse
+    COMMAND "${TS_BUILDDIR}/coarse")
+  add_test(NAME intel_svm_fine
+    COMMAND "${TS_BUILDDIR}/fine")
+
+  set_tests_properties( intel_svm_coarse intel_svm_fine
+    PROPERTIES  LABELS "IntelSVM")
+
+else()
+
+  message(STATUS "Disabling testsuite ${TS_NAME}, required files not found" )
+
+endif()

--- a/examples/IntelSVM/intelsvm_CMakeLists.txt
+++ b/examples/IntelSVM/intelsvm_CMakeLists.txt
@@ -1,0 +1,44 @@
+#=============================================================================
+#   CMake build system files
+#
+#   Copyright (c) 2015 pocl developers
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#   THE SOFTWARE.
+#
+#=============================================================================
+
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
+project(intelsvm)
+
+add_compile_options("-std=c++11")
+
+include_directories("common")
+
+add_executable(fine SVMBasicFineGrained/svmbasic.cpp
+    common/basic.cpp  common/basic.hpp
+    common/cmdparser.cpp  common/cmdparser.hpp
+    common/oclobject.cpp  common/oclobject.hpp)
+target_link_libraries(fine "${OPENCL_LIBRARIES}")
+
+add_executable(coarse SVMBasicCoarseGrained/svmbasic.cpp
+    common/basic.cpp  common/basic.hpp
+    common/cmdparser.cpp  common/cmdparser.hpp
+    common/oclobject.cpp  common/oclobject.hpp)
+target_link_libraries(coarse "${OPENCL_LIBRARIES}")

--- a/examples/OpenCV/CMakeLists.txt
+++ b/examples/OpenCV/CMakeLists.txt
@@ -1,0 +1,328 @@
+#=============================================================================
+#   CMake build system files
+#
+#   Copyright (c) 2015 pocl developers
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#   THE SOFTWARE.
+#
+#=============================================================================
+
+set(TS_NAME "OpenCV")
+set(TS_BASEDIR "${TESTSUITE_BASEDIR}/${TS_NAME}")
+set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}-build")
+set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
+
+set(OPENCV "opencv-3.0.0-beta")
+set(OPENCV_ZIP "${TS_BASEDIR}/src/${OPENCV}.zip")
+
+if(EXISTS "${OPENCV_ZIP}")
+
+  message(STATUS "Enabling testsuite ${TS_NAME}")
+  set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+
+  ExternalProject_Add(
+    ${TS_NAME}
+    PREFIX "${TS_BASEDIR}"
+    # Download URL is "https://github.com/Itseez/opencv/archive/${OPENCV_ZIP}"
+    # but for some reason it doesn't work from cmake.
+    DOWNLOAD_COMMAND pwd && unzip "${OPENCV_ZIP}"
+      && patch -p1 -i "${CMAKE_CURRENT_SOURCE_DIR}/opencv.patch"
+      && rmdir OpenCV && mv ${OPENCV} OpenCV
+
+    # TODO this should be optimized to only build
+    # the stuff required for testing OpenCL
+    CMAKE_ARGS -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      -DWITH_CUDA=OFF
+      -DWITH_OPENCL=ON
+      -DWITH_FFMPEG=OFF
+      -DBUILD_TESTS=ON
+      -DBUILD_PERF_TESTS=ON
+      -DBUILD_EXAMPLES=ON
+      -DBUILD_DOCS=OFF
+
+    INSTALL_COMMAND /bin/true
+  )
+
+  add_test(NAME test_UMat
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=UMat.*")
+
+  add_test(NAME test_Core_UMat
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=Core_UMat.*")
+
+  add_test(NAME test_Image2D
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=Image2D.*")
+
+  add_test(NAME test_UMat_UMatBasicTests
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=UMat/UMatBasicTests.*")
+
+  add_test(NAME test_UMat_UMatTestReshape
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=UMat/UMatTestReshape.*")
+
+  add_test(NAME test_UMat_UMatTestRoi
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=UMat/UMatTestRoi.*")
+
+  add_test(NAME test_UMat_UMatTestSizeOperations
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=UMat/UMatTestSizeOperations.*")
+
+  add_test(NAME test_UMat_UMatTestUMatOperations
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=UMat/UMatTestUMatOperations.*")
+
+  add_test(NAME test_OCL_MeanStdDev_
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_MeanStdDev_.*")
+
+  add_test(NAME test_OCL_Channels_Merge
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Channels/Merge.*")
+
+  add_test(NAME test_OCL_Channels_Split
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Channels/Split.*")
+
+  add_test(NAME test_OCL_Channels_MixChannels
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Channels/MixChannels.*")
+
+  add_test(NAME test_OCL_Channels_InsertChannels
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Channels/InsertChannels.*")
+
+  add_test(NAME test_OCL_Channels_ExtractChannels
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Channels/ExtractChannels.*")
+
+  add_test(NAME test_OCL_Arithm_Lut
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Lut.*")
+
+  add_test(NAME test_OCL_Arithm_Add
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Add.*")
+
+  add_test(NAME test_OCL_Arithm_Subtract
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Substract.*")
+
+  add_test(NAME test_OCL_Arithm_Mul
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Mul.*")
+
+  add_test(NAME test_OCL_Arithm_Div
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Div.*")
+
+  add_test(NAME test_OCL_Arithm_AddWeighted
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/AddWeighted.*")
+
+  add_test(NAME test_OCL_Arithm_Min
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Min.*")
+
+  add_test(NAME test_OCL_Arithm_Max
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Max.*")
+
+  add_test(NAME test_OCL_Arithm_Absdiff
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Absdiff.*")
+
+  add_test(NAME test_OCL_Arithm_CartToPolar
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/CartToPolar.*")
+
+  add_test(NAME test_OCL_Arithm_PolarToCart
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/PolarToCart.*")
+
+  add_test(NAME test_OCL_Arithm_Transpose
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Transpose.*")
+
+  add_test(NAME test_OCL_Arithm_Bitwise_and
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/BitWise_and.*")
+
+  add_test(NAME test_OCL_Arithm_Bitwise_or
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Bitwise_or.*")
+
+  add_test(NAME test_OCL_Arithm_Bitwise_xor
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Bitwise_xor.*")
+
+  add_test(NAME test_OCL_Arithm_Bitwise_not
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Bitwise_not.*")
+
+  add_test(NAME test_OCL_Arithm_Compare
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Compare.*")
+
+  add_test(NAME test_OCL_Arithm_Pow
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Pow.*")
+
+  add_test(NAME test_OCL_Arithm_SetIdentity
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/SetIdentity.*")
+
+  add_test(NAME test_OCL_Arithm_Repeat
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Repeat.*")
+
+  add_test(NAME test_OCL_Arithm_CountNonZero
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/CountNonZero.*")
+
+  add_test(NAME test_OCL_Arithm_Sum
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Sum.*")
+
+  add_test(NAME test_OCL_Arithm_MeanStdDev
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/MeanStdDev.*")
+
+  add_test(NAME test_OCL_Arithm_Log
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Log.*")
+
+  add_test(NAME test_OCL_Arithm_Exp
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Exp.*")
+
+  add_test(NAME test_OCL_Arithm_Phase
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Phase.*")
+
+  add_test(NAME test_OCL_Arithm_Magnitude
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Magnitude.*")
+
+  add_test(NAME test_OCL_Arithm_Flip
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Flip.*")
+
+  add_test(NAME test_OCL_Arithm_MinMaxIdx
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/MinMaxIdx.*")
+
+  add_test(NAME test_OCL_Arithm_MinMaxIdx_Mask
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/MinMaxIdx_Mask.*")
+
+  add_test(NAME test_OCL_Arithm_Norm
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Norm.*")
+
+  add_test(NAME test_OCL_Arithm_UMatDot
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/UMatDot.*")
+
+  add_test(NAME test_OCL_Arithm_Sqrt
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Sqrt.*")
+
+  add_test(NAME test_OCL_Arithm_Normalize
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Normalize.*")
+
+  add_test(NAME test_OCL_Arithm_InRange
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/InRange.*")
+
+  add_test(NAME test_OCL_Arithm_ConvertScaleAbs
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/ConvertScaleAbs.*")
+
+  add_test(NAME test_OCL_Arithm_ScaleAdd
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/ScaleAdd.*")
+
+  add_test(NAME test_OCL_Arithm_PatchNaNs
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/PatchNaNs.*")
+
+  add_test(NAME test_OCL_Arithm_Psnr
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/Psnr.*")
+
+  add_test(NAME test_OCL_Arithm_ReduceSum
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/ReduceSum.*")
+
+  add_test(NAME test_OCL_Arithm_ReduceMax
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/ReduceMax.*")
+
+  add_test(NAME test_OCL_Arithm_ReduceMin
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/ReduceMin.*")
+
+  add_test(NAME test_OCL_Arithm_ReduceAvg
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Arithm/ReduceAvg.*")
+
+  add_test(NAME test_OCL_Core_Gemm
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Core/Gemm.*")
+
+  add_test(NAME test_OCL_Core_Dft
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_Core/Dft.*")
+
+  add_test(NAME test_OCL_OCL_ImgProc_MultiSpectrums
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_OCL_ImgProc/MultiSpectrums.*")
+
+  add_test(NAME test_OCL_MatrixOperation_ConvertTo
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_MatrixOperation/ConvertTo.*")
+
+  add_test(NAME test_OCL_MatrixOperation_CopyTo
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_MatrixOperation/CopyTo.*")
+
+  add_test(NAME test_OCL_MatrixOperation_SetTo
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_MatrixOperation/SetTo.*")
+
+  add_test(NAME test_OCL_MatrixOperation_UMatExpr
+     COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=OCL_MatrixOperation/UMatExpr.*")
+
+  set_tests_properties(
+    test_UMat
+    test_Core_UMat
+    test_Image2D
+    test_UMat_UMatBasicTests
+    test_UMat_UMatTestReshape
+    test_UMat_UMatTestRoi
+    test_UMat_UMatTestSizeOperations
+    test_UMat_UMatTestUMatOperations
+    test_OCL_MeanStdDev_
+    test_OCL_Channels_Merge
+    test_OCL_Channels_Split
+    test_OCL_Channels_MixChannels
+    test_OCL_Channels_InsertChannels
+    test_OCL_Channels_ExtractChannels
+    test_OCL_Arithm_Lut
+    test_OCL_Arithm_Add
+    test_OCL_Arithm_Subtract
+    test_OCL_Arithm_Mul
+    test_OCL_Arithm_Div
+    test_OCL_Arithm_AddWeighted
+    test_OCL_Arithm_Min
+    test_OCL_Arithm_Max
+    test_OCL_Arithm_Absdiff
+    test_OCL_Arithm_CartToPolar
+    test_OCL_Arithm_PolarToCart
+    test_OCL_Arithm_Transpose
+    test_OCL_Arithm_Bitwise_and
+    test_OCL_Arithm_Bitwise_or
+    test_OCL_Arithm_Bitwise_xor
+    test_OCL_Arithm_Bitwise_not
+    test_OCL_Arithm_Compare
+    test_OCL_Arithm_Pow
+    test_OCL_Arithm_SetIdentity
+    test_OCL_Arithm_Repeat
+    test_OCL_Arithm_CountNonZero
+    test_OCL_Arithm_Sum
+    test_OCL_Arithm_MeanStdDev
+    test_OCL_Arithm_Log
+    test_OCL_Arithm_Exp
+    test_OCL_Arithm_Phase
+    test_OCL_Arithm_Magnitude
+    test_OCL_Arithm_Flip
+    test_OCL_Arithm_MinMaxIdx
+    test_OCL_Arithm_MinMaxIdx_Mask
+    test_OCL_Arithm_Norm
+    test_OCL_Arithm_UMatDot
+    test_OCL_Arithm_Sqrt
+    test_OCL_Arithm_Normalize
+    test_OCL_Arithm_InRange
+    test_OCL_Arithm_ConvertScaleAbs
+    test_OCL_Arithm_ScaleAdd
+    test_OCL_Arithm_PatchNaNs
+    test_OCL_Arithm_Psnr
+    test_OCL_Arithm_ReduceSum
+    test_OCL_Arithm_ReduceMax
+    test_OCL_Arithm_ReduceMin
+    test_OCL_Arithm_ReduceAvg
+    test_OCL_Core_Gemm
+    test_OCL_Core_Dft
+    test_OCL_OCL_ImgProc_MultiSpectrums
+    test_OCL_MatrixOperation_ConvertTo
+    test_OCL_MatrixOperation_CopyTo
+    test_OCL_MatrixOperation_SetTo
+    test_OCL_MatrixOperation_UMatExpr
+
+    PROPERTIES
+      LABELS "OpenCV")
+
+
+else()
+
+  message(STATUS "Disabling testsuite ${TS_NAME}, required files not found" )
+
+endif()

--- a/examples/OpenCV/CMakeLists.txt
+++ b/examples/OpenCV/CMakeLists.txt
@@ -29,7 +29,7 @@ set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}-build")
 set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
 
 set(OPENCV "opencv-3.0.0-beta")
-set(OPENCV_ZIP "${TS_BASEDIR}/src/${OPENCV}.zip")
+set(OPENCV_ZIP "${TS_SRCDIR}/${OPENCV}.zip")
 
 if(EXISTS "${OPENCV_ZIP}")
 

--- a/examples/OpenCV/CMakeLists.txt
+++ b/examples/OpenCV/CMakeLists.txt
@@ -34,7 +34,8 @@ set(OPENCV_ZIP "${TS_BASEDIR}/src/${OPENCV}.zip")
 if(EXISTS "${OPENCV_ZIP}")
 
   message(STATUS "Enabling testsuite ${TS_NAME}")
-  set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+  list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
+  set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
 
   ExternalProject_Add(
     ${TS_NAME}
@@ -58,6 +59,9 @@ if(EXISTS "${OPENCV_ZIP}")
 
     INSTALL_COMMAND /bin/true
   )
+
+  set_target_properties(${TS_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  add_dependencies(prepare_examples ${TS_NAME})
 
   add_test(NAME test_UMat
      COMMAND "${TS_BUILDDIR}/bin/opencv_test_core" "--gtest_filter=UMat.*")

--- a/examples/Parboil/CMakeLists.txt
+++ b/examples/Parboil/CMakeLists.txt
@@ -47,7 +47,8 @@ if (EXISTS "${PB_DRIVER}" AND
   #file(APPEND "${PB_MAKE}" "OPENCL_LIB_PATH=/usr/lib\n")
 
   message(STATUS "Enabling testsuite ${TS_NAME}")
-  set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+  list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
+  set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
 
   ExternalProject_Add(
     ${TS_NAME}
@@ -76,6 +77,9 @@ if (EXISTS "${PB_DRIVER}" AND
 
     INSTALL_COMMAND /bin/true
   )
+
+  set_target_properties(${TS_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  add_dependencies(prepare_examples ${TS_NAME})
 
   add_test(NAME parboil_spmv
            COMMAND "${PYTHON_EXECUTABLE}" ./parboil run

--- a/examples/Parboil/CMakeLists.txt
+++ b/examples/Parboil/CMakeLists.txt
@@ -1,0 +1,145 @@
+#=============================================================================
+#   CMake build system files
+#
+#   Copyright (c) 2015 pocl developers
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#   THE SOFTWARE.
+#
+#=============================================================================
+
+set(TS_NAME "Parboil")
+set(TS_BASEDIR "${TESTSUITE_BASEDIR}/${TS_NAME}")
+set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}")
+set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
+
+set(PB_DRIVER "${TS_SRCDIR}/pb2.5driver.tgz")
+set(PB_BENCH "${TS_SRCDIR}/pb2.5benchmarks.tgz")
+set(PB_DATASET "${TS_SRCDIR}/pb2.5datasets_standard.tgz")
+set(PB_MAKE "${CMAKE_BINARY_DIR}/Parboil.makefile")
+
+if (EXISTS "${PB_DRIVER}" AND
+    EXISTS "${PB_BENCH}" AND
+    EXISTS "${PB_DATASET}")
+
+  # Parboil is not python 3 compatible
+  find_package(PythonInterp 2.7)
+  if (NOT PYTHONINTERP_FOUND)
+    message(FATAL_ERROR "Parboil testsuite requires python 2.7, can't find it")
+  endif()
+
+  file(WRITE "${PB_MAKE}" "OPENCL_PATH=${CMAKE_SOURCE_DIR}\n")
+  #file(APPEND "${PB_MAKE}" "OPENCL_LIB_PATH=/usr/lib\n")
+
+  message(STATUS "Enabling testsuite ${TS_NAME}")
+  set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+
+  ExternalProject_Add(
+    ${TS_NAME}
+    PREFIX "${TS_BASEDIR}"
+    DOWNLOAD_COMMAND pwd &&
+      tar xvzf "${PB_DRIVER}" && cd parboil &&
+      tar xvzf "${PB_BENCH}" &&
+      tar xvzf "${PB_DATASET}" && cd .. &&
+      rmdir Parboil && mv parboil Parboil &&
+      cp "${PB_MAKE}" ./Parboil/common/Makefile.conf
+
+    CONFIGURE_COMMAND /bin/true
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND pwd &&
+      "${PYTHON_EXECUTABLE}" ./parboil compile spmv opencl_base &&
+      "${PYTHON_EXECUTABLE}" ./parboil compile stencil opencl_base &&
+      "${PYTHON_EXECUTABLE}" ./parboil compile tpacf opencl_base &&
+      "${PYTHON_EXECUTABLE}" ./parboil compile cutcp opencl_base &&
+      "${PYTHON_EXECUTABLE}" ./parboil compile mri-gridding opencl_base &&
+      "${PYTHON_EXECUTABLE}" ./parboil compile sad opencl_base &&
+      "${PYTHON_EXECUTABLE}" ./parboil compile bfs opencl_base &&
+      "${PYTHON_EXECUTABLE}" ./parboil compile histo opencl_base &&
+      "${PYTHON_EXECUTABLE}" ./parboil compile sgemm opencl_base &&
+      "${PYTHON_EXECUTABLE}" ./parboil compile lbm opencl_base &&
+      "${PYTHON_EXECUTABLE}" ./parboil compile mri-q opencl
+
+    INSTALL_COMMAND /bin/true
+  )
+
+  add_test(NAME parboil_spmv
+           COMMAND "${PYTHON_EXECUTABLE}" ./parboil run
+           spmv opencl_base small
+           WORKING_DIRECTORY "${TS_BUILDDIR}")
+  add_test(NAME parboil_stencil
+           COMMAND "${PYTHON_EXECUTABLE}" ./parboil run
+           stencil opencl_base small
+           WORKING_DIRECTORY "${TS_BUILDDIR}")
+  add_test(NAME parboil_tpacf
+           COMMAND "${PYTHON_EXECUTABLE}" ./parboil run
+           tpacf opencl_base small
+           WORKING_DIRECTORY "${TS_BUILDDIR}")
+  add_test(NAME parboil_cutcp
+           COMMAND "${PYTHON_EXECUTABLE}" ./parboil run
+           cutcp opencl_base small
+           WORKING_DIRECTORY "${TS_BUILDDIR}")
+  add_test(NAME parboil_mri_gridding
+           COMMAND "${PYTHON_EXECUTABLE}" ./parboil run
+           mri-gridding opencl_base small
+           WORKING_DIRECTORY "${TS_BUILDDIR}")
+  add_test(NAME parboil_sad
+           COMMAND "${PYTHON_EXECUTABLE}" ./parboil run
+           sad opencl_base default
+           WORKING_DIRECTORY "${TS_BUILDDIR}")
+  add_test(NAME parboil_bfs
+           COMMAND "${PYTHON_EXECUTABLE}" ./parboil run
+           bfs opencl_base NY
+           WORKING_DIRECTORY "${TS_BUILDDIR}")
+  add_test(NAME parboil_histo
+           COMMAND "${PYTHON_EXECUTABLE}" ./parboil run
+           histo opencl_base default
+           WORKING_DIRECTORY "${TS_BUILDDIR}")
+  add_test(NAME parboil_sgemm
+           COMMAND "${PYTHON_EXECUTABLE}" ./parboil run
+           sgemm opencl_base medium
+           WORKING_DIRECTORY "${TS_BUILDDIR}")
+  add_test(NAME parboil_mri_q
+           COMMAND "${PYTHON_EXECUTABLE}" ./parboil run
+           mri-q opencl small
+           WORKING_DIRECTORY "${TS_BUILDDIR}")
+  add_test(NAME parboil_lbm
+           COMMAND "${PYTHON_EXECUTABLE}" ./parboil run
+           lbm opencl_base short
+           WORKING_DIRECTORY "${TS_BUILDDIR}")
+
+  set_tests_properties(
+    parboil_spmv
+    parboil_stencil
+    parboil_tpacf
+    parboil_cutcp
+    parboil_mri_gridding
+    parboil_sad
+    parboil_bfs
+    parboil_histo
+    parboil_sgemm
+    parboil_mri_q
+    parboil_lbm
+
+    PROPERTIES
+      LABELS "Parboil")
+
+else()
+
+  message(STATUS "Disabling testsuite ${TS_NAME}, required files not found" )
+
+endif()

--- a/examples/PyOpenCL/README
+++ b/examples/PyOpenCL/README
@@ -1,7 +1,7 @@
 Installation:
 
 $ git clone --recursive git://github.com/inducer/pyopencl
-$ apt-get install python-pip python-virtualenv
+$ apt-get install python-pip python-virtualenv python-numpy python-mako
 
   (or equivalent, for example:
   curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py

--- a/examples/Rodinia/CMakeLists.txt
+++ b/examples/Rodinia/CMakeLists.txt
@@ -27,7 +27,8 @@ set(TS_NAME "Rodinia")
 set(TS_BASEDIR "${TESTSUITE_BASEDIR}/${TS_NAME}")
 set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}")
 set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
-set(RODINIA_TGZ "${TS_SRCDIR}/rodinia_3.1.tar.bz2")
+set(RODINIA "rodinia_3.1")
+set(RODINIA_TGZ "${TS_SRCDIR}/${RODINIA}.tar.bz2")
 
 if (EXISTS "${RODINIA_TGZ}")
 
@@ -40,7 +41,7 @@ if (EXISTS "${RODINIA_TGZ}")
     PREFIX "${TS_BASEDIR}"
     DOWNLOAD_COMMAND pwd && tar xjf "${RODINIA_TGZ}"
       && patch -p1 -i "${CMAKE_CURRENT_SOURCE_DIR}/Rodinia.patch"
-      && rmdir Rodinia && mv rodinia_3.1 Rodinia
+      && rmdir Rodinia && mv ${RODINIA} Rodinia
     CONFIGURE_COMMAND /bin/true
     BUILD_IN_SOURCE 1
     BUILD_COMMAND pwd && make OPENCL
@@ -57,7 +58,7 @@ if (EXISTS "${RODINIA_TGZ}")
   add_test(NAME rodinia_bfs                               COMMAND ./run
            WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/bfs")
   add_test(NAME rodinia_euler3d                           COMMAND ./run
-           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/euler3d")
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/cfd")
   add_test(NAME rodinia_gaussian                          COMMAND ./run
            WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/gaussian")
   add_test(NAME rodinia_heartwall                         COMMAND ./run
@@ -69,19 +70,15 @@ if (EXISTS "${RODINIA_TGZ}")
   add_test(NAME rodinia_lavaMD                            COMMAND ./run
            WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/lavaMD")
   add_test(NAME rodinia_leukocyte                         COMMAND ./run
-           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/leukocyte")
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/leukocyte/OpenCL")
   add_test(NAME rodinia_lud                               COMMAND ./run
-           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/lud")
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/lud/ocl")
   add_test(NAME rodinia_nn                                COMMAND ./run
            WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/nn")
   add_test(NAME rodinia_nw                                COMMAND ./run
            WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/nw")
-  add_test(NAME rodinia_OCL_particlefilter_double         COMMAND ./run
-           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/OCL_particlefilter_double")
-  add_test(NAME rodinia_OCL_particlefilter_naive          COMMAND ./run
-           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/OCL_particlefilter_naive")
-  add_test(NAME rodinia_OCL_particlefilter_single         COMMAND ./run
-           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/OCL_particlefilter_single")
+  add_test(NAME rodinia_particlefilter                    COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/particlefilter")
   add_test(NAME rodinia_pathfinder                        COMMAND ./run
            WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/pathfinder")
   add_test(NAME rodinia_srad                              COMMAND ./run
@@ -102,9 +99,7 @@ if (EXISTS "${RODINIA_TGZ}")
     rodinia_lud
     rodinia_nn
     rodinia_nw
-    rodinia_OCL_particlefilter_double
-    rodinia_OCL_particlefilter_naive
-    rodinia_OCL_particlefilter_single
+    rodinia_particlefilter
     rodinia_pathfinder
     rodinia_srad
     rodinia_streamcluster

--- a/examples/Rodinia/CMakeLists.txt
+++ b/examples/Rodinia/CMakeLists.txt
@@ -32,7 +32,8 @@ set(RODINIA_TGZ "${TS_SRCDIR}/rodinia_3.1.tar.bz2")
 if (EXISTS "${RODINIA_TGZ}")
 
   message(STATUS "Enabling testsuite ${TS_NAME}")
-  set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+  list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
+  set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
 
   ExternalProject_Add(
     ${TS_NAME}
@@ -48,7 +49,8 @@ if (EXISTS "${RODINIA_TGZ}")
     INSTALL_COMMAND /bin/true
   )
 
-  set(TS_BINDIR "${TS_BUILDDIR}/bin/linux/opencl/")
+  set_target_properties(${TS_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  add_dependencies(prepare_examples ${TS_NAME})
 
   add_test(NAME rodinia_backprop                          COMMAND ./run
            WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/backprop")

--- a/examples/Rodinia/CMakeLists.txt
+++ b/examples/Rodinia/CMakeLists.txt
@@ -1,0 +1,117 @@
+#=============================================================================
+#   CMake build system files
+#
+#   Copyright (c) 2015 pocl developers
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#   THE SOFTWARE.
+#
+#=============================================================================
+
+set(TS_NAME "Rodinia")
+set(TS_BASEDIR "${TESTSUITE_BASEDIR}/${TS_NAME}")
+set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}")
+set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
+set(RODINIA_TGZ "${TS_SRCDIR}/rodinia_3.1.tar.bz2")
+
+if (EXISTS "${RODINIA_TGZ}")
+
+  message(STATUS "Enabling testsuite ${TS_NAME}")
+  set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+
+  ExternalProject_Add(
+    ${TS_NAME}
+    PREFIX "${TS_BASEDIR}"
+    DOWNLOAD_COMMAND pwd && tar xjf "${RODINIA_TGZ}"
+      && patch -p1 -i "${CMAKE_CURRENT_SOURCE_DIR}/Rodinia.patch"
+      && rmdir Rodinia && mv rodinia_3.1 Rodinia
+    CONFIGURE_COMMAND /bin/true
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND pwd && make OPENCL
+      "CFLAGS=-Wno-unused-result -DCL_USE_DEPRECATED_OPENCL_1_2_APIS -DCL_USE_DEPRECATED_OPENCL_1_1_APIS"
+      "OPENCL_INC=${CMAKE_SOURCE_DIR}/include"
+    INSTALL_COMMAND /bin/true
+  )
+
+  set(TS_BINDIR "${TS_BUILDDIR}/bin/linux/opencl/")
+
+  add_test(NAME rodinia_backprop                          COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/backprop")
+  add_test(NAME rodinia_bfs                               COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/bfs")
+  add_test(NAME rodinia_euler3d                           COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/euler3d")
+  add_test(NAME rodinia_gaussian                          COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/gaussian")
+  add_test(NAME rodinia_heartwall                         COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/heartwall")
+  add_test(NAME rodinia_hotspot                           COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/hotspot")
+  add_test(NAME rodinia_kmeans                            COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/kmeans")
+  add_test(NAME rodinia_lavaMD                            COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/lavaMD")
+  add_test(NAME rodinia_leukocyte                         COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/leukocyte")
+  add_test(NAME rodinia_lud                               COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/lud")
+  add_test(NAME rodinia_nn                                COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/nn")
+  add_test(NAME rodinia_nw                                COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/nw")
+  add_test(NAME rodinia_OCL_particlefilter_double         COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/OCL_particlefilter_double")
+  add_test(NAME rodinia_OCL_particlefilter_naive          COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/OCL_particlefilter_naive")
+  add_test(NAME rodinia_OCL_particlefilter_single         COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/OCL_particlefilter_single")
+  add_test(NAME rodinia_pathfinder                        COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/pathfinder")
+  add_test(NAME rodinia_srad                              COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/srad")
+  add_test(NAME rodinia_streamcluster                     COMMAND ./run
+           WORKING_DIRECTORY "${TS_BUILDDIR}/opencl/streamcluster")
+
+  set_tests_properties(
+    rodinia_backprop
+    rodinia_bfs
+    rodinia_euler3d
+    rodinia_gaussian
+    rodinia_heartwall
+    rodinia_hotspot
+    rodinia_kmeans
+    rodinia_lavaMD
+    rodinia_leukocyte
+    rodinia_lud
+    rodinia_nn
+    rodinia_nw
+    rodinia_OCL_particlefilter_double
+    rodinia_OCL_particlefilter_naive
+    rodinia_OCL_particlefilter_single
+    rodinia_pathfinder
+    rodinia_srad
+    rodinia_streamcluster
+
+    PROPERTIES
+      LABELS "Rodinia")
+
+else()
+
+  message(STATUS "Disabling testsuite ${TS_NAME}, required files not found" )
+
+endif()

--- a/examples/Rodinia/Rodinia.patch
+++ b/examples/Rodinia/Rodinia.patch
@@ -1,16 +1,13 @@
-diff -uNr a/rodinia_2.0.1/opencl/pathfinder/OpenCL.cpp b/rodinia_2.0.1/opencl/pathfinder/OpenCL.cpp
---- a/rodinia_2.0.1/opencl/pathfinder/OpenCL.cpp	2011-09-20 16:45:58.000000000 +0300
-+++ b/rodinia_2.0.1/opencl/pathfinder/OpenCL.cpp	2014-02-14 13:00:35.137395239 +0200
-@@ -120,10 +120,10 @@
- 	source_size = ftell(theFile);
- 	rewind(theFile);
- 	// Read in the file.
--	source_str = (char*) malloc(sizeof(char) * source_size);
-+	source_str = (char*) malloc(sizeof(char) * source_size + 1);
- 	fread(source_str, 1, source_size, theFile);
- 	fclose(theFile);
--
-+	source_str[source_size] = 0;
- 	// Create a program from the kernel source.
- 	program = clCreateProgramWithSource(context,
- 	                                    1,
+--- a/rodinia_3.1/opencl/leukocyte/OpenCL/Makefile	2015-12-19 19:13:31.078863235 +0100
++++ b/rodinia_3.1/opencl/leukocyte/OpenCL/Makefile	2015-12-19 19:15:37.812197722 +0100
+@@ -22,8 +22,8 @@
+ leukocyte: detect_main.o avilib.o find_ellipse.o find_ellipse_opencl.o track_ellipse.o track_ellipse_opencl.o misc_math.o OpenCL_helper_library.o $(MATRIX_DIR)/meschach.a
+ 	$(CC) $(CC_FLAGS) -lm avilib.o find_ellipse.o find_ellipse_opencl.o track_ellipse.o track_ellipse_opencl.o misc_math.o OpenCL_helper_library.o detect_main.o -o leukocyte $(MATRIX_DIR)/meschach.a -L$(OPENCL_LIB) -lm -lOpenCL
+ 
+-%.o: %.[ch]
+-	$(CC) $(OUTPUT) $(CC_FLAGS) $< -c
++%.o: %.c
++	$(CC) $(OUTPUT) $(CC_FLAGS) -o $@ -c $<
+ 
+ detect_main.o: detect_main.c find_ellipse.h track_ellipse.h avilib.h
+ 

--- a/examples/VexCL/CMakeLists.txt
+++ b/examples/VexCL/CMakeLists.txt
@@ -29,7 +29,8 @@ set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}-build")
 set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
 
 message(STATUS "Enabling testsuite ${TS_NAME}")
-set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
+set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
 
 ExternalProject_Add(
   ${TS_NAME}
@@ -40,6 +41,9 @@ ExternalProject_Add(
     -DVEXCL_BACKEND=OpenCL
   INSTALL_COMMAND /bin/true
 )
+
+set_target_properties(${TS_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+add_dependencies(prepare_examples ${TS_NAME})
 
 add_test(NAME vexcl_boost_version
          COMMAND "${TS_BUILDDIR}/tests/boost_version")

--- a/examples/VexCL/CMakeLists.txt
+++ b/examples/VexCL/CMakeLists.txt
@@ -1,0 +1,108 @@
+#=============================================================================
+#   CMake build system files
+#
+#   Copyright (c) 2015 pocl developers
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#   THE SOFTWARE.
+#
+#=============================================================================
+
+set(TS_NAME "VexCL")
+set(TS_BASEDIR "${TESTSUITE_BASEDIR}/${TS_NAME}")
+set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}-build")
+set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
+
+message(STATUS "Enabling testsuite ${TS_NAME}")
+set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+
+ExternalProject_Add(
+  ${TS_NAME}
+  PREFIX "${TS_BASEDIR}"
+  GIT_REPOSITORY "https://github.com/ddemidov/vexcl.git"
+  CMAKE_ARGS
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    -DVEXCL_BACKEND=OpenCL
+  INSTALL_COMMAND /bin/true
+)
+
+add_test(NAME vexcl_boost_version
+         COMMAND "${TS_BUILDDIR}/tests/boost_version")
+add_test(NAME vexcl_types
+         COMMAND "${TS_BUILDDIR}/tests/types")
+add_test(NAME vexcl_deduce
+         COMMAND "${TS_BUILDDIR}/tests/deduce")
+add_test(NAME vexcl_context
+         COMMAND "${TS_BUILDDIR}/tests/context")
+add_test(NAME vexcl_vector_create
+         COMMAND "${TS_BUILDDIR}/tests/vector_create")
+add_test(NAME vexcl_vector_copy
+         COMMAND "${TS_BUILDDIR}/tests/vector_copy")
+add_test(NAME vexcl_vector_arithmetics
+         COMMAND "${TS_BUILDDIR}/tests/vector_arithmetics")
+add_test(NAME vexcl_vector_view
+         COMMAND "${TS_BUILDDIR}/tests/vector_view")
+add_test(NAME vexcl_tensordot
+         COMMAND "${TS_BUILDDIR}/tests/tensordot")
+add_test(NAME vexcl_vector_pointer
+         COMMAND "${TS_BUILDDIR}/tests/vector_pointer")
+add_test(NAME vexcl_tagged_terminal
+         COMMAND "${TS_BUILDDIR}/tests/tagged_terminal")
+add_test(NAME vexcl_temporary
+         COMMAND "${TS_BUILDDIR}/tests/temporary")
+add_test(NAME vexcl_cast
+         COMMAND "${TS_BUILDDIR}/tests/cast")
+add_test(NAME vexcl_multivector_create
+         COMMAND "${TS_BUILDDIR}/tests/multivector_create")
+add_test(NAME vexcl_multivector_arithmetics
+         COMMAND "${TS_BUILDDIR}/tests/multivector_arithmetics")
+add_test(NAME vexcl_multi_array
+         COMMAND "${TS_BUILDDIR}/tests/multi_array")
+add_test(NAME vexcl_spmv
+         COMMAND "${TS_BUILDDIR}/tests/spmv")
+add_test(NAME vexcl_stencil
+         COMMAND "${TS_BUILDDIR}/tests/stencil")
+add_test(NAME vexcl_generator
+         COMMAND "${TS_BUILDDIR}/tests/generator")
+add_test(NAME vexcl_mba
+         COMMAND "${TS_BUILDDIR}/tests/mba")
+add_test(NAME vexcl_random
+         COMMAND "${TS_BUILDDIR}/tests/random")
+add_test(NAME vexcl_sort
+         COMMAND "${TS_BUILDDIR}/tests/sort")
+add_test(NAME vexcl_scan
+         COMMAND "${TS_BUILDDIR}/tests/scan")
+add_test(NAME vexcl_scan_by_key
+         COMMAND "${TS_BUILDDIR}/tests/scan_by_key")
+add_test(NAME vexcl_reduce_by_key
+         COMMAND "${TS_BUILDDIR}/tests/reduce_by_key")
+add_test(NAME vexcl_logical
+         COMMAND "${TS_BUILDDIR}/tests/logical")
+add_test(NAME vexcl_threads
+         COMMAND "${TS_BUILDDIR}/tests/threads")
+
+set_tests_properties(vexcl_boost_version vexcl_types vexcl_deduce
+  vexcl_context vexcl_vector_create vexcl_vector_copy
+  vexcl_vector_arithmetics vexcl_vector_view vexcl_tensordot
+  vexcl_vector_pointer vexcl_tagged_terminal vexcl_temporary
+  vexcl_cast vexcl_multivector_create vexcl_multivector_arithmetics
+  vexcl_multi_array vexcl_spmv vexcl_stencil vexcl_generator
+  vexcl_mba vexcl_random vexcl_sort vexcl_scan vexcl_scan_by_key
+  vexcl_reduce_by_key vexcl_logical vexcl_threads
+  PROPERTIES
+    LABELS "VexCL")

--- a/examples/ViennaCL/CMakeLists.txt
+++ b/examples/ViennaCL/CMakeLists.txt
@@ -1,0 +1,236 @@
+#=============================================================================
+#   CMake build system files
+#
+#   Copyright (c) 2015 pocl developers
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#   THE SOFTWARE.
+#
+#=============================================================================
+
+set(TS_NAME "ViennaCL")
+set(TS_BASEDIR "${TESTSUITE_BASEDIR}/${TS_NAME}")
+set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}-build")
+set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
+set(VIENNA "ViennaCL-1.7.0")
+set(ViennaCL_TGZ "${TS_SRCDIR}/${VIENNA}.tar.gz")
+
+if(EXISTS "${ViennaCL_TGZ}")
+
+  message(STATUS "Enabling testsuite ${TS_NAME}")
+  set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+
+  ExternalProject_Add(
+    ${TS_NAME}
+    PREFIX "${TS_BASEDIR}"
+    SOURCE_DIR "${TS_BASEDIR}/src/${VIENNA}"
+    DOWNLOAD_COMMAND pwd && echo untaring && tar xzf "${ViennaCL_TGZ}"
+    CMAKE_ARGS
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      -DBUILD_TESTING:BOOL=ON
+      -DBUILD_EXAMPLES:BOOL=ON
+      -DENABLE_OPENCL:BOOL=ON
+      -DENABLE_CUDA:BOOL=OFF
+      -DENABLE_UBLAS:BOOL=OFF
+      "-DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING=-g -O0 -DCL_USE_DEPRECATED_OPENCL_1_1_APIS"
+    INSTALL_COMMAND /bin/true
+  )
+
+  add_test(NAME viennacl_examples_amg
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/amg")
+  add_test(NAME viennacl_examples_bandwidth_reduction
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/bandwidth-reduction")
+  add_test(NAME viennacl_examples_custom_kernels
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/custom-kernels")
+  add_test(NAME viennacl_examples_blas1
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/blas1")
+  add_test(NAME viennacl_examples_custom_context
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/custom-context")
+  add_test(NAME viennacl_examples_bisect
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/bisect")
+  add_test(NAME viennacl_examples_fft
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/fft")
+  add_test(NAME viennacl_examples_iterative_custom
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/iterative-custom")
+  add_test(NAME viennacl_examples_matrix_free
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/matrix-free")
+  add_test(NAME viennacl_examples_nmf
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/nmf")
+  add_test(NAME viennacl_examples_viennacl_info
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/viennacl-info")
+  add_test(NAME viennacl_examples_wrap_host_buffer
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/wrap-host-buffer")
+  add_test(NAME viennacl_examples_scheduler
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/scheduler")
+  add_test(NAME viennacl_examples_libviennacl_tutorial
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/libviennacl-tutorial")
+
+  add_test(NAME viennacl_benchmarks_opencl_bench_opencl
+          COMMAND "${TS_BUILDDIR}/examples/benchmarks/opencl-bench-opencl")
+  add_test(NAME viennacl_benchmarks_dense_blas_bench_opencl
+          COMMAND "${TS_BUILDDIR}/examples/benchmarks/dense_blas-bench-opencl")
+
+  add_test(NAME viennacl_tests_bisect_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/bisect-test-opencl")
+  add_test(NAME viennacl_tests_fft_1d_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/fft_1d-test-opencl")
+  add_test(NAME viennacl_tests_external_linkage_opencl
+          COMMAND "${TS_BUILDDIR}/tests/external_linkage-opencl")
+  add_test(NAME viennacl_tests_blas3_solve_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/blas3_solve-test-opencl")
+  add_test(NAME viennacl_tests_fft_2d_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/fft_2d-test-opencl")
+  add_test(NAME viennacl_tests_libviennacl_blas1_test
+          COMMAND "${TS_BUILDDIR}/tests/libviennacl_blas1-test")
+  add_test(NAME viennacl_tests_iterators_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/iterators-test-opencl")
+  add_test(NAME viennacl_tests_global_variables_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/global_variables-test-opencl")
+  add_test(NAME viennacl_tests_libviennacl_blas2_test
+          COMMAND "${TS_BUILDDIR}/tests/libviennacl_blas2-test")
+  add_test(NAME viennacl_tests_libviennacl_blas3_test
+          COMMAND "${TS_BUILDDIR}/tests/libviennacl_blas3-test")
+  add_test(NAME viennacl_tests_matrix_col_double_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/matrix_col_double-test-opencl")
+  add_test(NAME viennacl_tests_matrix_col_float_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/matrix_col_float-test-opencl")
+  add_test(NAME viennacl_tests_matrix_col_int_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/matrix_col_int-test-opencl")
+  add_test(NAME viennacl_tests_matrix_product_double_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/matrix_product_double-test-opencl")
+  add_test(NAME viennacl_tests_matrix_convert_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/matrix_convert-test-opencl")
+  add_test(NAME viennacl_tests_matrix_product_float_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/matrix_product_float-test-opencl")
+  add_test(NAME viennacl_tests_matrix_row_double_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/matrix_row_double-test-opencl")
+  add_test(NAME viennacl_tests_matrix_row_float_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/matrix_row_float-test-opencl")
+  add_test(NAME viennacl_tests_matrix_row_int_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/matrix_row_int-test-opencl")
+  add_test(NAME viennacl_tests_matrix_vector_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/matrix_vector-test-opencl")
+  add_test(NAME viennacl_tests_nmf_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/nmf-test-opencl")
+  add_test(NAME viennacl_tests_scalar_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/scalar-test-opencl")
+  add_test(NAME viennacl_tests_matrix_vector_int_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/matrix_vector_int-test-opencl")
+  add_test(NAME viennacl_tests_qr_method_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/qr_method-test-opencl")
+  add_test(NAME viennacl_tests_qr_method_func_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/qr_method_func-test-opencl")
+  add_test(NAME viennacl_tests_scan_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/scan-test-opencl")
+  add_test(NAME viennacl_tests_self_assign_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/self_assign-test-opencl")
+  add_test(NAME viennacl_tests_sparse_prod_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/sparse_prod-test-opencl")
+  add_test(NAME viennacl_tests_sparse_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/sparse-test-opencl")
+  add_test(NAME viennacl_tests_structured_matrices_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/structured-matrices-test-opencl")
+  add_test(NAME viennacl_tests_spmdm_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/spmdm-test-opencl")
+  add_test(NAME viennacl_tests_svd_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/svd-test-opencl")
+  add_test(NAME viennacl_tests_tql_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/tql-test-opencl")
+  add_test(NAME viennacl_tests_vector_convert_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/vector_convert-test-opencl")
+  add_test(NAME viennacl_tests_vector_float_double_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/vector_float_double-test-opencl")
+  add_test(NAME viennacl_tests_vector_multi_inner_prod_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/vector_multi_inner_prod-test-opencl")
+  add_test(NAME viennacl_tests_vector_int_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/vector_int-test-opencl")
+  add_test(NAME viennacl_tests_vector_uint_test_opencl
+          COMMAND "${TS_BUILDDIR}/tests/vector_uint-test-opencl")
+
+  set_tests_properties(
+  viennacl_examples_amg
+  viennacl_examples_bandwidth_reduction
+  viennacl_examples_custom_kernels
+  viennacl_examples_blas1
+  viennacl_examples_custom_context
+  viennacl_examples_bisect
+  viennacl_examples_fft
+  viennacl_examples_iterative_custom
+  viennacl_examples_matrix_free
+  viennacl_examples_nmf
+  viennacl_examples_viennacl_info
+  viennacl_examples_wrap_host_buffer
+  viennacl_examples_scheduler
+  viennacl_examples_libviennacl_tutorial
+    PROPERTIES
+      LABELS "ViennaCL ViennaCL_examples")
+
+  set_tests_properties(
+  viennacl_benchmarks_opencl_bench_opencl
+  viennacl_benchmarks_dense_blas_bench_opencl
+    PROPERTIES
+      LABELS "ViennaCL ViennaCL_benchmarks")
+
+  set_tests_properties(
+  viennacl_tests_bisect_test_opencl
+  viennacl_tests_fft_1d_test_opencl
+  viennacl_tests_external_linkage_opencl
+  viennacl_tests_blas3_solve_test_opencl
+  viennacl_tests_fft_2d_test_opencl
+  viennacl_tests_libviennacl_blas1_test
+  viennacl_tests_iterators_test_opencl
+  viennacl_tests_global_variables_test_opencl
+  viennacl_tests_libviennacl_blas2_test
+  viennacl_tests_libviennacl_blas3_test
+  viennacl_tests_matrix_col_double_test_opencl
+  viennacl_tests_matrix_col_float_test_opencl
+  viennacl_tests_matrix_col_int_test_opencl
+  viennacl_tests_matrix_product_double_test_opencl
+  viennacl_tests_matrix_convert_test_opencl
+  viennacl_tests_matrix_product_float_test_opencl
+  viennacl_tests_matrix_row_double_test_opencl
+  viennacl_tests_matrix_row_float_test_opencl
+  viennacl_tests_matrix_row_int_test_opencl
+  viennacl_tests_matrix_vector_test_opencl
+  viennacl_tests_nmf_test_opencl
+  viennacl_tests_scalar_test_opencl
+  viennacl_tests_matrix_vector_int_test_opencl
+  viennacl_tests_qr_method_test_opencl
+  viennacl_tests_qr_method_func_test_opencl
+  viennacl_tests_scan_test_opencl
+  viennacl_tests_self_assign_test_opencl
+  viennacl_tests_sparse_prod_test_opencl
+  viennacl_tests_sparse_test_opencl
+  viennacl_tests_structured_matrices_test_opencl
+  viennacl_tests_spmdm_test_opencl
+  viennacl_tests_svd_test_opencl
+  viennacl_tests_tql_test_opencl
+  viennacl_tests_vector_convert_test_opencl
+  viennacl_tests_vector_float_double_test_opencl
+  viennacl_tests_vector_multi_inner_prod_test_opencl
+  viennacl_tests_vector_int_test_opencl
+  viennacl_tests_vector_uint_test_opencl
+    PROPERTIES
+      LABELS "ViennaCL ViennaCL_tests")
+
+
+else()
+
+  message(STATUS "Disabling testsuite ${TS_NAME}, required files not found" )
+
+endif()

--- a/examples/ViennaCL/CMakeLists.txt
+++ b/examples/ViennaCL/CMakeLists.txt
@@ -56,119 +56,173 @@ if(EXISTS "${ViennaCL_TGZ}")
   add_dependencies(prepare_examples ${TS_NAME})
 
   add_test(NAME viennacl_examples_amg
-          COMMAND "${TS_BUILDDIR}/examples/tutorial/amg")
-  add_test(NAME viennacl_examples_bandwidth_reduction
-          COMMAND "${TS_BUILDDIR}/examples/tutorial/bandwidth-reduction")
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/amg"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
+#  add_test(NAME viennacl_examples_bandwidth_reduction
+#          COMMAND "${TS_BUILDDIR}/examples/tutorial/bandwidth-reduction"
+#          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_examples_custom_kernels
-          COMMAND "${TS_BUILDDIR}/examples/tutorial/custom-kernels")
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/custom-kernels"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_examples_blas1
-          COMMAND "${TS_BUILDDIR}/examples/tutorial/blas1")
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/blas1"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_examples_custom_context
-          COMMAND "${TS_BUILDDIR}/examples/tutorial/custom-context")
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/custom-context"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_examples_bisect
-          COMMAND "${TS_BUILDDIR}/examples/tutorial/bisect")
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/bisect"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_examples_fft
-          COMMAND "${TS_BUILDDIR}/examples/tutorial/fft")
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/fft"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_examples_iterative_custom
-          COMMAND "${TS_BUILDDIR}/examples/tutorial/iterative-custom")
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/iterative-custom"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_examples_matrix_free
-          COMMAND "${TS_BUILDDIR}/examples/tutorial/matrix-free")
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/matrix-free"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_examples_nmf
-          COMMAND "${TS_BUILDDIR}/examples/tutorial/nmf")
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/nmf"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_examples_viennacl_info
-          COMMAND "${TS_BUILDDIR}/examples/tutorial/viennacl-info")
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/viennacl-info"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_examples_wrap_host_buffer
-          COMMAND "${TS_BUILDDIR}/examples/tutorial/wrap-host-buffer")
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/wrap-host-buffer"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_examples_scheduler
-          COMMAND "${TS_BUILDDIR}/examples/tutorial/scheduler")
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/scheduler"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_examples_libviennacl_tutorial
-          COMMAND "${TS_BUILDDIR}/examples/tutorial/libviennacl-tutorial")
+          COMMAND "${TS_BUILDDIR}/examples/tutorial/libviennacl-tutorial"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
 
   add_test(NAME viennacl_benchmarks_opencl_bench_opencl
-          COMMAND "${TS_BUILDDIR}/examples/benchmarks/opencl-bench-opencl")
+          COMMAND "${TS_BUILDDIR}/examples/benchmarks/opencl-bench-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_benchmarks_dense_blas_bench_opencl
-          COMMAND "${TS_BUILDDIR}/examples/benchmarks/dense_blas-bench-opencl")
+          COMMAND "${TS_BUILDDIR}/examples/benchmarks/dense_blas-bench-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
 
   add_test(NAME viennacl_tests_bisect_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/bisect-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/bisect-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_fft_1d_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/fft_1d-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/fft_1d-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_external_linkage_opencl
-          COMMAND "${TS_BUILDDIR}/tests/external_linkage-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/external_linkage-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_blas3_solve_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/blas3_solve-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/blas3_solve-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_fft_2d_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/fft_2d-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/fft_2d-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_libviennacl_blas1_test
-          COMMAND "${TS_BUILDDIR}/tests/libviennacl_blas1-test")
+          COMMAND "${TS_BUILDDIR}/tests/libviennacl_blas1-test"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_iterators_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/iterators-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/iterators-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_global_variables_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/global_variables-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/global_variables-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_libviennacl_blas2_test
-          COMMAND "${TS_BUILDDIR}/tests/libviennacl_blas2-test")
+          COMMAND "${TS_BUILDDIR}/tests/libviennacl_blas2-test"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_libviennacl_blas3_test
-          COMMAND "${TS_BUILDDIR}/tests/libviennacl_blas3-test")
+          COMMAND "${TS_BUILDDIR}/tests/libviennacl_blas3-test"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_matrix_col_double_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/matrix_col_double-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/matrix_col_double-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_matrix_col_float_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/matrix_col_float-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/matrix_col_float-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_matrix_col_int_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/matrix_col_int-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/matrix_col_int-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_matrix_product_double_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/matrix_product_double-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/matrix_product_double-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_matrix_convert_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/matrix_convert-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/matrix_convert-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_matrix_product_float_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/matrix_product_float-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/matrix_product_float-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_matrix_row_double_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/matrix_row_double-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/matrix_row_double-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_matrix_row_float_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/matrix_row_float-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/matrix_row_float-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_matrix_row_int_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/matrix_row_int-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/matrix_row_int-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_matrix_vector_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/matrix_vector-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/matrix_vector-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_nmf_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/nmf-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/nmf-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_scalar_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/scalar-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/scalar-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_matrix_vector_int_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/matrix_vector_int-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/matrix_vector_int-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_qr_method_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/qr_method-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/qr_method-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_qr_method_func_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/qr_method_func-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/qr_method_func-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_scan_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/scan-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/scan-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_self_assign_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/self_assign-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/self_assign-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_sparse_prod_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/sparse_prod-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/sparse_prod-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_sparse_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/sparse-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/sparse-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_structured_matrices_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/structured-matrices-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/structured-matrices-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_spmdm_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/spmdm-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/spmdm-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_svd_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/svd-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/svd-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_tql_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/tql-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/tql-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_vector_convert_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/vector_convert-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/vector_convert-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_vector_float_double_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/vector_float_double-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/vector_float_double-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_vector_multi_inner_prod_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/vector_multi_inner_prod-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/vector_multi_inner_prod-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_vector_int_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/vector_int-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/vector_int-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
   add_test(NAME viennacl_tests_vector_uint_test_opencl
-          COMMAND "${TS_BUILDDIR}/tests/vector_uint-test-opencl")
+          COMMAND "${TS_BUILDDIR}/tests/vector_uint-test-opencl"
+          WORKING_DIRECTORY "${TS_BUILDDIR}/tests")
 
+#  viennacl_examples_bandwidth_reduction
   set_tests_properties(
   viennacl_examples_amg
-  viennacl_examples_bandwidth_reduction
   viennacl_examples_custom_kernels
   viennacl_examples_blas1
   viennacl_examples_custom_context

--- a/examples/ViennaCL/CMakeLists.txt
+++ b/examples/ViennaCL/CMakeLists.txt
@@ -33,7 +33,8 @@ set(ViennaCL_TGZ "${TS_SRCDIR}/${VIENNA}.tar.gz")
 if(EXISTS "${ViennaCL_TGZ}")
 
   message(STATUS "Enabling testsuite ${TS_NAME}")
-  set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+  list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
+  set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
 
   ExternalProject_Add(
     ${TS_NAME}
@@ -50,6 +51,9 @@ if(EXISTS "${ViennaCL_TGZ}")
       "-DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING=-g -O0 -DCL_USE_DEPRECATED_OPENCL_1_1_APIS"
     INSTALL_COMMAND /bin/true
   )
+
+  set_target_properties(${TS_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+  add_dependencies(prepare_examples ${TS_NAME})
 
   add_test(NAME viennacl_examples_amg
           COMMAND "${TS_BUILDDIR}/examples/tutorial/amg")

--- a/examples/piglit/CMakeLists.txt
+++ b/examples/piglit/CMakeLists.txt
@@ -29,7 +29,8 @@ set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}-build")
 set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
 
 message(STATUS "Enabling testsuite ${TS_NAME}")
-set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
+set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
 
 #-- Found PythonInterp: /usr/bin/python2.7 (found suitable version "2.7.11", minimum required is "2.7")
 #-- Found PythonNumpy: success (found suitable version "1.10.2", minimum required is "1.6.2")
@@ -56,6 +57,8 @@ ExternalProject_Add(
   INSTALL_COMMAND /bin/true
 )
 
+set_target_properties(${TS_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+add_dependencies(prepare_examples ${TS_NAME})
 
 add_test(NAME piglit_cl_api_build_program
          COMMAND "${TS_BUILDDIR}/bin/cl-api-build-program")

--- a/examples/piglit/CMakeLists.txt
+++ b/examples/piglit/CMakeLists.txt
@@ -1,0 +1,217 @@
+#=============================================================================
+#   CMake build system files
+#
+#   Copyright (c) 2015 pocl developers
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#   THE SOFTWARE.
+#
+#=============================================================================
+
+set(TS_NAME "piglit")
+set(TS_BASEDIR "${TESTSUITE_BASEDIR}/${TS_NAME}")
+set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}-build")
+set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
+
+message(STATUS "Enabling testsuite ${TS_NAME}")
+set(ENABLED_TESTSUITES "${ENABLED_TESTSUITES};${TS_NAME}" PARENT_SCOPE)
+
+#-- Found PythonInterp: /usr/bin/python2.7 (found suitable version "2.7.11", minimum required is "2.7")
+#-- Found PythonNumpy: success (found suitable version "1.10.2", minimum required is "1.6.2")
+#-- Found PythonMako: success (found suitable version "1.0.3", minimum required is "0.8.0")
+#-- Found PythonSix: success (found suitable version "1.10.0", minimum required is "1.4.0")
+
+ExternalProject_Add(
+  ${TS_NAME}
+  PREFIX "${TS_BASEDIR}"
+  GIT_REPOSITORY "git://anongit.freedesktop.org/piglit"
+  CMAKE_ARGS
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    "-DCMAKE_CXX_FLAGS_RELWITHDEBINFO=-O2 -g -DCL_USE_DEPRECATED_OPENCL_1_2_APIS"
+    -DPIGLIT_BUILD_CL_TESTS=ON
+    -DPIGLIT_BUILD_DMA_BUF_TESTS:BOOL=OFF
+    -DPIGLIT_BUILD_GL_TESTS=OFF
+    -DPIGLIT_BUILD_GLES1_TESTS=OFF
+    -DPIGLIT_BUILD_GLES2_TESTS=OFF
+    -DPIGLIT_BUILD_GLES3_TESTS=OFF
+    -DPIGLIT_USE_WAFFLE=OFF
+    -DPIGLIT_BUILD_GLX_TESTS=OFF
+    "-DOPENCL_INCLUDE_PATH=${CMAKE_SOURCE_DIR}/include/"
+    "-DOPENCL_opencl_LIBRARY:LIST=OpenCL"
+  INSTALL_COMMAND /bin/true
+)
+
+
+add_test(NAME piglit_cl_api_build_program
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-build-program")
+add_test(NAME piglit_cl_api_compile_program
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-compile-program")
+add_test(NAME piglit_cl_api_create_buffer
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-create-buffer")
+add_test(NAME piglit_cl_api_create_command_queue
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-create-command-queue")
+add_test(NAME piglit_cl_api_create_context
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-create-context")
+add_test(NAME piglit_cl_api_create_context_from_type
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-create-context-from-type")
+add_test(NAME piglit_cl_api_create_image
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-create-image")
+add_test(NAME piglit_cl_api_create_kernel
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-create-kernel")
+add_test(NAME piglit_cl_api_create_kernels_in_program
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-create-kernels-in-program")
+add_test(NAME piglit_cl_api_create_program_with_binary
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-create-program-with-binary")
+add_test(NAME piglit_cl_api_create_program_with_source
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-create-program-with-source")
+add_test(NAME piglit_cl_api_create_sampler
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-create-sampler")
+add_test(NAME piglit_cl_api_enqueue_copy_buffer
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-enqueue-copy-buffer")
+add_test(NAME piglit_cl_api_enqueue_copy_buffer_rect
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-enqueue-copy-buffer-rect")
+add_test(NAME piglit_cl_api_enqueue_fill_buffer
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-enqueue-fill-buffer")
+add_test(NAME piglit_cl_api_enqueue_fill_image
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-enqueue-fill-image")
+add_test(NAME piglit_cl_api_enqueue_map_buffer
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-enqueue-map-buffer")
+add_test(NAME piglit_cl_api_enqueue_migrate_mem_objects
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-enqueue-migrate-mem-objects")
+add_test(NAME piglit_cl_api_enqueue_read_write_buffer
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-enqueue-read_write-buffer")
+add_test(NAME piglit_cl_api_get_command_queue_info
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-get-command-queue-info")
+add_test(NAME piglit_cl_api_get_context_info
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-get-context-info")
+add_test(NAME piglit_cl_api_get_device_ids
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-get-device-ids")
+add_test(NAME piglit_cl_api_get_device_info
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-get-device-info")
+add_test(NAME piglit_cl_api_get_event_info
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-get-event-info")
+add_test(NAME piglit_cl_api_get_image_info
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-get-image-info")
+add_test(NAME piglit_cl_api_get_kernel_arg_info
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-get-kernel-arg-info")
+add_test(NAME piglit_cl_api_get_kernel_info
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-get-kernel-info")
+add_test(NAME piglit_cl_api_get_kernel_work_group_info
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-get-kernel-work-group-info")
+add_test(NAME piglit_cl_api_get_mem_object_info
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-get-mem-object-info")
+add_test(NAME piglit_cl_api_get_platform_ids
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-get-platform-ids")
+add_test(NAME piglit_cl_api_get_platform_info
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-get-platform-info")
+add_test(NAME piglit_cl_api_get_program_build_info
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-get-program-build-info")
+add_test(NAME piglit_cl_api_get_program_info
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-get-program-info")
+add_test(NAME piglit_cl_api_link_program
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-link-program")
+add_test(NAME piglit_cl_api_retain_release_command_queue
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-retain_release-command-queue")
+add_test(NAME piglit_cl_api_retain_release_context
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-retain_release-context")
+add_test(NAME piglit_cl_api_retain_release_event
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-retain_release-event")
+add_test(NAME piglit_cl_api_retain_release_kernel
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-retain_release-kernel")
+add_test(NAME piglit_cl_api_retain_release_mem_object
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-retain_release-mem-object")
+add_test(NAME piglit_cl_api_retain_release_program
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-retain_release-program")
+add_test(NAME piglit_cl_api_set_kernel_arg
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-set-kernel-arg")
+add_test(NAME piglit_cl_api_unload_compiler
+         COMMAND "${TS_BUILDDIR}/bin/cl-api-unload-compiler")
+add_test(NAME piglit_cl_custom_buffer_flags
+         COMMAND "${TS_BUILDDIR}/bin/cl-custom-buffer-flags")
+add_test(NAME piglit_cl_custom_flush_after_enqueue_kernel
+         COMMAND "${TS_BUILDDIR}/bin/cl-custom-flush-after-enqueue-kernel")
+add_test(NAME piglit_cl_custom_r600_create_release_buffer_bug
+         COMMAND "${TS_BUILDDIR}/bin/cl-custom-r600-create-release-buffer-bug")
+add_test(NAME piglit_cl_custom_run_simple_kernel
+         COMMAND "${TS_BUILDDIR}/bin/cl-custom-run-simple-kernel")
+add_test(NAME piglit_cl_custom_use_sub_buffer_in_kernel
+         COMMAND "${TS_BUILDDIR}/bin/cl-custom-use-sub-buffer-in-kernel")
+add_test(NAME piglit_cl_program_bitcoin_phatk
+         COMMAND "${TS_BUILDDIR}/bin/cl-program-bitcoin-phatk")
+add_test(NAME piglit_cl_program_max_work_item_sizes
+         COMMAND "${TS_BUILDDIR}/bin/cl-program-max-work-item-sizes")
+add_test(NAME piglit_cl_program_tester
+         COMMAND "${TS_BUILDDIR}/bin/cl-program-tester")
+
+
+
+
+set_tests_properties(
+  piglit_cl_api_build_program
+  piglit_cl_api_compile_program
+  piglit_cl_api_create_buffer
+  piglit_cl_api_create_command_queue
+  piglit_cl_api_create_context
+  piglit_cl_api_create_context_from_type
+  piglit_cl_api_create_image
+  piglit_cl_api_create_kernel
+  piglit_cl_api_create_kernels_in_program
+  piglit_cl_api_create_program_with_binary
+  piglit_cl_api_create_program_with_source
+  piglit_cl_api_create_sampler
+  piglit_cl_api_enqueue_copy_buffer
+  piglit_cl_api_enqueue_copy_buffer_rect
+  piglit_cl_api_enqueue_fill_buffer
+  piglit_cl_api_enqueue_fill_image
+  piglit_cl_api_enqueue_map_buffer
+  piglit_cl_api_enqueue_migrate_mem_objects
+  piglit_cl_api_enqueue_read_write_buffer
+  piglit_cl_api_get_command_queue_info
+  piglit_cl_api_get_context_info
+  piglit_cl_api_get_device_ids
+  piglit_cl_api_get_device_info
+  piglit_cl_api_get_event_info
+  piglit_cl_api_get_image_info
+  piglit_cl_api_get_kernel_arg_info
+  piglit_cl_api_get_kernel_info
+  piglit_cl_api_get_kernel_work_group_info
+  piglit_cl_api_get_mem_object_info
+  piglit_cl_api_get_platform_ids
+  piglit_cl_api_get_platform_info
+  piglit_cl_api_get_program_build_info
+  piglit_cl_api_get_program_info
+  piglit_cl_api_link_program
+  piglit_cl_api_retain_release_command_queue
+  piglit_cl_api_retain_release_context
+  piglit_cl_api_retain_release_event
+  piglit_cl_api_retain_release_kernel
+  piglit_cl_api_retain_release_mem_object
+  piglit_cl_api_retain_release_program
+  piglit_cl_api_set_kernel_arg
+  piglit_cl_api_unload_compiler
+  piglit_cl_custom_buffer_flags
+  piglit_cl_custom_flush_after_enqueue_kernel
+  piglit_cl_custom_r600_create_release_buffer_bug
+  piglit_cl_custom_run_simple_kernel
+  piglit_cl_custom_use_sub_buffer_in_kernel
+  piglit_cl_program_bitcoin_phatk
+  piglit_cl_program_max_work_item_sizes
+  piglit_cl_program_tester
+
+  PROPERTIES
+    LABELS "piglit")

--- a/lib/CL/devices/tce/CMakeLists.txt
+++ b/lib/CL/devices/tce/CMakeLists.txt
@@ -23,19 +23,20 @@
 #
 #=============================================================================
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TCE_INCLUDES}")
+add_compile_options(${TCE_INCLUDES})
+add_compile_options(${TCE_CXXFLAGS})
 
 if(ENABLE_TCE)
   add_subdirectory("ttasim")
-  set(POCL_DEVICES_OBJS "${POCL_DEVICES_OBJS};$<TARGET_OBJECTS:pocl-devices-tce-ttasim>" PARENT_SCOPE)
 endif()
 
 if(MSVC)
   set_source_files_properties( tce_common.h tce_common.cc PROPERTIES LANGUAGE CXX )
 endif(MSVC)
+
 add_library("pocl-devices-tce" OBJECT tce_common.h tce_common.cc)
 set(POCL_DEVICES_OBJS "${POCL_DEVICES_OBJS};$<TARGET_OBJECTS:pocl-devices-tce>" PARENT_SCOPE)
 
 # dist_pkgdata_DATA = tta_device_main.c
-install(FILES "tta_device_main.c" "tta_device_main_dthread.c"
+install(FILES "tta_device_main.c"
         DESTINATION ${POCL_INSTALL_PRIVATE_HEADER_DIR})

--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -80,7 +80,7 @@ TCEDevice::~TCEDevice() {
 
 bool
 TCEDevice::isMultiCoreMachine() const {
-#if defined(TCEMC_AVAILABLE) && TCEMC_AVAILABLE == 1
+#ifdef TCEMC_AVAILABLE
   assert (machine_ != NULL);
   return machine_->coreCount() > 1;
 #else

--- a/lib/CL/devices/tce/ttasim/CMakeLists.txt
+++ b/lib/CL/devices/tce/ttasim/CMakeLists.txt
@@ -28,5 +28,6 @@ include_directories(BEFORE "..")
 if(MSVC)
   set_source_files_properties( ttasim.h ttasim.cc PROPERTIES LANGUAGE CXX )
 endif(MSVC)
-add_library("pocl-devices-tce-ttasim" OBJECT ttasim.h ttasim.cc ../tce_common.h)
+add_library("pocl-devices-tce-ttasim" OBJECT ttasim.h ttasim.cc)
+set(POCL_DEVICES_OBJS "${POCL_DEVICES_OBJS};$<TARGET_OBJECTS:pocl-devices-tce-ttasim>" PARENT_SCOPE)
 

--- a/lib/CL/pocl_debug.c
+++ b/lib/CL/pocl_debug.c
@@ -22,8 +22,11 @@ int stderr_is_a_tty;
         gmtime_r(&timespec.tv_sec, &t);
         const char* formatstring;
         if (stderr_is_a_tty)
-          formatstring = BLUE "[%04i-%02i-%02i %02i:%02i:%02i.%09li] "
-              RESET "POCL: in fn" CYAN " %s " RESET "at line %u:\n";
+          formatstring = POCL_COLOR_BLUE
+              "[%04i-%02i-%02i %02i:%02i:%02i.%09li] "
+              POCL_COLOR_RESET "POCL: in fn"
+              POCL_COLOR_CYAN " %s "
+              POCL_COLOR_RESET "at line %u:\n";
         else
           formatstring = "[%04i-%02i-%02i %02i:%02i:%02i.%09li] "
               "POCL: in fn %s at line %u:\n";
@@ -46,8 +49,8 @@ int stderr_is_a_tty;
         return;
       const char* formatstring;
       if (stderr_is_a_tty)
-        formatstring = "      >>>  " MAGENTA "     %3" PRIu64
-                       ".%03" PRIu64 " " RESET " %s    %s\n";
+        formatstring = "      >>>  " POCL_COLOR_MAGENTA "     %3" PRIu64
+                       ".%03" PRIu64 " " POCL_COLOR_RESET " %s    %s\n";
       else
         formatstring = "      >>>       %3" PRIu64 ".%03"
                        PRIu64 "  %s    %s\n";
@@ -60,7 +63,8 @@ int stderr_is_a_tty;
         {
           b = nsec % 1000;
           if (stderr_is_a_tty)
-            formatstring = "      >>>      " MAGENTA "     %3" PRIu64 " " RESET " ns    %s\n";
+            formatstring = "      >>>      " POCL_COLOR_MAGENTA
+                    "     %3" PRIu64 " " POCL_COLOR_RESET " ns    %s\n";
           else
             formatstring = "      >>>           %3" PRIu64 "  ns    %s\n";
           POCL_MSG_PRINT2(func, line, formatstring, b, msg);

--- a/lib/CL/pocl_debug.h
+++ b/lib/CL/pocl_debug.h
@@ -29,7 +29,7 @@ extern "C" {
 #define POCL_COLOR_BLACK   "\033[30m"      /* Black */
 #define POCL_COLOR_RED     "\033[31m"      /* Red */
 #define POCL_COLOR_GREEN   "\033[32m"      /* Green */
-#define POCL_COLOR_POCL_COLOR_YELLOW  "\033[33m"      /* Yellow */
+#define POCL_COLOR_YELLOW  "\033[33m"      /* Yellow */
 #define POCL_COLOR_BLUE    "\033[34m"      /* Blue */
 #define POCL_COLOR_MAGENTA "\033[35m"      /* Magenta */
 #define POCL_COLOR_CYAN    "\033[36m"      /* Cyan */
@@ -37,7 +37,7 @@ extern "C" {
 #define POCL_COLOR_BOLDBLACK   "\033[1m\033[30m"      /* Bold Black */
 #define POCL_COLOR_BOLDRED     "\033[1m\033[31m"      /* Bold Red */
 #define POCL_COLOR_BOLDGREEN   "\033[1m\033[32m"      /* Bold Green */
-#define POCL_COLOR_BOLDPOCL_COLOR_YELLOW  "\033[1m\033[33m"      /* Bold Yellow */
+#define POCL_COLOR_BOLDYELLOW  "\033[1m\033[33m"      /* Bold Yellow */
 #define POCL_COLOR_BOLDBLUE    "\033[1m\033[34m"      /* Bold Blue */
 #define POCL_COLOR_BOLDMAGENTA "\033[1m\033[35m"      /* Bold Magenta */
 #define POCL_COLOR_BOLDCYAN    "\033[1m\033[36m"      /* Bold Cyan */

--- a/lib/CL/pocl_debug.h
+++ b/lib/CL/pocl_debug.h
@@ -25,23 +25,23 @@ extern "C" {
 #endif
 
 // should use some terminfo library, but..
-#define RESET   "\033[0m"
-#define BLACK   "\033[30m"      /* Black */
-#define RED     "\033[31m"      /* Red */
-#define GREEN   "\033[32m"      /* Green */
-#define YELLOW  "\033[33m"      /* Yellow */
-#define BLUE    "\033[34m"      /* Blue */
-#define MAGENTA "\033[35m"      /* Magenta */
-#define CYAN    "\033[36m"      /* Cyan */
-#define WHITE   "\033[37m"      /* White */
-#define BOLDBLACK   "\033[1m\033[30m"      /* Bold Black */
-#define BOLDRED     "\033[1m\033[31m"      /* Bold Red */
-#define BOLDGREEN   "\033[1m\033[32m"      /* Bold Green */
-#define BOLDYELLOW  "\033[1m\033[33m"      /* Bold Yellow */
-#define BOLDBLUE    "\033[1m\033[34m"      /* Bold Blue */
-#define BOLDMAGENTA "\033[1m\033[35m"      /* Bold Magenta */
-#define BOLDCYAN    "\033[1m\033[36m"      /* Bold Cyan */
-#define BOLDWHITE   "\033[1m\033[37m"      /* Bold White */
+#define POCL_COLOR_RESET   "\033[0m"
+#define POCL_COLOR_BLACK   "\033[30m"      /* Black */
+#define POCL_COLOR_RED     "\033[31m"      /* Red */
+#define POCL_COLOR_GREEN   "\033[32m"      /* Green */
+#define POCL_COLOR_POCL_COLOR_YELLOW  "\033[33m"      /* Yellow */
+#define POCL_COLOR_BLUE    "\033[34m"      /* Blue */
+#define POCL_COLOR_MAGENTA "\033[35m"      /* Magenta */
+#define POCL_COLOR_CYAN    "\033[36m"      /* Cyan */
+#define POCL_COLOR_WHITE   "\033[37m"      /* White */
+#define POCL_COLOR_BOLDBLACK   "\033[1m\033[30m"      /* Bold Black */
+#define POCL_COLOR_BOLDRED     "\033[1m\033[31m"      /* Bold Red */
+#define POCL_COLOR_BOLDGREEN   "\033[1m\033[32m"      /* Bold Green */
+#define POCL_COLOR_BOLDPOCL_COLOR_YELLOW  "\033[1m\033[33m"      /* Bold Yellow */
+#define POCL_COLOR_BOLDBLUE    "\033[1m\033[34m"      /* Bold Blue */
+#define POCL_COLOR_BOLDMAGENTA "\033[1m\033[35m"      /* Bold Magenta */
+#define POCL_COLOR_BOLDCYAN    "\033[1m\033[36m"      /* Bold Cyan */
+#define POCL_COLOR_BOLDWHITE   "\033[1m\033[37m"      /* Bold White */
 
 #ifdef __GNUC__
 #pragma GCC visibility push(hidden)
@@ -132,7 +132,7 @@ extern "C" {
             if (pocl_debug_messages) {                                      \
                 POCL_DEBUG_HEADER                                           \
                 if (stderr_is_a_tty)                                        \
-                  fprintf(stderr, TYPE CYAN ERRCODE " "  RESET);            \
+                  fprintf(stderr, TYPE POCL_COLOR_CYAN ERRCODE " "  POCL_COLOR_RESET);            \
                 else                                                        \
                   fprintf(stderr, TYPE ERRCODE " ");                        \
                 fprintf(stderr, __VA_ARGS__);                               \
@@ -148,17 +148,17 @@ extern "C" {
         } while (0)
 
     #define POCL_MSG_WARN2(errcode, ...)   do { if (stderr_is_a_tty) \
-          POCL_MSG_PRINT(YELLOW " *** WARNING *** ", errcode, __VA_ARGS__); \
+          POCL_MSG_PRINT(POCL_COLOR_YELLOW " *** WARNING *** ", errcode, __VA_ARGS__); \
           else POCL_MSG_PRINT(" *** WARNING *** ", errcode, __VA_ARGS__); } while(0)
     #define POCL_MSG_WARN(...)  POCL_MSG_WARN2("", __VA_ARGS__)
 
     #define POCL_MSG_ERR2(errcode, ...)    do { if (stderr_is_a_tty) \
-          POCL_MSG_PRINT(RED " *** ERROR *** ", errcode, __VA_ARGS__); \
+          POCL_MSG_PRINT(POCL_COLOR_RED " *** ERROR *** ", errcode, __VA_ARGS__); \
           else POCL_MSG_PRINT(" *** ERROR *** ", errcode, __VA_ARGS__); } while (0)
     #define POCL_MSG_ERR(...)  POCL_MSG_ERR2("", __VA_ARGS__)
 
     #define POCL_MSG_PRINT_INFO2(errcode, ...) do { if (stderr_is_a_tty) \
-          POCL_MSG_PRINT(GREEN " *** INFO *** ", errcode, __VA_ARGS__); \
+          POCL_MSG_PRINT(POCL_COLOR_GREEN " *** INFO *** ", errcode, __VA_ARGS__); \
           else POCL_MSG_PRINT(" *** INFO *** ", errcode, __VA_ARGS__); } while (0)
     #define POCL_MSG_PRINT_INFO(...) POCL_MSG_PRINT_INFO2("", __VA_ARGS__)
 

--- a/tests/kernel/test_shuffle.cc
+++ b/tests/kernel/test_shuffle.cc
@@ -298,7 +298,6 @@ public:
     unsigned errors = 0;
     for(unsigned n_loop=0; n_loop<5; n_loop++) {
           for(unsigned m_loop=0; m_loop<5; m_loop++) {
-              unsigned n = vecelts[n_loop];
               unsigned m = vecelts[m_loop];
               for(unsigned i=0; i<m; i++) {
                 in2[i]=(D)(i+m);


### PR DESCRIPTION
This adds most of the external testsuites to the CMake buildsystem, and also TCE support.
Known issues:

* TCE compiles but tests are not added/run yet
* Testsuites compile and run, but are not yet patched, so many (sometimes 100%) of tests fail
* Adds a new testsuite - ASL https://github.com/AvtechScientific/ASL

Usage: invoke cmake with 
`-DENABLE_TESTSUITES="all"  `
or 
`-DENABLE_TESTSUITES="piglit;X;Y..."` note the testsuite delimiter is semicolon, which is command separator in bash :] check the cmake output for which testsuites are actually enabled ( `-- Enabled testsuites: ...` )

For every testsuite that was found, CMake tests are added, but the testsuite is not built automagically. Use `make prepare_examples` to build all testsuites. This is done because you may keep the testsuite sources and builds out of pocl source/build trees, build them only once, and use them with different pocl builds later. Relevant cmake arguments:

`-DTESTSUITE_SOURCE_BASEDIR=<source-dir>`
Directory with tarballs of testsuites. Defauts to `<pocl source dir>/examples`. Directory structure is exactly the same as current pocl examples, i.e. for AMD 2.8 tarball it will search for TESTSUITE_SOURCE_BASEDIR/AMD/AMD-APP-SDK-v2.8-RC-lnx64.tgz

`-DTESTSUITE_BASEDIR=<build-dir>`
Directory where to store built testsuites. Defaults to `<pocl-cmake-builddir>/examples`.