### PR TITLE
Fix AutomaticLocals breaking constant expressions

### DIFF
--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -1376,7 +1376,6 @@ static PassManager& kernel_compiler_passes
   passes.push_back("workitem-handler-chooser");
   passes.push_back("mem2reg");
   passes.push_back("domtree");
-  passes.push_back("break-constgeps");
   if (device->autolocals_to_args)
 	  passes.push_back("automatic-locals");
   passes.push_back("flatten");

--- a/lib/llvmopencl/AutomaticLocals.cc
+++ b/lib/llvmopencl/AutomaticLocals.cc
@@ -123,6 +123,25 @@ AutomaticLocals::runOnModule(Module &M)
   return changed;
 }
 
+// Recursively descend a Value's users and convert any constant expressions into
+// regular instructions.
+static void breakConstantExpressions(llvm::Value *Val, llvm::Function *Func) {
+  std::vector<llvm::Value *> Users(Val->user_begin(), Val->user_end());
+  for (auto *U : Users) {
+    if (auto *CE = llvm::dyn_cast<llvm::ConstantExpr>(U)) {
+      // First, make sure no users of this constant expression are themselves
+      // constant expressions.
+      breakConstantExpressions(U, Func);
+
+      // Convert this constant expression to an instruction.
+      llvm::Instruction *I = CE->getAsInstruction();
+      I->insertBefore(&*Func->begin()->begin());
+      CE->replaceAllUsesWith(I);
+      CE->destroyConstant();
+    }
+  }
+}
+
 Function *
 AutomaticLocals::processAutomaticLocals(Function *F) {
 
@@ -146,14 +165,7 @@ AutomaticLocals::processAutomaticLocals(Function *F) {
 
       // Replace any constant expression users with an equivalent instruction.
       // Otherwise, the IR breaks when we replace the local with an argument.
-      std::vector<llvm::Value *> Users(i->user_begin(), i->user_end());
-      for (auto *U : Users) {
-        if (auto *CE = llvm::dyn_cast<llvm::ConstantExpr>(U)) {
-          llvm::Instruction *I = CE->getAsInstruction();
-          I->insertBefore(&*F->begin()->begin());
-          U->replaceAllUsesWith(I);
-        }
-      }
+      breakConstantExpressions(&*i, F);
     }
   }
 

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -44,7 +44,8 @@ set(PROGRAMS_TO_BUILD test_barrier_between_for_loops test_early_return
   test_simple_for_with_a_barrier test_structs_as_args test_vectors_as_args
   test_barrier_before_return test_infinite_loop test_constant_array
   test_undominated_variable test_setargs test_null_arg
-  test_fors_with_var_iteration_counts test_issue_231 test_issue_445)
+  test_fors_with_var_iteration_counts test_issue_231 test_issue_445
+  test_autolocals_in_constexprs)
 
 
 if (MSVC)
@@ -186,6 +187,8 @@ add_test_pocl(NAME "regression/passing_a_constant_array_as_an_arg" COMMAND "test
 
 add_test_pocl(NAME "regression/case_with_multiple_variable_length_loops_and_a_barrier_in_one" COMMAND "test_fors_with_var_iteration_counts")
 
+add_test_pocl(NAME "regression/autolocals_in_constexprs" COMMAND "test_autolocals_in_constexprs")
+
 # these 2 will fail
 add_test_pocl(NAME "regression/struct_kernel_arguments" COMMAND "test_structs_as_args")
 
@@ -196,6 +199,7 @@ set_tests_properties("regression/setting_a_buffer_argument_to_NULL_causes_a_segf
   "regression/passing_a_constant_array_as_an_arg"
   "regression/case_with_multiple_variable_length_loops_and_a_barrier_in_one"
   "regression/struct_kernel_arguments" "regression/vector_kernel_arguments"
+  "regression/autolocals_in_constexprs"
   PROPERTIES
     COST 1.5
     PROCESSORS 1
@@ -246,6 +250,7 @@ set_property(TEST
   "regression/vector_kernel_arguments"
   "regression/infinite_loop_REPL"
   "regression/infinite_loop_LOOPS"
+  "regression/autolocals_in_constexprs"
   APPEND PROPERTY LABELS "cuda")
 
 # The vector/struct kernel arguments are known to be flaky and

--- a/tests/regression/test_autolocals_in_constexprs.cpp
+++ b/tests/regression/test_autolocals_in_constexprs.cpp
@@ -1,0 +1,114 @@
+/* AutomaticLocals pass might break the IR if it promotes a local used in a
+   constant expression to an argument (which is no longer constant)
+   (GitHub issue #467).
+
+   Copyright (c) 2017 pocl developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+// Enable OpenCL C++ exceptions
+#define CL_HPP_ENABLE_EXCEPTIONS
+#define CL_HPP_MINIMUM_OPENCL_VERSION 120
+#define CL_HPP_TARGET_OPENCL_VERSION 120
+#include <CL/cl2.hpp>
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+
+#include "poclu.h"
+
+static char
+kernelSourceCode[] =
+"kernel void test_kernel (global ulong *output)\n"
+"{\n"
+"   local char  l_int8[3]; \n"
+"   local int   l_int32[3]; \n"
+"   local float l_float[3]; \n"
+"   output[0] = (ulong)l_int8;\n"
+"   output[1] = (ulong)l_int32;\n"
+"   output[2] = (ulong)l_float;\n"
+"}\n";
+
+int
+main(void)
+{
+  uint64_t A[3];
+
+  try {
+    std::vector<cl::Platform> platformList;
+
+    // Pick platform
+    cl::Platform::get(&platformList);
+
+    // Pick first platform
+    cl_context_properties cprops[] = {
+      CL_CONTEXT_PLATFORM, (cl_context_properties)(platformList[0])(), 0};
+    cl::Context context(CL_DEVICE_TYPE_CPU|CL_DEVICE_TYPE_GPU, cprops);
+
+    // Query the set of devices attched to the context
+    std::vector<cl::Device> devices = context.getInfo<CL_CONTEXT_DEVICES>();
+
+    // Create and program from source
+    cl::Program::Sources sources({kernelSourceCode});
+    cl::Program program(context, sources);
+
+    cl_device_id dev_id = devices.at(0)();
+
+    for (int i = 0; i < 3; ++i)
+      A[i] = 0;
+
+    // Build program
+    program.build(devices);
+
+    cl::Buffer aBuffer = cl::Buffer(
+        context,
+        CL_MEM_COPY_HOST_PTR,
+        3 * sizeof(uint64_t),
+        (void *) &A[0]);
+
+    // Create kernel object
+    cl::Kernel kernel(program, "test_kernel");
+
+    // Set kernel args
+    kernel.setArg(0, aBuffer);
+
+    // Create command queue
+    cl::CommandQueue queue(context, devices[0], 0);
+
+    // Do the work
+    queue.enqueueNDRangeKernel(kernel, cl::NullRange, cl::NDRange(1));
+    queue.finish();
+
+    // We don't actually care about the result.
+  }
+  catch (cl::Error err) {
+    std::cerr
+      << "ERROR: "
+      << err.what()
+      << "("
+      << err.err()
+      << ")"
+      << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Replacing an automatic local with an argument doesn't work if one of the
users is a constant expressions, since function arguments aren't
constants. Instead, we first replace any constant expression users with
their equivalent instructions.

Fixes #467.