### PR TITLE
Add support for SPIR build flags

### DIFF
--- a/examples/example1-spir32/example1_exec.c
+++ b/examples/example1-spir32/example1_exec.c
@@ -101,7 +101,7 @@ exec_dot_product_kernel(const char *program_source, size_t source_size,
     } 
  
   // build the program 
-  err = clBuildProgram(program, 0, NULL, NULL, NULL, NULL); 
+  err = clBuildProgram(program, 0, NULL, "-x spir -spir-std=1.2", NULL, NULL);
   if (err != CL_SUCCESS) 
     { 
       delete_memobjs(memobjs, 3); 

--- a/examples/example1-spir64/example1_exec.c
+++ b/examples/example1-spir64/example1_exec.c
@@ -101,7 +101,7 @@ exec_dot_product_kernel(const char *program_source, size_t source_size,
     } 
  
   // build the program 
-  err = clBuildProgram(program, 0, NULL, NULL, NULL, NULL); 
+  err = clBuildProgram(program, 0, NULL, "-x spir -spir-std=1.2", NULL, NULL);
   if (err != CL_SUCCESS) 
     { 
       delete_memobjs(memobjs, 3); 

--- a/lib/CL/clBuildProgram.c
+++ b/lib/CL/clBuildProgram.c
@@ -257,6 +257,38 @@ CL_API_SUFFIX__VERSION_1_0
                   continue;
                 }
             }
+          else if (memcmp (token, "-x", 2) == 0 && strlen (token) == 2)
+            {
+              /* only "-x spir" is valid for the "-x" option */
+              token = strtok_r (NULL, " ", &saveptr);
+              if (!token || memcmp (token, "spir", 4) != 0)
+                {
+                  APPEND_TO_MAIN_BUILD_LOG("Invalid parameter to -x build option\n");
+                  errcode = CL_INVALID_BUILD_OPTIONS;
+                  goto ERROR_CLEAN_OPTIONS;
+                }
+              /* "-x spir" is not valid if we are building from source */
+              else if (program->source)
+                {
+                  APPEND_TO_MAIN_BUILD_LOG("\"-x spir\" is not valid when building from source\n");
+                  errcode = CL_INVALID_BUILD_OPTIONS;
+                  goto ERROR_CLEAN_OPTIONS;
+                }
+              token = strtok_r (NULL, " ", &saveptr);
+              continue;
+            }
+          else if (memcmp (token, "-spir-std=1.2", 13) == 0)
+            {
+              /* "-spir-std=" flags are not valid when building from source */
+              if (program->source)
+                {
+                  APPEND_TO_MAIN_BUILD_LOG("\"-spir-std=\" flag is not valid when building from source\n");
+                  errcode = CL_INVALID_BUILD_OPTIONS;
+                  goto ERROR_CLEAN_OPTIONS;
+                }
+              token = strtok_r (NULL, " ", &saveptr);
+              continue;
+            }
           else
             {
               APPEND_TO_MAIN_BUILD_LOG("Invalid build option: %s\n", token);


### PR DESCRIPTION
The [`cl_khr_spir` extension](https://www.khronos.org/registry/cl/sdk/2.0/docs/man/xhtml/cl_khr_spir.html) requires any application that makes use of SPIR to pass the `-x spir` and `-spir-std=*` flags to `clBuildProgram`. This patch adds support for these flags so that pocl can work with a SPIR-based application (for context I'm currently working with the [ComputeCpp implementation of SYCL from Codeplay](https://www.codeplay.com/products/computesuite/computecpp)).
