### PR TITLE
Random fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -784,7 +784,19 @@ if(ENABLE_TCE)
 
   set(TCE_DEVICE_CL_VERSION "120")
 
+  if("${LLVM_CXXFLAGS}" MATCHES "-fno-rtti")
+    message(WARNING "TCE is enabled but your LLVM was not built with RTTI. You should rebuild LLVM with 'make REQUIRES_RTTI=1'. See the INSTALL file for more information.")
+  endif()
+
 else()
+
+  # - '-fno-rtti' is a work-around for llvm bug 14200
+  # Which according to bug report has been fixed in llvm 3.7
+  # sadly, that bugreport is mistaken, it's not fixed in 3.7
+  if (NOT MSVC)
+    set(LLVM_CXXFLAGS "${LLVM_CXXFLAGS} -fno-rtti")
+  endif()
+
   set(ENABLE_TCEMC 0)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,19 +577,6 @@ endif()
 
 ######################################################################################
 
-if(NOT MSVC)
-  pkg_check_modules(GLEW glew)
-endif()
-
-if(GLEW_FOUND)
-  set(HAVE_GLEW 1)
-else()
-  set(HAVE_GLEW 0)
-  message(WARNING "libGLEW not found. A few tests will not work")
-endif()
-
-######################################################################################
-
 set_expr(POCL_KERNEL_CACHE_DEFAULT KERNEL_CACHE_DEFAULT)
 
 string(TIMESTAMP POCL_BUILD_TIMESTAMP "%d%m%Y%H%M%S")

--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -175,26 +175,11 @@ endif()
 
 ####################################################################
 
