### PR TITLE
Crosscompilation support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 Highlights
 ----------
 - Out of order execution execution now enabled.
+  - It's now possible to cross-compile pocl (when building a LLVM-less build)
   - New driver api extension to support OoO and asynchronous devices/drivers.
   - Pthread driver now fully asynchronous.
   - HSA driver now fully asynchronous

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,6 +410,10 @@ endif()
 
 ######################################################################################
 
+include_directories("fix-include" "include")
+
+######################################################################################
+
 if(WIN32)
     message(STATUS "Using LoadLibrary/FreeLibrary in Windows, libltdl not needed.")
 else()
@@ -954,8 +958,6 @@ if(UNIX)
 endif()
 
 #############################################################
-
-include_directories("fix-include" "include")
 
 add_subdirectory("include")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,7 +425,8 @@ else()
     get_filename_component(LTDL_H_INCLUDE_DIR "${LTDL_H}" DIRECTORY)
     string(FIND "${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}" "${LTDL_H_INCLUDE_DIR}" LTPOSITION)
     # include the directory of ltdl.h, if its not in the default system include dirs
-    if(LTPOSITION LESS "0")
+    # also when cross-compiling this includes <cross-compile-root>/usr/include, which screws things up
+    if((LTPOSITION LESS "0") AND (NOT CMAKE_CROSSCOMPILING))
       include_directories("${LTDL_H_INCLUDE_DIR}")
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,13 +473,34 @@ if (MSVC)
   set(DEFAULT_ENABLE_ICD 0 CACHE INTERNAL "Going to use ICD loader")
 else()
 
-  pkg_check_modules(OCL_ICD ocl-icd>=1.3)
+  # pkg-config doesn't work with cross-compiling
+  if (NOT CMAKE_CROSSCOMPILING)
+    pkg_check_modules(OCL_ICD ocl-icd>=1.3)
+  endif()
+  if (CMAKE_CROSSCOMPILING OR (NOT OCL_ICD_FOUND))
+    find_path(OCL_ICD_INCLUDE_DIR
+      NAMES
+        ocl_icd.h
+    )
+    find_library(OCL_ICD_LIBRARIES
+      NAMES
+        OpenCL
+    )
+    if(OCL_ICD_INCLUDE_DIR AND OCL_ICD_LIBRARIES)
+      set(OCL_ICD_FOUND 1)
+    endif()
+  endif()
 
   if(OCL_ICD_FOUND)
 
     set(HAVE_OCL_ICD 1 CACHE INTERNAL "ICL library is ocl-icd")
     set(OPENCL_FOUND 1 CACHE INTERNAL "opencl ICD/library found")
-    set(OPENCL_LIBRARIES "OpenCL" CACHE INTERNAL "opencl ICD/library paths") # duh, why doesnt ocl-icd set this in .pc file ??
+    # duh, why doesnt ocl-icd set this in it's .pc file ??
+    if (CMAKE_CROSSCOMPILING)
+      set(OPENCL_LIBRARIES "${OCL_ICD_LIBRARIES}" CACHE INTERNAL "opencl ICD/library paths")
+    else()
+      set(OPENCL_LIBRARIES "OpenCL" CACHE INTERNAL "opencl ICD/library paths")
+    endif()
     set(DEFAULT_ENABLE_ICD 1 CACHE INTERNAL "ICD loader availability")
 
   else()

--- a/ToolchainExample.cmake
+++ b/ToolchainExample.cmake
@@ -1,13 +1,17 @@
-# This is an example Toolchain file to cross-compile for ARM
-# or other boards from x86_64
+# This is an example Toolchain file to cross-compile for ARM/MIPS/other
+# boards from x86_64. Copy & modify
+#
 # Steps:
-# 1) Install g++ and gcc cross-compilers (apt install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf)
+# 1) Install g++ and gcc cross-compilers
+#    (apt install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf)
 # 2) On your board, install libltdl, ocl-icd and libhwloc + their development headers
-# 3) copy the entire root filesystem of the board somewhere on your host, then set CMAKE_FIND_ROOT_PATH to this path
+# 3) copy the entire root filesystem of the board somewhere on your host,
+     then set CMAKE_FIND_ROOT_PATH below to this path
 # 4) run cmake like this:
 #          cmake -DHOST_DEVICE_BUILD_HASH=<SOME_HASH> -DOCS_AVAILABLE=0
-#           -DCMAKE_TOOLCHAIN_FILE=<path-to-Toolchain.cmake>
-#           -DLLC_TRIPLE=arm-gnueabihf-linux-gnu -DLLC_HOST_CPU=armv7a
+#           -DCMAKE_TOOLCHAIN_FILE=<path-to-this-file>
+#           -DLLC_TRIPLE=<your-triple (e.g.arm-gnueabihf-linux-gnu)
+#           -DLLC_HOST_CPU=<your-cpu (e.g. armv7a)>
 #           <path-to-pocl-source>
 
 SET(CMAKE_SYSTEM_NAME Linux)

