### PR TITLE
clGetProgramBuildInfo binary_type information added

### DIFF
--- a/include/pocl.h
+++ b/include/pocl.h
@@ -59,7 +59,6 @@ struct _mem_destructor_callback
 };
 
 typedef struct _build_program_callback build_program_callback_t;
-/* represents a build program callback */
 struct _build_program_callback
 {
     void (CL_CALLBACK * callback_function) (cl_program, void*); /* callback function */

--- a/lib/CL/clBuildProgram.c
+++ b/lib/CL/clBuildProgram.c
@@ -510,7 +510,6 @@ CL_API_SUFFIX__VERSION_1_0
   program->build_status = CL_BUILD_SUCCESS;
   POCL_UNLOCK_OBJ(program);
 
-  /* callback freed in ProgramRelease */
   if (program->buildprogram_callback)
     program->buildprogram_callback->callback_function (program,
                                   program->buildprogram_callback->user_data);

--- a/lib/CL/clCreateProgramWithBinary.c
+++ b/lib/CL/clCreateProgramWithBinary.c
@@ -123,6 +123,7 @@ POname(clCreateProgramWithBinary)(cl_context                     context,
   program->num_devices = num_devices;
   program->devices = unique_devlist;
   program->build_status = CL_BUILD_NONE;
+  program->binary_type = CL_PROGRAM_BINARY_TYPE_EXECUTABLE;
   char program_bc_path[POCL_FILENAME_LENGTH];
 
   for (i = 0; i < num_devices; ++i)
@@ -167,7 +168,7 @@ POname(clCreateProgramWithBinary)(cl_context                     context,
           goto ERROR_CLEAN_PROGRAM_AND_BINARIES;
         }
     }
-  
+
   POCL_RETAIN_OBJECT(context);
 
   if (errcode_ret != NULL)

--- a/lib/CL/clCreateProgramWithSource.c
+++ b/lib/CL/clCreateProgramWithSource.c
@@ -98,6 +98,16 @@ POname(clCreateProgramWithSource)(cl_context context,
   program->num_devices = context->num_devices;
   program->devices = context->devices;
   program->build_status = CL_BUILD_NONE;
+  /* we set binary type to NONE here. Based on OCL1.2 spec
+     if program will be compiled using clCompileProgram its binary_type
+     will be set to CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT.
+     clCompileProgram is currently missing in pocl!
+     if program was created by clLinkProgram which is called
+     with the –createlibrary link option its binary_type will be set to
+     CL_PROGRAM_BINARY_TYPE_LIBRARY.
+     clLinkProgram is currently missing in pocl!
+   */
+  program->binary_type = CL_PROGRAM_BINARY_TYPE_NONE;
 
   if ((program->binary_sizes =
        (size_t*) calloc (program->num_devices, sizeof(size_t))) == NULL ||

--- a/lib/CL/clGetProgramBuildInfo.c
+++ b/lib/CL/clGetProgramBuildInfo.c
@@ -86,6 +86,10 @@ POname(clGetProgramBuildInfo)(cl_program            program,
         *param_value_size_ret = value_size;
       return CL_SUCCESS;
     }
+  case CL_PROGRAM_BINARY_TYPE:
+    {
+      POCL_RETURN_GETINFO(cl_program_binary_type, program->binary_type);
+    }
   }
   
   return CL_INVALID_VALUE;

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -649,6 +649,8 @@ struct _cl_program {
   void** read_locks;
   /* Use to store build status */
   cl_build_status build_status;
+  /* Use to store binary type */
+  cl_program_binary_type binary_type;
   /* Use to store build porgram callback (pfn_notify) */
   build_program_callback_t *buildprogram_callback;
 };

--- a/tests/runtime/test_clBuildProgram.c
+++ b/tests/runtime/test_clBuildProgram.c
@@ -270,7 +270,31 @@ main(void){
           log[log_size] = '\0';
           /*As this build option deprecated after OCL1.0 we should see a warning here*/
           fprintf(stderr, "Deprecated -cl-strict-aliasing log[%u]: %s\n", i, log);
+
           free(log);
+
+          cl_program_binary_type bin_type = 0;
+          err = clGetProgramBuildInfo(program, devices[i],
+                                      CL_PROGRAM_BINARY_TYPE,
+                                      sizeof(bin_type), (void *)&bin_type,
+                                      NULL);
+          CHECK_OPENCL_ERROR_IN("get program binary type");
+
+          /* cl_program_binary_type */
+          switch(bin_type) {
+            case CL_PROGRAM_BINARY_TYPE_NONE: /*0x0*/
+              fprintf(stderr, "program binary type: CL_PROGRAM_BINARY_TYPE_NONE\n");
+            break;
+            case CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT: /*0x1*/
+              fprintf(stderr, "program binary type: CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT\n");
+            break;
+            case CL_PROGRAM_BINARY_TYPE_LIBRARY: /*0x2*/
+              fprintf(stderr, "program binary type: CL_PROGRAM_BINARY_TYPE_LIBRARY\n");
+            break;
+            case CL_PROGRAM_BINARY_TYPE_EXECUTABLE: /*0x4*/
+              fprintf(stderr, "program binary type: CL_PROGRAM_BINARY_TYPE_EXECUTABLE\n");
+            break;
+          }
       }
 
       CHECK_CL_ERROR(clReleaseCommandQueue(q));

--- a/tests/runtime/test_clCreateProgramWithBinary.c
+++ b/tests/runtime/test_clCreateProgramWithBinary.c
@@ -80,6 +80,30 @@ main(void){
 						  binaries, binary_statuses, &err);
   CHECK_OPENCL_ERROR_IN("clCreateProgramWithBinary");
 
+  for (i = 0; i < num; ++i) {
+      cl_program_binary_type bin_type = 0;
+      err = clGetProgramBuildInfo(program_with_binary, devices[i],
+                                  CL_PROGRAM_BINARY_TYPE,
+                                  sizeof(bin_type), (void *)&bin_type,
+                                  NULL);
+      CHECK_OPENCL_ERROR_IN("get program binary type");
+
+      /* cl_program_binary_type */
+      switch(bin_type) {
+        case CL_PROGRAM_BINARY_TYPE_NONE: /*0x0*/
+          fprintf(stderr, "program binary type: CL_PROGRAM_BINARY_TYPE_NONE\n");
+        break;
+        case CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT: /*0x1*/
+          fprintf(stderr, "program binary type: CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT\n");
+        break;
+        case CL_PROGRAM_BINARY_TYPE_LIBRARY: /*0x2*/
+          fprintf(stderr, "program binary type: CL_PROGRAM_BINARY_TYPE_LIBRARY\n");
+        break;
+        case CL_PROGRAM_BINARY_TYPE_EXECUTABLE: /*0x4*/
+          fprintf(stderr, "program binary type: CL_PROGRAM_BINARY_TYPE_EXECUTABLE\n");
+         break;
+      }
+  }
   err = clReleaseProgram(program_with_binary);
   CHECK_OPENCL_ERROR_IN("clReleaseProgram");
 


### PR DESCRIPTION
Based on OCL1.2 spec
if program will be compiled using clCompileProgram its binary_type will be set to CL_PROGRAM_BINARY_TYPE_COMPILED_OBJECT.
clCompileProgram is currently missing in pocl!
if program was created by clLinkProgram which is called with the –createlibrary link option its binary_type will be set to CL_PROGRAM_BINARY_TYPE_LIBRARY.
clLinkProgram is currently missing in pocl!

clCreateProgramWithBinary
sets CL_PROGRAM_BINARY_TYPE_EXECUTABLE
clCreateProgramWithSource
sets CL_PROGRAM_BINARY_TYPE_NONE