### PR TITLE
Add native_sqrt to math builtin list

### DIFF
--- a/lib/kernel/CMakeLists.txt
+++ b/lib/kernel/CMakeLists.txt
@@ -139,6 +139,7 @@ native_powr.cl
 native_recip.cl
 native_rsqrt.cl
 native_sin.cl
+native_sqrt.cl
 native_tan.cl
 nextafter.cl
 normalize.cl
@@ -334,6 +335,7 @@ vecmathlib-pocl/native_powr.cl
 vecmathlib-pocl/native_recip.cl
 vecmathlib-pocl/native_rsqrt.cl
 vecmathlib-pocl/native_sin.cl
+vecmathlib-pocl/native_sqrt.cl
 vecmathlib-pocl/native_tan.cl
 vecmathlib-pocl/normalize.cl
 vecmathlib-pocl/pow.cc

--- a/lib/kernel/sources-vml.mk
+++ b/lib/kernel/sources-vml.mk
@@ -100,6 +100,7 @@ LKERNEL_SRCS_EXCLUDE =				\
         native_recip.cl                         \
         native_rsqrt.cl                         \
         native_sin.cl                           \
+        native_sqrt.cl                          \
         native_tan.cl                           \
 	normalize.cl				\
 	pow.cl					\
@@ -221,6 +222,7 @@ LKERNEL_SRCS_EXTRA = $(addprefix vecmathlib-pocl/,	\
 	native_recip.cl					\
 	native_rsqrt.cl					\
 	native_sin.cl					\
+	native_sqrt.cl  				\
 	native_tan.cl					\
 	normalize.cl					\
 	pow.cc						\


### PR DESCRIPTION
This was causing any use of `native_sqrt` inside a kernel to produce a linker error.