### PR TITLE
Buffer image copy

### DIFF
--- a/lib/CL/clEnqueueCopyBufferToImage.c
+++ b/lib/CL/clEnqueueCopyBufferToImage.c
@@ -1,77 +1,26 @@
-#include "pocl_util.h"
-#include "pocl_image_util.h"
+#include "pocl_shared.h"
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 POname(clEnqueueCopyBufferToImage)(cl_command_queue  command_queue,
                                    cl_mem            buffer,
-                                   cl_mem            image, 
+                                   cl_mem            image,
                                    size_t            src_offset,
                                    const size_t *    dst_origin, /*[3]*/
                                    const size_t *    region,  /*[3]*/
                                    cl_uint           num_events_in_wait_list,
                                    const cl_event *  event_wait_list,
-                                   cl_event *        event ) 
+                                   cl_event *        event )
 CL_API_SUFFIX__VERSION_1_0
 {
-  int errcode;
-
-  POCL_RETURN_ERROR_COND((command_queue == NULL), CL_INVALID_COMMAND_QUEUE);
-
-  POCL_RETURN_ERROR_ON((!command_queue->device->image_support), CL_INVALID_OPERATION,
-    "Device %s does not support images\n", command_queue->device->long_name);
-
-  POCL_RETURN_ERROR_COND((buffer == NULL), CL_INVALID_MEM_OBJECT);
-  POCL_RETURN_ERROR_ON((buffer->type != CL_MEM_OBJECT_BUFFER),
-    CL_INVALID_MEM_OBJECT, "buffer is not a CL_MEM_OBJECT_BUFFER\n");
-
-  POCL_RETURN_ERROR_COND((image == NULL), CL_INVALID_MEM_OBJECT);
-
-  POCL_RETURN_ERROR_ON((!image->is_image), CL_INVALID_MEM_OBJECT,
-    "dst_image is not an image\n");
-
-  POCL_RETURN_ERROR_COND((region == NULL), CL_INVALID_MEM_OBJECT);
-
-
-  if (region[2] != 1) {
-    POCL_ABORT_UNIMPLEMENTED("clEnqueueCopyBufferToImage on 3D images");
-  }
-
-  POCL_RETURN_ERROR_ON(((buffer->context != image->context) ||
-    (buffer->context != command_queue->context)), CL_INVALID_CONTEXT, "src_buffer, "
-    "dst_image and command_queue are not from the same context\n");
-
-  POCL_RETURN_ERROR_COND((event_wait_list == NULL && num_events_in_wait_list > 0),
-    CL_INVALID_EVENT_WAIT_LIST);
-
-  POCL_RETURN_ERROR_COND((event_wait_list != NULL && num_events_in_wait_list == 0),
-    CL_INVALID_EVENT_WAIT_LIST);
-
-  errcode = pocl_check_device_supports_image(image, command_queue);
-  if (errcode != CL_SUCCESS)
-    return errcode;
-    
-
-  int host_elem_size;    
-  int host_channels;
-  pocl_get_image_information (image->image_channel_order,
-                              image->image_channel_data_type,
-                              &host_channels, &host_elem_size);
-    
-  char* temp = (char*) malloc (image->size);
-    
-  cl_device_id device_id = command_queue->device;
-
-  device_id->ops->read
-    (device_id->data, 
-     temp, 
-     image->device_ptrs[device_id->dev_id].mem_ptr, src_offset,
-     image->size); 
-            
-  cl_int ret_code = pocl_write_image (image, command_queue->device, dst_origin,
-                                      region, 0, 0, temp+src_offset);
-    
-  POCL_MEM_FREE(temp);
-  POCL_UPDATE_EVENT_COMPLETE(event);
-  return ret_code;
+  /* pass src_origin through in a format pocl_rect_copy understands */
+  const size_t src_origin[3] = { src_offset, 0, 0};
+  return pocl_rect_copy(command_queue, CL_COMMAND_COPY_BUFFER_TO_IMAGE,
+    buffer, CL_FALSE,
+    image, CL_TRUE,
+    src_origin, dst_origin, region,
+    0, 0,
+    0, 0,
+    num_events_in_wait_list, event_wait_list,
+    event);
 }
