### PR TITLE
Pass offset to driver unmapping routines

### DIFF
--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -903,7 +903,7 @@ pocl_basic_map_mem (void *data, void *buf_ptr,
 
 void* pocl_basic_unmap_mem(void *data, void *host_ptr,
                            void *device_start_ptr,
-                           size_t size)
+                           size_t offset, size_t size)
 {
   return host_ptr;
 }

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -390,13 +390,12 @@ pocl_exec_command (_cl_command_node * volatile node)
           /* Assume the region is automatically up to date. */
         } else 
         {
-          /* TODO: fixme. The offset computation must be done at the device 
-             driver. */
           if (node->device->ops->unmap_mem != NULL)        
             node->device->ops->unmap_mem
               (node->device->data, 
                (node->command.unmap.mapping)->host_ptr, 
                (node->command.unmap.memobj)->device_ptrs[node->device->dev_id].mem_ptr, 
+               (node->command.unmap.mapping)->offset,
                (node->command.unmap.mapping)->size);
         }
       DL_DELETE((node->command.unmap.memobj)->mappings, 
@@ -488,7 +487,7 @@ pocl_exec_command (_cl_command_node * volatile node)
       else
         node->device->ops->unmap_mem
           (node->device->data, NULL,
-           node->command.svm_unmap.svm_ptr, 0);
+           node->command.svm_unmap.svm_ptr, 0, 0);
       POCL_UPDATE_EVENT_COMPLETE(event);
       POCL_DEBUG_EVENT_TIME(event, "SVM Unmap             ");
       break;

--- a/lib/CL/devices/prototypes.inc
+++ b/lib/CL/devices/prototypes.inc
@@ -105,7 +105,8 @@
   void* pocl_##__DRV__##_map_mem (void *data, void *buf_ptr,         \
                         size_t offset, size_t size, void *host_ptr); \
   void* pocl_##__DRV__##_unmap_mem (void *data, void *host_ptr, \
-                                    void *device_start_ptr, size_t size); \
+                                    void *device_start_ptr, size_t offset, \
+                                    size_t size); \
   cl_ulong pocl_##__DRV__##_get_timer_value(void *data); \
   char* pocl_##__DRV__##_init_build (void *data); \
   char* pocl_##__DRV__##_build_hash (cl_device_id device); \

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -318,7 +318,7 @@ struct pocl_device_ops {
      host-accessible memory. This might or might not involve copying 
      the block from the device. */
   void* (*map_mem) (void *data, void *buf_ptr, size_t offset, size_t size, void *host_ptr);
-  void* (*unmap_mem) (void *data, void *host_ptr, void *device_start_ptr, size_t size);
+  void* (*unmap_mem) (void *data, void *host_ptr, void *device_start_ptr, size_t offset, size_t size);
 
   void (*compile_kernel) (_cl_command_node* cmd, cl_kernel kernel, cl_device_id device);
   void (*run) (void *data, _cl_command_node* cmd);


### PR DESCRIPTION
This is required for any devices that don't have unified memory with the host CPU and therefore need to manually update device memory during an unmap operation.