--- a/ToolchainExample.cmake
+++ b/ToolchainExample.cmake
@@ -1,0 +1,31 @@
+# This is an example Toolchain file to cross-compile for ARM
+# or other boards from x86_64
+# Steps:
+# 1) Install g++ and gcc cross-compilers (apt install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf)
+# 2) On your board, install libltdl, ocl-icd and libhwloc + their development headers
+# 3) copy the entire root filesystem of the board somewhere on your host, then set CMAKE_FIND_ROOT_PATH to this path
+# 4) run cmake like this:
+#          cmake -DHOST_DEVICE_BUILD_HASH=<SOME_HASH> -DOCS_AVAILABLE=0
+#           -DCMAKE_TOOLCHAIN_FILE=<path-to-Toolchain.cmake>
+#           -DLLC_TRIPLE=arm-gnueabihf-linux-gnu -DLLC_HOST_CPU=armv7a
+#           <path-to-pocl-source>
+
+SET(CMAKE_SYSTEM_NAME Linux)
+
+# specify the cross compiler
+SET(CMAKE_C_COMPILER   /usr/bin/arm-linux-gnueabihf-gcc)
+SET(CMAKE_CXX_COMPILER /usr/bin/arm-linux-gnueabihf-g++)
+
+# should work, but does not yet. Instead set FIND_ROOT below
+# set(CMAKE_SYSROOT /home/a/zynq/ZYNQ_ROOT)
+# where is the target environment
+SET(CMAKE_FIND_ROOT_PATH  /path/to/target_ROOT)
+# where to find libraries in target environment
+SET(CMAKE_LIBRARY_PATH /path/to/target_ROOT/usr/lib/arm-linux-gnueabihf)
+
+
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/cmake/FindHwloc.cmake
+++ b/cmake/FindHwloc.cmake
@@ -134,7 +134,30 @@ if(WIN32)
 
 else()
 
-  # Find with pkgconfig
+  if(CMAKE_CROSSCOMPILING)
+
+  find_path(Hwloc_INCLUDE_DIRS
+    NAMES
+      hwloc.h
+    PATHS
+      ENV HWLOC_ROOT
+  )
+
+  find_library(Hwloc_LIBRARIES
+    NAMES
+      hwloc
+    PATHS
+      ENV HWLOC_ROOT
+  )
+
+  if(Hwloc_INCLUDE_DIRS AND Hwloc_LIBRARIES)
+    # this is kindof arbitrary
+    set(Hwloc_FOUND 1)
+    set(Hwloc_VERSION "1.7.0")
+  endif()
+
+  else() # Find with pkgconfig for non-crosscompile builds
+
   find_package(PkgConfig)
 
   if(HWLOC_ROOT)
@@ -177,5 +200,8 @@ else()
         "Found hwloc ${Hwloc_VERSION} in ${Hwloc_INCLUDE_DIRS}:${Hwloc_LIBRARIES}")
     endif()
   endif()
+
+  endif() # cross-compile else
+
 endif()
 

--- a/cmake/FindHwloc.cmake
+++ b/cmake/FindHwloc.cmake
@@ -151,7 +151,7 @@ else()
   )
 
   if(Hwloc_INCLUDE_DIRS AND Hwloc_LIBRARIES)
-    # this is kindof arbitrary
+    message(WARNING "HWLOC library found using find_library() - cannot determine version. Assuming 1.7.0")
     set(Hwloc_FOUND 1)
     set(Hwloc_VERSION "1.7.0")
   endif()

--- a/doc/sphinx/source/pocl_binary.rst
+++ b/doc/sphinx/source/pocl_binary.rst
@@ -29,6 +29,12 @@ The string after "HSTR:" is the device build hash.
   This is required because pocl binaries contain a device hash, and the LLVM-less
   pocl needs to know which binaries it can load.
 
+Cross-compile pocl LLVM-less build
+-----------------------------------
+It's now possible to cross-compile pocl on x86-64 to run on ARM/MIPS/etc,
+but only the LLVM-less build. There is a ToolchainExample.cmake file;
+copy it under different name, then follow the instructions in the file.
+
 Binary inputs format
 --------------------
 

--- a/lib/CL/devices/CMakeLists.txt
+++ b/lib/CL/devices/CMakeLists.txt
@@ -26,7 +26,11 @@
 add_subdirectory("pthread")
 add_subdirectory("basic")
 add_subdirectory("topology")
-set(POCL_DEVICES_LINK_LIST ${Hwloc_LDFLAGS})
+if(Hwloc_LDFLAGS)
+  set(POCL_DEVICES_LINK_LIST ${Hwloc_LDFLAGS})
+else()
+  set(POCL_DEVICES_LINK_LIST ${Hwloc_LIBRARIES})
+endif()
 
 set(POCL_DEVICES_OBJS "$<TARGET_OBJECTS:pocl-devices>"
       "$<TARGET_OBJECTS:pocl-devices-pthread>"

--- a/lib/CL/devices/topology/CMakeLists.txt
+++ b/lib/CL/devices/topology/CMakeLists.txt
@@ -23,7 +23,12 @@
 #
 #=============================================================================
 
-add_compile_options(${Hwloc_CFLAGS})
+if(Hwloc_CFLAGS)
+  add_compile_options(${Hwloc_CFLAGS})
+else()
+  include_directories(${Hwloc_INCLUDE_DIRS})
+endif()
+
 if(MSVC)
   set_source_files_properties( pocl_topology.c pocl_topology.h PROPERTIES LANGUAGE CXX )
 endif(MSVC)


### PR DESCRIPTION
Note this is only for LLVM-less builds.

Toolchain.example has the required steps to use it.