### PR TITLE
Fixed lib/CL/pocl_timing.c

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -46,4 +46,5 @@ Pavan Yalamanchili <pavan@arrayfire.com>
 Romaric Jodin <rjodin@kalray.eu>
 Masataro Asai <guicho2.71828@gmail.com>
 Richard Crowder <riccro@gmail.com>
+Matthias Noack <ma.noack.pr@gmail.com>
 

--- a/lib/CL/pocl_timing.c
+++ b/lib/CL/pocl_timing.c
@@ -66,11 +66,16 @@ uint64_t pocl_gettimemono_ns() {
 #ifdef HAVE_CLOCK_GETTIME
   struct timespec timespec;
 # ifdef __linux__
+#  ifdef CLOCK_MONOTONIC_RAW 
   clock_gettime(CLOCK_MONOTONIC_RAW, &timespec);
+#  else
+#   warning Using clock_gettime with CLOCK_MONOTONIC for monotonic clocks
+  clock_gettime(CLOCK_MONOTONIC, &timespec);
+#  endif
 # elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
   clock_gettime(CLOCK_UPTIME_FAST, &timespec);
 # else
-# warn Using clock_gettime with CLOCK_REALTIME for monotonic clocks
+# warning Using clock_gettime with CLOCK_REALTIME for monotonic clocks
   clock_gettime(CLOCK_REALTIME, &timespec);
 # endif
   return ((timespec.tv_sec * 1000000000UL) + timespec.tv_nsec);


### PR DESCRIPTION
Falls back to CLOCK_MONOTONIC for Linux distributions that come without CLOCK_MONOTONIC_RAW, e.g. SLES (used in Cray's software environment).

- Including "linux/time.h" instead of "time.h" would also solve the issue, but conflicts with other "time.h" includes across the project, which would lead to a much larger patch, so keeping it simple.
- The generic fall back to CLOCK_REALTIME would also work, but CLOCK_MONOTONIC is closer to CLOCK_MONOTONIC_RAW, see http://man7.org/linux/man-pages/man2/clock_gettime.2.html
- Also changed the "#warn" to "#warning", as gcc 5.3.0 wouldn't accept "#warn" and yield an error