### PR TITLE
pfn_notify callback added for clBuildPorgram, related test added and -Werror test revised

### DIFF
--- a/include/pocl.h
+++ b/include/pocl.h
@@ -58,6 +58,14 @@ struct _mem_destructor_callback
   mem_destructor_callback_t *next;
 };
 
+typedef struct _build_program_callback build_program_callback_t;
+/* represents a build program callback */
+struct _build_program_callback
+{
+    void (CL_CALLBACK * callback_function) (cl_program, void*); /* callback function */
+    void *user_data; /* user supplied data passed to callback function */
+};
+
 // Command Queue datatypes
 
 // clEnqueueNDRangeKernel

--- a/lib/CL/clCreateProgramWithBinary.c
+++ b/lib/CL/clCreateProgramWithBinary.c
@@ -118,6 +118,7 @@ POname(clCreateProgramWithBinary)(cl_context                     context,
       goto ERROR_CLEAN_PROGRAM_AND_BINARIES;
     }
 
+  program->buildprogram_callback = NULL;
   program->context = context;
   program->num_devices = num_devices;
   program->devices = unique_devlist;

--- a/lib/CL/clCreateProgramWithSource.c
+++ b/lib/CL/clCreateProgramWithSource.c
@@ -70,6 +70,7 @@ POname(clCreateProgramWithSource)(cl_context context,
     goto ERROR;
   }
 
+  program->buildprogram_callback = NULL;
   program->source = source;
 
   for (i = 0; i < count; ++i)

--- a/lib/CL/clReleaseProgram.c
+++ b/lib/CL/clReleaseProgram.c
@@ -59,6 +59,9 @@ POname(clReleaseProgram)(cl_program program) CL_API_SUFFIX__VERSION_1_0
           k->program = NULL;
         }
 
+      if (program->buildprogram_callback)
+        POCL_MEM_FREE(program->buildprogram_callback);
+
       if (program->devices != program->context->devices)
         POCL_MEM_FREE(program->devices);
 

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -649,6 +649,8 @@ struct _cl_program {
   void** read_locks;
   /* Use to store build status */
   cl_build_status build_status;
+  /* Use to store build porgram callback (pfn_notify) */
+  build_program_callback_t *buildprogram_callback;
 };
 
 struct _cl_kernel {


### PR DESCRIPTION
pfn_notify callback added for clBuildProgram, and related test added to clBuildProgram tests.

OCL1.2 spec says:
"If pfn_notify is not NULL, clBuildProgram does not need to wait for the build to complete and can return immediately once the build operation can begin."
This feature still missing.

Also -Werror test revised to test full functionality: warning in the kernel build turned to error and checked in the test.