### PR TITLE
Use device triple instead of module triple for address space remapping

### DIFF
--- a/lib/llvmopencl/TargetAddressSpaces.cc
+++ b/lib/llvmopencl/TargetAddressSpaces.cc
@@ -39,7 +39,11 @@
 #include "Workgroup.h"
 #include "LLVMUtils.h"
 
+#include "pocl_cl.h"
+
 #define DEBUG_TARGET_ADDRESS_SPACES
+
+extern cl_device_id currentPoclDevice;
 
 namespace pocl {
 
@@ -458,7 +462,7 @@ TargetAddressSpaces::runOnModule(llvm::Module &M) {
 
   std::map<unsigned, unsigned> addrSpaceMapDown;
 
-  llvm::StringRef arch(M.getTargetTriple());
+  llvm::StringRef arch = currentPoclDevice->llvm_target_triplet;
 
   if (arch.startswith("x86_64")) {
     /* x86_64 supports flattening the address spaces at the backend, but


### PR DESCRIPTION
This should address issue #336 that I recently raised. The fix is to use the external `currentPoclDevice` handle that is also used by the Workgroup pass, and get the device target triple from this, instead of using the module's target triple.

This fixes SPIR consumption for a private backend that I'm working on and still works for x86, but I haven't been able to test any of the other non-flat address space targets such as TCE/HSA, so maybe worth a check on those platforms before merging.
