### PR TITLE
Rect fixes

### DIFF
--- a/include/pocl.h
+++ b/include/pocl.h
@@ -175,6 +175,19 @@ typedef struct
   cl_mem buffer;
 } _cl_command_write_image;
 
+typedef struct
+{
+  void *dst_ptr;
+  const void *src_ptr;
+  size_t dst_origin[3];
+  size_t src_origin[3];
+  size_t region[3];
+  size_t dst_rowpitch;
+  size_t dst_slicepitch;
+  size_t src_rowpitch;
+  size_t src_slicepitch;
+} _cl_command_copy_image;
+
 /* clEnqueueUnMapMemObject */
 typedef struct
 {
@@ -268,6 +281,7 @@ typedef union
   _cl_command_fill_image fill_image;
   _cl_command_read_image read_image;
   _cl_command_write_image write_image;
+  _cl_command_copy_image copy_image;
   _cl_command_marker marker;
   _cl_command_barrier barrier;
   _cl_command_unmap unmap;

--- a/lib/CL/clEnqueueCopyBufferRect.c
+++ b/lib/CL/clEnqueueCopyBufferRect.c
@@ -42,7 +42,7 @@ POname(clEnqueueCopyBufferRect)(cl_command_queue command_queue,
                                 cl_event *event) CL_API_SUFFIX__VERSION_1_1
 {
   dst_buffer->owning_device = command_queue->device;
-  return pocl_rect_copy(command_queue,
+  return pocl_rect_copy(command_queue, CL_COMMAND_COPY_BUFFER_RECT,
     src_buffer, CL_FALSE,
     dst_buffer, CL_FALSE,
     src_origin, dst_origin, region,

--- a/lib/CL/clEnqueueCopyImage.c
+++ b/lib/CL/clEnqueueCopyImage.c
@@ -12,7 +12,7 @@ POname(clEnqueueCopyImage)(cl_command_queue      command_queue ,
                    const cl_event *      event_wait_list ,
                    cl_event *            event ) CL_API_SUFFIX__VERSION_1_0
 {
-  return pocl_rect_copy(command_queue,
+  return pocl_rect_copy(command_queue, CL_COMMAND_COPY_IMAGE,
     src_image, CL_TRUE,
     dst_image, CL_TRUE,
     src_origin, dst_origin, region,

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -377,6 +377,23 @@ pocl_exec_command (_cl_command_node * volatile node)
       POCL_UPDATE_EVENT_COMPLETE(event);
       POCL_DEBUG_EVENT_TIME(event, "Read Buffer Rect      ");
       break;
+    case CL_COMMAND_COPY_BUFFER_RECT:
+    case CL_COMMAND_COPY_IMAGE:
+      POCL_UPDATE_EVENT_RUNNING(event);
+      node->device->ops->copy_rect
+        (node->device->data,
+         node->command.copy_image.src_ptr,
+         node->command.copy_image.dst_ptr,
+         node->command.copy_image.src_origin,
+         node->command.copy_image.dst_origin,
+         node->command.copy_image.region,
+         node->command.copy_image.src_rowpitch,
+         node->command.copy_image.src_slicepitch,
+         node->command.copy_image.dst_rowpitch,
+         node->command.copy_image.dst_slicepitch);
+      POCL_UPDATE_EVENT_COMPLETE(event);
+      POCL_DEBUG_EVENT_TIME(event, "Copy Buffer Rect      ");
+      break;
     case CL_COMMAND_UNMAP_MEM_OBJECT:
       POCL_UPDATE_EVENT_RUNNING(event);
       if ((node->command.unmap.memobj)->flags & 

--- a/lib/CL/pocl_shared.h
+++ b/lib/CL/pocl_shared.h
@@ -43,6 +43,7 @@ pocl_map_mem_cmd(cl_device_id device,
                  mem_mapping_t *mapping_info);
 
 cl_int pocl_rect_copy(cl_command_queue command_queue,
+                      cl_command_type command_type,
                       cl_mem src,
                       cl_int src_is_image,
                       cl_mem dst,


### PR DESCRIPTION
This should fix #349 and bring the buffer rect and image copies in line with the rest of the enqueued ops.