### PR TITLE
Add dependency checks for example-tests

### DIFF
--- a/examples/CloverLeaf/CMakeLists.txt
+++ b/examples/CloverLeaf/CMakeLists.txt
@@ -39,10 +39,11 @@ endif()
 find_program(MPI_F90 mpif90)
 find_program(MPI_CC  mpicc)
 find_program(MPI_CXX  mpiCC)
+find_program(GFORTRAN gfortran)
 find_library(MPI_LIB mpi_cxx ${EXTRA_LIB_HINTS})
 
 if(HAVE_GIT)
-if (MPI_F90 AND MPI_CC AND MPI_CXX AND MPI_LIB)
+if (MPI_F90 AND MPI_CC AND MPI_CXX AND MPI_LIB AND GFORTRAN)
 
   message(STATUS "Enabling testsuite ${TS_NAME}")
   list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")

--- a/examples/VexCL/CMakeLists.txt
+++ b/examples/VexCL/CMakeLists.txt
@@ -28,8 +28,12 @@ set(TS_BASEDIR "${TESTSUITE_BASEDIR}/${TS_NAME}")
 set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}-build")
 set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
 
-if(HAVE_GIT)
+if(HAVE_GIT==false)
+  message(STATUS "Disabling testsuite ${TS_NAME}, requires git to checkout sources")
+elseif(NOT TESTS_USE_ICD)
+  message(STATUS "Disabling testsuite ${TS_NAME}, requires ocl-icd")
 
+else()
 message(STATUS "Enabling testsuite ${TS_NAME}")
 list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
 set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
@@ -114,6 +118,4 @@ set_tests_properties(vexcl_boost_version vexcl_types vexcl_deduce
   PROPERTIES
     LABELS "VexCL")
 
-else()
-  message(STATUS "Disabling testsuite ${TS_NAME}, requires git to checkout sources")
 endif()

--- a/examples/clBLAS/CMakeLists.txt
+++ b/examples/clBLAS/CMakeLists.txt
@@ -30,9 +30,14 @@ set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
 
 find_package(Boost 1.44 QUIET)
 
-if(HAVE_GIT)
-if(Boost_FOUND)
+if(NOT HAVE_GIT)
+  message(STATUS "Disabling testsuite ${TS_NAME}, requires git to checkout sources")
+elseif(NOT Boost_FOUND)
+  message(STATUS "Disabling testsuite ${TS_NAME}, required Boost version not found" )
+elseif(NOT TESTS_USE_ICD)
+  message(STATUS "Disabling testsuite ${TS_NAME}, requires ocl-icd" )
 
+else()
   message(STATUS "Enabling testsuite ${TS_NAME}")
   list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
   set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
@@ -261,10 +266,4 @@ if(Boost_FOUND)
       LABELS "${TS_NAME}"
       ENVIRONMENT "LD_LIBRARY_PATH=${TS_BUILDDIR}/library")
 
-else()
-  message(STATUS "Disabling testsuite ${TS_NAME}, required Boost version not found" )
-endif()
-
-else()
-  message(STATUS "Disabling testsuite ${TS_NAME}, requires git to checkout sources")
 endif()

--- a/examples/clFFT/CMakeLists.txt
+++ b/examples/clFFT/CMakeLists.txt
@@ -30,9 +30,14 @@ set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
 
 find_package(Boost 1.44 QUIET)
 
-if(HAVE_GIT)
-if(Boost_FOUND)
+if(NOT HAVE_GIT)
+  message(STATUS "Disabling testsuite ${TS_NAME}, requires git to checkout sources")
+elseif(NOT TESTS_USE_ICD)
+  message(STATUS "Disabling testsuite ${TS_NAME}, requires ocl-icd")
+elseif(NOT Boost_FOUND)
+  message(STATUS "Disabling testsuite ${TS_NAME}, required Boost version not found" )
 
+else()
   message(STATUS "Enabling testsuite ${TS_NAME}")
   list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
   set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
@@ -81,9 +86,4 @@ if(Boost_FOUND)
     PROPERTIES
       LABELS "${TS_NAME}")
 
-else()
-  message(STATUS "Disabling testsuite ${TS_NAME}, required Boost version not found" )
-endif()
-else()
-  message(STATUS "Disabling testsuite ${TS_NAME}, requires git to checkout sources")
 endif()

--- a/examples/piglit/CMakeLists.txt
+++ b/examples/piglit/CMakeLists.txt
@@ -28,8 +28,17 @@ set(TS_BASEDIR "${TESTSUITE_BASEDIR}/${TS_NAME}")
 set(TS_BUILDDIR "${TS_BASEDIR}/src/${TS_NAME}-build")
 set(TS_SRCDIR "${TESTSUITE_SOURCE_BASEDIR}/${TS_NAME}")
 
-if(HAVE_GIT)
+find_package(GLUT QUIET)
+find_package(PNG QUIET)
 
+if(NOT HAVE_GIT)
+  message(STATUS "Disabling testsuite ${TS_NAME}, requires git to checkout sources")
+elseif(NOT GLUT_FOUND)
+  message(STATUS "Disabling testsuite ${TS_NAME}, requires glut library")
+elseif(NOT PNG_FOUND)
+  message(STATUS "Disabling testsuite ${TS_NAME}, requires PNG library")
+
+else()
 message(STATUS "Enabling testsuite ${TS_NAME}")
 list(APPEND ACTUALLY_ENABLED_TESTSUITES "${TS_NAME}")
 set(ACTUALLY_ENABLED_TESTSUITES ${ACTUALLY_ENABLED_TESTSUITES} PARENT_SCOPE)
@@ -221,6 +230,4 @@ set_tests_properties(
   PROPERTIES
     LABELS "piglit")
 
-else()
-  message(STATUS "Disabling testsuite ${TS_NAME}, requires git to checkout sources")
 endif()


### PR DESCRIPTION
For the most part, just add a check that a ICD loader is available.
This should make the ARM buildbot pass again.