### PR TITLE
Fix race condition when unmapping memory objects

### DIFF
--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -427,9 +427,11 @@ pocl_exec_command (_cl_command_node * volatile node)
                (node->command.unmap.mapping)->offset,
                (node->command.unmap.mapping)->size);
         }
+      POCL_LOCK_OBJ (node->command.unmap.memobj);
       DL_DELETE((node->command.unmap.memobj)->mappings, 
                 node->command.unmap.mapping);
       (node->command.unmap.memobj)->map_count--;
+      POCL_UNLOCK_OBJ (node->command.unmap.memobj);
       POCL_UPDATE_EVENT_COMPLETE(event);
       POCL_DEBUG_EVENT_TIME(event, "Unmap Mem obj         ");
       break;


### PR DESCRIPTION
Looks like this was just missing a mutex around the deletion of the mapping.

Fixes issue #447.

Candidate for cherry-picking to 0.14? Without this I don't always get a full suite of passes.
