### PR TITLE
NDRange fixes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,9 @@
 
 Highlights
 ----------
+- Improved automatic local work-group sizing on kernel enqueue, taking
+  into account standard constraints, SIMD width for vectorization as
+  well as the number of compute units available on the device.
 
 0.14 April 2017
 ===============

--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -162,11 +162,14 @@ POname(clEnqueueNDRangeKernel)(cl_command_queue command_queue,
           local_y != kernel->reqd_wg_size[1] ||
           local_z != kernel->reqd_wg_size[2]), CL_INVALID_WORK_GROUP_SIZE);
     }
-  /* otherwise, if the local work size was not specified or it's bigger
-   * than the global work size, find the optimal one
+  /* otherwise, if the local work size was not specified find the optimal one.
+   * Note that at some point we also checked for local > global. This doesn't
+   * make sense while we only have 1.2 support for kernel enqueue (and
+   * when only uniform group sizes are allowed), but it might turn useful
+   * when picking the hardware sub-group size in more sophisticated
+   * 2.0 support scenarios.
    */
-  else if (local_work_size == NULL ||
-      (local_x > global_x || local_y > global_y || local_z > global_z))
+  else if (local_work_size == NULL)
     {
       /* Embarrassingly parallel kernel with a free work-group
          size. Try to figure out one which utilizes all the

--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -138,6 +138,15 @@ POname(clEnqueueNDRangeKernel)(cl_command_queue command_queue,
           (local_z > command_queue->device->max_work_item_sizes[2]),
           CL_INVALID_WORK_ITEM_SIZE,
           "local_work_size.z > device's max_workitem_sizes[2]\n");
+
+      /* TODO For full 2.x conformance the 'local must divide global'
+       * requirement will have to be limited to the cases of kernels compiled
+       * with the -cl-uniform-work-group-size option
+       */
+      POCL_RETURN_ERROR_COND((global_x % local_x != 0), CL_INVALID_WORK_GROUP_SIZE);
+      POCL_RETURN_ERROR_COND((global_y % local_y != 0), CL_INVALID_WORK_GROUP_SIZE);
+      POCL_RETURN_ERROR_COND((global_z % local_z != 0), CL_INVALID_WORK_GROUP_SIZE);
+
     }
 
   /* If the kernel has the reqd_work_group_size attribute, then the local
@@ -257,9 +266,10 @@ POname(clEnqueueNDRangeKernel)(cl_command_queue command_queue,
   assert(local_y <= command_queue->device->max_work_item_sizes[1]);
   assert(local_z <= command_queue->device->max_work_item_sizes[2]);
 
-  POCL_RETURN_ERROR_COND((global_x % local_x != 0), CL_INVALID_WORK_GROUP_SIZE);
-  POCL_RETURN_ERROR_COND((global_y % local_y != 0), CL_INVALID_WORK_GROUP_SIZE);
-  POCL_RETURN_ERROR_COND((global_z % local_z != 0), CL_INVALID_WORK_GROUP_SIZE);
+  /* See TODO above for 'local must divide global' */
+  assert(global_x % local_x == 0);
+  assert(global_y % local_y == 0);
+  assert(global_z % local_z == 0);
 
   POCL_RETURN_ERROR_COND((event_wait_list == NULL && num_events_in_wait_list > 0),
     CL_INVALID_EVENT_WAIT_LIST);

--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -217,10 +217,13 @@ POname(clEnqueueNDRangeKernel)(cl_command_queue command_queue,
          SIMD instruction utilization).
       */
       size_t preferred_wg_multiple;
-      POname(clGetKernelWorkGroupInfo)
+      cl_int prop_err = POname(clGetKernelWorkGroupInfo)
         (kernel, command_queue->device,
          CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE,
          sizeof (size_t), &preferred_wg_multiple, NULL);
+
+      if (prop_err != CL_SUCCESS) /* unlikely */
+        preferred_wg_multiple = 1;
 
       POCL_MSG_PRINT_INFO("Preferred WG size multiple %zu\n",
                           preferred_wg_multiple);

--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -115,10 +115,10 @@ POname(clEnqueueNDRangeKernel)(cl_command_queue command_queue,
       local_x = local_work_size[0];
       local_y = work_dim > 1 ? local_work_size[1] : 1;
       local_z = work_dim > 2 ? local_work_size[2] : 1;
-      if (local_x > global_x || local_y > global_y || local_z > global_z)
-        goto DETERMINE_LOCAL_SIZE;
     }
-  else
+
+  if (local_work_size == NULL ||
+      (local_x > global_x || local_y > global_y || local_z > global_z))
     {
       /* Embarrassingly parallel kernel with a free work-group
          size. Try to figure out one which utilizes all the
@@ -129,7 +129,6 @@ POname(clEnqueueNDRangeKernel)(cl_command_queue command_queue,
          SIMD instruction utilization).
       */
       size_t preferred_wg_multiple;
-DETERMINE_LOCAL_SIZE:
       POname(clGetKernelWorkGroupInfo)
         (kernel, command_queue->device,
          CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE,

--- a/tests/regression/test_issue_445.cpp
+++ b/tests/regression/test_issue_445.cpp
@@ -29,7 +29,7 @@ private_local_array(__global int *__restrict__ out)
 }
 )CLC";
 
-int main(int, char *)
+int main(int, char **)
 {
   try {
     int N = 9;


### PR DESCRIPTION
This is a set of cleanups and fixes for `clEnqueueNDRangeKernel`. The main highlights are checks that for kernels with a required work-group size the user submitted that work-group size (which should fix #450), and a rewrite of the logic used to determine the work-group size in the NULL case, designed around the hard sizing constrains of dividing the global size, being less than the maximum allowed local size in each dimension while still trying to take the preferred work-group size multiple of the device into account.