### PR TITLE
Implement clSetMemObjectDestructorCallback

### DIFF
--- a/include/pocl.h
+++ b/include/pocl.h
@@ -62,6 +62,14 @@ struct _mem_mapping {
   mem_mapping_t *prev, *next;
 };
 
+typedef struct _mem_destructor_callback mem_destructor_callback_t;
+/* represents a memory object destructor callback */
+struct _mem_destructor_callback {
+  void (CL_CALLBACK * pfn_notify)(cl_mem, void*); /* callback function */
+  void *user_data; /* user supplied data passed to callback function */
+  mem_destructor_callback_t *prev, *next;
+};
+
 // Command Queue datatypes
 
 // clEnqueueNDRangeKernel

--- a/lib/CL/clCreateBuffer.c
+++ b/lib/CL/clCreateBuffer.c
@@ -110,6 +110,7 @@ POname(clCreateBuffer)(cl_context   context,
   mem->parent = NULL;
   mem->map_count = 0;
   mem->mappings = NULL;
+  mem->destructor_callbacks = NULL;
   mem->type = CL_MEM_OBJECT_BUFFER;
   mem->flags = flags;
   mem->is_image = CL_FALSE;

--- a/lib/CL/clReleaseMemObject.c
+++ b/lib/CL/clReleaseMemObject.c
@@ -32,6 +32,7 @@ POname(clReleaseMemObject)(cl_mem memobj) CL_API_SUFFIX__VERSION_1_0
   cl_mem parent = NULL;
   unsigned i;
   mem_mapping_t *mapping, *temp;
+  mem_destructor_callback_t *callback, *next_callback;
   cl_context context = memobj->context;
 
   POCL_RETURN_ERROR_COND((memobj == NULL), CL_INVALID_MEM_OBJECT);
@@ -82,6 +83,17 @@ POname(clReleaseMemObject)(cl_mem memobj) CL_API_SUFFIX__VERSION_1_0
           POCL_MEM_FREE(memobj->mem_host_ptr);
         }
       POCL_MEM_FREE(memobj->device_ptrs);
+
+      /* Fire any registered destructor callbacks */
+      callback = memobj->destructor_callbacks;
+      while (callback)
+      {
+        callback->pfn_notify(memobj, callback->user_data);
+        next_callback = callback->next;
+        free(callback);
+        callback = next_callback;
+      }
+
       POCL_MEM_FREE(memobj);
 
       if (parent)

--- a/lib/CL/clSetMemObjectDestructorCallback.c
+++ b/lib/CL/clSetMemObjectDestructorCallback.c
@@ -5,7 +5,20 @@ POname(clSetMemObjectDestructorCallback)(  cl_mem  memobj ,
                                     void (CL_CALLBACK * pfn_notify)( cl_mem /* memobj */, void* /*user_data*/), 
                                     void * user_data  )             CL_API_SUFFIX__VERSION_1_1
 {
-  POCL_ABORT_UNIMPLEMENTED("The entire clSetMemObjectDestructorCallback call");
+  mem_destructor_callback_t *callback;
+
+  POCL_RETURN_ERROR_COND((memobj == NULL), CL_INVALID_MEM_OBJECT);
+  POCL_RETURN_ERROR_COND((pfn_notify == NULL), CL_INVALID_VALUE);
+
+  callback = malloc(sizeof(mem_destructor_callback_t));
+  if (callback == NULL)
+    return CL_OUT_OF_HOST_MEMORY;
+
+  callback->pfn_notify = pfn_notify;
+  callback->user_data  = user_data;
+  callback->next       = memobj->destructor_callbacks;
+  memobj->destructor_callbacks = callback;
+
   return CL_SUCCESS;
 }
 POsym(clSetMemObjectDestructorCallback)

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -570,6 +570,8 @@ struct _cl_mem {
   /* in case this is a sub buffer, this points to the parent
      buffer */
   cl_mem_t *parent;
+  /* A linked list of destructor callbacks */
+  mem_destructor_callback_t *destructor_callbacks;
 
   /* Image flags */
   cl_bool                 is_image;

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -30,7 +30,8 @@ set(PROGRAMS_TO_BUILD test_clFinish test_clGetDeviceInfo test_clGetEventInfo
   test_clCreateKernelsInProgram test_clCreateKernel test_clGetKernelArgInfo
   test_version test_kernel_cache_includes test_event_cycle test_link_error
   test_read-copy-write-buffer test_clCreateSubDevices test_event_free
-  test_enqueue_kernel_from_binary test_user_event)
+  test_enqueue_kernel_from_binary test_user_event
+  test_clSetMemObjectDestructorCallback)
 
 #EXTRA_DIST= \
 # test_kernel_src_in_pwd.h \
