### PR TITLE
use memcpy to avoid unaligned access in pocl_binary

### DIFF
--- a/lib/CL/pocl_binary.c
+++ b/lib/CL/pocl_binary.c
@@ -128,11 +128,14 @@ typedef struct pocl_binary_s
 /***********************************************************/
 
 #define BUFFER_STORE(elem, type)                  \
-  *(type*)buffer = (type)TO_LE((type)elem);       \
-  buffer += sizeof(type)
+  do {                                            \
+    type b_s_tmp = (type)TO_LE((type)elem);       \
+    memcpy(buffer, &b_s_tmp, sizeof(type));       \
+    buffer += sizeof(type);                       \
+  } while(0)
 
 #define BUFFER_READ(elem, type)                   \
-  elem = *(type*)buffer;                          \
+  memcpy(&elem, buffer, sizeof(type));            \
   elem = (type)FROM_LE((type)elem);               \
   buffer += sizeof(type)
 

--- a/lib/CL/pocl_binary.c
+++ b/lib/CL/pocl_binary.c
@@ -128,16 +128,18 @@ typedef struct pocl_binary_s
 /***********************************************************/
 
 #define BUFFER_STORE(elem, type)                  \
-  do {                                            \
-    type b_s_tmp = (type)TO_LE((type)elem);       \
-    memcpy(buffer, &b_s_tmp, sizeof(type));       \
-    buffer += sizeof(type);                       \
-  } while(0)
+  do                                              \
+    {                                             \
+      type b_s_tmp = (type) TO_LE ( (type) elem); \
+      memcpy (buffer, &b_s_tmp, sizeof (type));   \
+      buffer += sizeof (type);                    \
+    }                                             \
+  while(0)
 
 #define BUFFER_READ(elem, type)                   \
-  memcpy(&elem, buffer, sizeof(type));            \
-  elem = (type)FROM_LE((type)elem);               \
-  buffer += sizeof(type)
+  memcpy (&elem, buffer, sizeof (type));          \
+  elem = (type) FROM_LE ( (type) elem);           \
+  buffer += sizeof (type)
 
 #define BUFFER_STORE_STR2(elem, len)              \
   do {                                            \


### PR DESCRIPTION
When a processor does not support unaligned access, reading a pocl binary file creates an unauthorized memory access.
"memcpy" function is normaly implemented so that it does no unaligned access if the architecture does not support it.