-POsym(clEnqueueCopyBufferToImage) 
+POsym(clEnqueueCopyBufferToImage)

--- a/lib/CL/clEnqueueCopyImageToBuffer.c
+++ b/lib/CL/clEnqueueCopyImageToBuffer.c
@@ -1,20 +1,27 @@
-#include "pocl_cl.h"
-
+#include "pocl_shared.h"
 
 CL_API_ENTRY cl_int CL_API_CALL
 POname(clEnqueueCopyImageToBuffer)(cl_command_queue  command_queue ,
                            cl_mem            src_image ,
-                           cl_mem            dst_buffer , 
+                           cl_mem            dst_buffer ,
                            const size_t *    src_origin ,
-                           const size_t *    region , 
+                           const size_t *    region ,
                            size_t            dst_offset ,
                            cl_uint           num_events_in_wait_list ,
                            const cl_event *  event_wait_list ,
                            cl_event *        event ) CL_API_SUFFIX__VERSION_1_0
 {
-  POCL_ABORT_UNIMPLEMENTED("The entire clEnqueueCopyImageToBuffer call");
-  return CL_SUCCESS;
+  /* pass dst_origin through in a format pocl_rect_copy understands */
+  const size_t dst_origin[3] = { dst_offset, 0, 0};
+  return pocl_rect_copy(command_queue, CL_COMMAND_COPY_IMAGE_TO_BUFFER,
+    src_image, CL_TRUE,
+    dst_buffer, CL_FALSE,
+    src_origin, dst_origin, region,
+    0, 0,
+    0, 0,
+    num_events_in_wait_list, event_wait_list,
+    event);
 }
 POsym(clEnqueueCopyImageToBuffer)
