### PR TITLE
Fix piglit examples

### DIFF
--- a/examples/piglit/CMakeLists.txt
+++ b/examples/piglit/CMakeLists.txt
@@ -37,6 +37,8 @@ elseif(NOT GLUT_FOUND)
   message(STATUS "Disabling testsuite ${TS_NAME}, requires glut library")
 elseif(NOT PNG_FOUND)
   message(STATUS "Disabling testsuite ${TS_NAME}, requires PNG library")
+elseif(NOT TESTS_USE_ICD)
+  message(STATUS "Disabling testsuite ${TS_NAME}, requires ocl-icd")
 
 else()
 message(STATUS "Enabling testsuite ${TS_NAME}")

--- a/examples/piglit/CMakeLists.txt
+++ b/examples/piglit/CMakeLists.txt
@@ -65,7 +65,7 @@ ExternalProject_Add(
     -DPIGLIT_BUILD_GLX_TESTS=OFF
     "-DOPENCL_INCLUDE_PATH=${CMAKE_SOURCE_DIR}/include/"
     "-DOPENCL_opencl_LIBRARY:LIST=OpenCL"
-  INSTALL_COMMAND /bin/true
+  INSTALL_COMMAND ""
 )
 
 set_target_properties(${TS_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE)


### PR DESCRIPTION
The piglet tests require `ocd-icd`, otherwise they just use whatever OpenCL platform is first on the host system.

Also use an empty string for the INSTALL_COMMAND instead of `/bin/true`, since the latter isn't available on all *nix systems.