### PR TITLE
Ensure destructor callback list initialized to NULL for sub-buffers

### DIFF
--- a/lib/CL/clCreateSubBuffer.c
+++ b/lib/CL/clCreateSubBuffer.c
@@ -65,6 +65,7 @@ POname(clCreateSubBuffer)(cl_mem                   buffer,
 
   POCL_INIT_OBJECT(mem);
   mem->mappings = NULL;
+  mem->destructor_callbacks = NULL;
   mem->parent = buffer;
 
   mem->type = CL_MEM_OBJECT_BUFFER;


### PR DESCRIPTION
Missed this from my recent addition of `clSetMemObjectDestructorCallback`, otherwise any use of `clCreateSubBuffer` is likely to cause crashes.

Sorry!