-# DONE
-if("${LLVM_CXXFLAGS}" MATCHES "-fno-rtti")
-  message(WARNING "Your LLVM was not built with RTTI.
-       You should rebuild LLVM with 'make REQUIRES_RTTI=1'.
-       See the INSTALL file for more information.")
-endif()
-
 # A few work-arounds for llvm-config issues
 
 # - pocl doesn't compile with '-pedantic'
 #LLVM_CXX_FLAGS=$($LLVM_CONFIG --cxxflags | sed -e 's/ -pedantic / /g')
 string(REPLACE " -pedantic" "" LLVM_CXXFLAGS "${LLVM_CXXFLAGS}")
-
-# - '-fno-rtti' is a work-around for llvm bug 14200
-# Which according to bug report has been fixed in llvm 3.7
-# sadly, that bugreport is mistaken, it's not fixed in 3.7
-if (NOT MSVC)
-  set(LLVM_CXXFLAGS "${LLVM_CXXFLAGS} -fno-rtti")
-endif()
-
 
 # Llvm-config may be installed or it might be used from build directory, in which case
 # we need to add few extra include paths to find clang includes and compiled includes

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -120,3 +120,20 @@ foreach(TS ${ACTUALLY_ENABLED_TESTSUITES})
 endforeach()
 
 set(DISABLED_TESTSUITES ${DISABLED} PARENT_SCOPE)
+
+######################################################################################
+
+if(ACTUALLY_ENABLED_TESTSUITES MATCHES "AMD")
+
+  if(NOT MSVC)
+    pkg_check_modules(GLEW glew)
+  endif()
+
+  if(GLEW_FOUND)
+    set(HAVE_GLEW 1 PARENT_SCOPE)
+  else()
+    set(HAVE_GLEW 0 PARENT_SCOPE)
+    message(WARNING "libGLEW not found. A few tests from AMD testsuite will not work")
+  endif()
+
+endif()

--- a/include/pocl_cache.h
+++ b/include/pocl_cache.h
@@ -88,14 +88,14 @@ int pocl_cache_write_descriptor(cl_program   program,
                                 const char*  content,
                                 size_t       size);
 
-int pocl_cache_make_kernel_cachedir_path(char*        kernel_cachedir_path,
-                                         cl_program   program,
-                                         cl_device_id device,
-                                         cl_kernel    kernel,
-                                         size_t       local_x,
-                                         size_t       local_y,
-                                         size_t       local_z);
-
+void pocl_cache_kernel_cachedir_path (char* kernel_cachedir_path,
+                                             cl_program program,
+                                             unsigned device_i,
+                                             cl_kernel kernel,
+                                             char* append_str,
+                                             size_t local_x,
+                                             size_t local_y,
+                                             size_t local_z);
 
 
 int pocl_cache_write_kernel_parallel_bc(void*        bc,

--- a/include/pocl_cache.h
+++ b/include/pocl_cache.h
@@ -89,13 +89,13 @@ int pocl_cache_write_descriptor(cl_program   program,
                                 size_t       size);
 
 void pocl_cache_kernel_cachedir_path (char* kernel_cachedir_path,
-                                             cl_program program,
-                                             unsigned device_i,
-                                             cl_kernel kernel,
-                                             char* append_str,
-                                             size_t local_x,
-                                             size_t local_y,
-                                             size_t local_z);
+                                      cl_program program,
+                                      unsigned device_i,
+                                      cl_kernel kernel,
+                                      char* append_str,
+                                      size_t local_x,
+                                      size_t local_y,
+                                      size_t local_z);
 
 
 int pocl_cache_write_kernel_parallel_bc(void*        bc,

--- a/lib/CL/clBuildProgram.c
+++ b/lib/CL/clBuildProgram.c
@@ -139,12 +139,11 @@ program_compile_dynamic_wg_binaries(cl_program program)
               local_z = kernel->reqd_wg_size[2];
             }
 
-          pocl_cache_make_kernel_cachedir_path (cachedir, program, device,
-                                                kernel, local_x, local_y, local_z);
+          pocl_cache_kernel_cachedir_path(cachedir, program, device_i, kernel,
+                                          "", local_x, local_y, local_z);
 
-          errcode
-            = pocl_llvm_generate_workgroup_function
-            (device, kernel, local_x, local_y, local_z);
+          errcode = pocl_llvm_generate_workgroup_function(cachedir, device, kernel,
+                                                          local_x, local_y, local_z);
           if (errcode != CL_SUCCESS)
             {
               POCL_MSG_ERR("Failed to generate workgroup function for "

--- a/lib/CL/clBuildProgram.c
+++ b/lib/CL/clBuildProgram.c
@@ -139,11 +139,11 @@ program_compile_dynamic_wg_binaries(cl_program program)
               local_z = kernel->reqd_wg_size[2];
             }
 
-          pocl_cache_kernel_cachedir_path(cachedir, program, device_i, kernel,
-                                          "", local_x, local_y, local_z);
+          pocl_cache_kernel_cachedir_path (cachedir, program, device_i, kernel,
+                                           "", local_x, local_y, local_z);
 
-          errcode = pocl_llvm_generate_workgroup_function(cachedir, device, kernel,
-                                                          local_x, local_y, local_z);
+          errcode = pocl_llvm_generate_workgroup_function (cachedir, device, kernel,
+                                                           local_x, local_y, local_z);
           if (errcode != CL_SUCCESS)
             {
               POCL_MSG_ERR("Failed to generate workgroup function for "

--- a/lib/CL/clCreateKernel.c
+++ b/lib/CL/clCreateKernel.c
@@ -92,8 +92,11 @@ POname(clCreateKernel)(cl_program program,
           cl_device_id device = program->devices[device_i];
           if (device->spmd)
             {
-              errcode = pocl_llvm_generate_workgroup_function(device,
-                                                            kernel, 0, 0, 0);
+              char cachedir[POCL_FILENAME_LENGTH];
+              pocl_cache_kernel_cachedir_path(cachedir, program, device_i, kernel, "", 0, 0, 0);
+
+              errcode = pocl_llvm_generate_workgroup_function(cachedir, device,
+                                                              kernel, 0, 0, 0);
               if (errcode == CL_SUCCESS)
                 device->ops->compile_kernel(NULL, kernel, device);
             }

--- a/lib/CL/clCreateKernel.c
+++ b/lib/CL/clCreateKernel.c
@@ -87,16 +87,17 @@ POname(clCreateKernel)(cl_program program,
           pocl_cache_device_cachedir_exists(program, device_i))
         {
 #ifdef OCS_AVAILABLE
-          pocl_llvm_get_kernel_metadata(program, kernel, device_i,
-                                        kernel_name, &errcode);
+          pocl_llvm_get_kernel_metadata (program, kernel, device_i,
+                                         kernel_name, &errcode);
           cl_device_id device = program->devices[device_i];
           if (device->spmd)
             {
               char cachedir[POCL_FILENAME_LENGTH];
-              pocl_cache_kernel_cachedir_path(cachedir, program, device_i, kernel, "", 0, 0, 0);
+              pocl_cache_kernel_cachedir_path (cachedir, program, device_i,
+                                               kernel, "", 0, 0, 0);
 
-              errcode = pocl_llvm_generate_workgroup_function(cachedir, device,
-                                                              kernel, 0, 0, 0);
+              errcode = pocl_llvm_generate_workgroup_function (cachedir, device,
+                                                               kernel, 0, 0, 0);
               if (errcode == CL_SUCCESS)
                 device->ops->compile_kernel(NULL, kernel, device);
             }

--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -237,11 +237,10 @@ DETERMINE_LOCAL_SIZE:
     CL_INVALID_EVENT_WAIT_LIST);
 
   char cachedir[POCL_FILENAME_LENGTH];
-  pocl_cache_make_kernel_cachedir_path (cachedir, kernel->program,
-                                        realdev, kernel,
-                                        local_x, local_y, local_z);
-
   int realdev_i = pocl_cl_device_to_index(kernel->program, realdev);
+  assert(realdev_i >= 0);
+  pocl_cache_kernel_cachedir_path(cachedir, kernel->program, realdev_i, kernel, "", local_x, local_y, local_z);
+
   if (kernel->program->source || kernel->program->binaries[realdev_i])
     {
 #ifdef OCS_AVAILABLE
@@ -249,8 +248,7 @@ DETERMINE_LOCAL_SIZE:
       if (realdev->spmd)
         error = CL_SUCCESS;
       else
-        error = pocl_llvm_generate_workgroup_function(realdev,
-                                                      kernel,
+        error = pocl_llvm_generate_workgroup_function(cachedir, realdev, kernel,
                                                       local_x, local_y, local_z);
 #else
       error = 1;

--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -237,9 +237,11 @@ DETERMINE_LOCAL_SIZE:
     CL_INVALID_EVENT_WAIT_LIST);
 
   char cachedir[POCL_FILENAME_LENGTH];
-  int realdev_i = pocl_cl_device_to_index(kernel->program, realdev);
+  int realdev_i = pocl_cl_device_to_index (kernel->program, realdev);
   assert(realdev_i >= 0);
-  pocl_cache_kernel_cachedir_path(cachedir, kernel->program, realdev_i, kernel, "", local_x, local_y, local_z);
+  pocl_cache_kernel_cachedir_path (cachedir, kernel->program,
+                                   realdev_i, kernel, "",
+                                   local_x, local_y, local_z);
 
   if (kernel->program->source || kernel->program->binaries[realdev_i])
     {
@@ -248,8 +250,8 @@ DETERMINE_LOCAL_SIZE:
       if (realdev->spmd)
         error = CL_SUCCESS;
       else
-        error = pocl_llvm_generate_workgroup_function(cachedir, realdev, kernel,
-                                                      local_x, local_y, local_z);
+        error = pocl_llvm_generate_workgroup_function (cachedir, realdev, kernel,
+                                                       local_x, local_y, local_z);
 #else
       error = 1;
 #endif

--- a/lib/CL/pocl_cache.c
+++ b/lib/CL/pocl_cache.c
@@ -107,7 +107,7 @@ void pocl_cache_program_bc_path(char*        program_bc_path,
                        device_i, POCL_PROGRAM_BC_FILENAME);
 }
 
-static void pocl_cache_kernel_cachedir_path (char* kernel_cachedir_path,
+void pocl_cache_kernel_cachedir_path (char* kernel_cachedir_path,
                                              cl_program program,
                                              unsigned device_i,
                                              cl_kernel kernel,
@@ -364,33 +364,10 @@ int pocl_cache_write_kernel_parallel_bc(void*        bc,
     strcat(kernel_parallel_path, POCL_PARALLEL_BC_FILENAME);
     return pocl_write_module(bc, kernel_parallel_path, 0);
 }
-#endif
-
-int pocl_cache_make_kernel_cachedir_path (char*        kernel_cachedir_path,
-                                          cl_program   program,
-                                          cl_device_id device,
-                                          cl_kernel    kernel,
-                                          size_t       local_x,
-                                          size_t       local_y,
-                                          size_t       local_z) {
-    int index = pocl_cl_device_to_index (program, device);
-    assert (index >= 0);
-
-    pocl_cache_kernel_cachedir_path (kernel_cachedir_path, program, index,
-                                     kernel, "", local_x, local_y, local_z);
-
-    return pocl_mkdir_p (kernel_cachedir_path);
-}
 
 
 /******************************************************************************/
 
-
-
-
-
-
-#ifdef OCS_AVAILABLE
 static inline void
 build_program_compute_hash(cl_program program,
                            unsigned   device_i,

--- a/lib/CL/pocl_llvm.h
+++ b/lib/CL/pocl_llvm.h
@@ -67,8 +67,8 @@ int pocl_llvm_get_kernel_metadata
  * at a time or control the options through thread safe methods.
  */
 int pocl_llvm_generate_workgroup_function
-(cl_device_id device, cl_kernel kernel,
- size_t local_x, size_t local_y, size_t local_z
+(char* kernel_cachedir, cl_device_id device,
+ cl_kernel kernel, size_t local_x, size_t local_y, size_t local_z
 );
 
 /**

--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -1580,8 +1580,9 @@ kernel_library
 /* This is used to control the kernel we want to process in the kernel compilation. */
 extern cl::opt<std::string> KernelName;
 
-int pocl_llvm_generate_workgroup_function(char* kernel_cachedir, cl_device_id device, cl_kernel kernel,
-                                          size_t local_x, size_t local_y, size_t local_z)
+int pocl_llvm_generate_workgroup_function(char* kernel_cachedir, cl_device_id device,
+                                          cl_kernel kernel, size_t local_x,
+                                          size_t local_y, size_t local_z)
 {
 
   pocl::WGDynamicLocalSize = (local_x == 0 && local_y == 0 && local_z == 0);

--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -1580,7 +1580,7 @@ kernel_library
 /* This is used to control the kernel we want to process in the kernel compilation. */
 extern cl::opt<std::string> KernelName;
 
-int pocl_llvm_generate_workgroup_function(cl_device_id device, cl_kernel kernel,
+int pocl_llvm_generate_workgroup_function(char* kernel_cachedir, cl_device_id device, cl_kernel kernel,
                                           size_t local_x, size_t local_y, size_t local_z)
 {
 
@@ -1601,6 +1601,8 @@ int pocl_llvm_generate_workgroup_function(cl_device_id device, cl_kernel kernel,
 
   if (pocl_exists(final_binary_path))
     return CL_SUCCESS;
+
+  pocl_mkdir_p(kernel_cachedir);
 
   llvm::MutexGuard lockHolder(kernelCompilerLock);
   InitializeLLVM();
@@ -1838,6 +1840,7 @@ pocl_llvm_codegen(cl_kernel kernel,
     llvm::TargetMachine *target = GetTargetMachine(device);
 
     llvm::Module *input = ParseIRFile(infilename, Err, *GlobalContext());
+    assert(input);
 
     PassManager PM;
 #ifdef LLVM_OLDER_THAN_3_7


### PR DESCRIPTION
1) fix some random annoying warnings from CMake,

2) remove a redundant (for HSA at least) mkdir in clEnqueueNDRangeKernel() - improves performance of small kernel enqueues