### PR TITLE
Update for LLVM trunk

### DIFF
--- a/doc/sphinx/source/install.rst
+++ b/doc/sphinx/source/install.rst
@@ -32,6 +32,8 @@ you compile & build LLVM with ``make REQUIRES_RTTI=1``, as follows:
   of pocl release, **plus the previous** LLVM version. All older LLVM
   versions are unsupported.
 
+  [18 May 2016] pocl has been updated for LLVM trunk (rev 269957)
+
 
 Configure & Build using autotools
 ---------------------------------


### PR DESCRIPTION
This brings pocl up-to-date with LLVM trunk.

Most of the changes are relatively minor. The only two that I was a little unsure of are aa7534c and 8ef244b.

I tested with LLVM 3.8 on Linux and there were no regressions in the internal test-suite.

There was one test failure with LLVM trunk, which is `test_clGetKernelArgInfo`. The issue is that the definitions for `write_imagef` in `_kernel_c.h` don't include the `write_only` flag. I'm not sure how to resolve this - can the image function declarations be moved out of this C compatible header so that we can add the appropriate qualifiers?
