### PR TITLE
Work around Skylake codegen issue in LLVM 3.8 (0.13 branch)

### DIFF
--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -853,6 +853,12 @@ int pocl_llvm_get_kernel_metadata(cl_program program,
 
 char* get_cpu_name() {
   StringRef r = llvm::sys::getHostCPUName();
+#ifdef LLVM_OLDER_THAN_3_9
+  if (r.str() == "skylake")
+  {
+    r = llvm::StringRef("haswell");
+  }
+#endif
   assert(r.size() > 0);
   char* cpu_name = (char*) malloc (r.size()+1);
   strncpy(cpu_name, r.data(), r.size());

--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -853,7 +853,8 @@ int pocl_llvm_get_kernel_metadata(cl_program program,
 
 char* get_cpu_name() {
   StringRef r = llvm::sys::getHostCPUName();
-#ifdef LLVM_OLDER_THAN_3_9
+#ifdef LLVM_3_8
+  // https://github.com/pocl/pocl/issues/413
   if (r.str() == "skylake")
   {
     r = llvm::StringRef("haswell");


### PR DESCRIPTION
See #413.