-    
+
 

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -822,6 +822,9 @@ void pocl_basic_memfill(void *ptr,
   size_t i;
   unsigned j;
 
+  /* memfill size is in bytes, we wanto make it into elements */
+  size /= pattern_size;
+
   switch (pattern_size)
     {
     case 1:

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -378,6 +378,8 @@ pocl_exec_command (_cl_command_node * volatile node)
       POCL_DEBUG_EVENT_TIME(event, "Read Buffer Rect      ");
       break;
     case CL_COMMAND_COPY_BUFFER_RECT:
+    case CL_COMMAND_COPY_BUFFER_TO_IMAGE:
+    case CL_COMMAND_COPY_IMAGE_TO_BUFFER:
     case CL_COMMAND_COPY_IMAGE:
       POCL_UPDATE_EVENT_RUNNING(event);
       node->device->ops->copy_rect

--- a/lib/CL/pocl_img_buf_cpy.c
+++ b/lib/CL/pocl_img_buf_cpy.c
@@ -121,10 +121,15 @@ cl_int pocl_rect_copy(cl_command_queue command_queue,
   memcpy(mod_src_origin, src_origin, 3*sizeof(size_t));
   memcpy(mod_dst_origin, dst_origin, 3*sizeof(size_t));
 
-  if (src_is_image && dst_is_image)
+  if (src_is_image)
     {
       mod_region[0] *= src->image_elem_size * src->image_channels;
       mod_src_origin[0] *= src->image_elem_size * src->image_channels;
+    }
+  if (dst_is_image)
+    {
+      if (!src_is_image)
+        mod_region[0] *= dst->image_elem_size * dst->image_channels;
       mod_dst_origin[0] *= dst->image_elem_size * dst->image_channels;
     }
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -29,7 +29,7 @@ set(PROGRAMS_TO_BUILD test_clFinish test_clGetDeviceInfo test_clGetEventInfo
   test_clSetEventCallback test_clEnqueueNativeKernel test_clBuildProgram
   test_clCreateKernelsInProgram test_clCreateKernel test_clGetKernelArgInfo
   test_version test_kernel_cache_includes test_event_cycle test_link_error
-  test_read-copy-write-buffer test_clCreateSubDevices test_event_free
+  test_read-copy-write-buffer test_buffer-image-copy test_clCreateSubDevices test_event_free
   test_enqueue_kernel_from_binary test_user_event
   test_clSetMemObjectDestructorCallback)
 
@@ -80,6 +80,8 @@ add_test_pocl(NAME "runtime/test_event_cycle" COMMAND "test_event_cycle")
 
 add_test_pocl(NAME "runtime/test_read-copy-write-buffer" COMMAND "test_read-copy-write-buffer")
 
+add_test_pocl(NAME "runtime/test_buffer-image-copy" COMMAND "test_buffer-image-copy")
+
 add_test_pocl(NAME "runtime/clCreateKernel" COMMAND "test_clCreateKernel")
 
 add_test_pocl(NAME "runtime/clGetKernelArgInfo" COMMAND "test_clGetKernelArgInfo")
@@ -108,7 +110,7 @@ set_tests_properties( "runtime/clGetDeviceInfo" "runtime/clEnqueueNativeKernel"
   "runtime/clGetSupportedImageFormats" "runtime/clCreateKernelsInProgram"
   "runtime/clCreateKernel" "runtime/clGetKernelArgInfo"
   "runtime/test_kernel_cache_includes" "runtime/test_event_cycle"
-  "runtime/test_read-copy-write-buffer" #"runtime/test_link_error"
+  "runtime/test_read-copy-write-buffer" "runtime/test_buffer-image-copy" #"runtime/test_link_error"
   "runtime/test_event_free" "runtime/clCreateSubDevices"
   "runtime/test_enqueue_kernel_from_binary" "runtime/test_user_event"
   "runtime/clSetMemObjectDestructorCallback"

--- a/tests/runtime/Makefile.am
+++ b/tests/runtime/Makefile.am
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 
 noinst_PROGRAMS= test_clFinish test_clGetDeviceInfo test_clGetEventInfo \
-	test_read-copy-write-buffer test_event_cycle test_event_free \
+	test_read-copy-write-buffer test_buffer-image-copy test_event_cycle test_event_free \
 	test_clCreateProgramWithBinary test_clGetSupportedImageFormats \
 	test_clSetEventCallback test_clEnqueueNativeKernel test_clBuildProgram \
 	test_link_error test_kernel_cache_includes \

--- a/tests/runtime/test_buffer-image-copy.c
+++ b/tests/runtime/test_buffer-image-copy.c
@@ -1,0 +1,199 @@
+/* Test clEnqueueCopy{BufferToImage,ImageToBuffer}
+
+   Copyright (C) 2016 Giuseppe Bilotta <giuseppe.bilotta@gmail.com>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <CL/cl.h>
+#include "poclu.h"
+
+#define MAX_PLATFORMS 32
+#define MAX_DEVICES   32
+
+/* we will manipulate images with 4 16-bit channels, which are manadated
+ * as necessarily supported by the standard */
+static const cl_image_format img_format = {
+  .image_channel_order = CL_RGBA,
+  .image_channel_data_type = CL_UNSIGNED_INT16
+};
+
+static const size_t pixel_size = 4*sizeof(cl_ushort);
+#define CHANNEL_MAX 0xFFFFU
+
+int
+main(void)
+{
+  cl_int err;
+  cl_platform_id platforms[MAX_PLATFORMS];
+  cl_uint nplatforms;
+  cl_device_id devices[MAX_DEVICES];
+  cl_uint ndevices;
+  cl_uint i, j;
+  size_t el, row, col;
+
+  CHECK_CL_ERROR(clGetPlatformIDs(MAX_PLATFORMS, platforms, &nplatforms));
+
+  for (i = 0; i < nplatforms; i++)
+  {
+    CHECK_CL_ERROR(clGetDeviceIDs(platforms[i], CL_DEVICE_TYPE_ALL, MAX_DEVICES,
+      devices, &ndevices));
+
+    /* Only test the devices we actually have room for */
+    if (ndevices > MAX_DEVICES)
+      ndevices = MAX_DEVICES;
+
+    for (j = 0; j < ndevices; j++)
+    {
+      /* skip devices that do not support images */
+      cl_bool has_img;
+      CHECK_CL_ERROR(clGetDeviceInfo(devices[j], CL_DEVICE_IMAGE_SUPPORT, sizeof(has_img), &has_img, NULL));
+      if (!has_img)
+        continue;
+
+      cl_context context = clCreateContext(NULL, 1, &devices[j], NULL, NULL, &err);
+      CHECK_OPENCL_ERROR_IN("clCreateContext");
+      cl_command_queue queue = clCreateCommandQueue(context, devices[j], 0, &err);
+      CHECK_OPENCL_ERROR_IN("clCreateCommandQueue");
+
+      cl_ulong alloc;
+      size_t max_height;
+      size_t max_width;
+#define MAXALLOC (1024U*1024U)
+
+      CHECK_CL_ERROR(clGetDeviceInfo(devices[j], CL_DEVICE_MAX_MEM_ALLOC_SIZE,
+          sizeof(alloc), &alloc, NULL));
+      CHECK_CL_ERROR(clGetDeviceInfo(devices[j], CL_DEVICE_IMAGE2D_MAX_WIDTH,
+          sizeof(max_width), &max_width, NULL));
+      CHECK_CL_ERROR(clGetDeviceInfo(devices[j], CL_DEVICE_IMAGE2D_MAX_HEIGHT,
+          sizeof(max_height), &max_height, NULL));
+
+
+      while (alloc > MAXALLOC)
+        alloc /= 2;
+
+      // fit at least one max_width inside the alloc (shrink max_width for this)
+      while (max_width*pixel_size > alloc)
+        max_width /= 2;
+
+      // round number of elements to next multiple of max_width elements
+      const size_t nels = (alloc/pixel_size/max_width)*max_width;
+      const size_t buf_size = nels*pixel_size;
+
+      cl_image_desc img_desc;
+      memset(&img_desc, 0, sizeof(img_desc));
+      img_desc.image_type = CL_MEM_OBJECT_IMAGE2D;
+      img_desc.image_width = max_width;
+      img_desc.image_height = nels/max_width;
+      img_desc.image_depth = 1;
+
+      cl_ushort null_pixel[4] = {0, 0, 0, 0};
+      cl_ushort *host_buf = malloc(buf_size);
+      TEST_ASSERT(host_buf);
+
+      for (el = 0; el < nels; el+=4) {
+        host_buf[el] = el & CHANNEL_MAX;
+        host_buf[el+1] = (CHANNEL_MAX - el) & CHANNEL_MAX;
+        host_buf[el+2] = (CHANNEL_MAX/((el & 1) + 1) - el) & CHANNEL_MAX;
+        host_buf[el+3] = (CHANNEL_MAX - el/((el & 1) + 1)) & CHANNEL_MAX;
+      }
+
+      cl_mem buf = clCreateBuffer(context, CL_MEM_READ_WRITE, buf_size, NULL, &err);
+      CHECK_OPENCL_ERROR_IN("clCreateBuffer");
+      cl_mem img = clCreateImage(context, CL_MEM_READ_WRITE, &img_format, &img_desc, NULL, &err);
+      CHECK_OPENCL_ERROR_IN("clCreateImage");
+
+      CHECK_CL_ERROR(clEnqueueWriteBuffer(queue, buf, CL_TRUE, 0, buf_size, host_buf, 0, NULL, NULL));
+
+      const size_t offset = 0;
+      const size_t origin[] = {0, 0, 0};
+      const size_t region[] = {img_desc.image_width, img_desc.image_height, 1};
+
+      CHECK_CL_ERROR(clEnqueueCopyBufferToImage(queue, buf, img, offset, origin, region, 0, NULL, NULL));
+
+      size_t row_pitch, slice_pitch;
+      cl_ushort *img_map = clEnqueueMapImage(queue, img, CL_TRUE, CL_MAP_READ, origin, region,
+        &row_pitch, &slice_pitch, 0, NULL, NULL, &err);
+      CHECK_OPENCL_ERROR_IN("clEnqueueMapImage");
+
+      CHECK_CL_ERROR(clFinish(queue));
+
+      for (row = 0; row < img_desc.image_height; ++row) {
+        for (col = 0; col < img_desc.image_width; ++col) {
+          cl_ushort *img_pixel = (cl_ushort*)((char*)img_map + row*row_pitch) + col*4;
+          cl_ushort *buf_pixel = host_buf + (row*img_desc.image_width + col)*4;
+#if 0 // debug
+          if (memcmp(img_pixel, buf_pixel, pixel_size) != 0)
+            printf("%zu %zu %zu : %x %x %x %x | %x %x %x %x\n",
+              row, col, (size_t)(buf_pixel - host_buf),
+              buf_pixel[0],
+              buf_pixel[1],
+              buf_pixel[2],
+              buf_pixel[3],
+              img_pixel[0],
+              img_pixel[1],
+              img_pixel[2],
+              img_pixel[3]);
+#endif
+          TEST_ASSERT(memcmp(img_pixel, buf_pixel, pixel_size) == 0);
+
+        }
+      }
+
+      CHECK_CL_ERROR(clEnqueueUnmapMemObject(queue, img, img_map, 0, NULL, NULL));
+
+      /* Clear the buffer, and ensure it has been cleared */
+      CHECK_CL_ERROR(clEnqueueFillBuffer(queue, buf, null_pixel, sizeof(null_pixel), 0, buf_size, 0, NULL, NULL));
+      cl_ushort *buf_map = clEnqueueMapBuffer(queue, buf, CL_TRUE, CL_MAP_READ, 0, buf_size, 0, NULL, NULL, &err);
+      CHECK_OPENCL_ERROR_IN("clEnqueueMapBuffer");
+
+      CHECK_CL_ERROR(clFinish(queue));
+
+      for (el = 0; el < nels; ++el) {
+#if 0 // debug
+        if (buf_map[el] != 0) {
+          printf("%zu/%zu => %u\n", el, nels, buf_map[el]);
+        }
+#endif
+        TEST_ASSERT(buf_map[el] == 0);
+      }
+
+      CHECK_CL_ERROR(clEnqueueUnmapMemObject(queue, buf, buf_map, 0, NULL, NULL));
+
+      /* Copy data from image to buffer, and check that it's again equal to the original buffer */
+      CHECK_CL_ERROR(clEnqueueCopyImageToBuffer(queue, img, buf, origin, region, offset, 0, NULL, NULL));
+      buf_map = clEnqueueMapBuffer(queue, buf, CL_TRUE, CL_MAP_READ, 0, buf_size, 0, NULL, NULL, &err);
+      CHECK_CL_ERROR(clFinish(queue));
+
+      TEST_ASSERT(memcmp(buf_map, host_buf, buf_size) == 0);
+
+      CHECK_CL_ERROR(clEnqueueUnmapMemObject(queue, buf, buf_map, 0, NULL, NULL));
+      CHECK_CL_ERROR(clFinish(queue));
+
+      free(host_buf);
+      CHECK_CL_ERROR(clReleaseMemObject(img));
+      CHECK_CL_ERROR(clReleaseMemObject(buf));
+      CHECK_CL_ERROR(clReleaseCommandQueue(queue));
+    }
+  }
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
(Re)implement buffer <-> image copies via the existing 2D (and 3D) copy mechanism. This completes the missing parts of the implementation and brings everything in line with the new command/event mechanism.

The last commit fixes a buffer fill bug which was also exposed by the buffer image copy test.