### PR TITLE
adding read_imagef missing functions

### DIFF
--- a/include/_kernel_c.h
+++ b/include/_kernel_c.h
@@ -198,11 +198,9 @@ float4 _CL_OVERLOADABLE read_imagef (image2d_t image, sampler_t sampler,
                                      float2 coord);
 */
 
-float4 _CL_OVERLOADABLE read_imagef (image2d_t image,
-                                     int2 coord);
+float4 _CL_OVERLOADABLE read_imagef (image2d_t image, int2 coord);
 
-float4 _CL_OVERLOADABLE read_imagef (image2d_array_t image,
-                                     int4  coord);
+float4 _CL_OVERLOADABLE read_imagef (image2d_array_t image, int4 coord);
 
 float4 _CL_OVERLOADABLE read_imagef (image2d_array_t image, sampler_t sampler,
                                      int4 coord);

--- a/include/_kernel_c.h
+++ b/include/_kernel_c.h
@@ -1,4 +1,4 @@
-﻿/* pocl/_kernel_c.h - C compatible OpenCL types and runtime library
+/* pocl/_kernel_c.h - C compatible OpenCL types and runtime library
    functions declarations.
 
    Copyright (c) 2011 Universidad Rey Juan Carlos
@@ -190,19 +190,34 @@ typedef struct _pocl_image1d_array_t { dev_image_t base; }* image1d_array_t;
 #define IMG_WRITE_AQ __write_only
 #endif
 
+/* read_imagef 2d functions*/
 float4 _CL_OVERLOADABLE read_imagef (image2d_t image, sampler_t sampler,
                                      int2 coord);
-
+/* float coords not implemented yet
 float4 _CL_OVERLOADABLE read_imagef (image2d_t image, sampler_t sampler,
                                      float2 coord);
+*/
 
-float4 _CL_OVERLOADABLE read_imagef (image2d_t image, sampler_t sampler,
+float4 _CL_OVERLOADABLE read_imagef (image2d_t image,
+                                     int2 coord);
+
+float4 _CL_OVERLOADABLE read_imagef (image2d_array_t image,
+                                     int4  coord);
+
+float4 _CL_OVERLOADABLE read_imagef (image2d_array_t image, sampler_t sampler,
                                      int4 coord);
 
+/*float coords not immplemented yet
+float4 _CL_OVERLOADABLE read_imagef (image2d_array_t image, sampler_t sampler,
+                                     float4 coord);
+*/
+
+/* read_imagef 3d functions*/
 float4 _CL_OVERLOADABLE read_imagef (image3d_t image, sampler_t sampler,
                                      int4 coord);
 
-uint4 _CL_OVERLOADABLE read_imageui (image2d_t image, sampler_t sampler, 
+/* read_imageui 2d functions*/
+uint4 _CL_OVERLOADABLE read_imageui (image2d_t image, sampler_t sampler,
                                      int2 coord);
 
 uint4 _CL_OVERLOADABLE read_imageui (image2d_t image, sampler_t sampler, 

--- a/lib/kernel/read_image.cl
+++ b/lib/kernel/read_image.cl
@@ -218,14 +218,14 @@ void __pocl_read_pixel (void* color, ADDRESS_SPACE dev_image_t* dev_image, int4 
                                   CLK_ADDRESS_NONE |
                                   CLK_FILTER_NEAREST;
 */
-#define IMPLEMENT_READ_IMAGE_INT_COORD_NOSAMPLER(__IMGTYPE__,__RETVAL__,\
-                                                 __POSTFIX__,__COORD__) \
+#define IMPLEMENT_READ_IMAGE_INT_COORD_NOSAMPLER(__IMGTYPE__, __RETVAL__, \
+                                                 __POSTFIX__, __COORD__) \
   __RETVAL__ _CL_OVERLOADABLE read_image##__POSTFIX__ (__IMGTYPE__ image, \
                                                        __COORD__ coord) \
   {                                                                     \
     __RETVAL__ color;                                                   \
     int4 coord4;                                                        \
-    INITCOORD##__COORD__(coord4, coord);                                \
+    INITCOORD##__COORD__ (coord4, coord);                               \
     ADDRESS_SPACE dev_image_t* i_ptr =                                  \
       __builtin_astype (image, ADDRESS_SPACE dev_image_t*);             \
     __pocl_read_pixel (&color, i_ptr, coord4);  \
@@ -235,19 +235,19 @@ void __pocl_read_pixel (void* color, ADDRESS_SPACE dev_image_t* dev_image, int4 
 
 
 /* read_image 2d function instantions */
-IMPLEMENT_READ_IMAGE_INT_COORD(image2d_t, float4, f, int2)
+IMPLEMENT_READ_IMAGE_INT_COORD (image2d_t, float4, f, int2)
 
-IMPLEMENT_READ_IMAGE_INT_COORD_NOSAMPLER(image2d_t, float4, f, int2)
-IMPLEMENT_READ_IMAGE_INT_COORD_NOSAMPLER(image2d_array_t, float4, f, int4)
+IMPLEMENT_READ_IMAGE_INT_COORD_NOSAMPLER (image2d_t, float4, f, int2)
+IMPLEMENT_READ_IMAGE_INT_COORD_NOSAMPLER (image2d_array_t, float4, f, int4)
 
-IMPLEMENT_READ_IMAGE_INT_COORD(image2d_array_t, float4, f, int4)
+IMPLEMENT_READ_IMAGE_INT_COORD (image2d_array_t, float4, f, int4)
 
-IMPLEMENT_READ_IMAGE_INT_COORD(image2d_t, uint4, ui, int2)
-IMPLEMENT_READ_IMAGE_INT_COORD(image2d_t, int4, i, int2)
+IMPLEMENT_READ_IMAGE_INT_COORD (image2d_t, uint4, ui, int2)
+IMPLEMENT_READ_IMAGE_INT_COORD (image2d_t, int4, i, int2)
 
 /* read_image 3d function instantions */
-IMPLEMENT_READ_IMAGE_INT_COORD(image3d_t, uint4, ui, int4)
-IMPLEMENT_READ_IMAGE_INT_COORD(image3d_t, float4, f, int4)
+IMPLEMENT_READ_IMAGE_INT_COORD (image3d_t, uint4, ui, int4)
+IMPLEMENT_READ_IMAGE_INT_COORD (image3d_t, float4, f, int4)
 
 #else
 


### PR DESCRIPTION
added missing read_imagef functions with image2d_array_t and
no sampler versions.

Pocl currently does not support float coords so read_imagef
with float coord arguments commented out.