### PR TITLE
Correctly create command queue

### DIFF
--- a/lib/CL/clCreateCommandQueueWithProperties.c
+++ b/lib/CL/clCreateCommandQueueWithProperties.c
@@ -80,6 +80,9 @@ POname(clCreateCommandQueueWithProperties)(cl_context context,
 
           POCL_GOTO_ERROR_COND((queue_size > device->dev_queue_max_size),
                                CL_INVALID_QUEUE_PROPERTIES);
+
+         // create a device side queue
+         POCL_ABORT_UNIMPLEMENTED("Device side queue");
         }
       else
         POCL_GOTO_ERROR_ON((queue_size > 0), CL_INVALID_VALUE,
@@ -88,14 +91,10 @@ POname(clCreateCommandQueueWithProperties)(cl_context context,
       /* validate flags */
       POCL_GOTO_ERROR_ON((queue_props & (!valid_prop_flags)), CL_INVALID_VALUE,
                          "CL_QUEUE_PROPERTIES contain invalid entries");
+    }
 
-      // create a device side queue
-      POCL_ABORT_UNIMPLEMENTED("Device side queue");
-    }
-  else // create a host side queue.
-    {
-      return POname(clCreateCommandQueue)(context, device, queue_props, errcode_ret);
-    }
+  // currently thhere's only support for host side queues.
+  return POname(clCreateCommandQueue)(context, device, queue_props, errcode_ret);
 
 ERROR:
   if(errcode_ret)


### PR DESCRIPTION
This fixes the creation of command queues with OpenCL >= 2.0, so long as the CL_QUEUE_PROPERTIES property is set.

Please let me know if you'd prefer to have this pull request created against the release_0_14 branch.