@@ -99,6 +100,8 @@ add_test_pocl(NAME "runtime/test_enqueue_kernel_from_binary" COMMAND "test_enque
 
 add_test_pocl(NAME "runtime/test_user_event" COMMAND  "test_user_event")
 
+add_test_pocl(NAME "runtime/clSetMemObjectDestructorCallback" COMMAND  "test_clSetMemObjectDestructorCallback")
+
 set_tests_properties( "runtime/clGetDeviceInfo" "runtime/clEnqueueNativeKernel"
   "runtime/clGetEventInfo" "runtime/clCreateProgramWithBinary"
   "runtime/clBuildProgram" "runtime/clFinish" "runtime/clSetEventCallback"
@@ -108,6 +111,7 @@ set_tests_properties( "runtime/clGetDeviceInfo" "runtime/clEnqueueNativeKernel"
   "runtime/test_read-copy-write-buffer" #"runtime/test_link_error"
   "runtime/test_event_free" "runtime/clCreateSubDevices"
   "runtime/test_enqueue_kernel_from_binary" "runtime/test_user_event"
+  "runtime/clSetMemObjectDestructorCallback"
   PROPERTIES
     COST 2.0
     PROCESSORS 1
@@ -129,4 +133,3 @@ set_tests_properties("runtime/clFinish"
 set_tests_properties("runtime/test_kernel_cache_includes"
   PROPERTIES PASS_REGULAR_EXPRESSION
   "function 1.*first include.*function 2.*second include")
-

--- a/tests/runtime/test_clSetMemObjectDestructorCallback.c
+++ b/tests/runtime/test_clSetMemObjectDestructorCallback.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <CL/cl.h>
+#include "poclu.h"
+
+#define MAX_DEVICES   1
+
+#define FAKE_PTR 0xDEADBEEF
+
+void callback(cl_mem memobj, void *user_data)
+{
+  if (user_data == (void*)FAKE_PTR)
+    printf("OK\n");
+  else
+    printf("FAIL\n");
+}
+
+int
+main(void)
+{
+  cl_int err;
+  cl_platform_id platform[1];
+  cl_uint nplatforms;
+  cl_device_id devices[MAX_DEVICES];
+  cl_uint ndevices;
+
+  err = clGetPlatformIDs (1, platform, &nplatforms);
+  CHECK_OPENCL_ERROR_IN("clGetPlatformIDs");
+
+  err = clGetDeviceIDs (platform[0], CL_DEVICE_TYPE_ALL, MAX_DEVICES,
+                        devices, &ndevices);
+  CHECK_OPENCL_ERROR_IN("clGetDeviceIDs");
+
+  TEST_ASSERT(ndevices >= 1);
+
+  cl_context context = clCreateContext (NULL, 1, devices, NULL, NULL, &err);
+  CHECK_OPENCL_ERROR_IN("clCreateContext");
+
+  cl_mem mem = clCreateBuffer(context, 0, 1024, NULL, &err);
+  CHECK_OPENCL_ERROR_IN("clCreateBuffer");
+
+  err = clSetMemObjectDestructorCallback(mem, callback, (void*)FAKE_PTR);
+  CHECK_OPENCL_ERROR_IN("clSetMemObjectDestructorCallback");
+
+  err = clReleaseMemObject(mem);
+  CHECK_OPENCL_ERROR_IN("clReleaseMemObject");
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This just adds a simple linked-list of callbacks to the `cl_mem` struct, which are then fired in `clReleaseMemObject` when the ref count reaches zero.

Test case included.
