### PR TITLE
[RFC] Cleanup init devices

### DIFF
--- a/lib/CL/clCreateContextFromType.c
+++ b/lib/CL/clCreateContextFromType.c
@@ -50,7 +50,10 @@ POname(clCreateContextFromType)(const cl_context_properties *properties,
 
   /* initialize libtool here, LT will be needed when loading the kernels */     
   lt_dlinit();
-  pocl_init_devices();
+  errcode = pocl_init_devices();
+
+  if (errcode)
+    goto ERROR;
 
   cl_context context = (cl_context) malloc(sizeof(struct _cl_context));
   if (context == NULL)

--- a/lib/CL/clGetDeviceIDs.c
+++ b/lib/CL/clGetDeviceIDs.c
@@ -35,13 +35,16 @@ POname(clGetDeviceIDs)(cl_platform_id   platform,
   int total_num = 0;
   int devices_added = 0;
 
-  pocl_init_devices();
   /* TODO: OpenCL API specification allows implementation dependent
      behaviour if platform == NULL. Should we just allow it? */
   POCL_RETURN_ERROR_COND((platform == NULL), CL_INVALID_PLATFORM);
 
   POCL_RETURN_ERROR_COND((num_entries == 0 && devices != NULL), CL_INVALID_VALUE);
   POCL_RETURN_ERROR_COND((num_devices == NULL && devices == NULL), CL_INVALID_VALUE);
+
+  int err = pocl_init_devices();
+  if (err)
+    return err;
 
   total_num = pocl_get_device_type_count(device_type);
 

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -297,6 +297,8 @@ cl_int
 pocl_basic_init (unsigned j, cl_device_id device, const char* parameters)
 {
   struct data *d;
+  cl_int ret = CL_SUCCESS;
+  int err;
   static int first_basic_init = 1;
 
   if (first_basic_init)
@@ -307,6 +309,8 @@ pocl_basic_init (unsigned j, cl_device_id device, const char* parameters)
   device->global_mem_id = 0;
 
   d = (struct data *) calloc (1, sizeof (struct data));
+  if (d == NULL)
+    return CL_OUT_OF_HOST_MEMORY;
 
   d->current_kernel = NULL;
   d->current_dlhandle = 0;
@@ -317,7 +321,10 @@ pocl_basic_init (unsigned j, cl_device_id device, const char* parameters)
      initialize global_mem_size which it is not yet. Just put 
      a nonzero there for now. */
   device->global_mem_size = 1;
-  pocl_topology_detect_device_info(device);
+  err = pocl_topology_detect_device_info(device);
+  if (err)
+    ret = CL_INVALID_DEVICE;
+
   POCL_INIT_LOCK (d->cq_lock);
   pocl_cpuinfo_detect_device_info(device);
   pocl_set_buffer_image_limits(device);
@@ -345,7 +352,7 @@ pocl_basic_init (unsigned j, cl_device_id device, const char* parameters)
   device->has_64bit_long=0;
   #endif
 
-  return CL_SUCCESS;
+  return ret;
 }
 
 cl_int

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -293,12 +293,12 @@ pocl_basic_probe(struct pocl_device_ops *ops)
 
 
 
-void
+cl_int
 pocl_basic_init (unsigned j, cl_device_id device, const char* parameters)
 {
   struct data *d;
   static int first_basic_init = 1;
-  
+
   if (first_basic_init)
     {
       pocl_init_dlhandle_cache();
@@ -307,7 +307,7 @@ pocl_basic_init (unsigned j, cl_device_id device, const char* parameters)
   device->global_mem_id = 0;
 
   d = (struct data *) calloc (1, sizeof (struct data));
-  
+
   d->current_kernel = NULL;
   d->current_dlhandle = 0;
   device->data = d;
@@ -345,6 +345,7 @@ pocl_basic_init (unsigned j, cl_device_id device, const char* parameters)
   device->has_64bit_long=0;
   #endif
 
+  return CL_SUCCESS;
 }
 
 cl_int

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -145,7 +145,7 @@ pocl_basic_build_hash (cl_device_id device)
 }
 
 void
-pocl_basic_init_device_infos(struct _cl_device_id* dev)
+pocl_basic_init_device_infos(unsigned j, struct _cl_device_id* dev)
 {
   dev->type = CL_DEVICE_TYPE_CPU;
   dev->vendor_id = 0;
@@ -294,11 +294,10 @@ pocl_basic_probe(struct pocl_device_ops *ops)
 
 
 void
-pocl_basic_init (cl_device_id device, const char* parameters)
+pocl_basic_init (unsigned j, cl_device_id device, const char* parameters)
 {
   struct data *d;
   static int first_basic_init = 1;
-  static int device_number = 0;
   
   if (first_basic_init)
     {
@@ -330,8 +329,7 @@ pocl_basic_init (cl_device_id device, const char* parameters)
     device->vendor_id =
       magic[0] | magic[1] << 8 | magic[2] << 16 | magic[3] << 24;
 
-  device->vendor_id += device_number;
-  device_number++;
+  device->vendor_id += j;
 
   /* The basic driver represents only one "compute unit" as
      it doesn't exploit multiple hardware threads. Multiple

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -111,13 +111,13 @@ pocl_cuda_init_device_ops (struct pocl_device_ops *ops)
   /* free_event_data */
 }
 
-void
+cl_int
 pocl_cuda_init (unsigned j, cl_device_id dev, const char *parameters)
 {
   CUresult result;
 
   if (dev->data)
-    return;
+    return CL_SUCCESS;
 
   pocl_cuda_device_data_t *data = malloc (sizeof (pocl_cuda_device_data_t));
   result = cuDeviceGet (&data->device, j);
@@ -211,6 +211,7 @@ pocl_cuda_init (unsigned j, cl_device_id dev, const char *parameters)
   dev->data = data;
 
   POCL_INIT_LOCK (data->compile_lock);
+  return CL_SUCCESS;
 }
 
 char *

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -111,15 +111,8 @@ pocl_cuda_init_device_ops (struct pocl_device_ops *ops)
   /* free_event_data */
 }
 
-/* The CUDA device to be initialized next. This is reset when probing,
- * and incremented every time a device gets initialized.
- * TODO this is a bit of a hack, which is also shared by HSA. It might
- * be a good idea to consider extending the init() function to also
- * get a progressive index, and use that instead */
-static int next_cuda_device = 0;
-
 void
-pocl_cuda_init (cl_device_id dev, const char *parameters)
+pocl_cuda_init (unsigned j, cl_device_id dev, const char *parameters)
 {
   CUresult result;
 
@@ -127,7 +120,7 @@ pocl_cuda_init (cl_device_id dev, const char *parameters)
     return;
 
   pocl_cuda_device_data_t *data = malloc (sizeof (pocl_cuda_device_data_t));
-  result = cuDeviceGet (&data->device, next_cuda_device++);
+  result = cuDeviceGet (&data->device, j);
   CUDA_CHECK (result, "cuDeviceGet");
 
   // Get specific device name
@@ -229,9 +222,9 @@ pocl_cuda_build_hash (cl_device_id device)
 }
 
 void
-pocl_cuda_init_device_infos (struct _cl_device_id *dev)
+pocl_cuda_init_device_infos (unsigned j, struct _cl_device_id *dev)
 {
-  pocl_basic_init_device_infos (dev);
+  pocl_basic_init_device_infos (j, dev);
 
   dev->type = CL_DEVICE_TYPE_GPU;
   dev->address_bits = (sizeof (void *) * 8);
@@ -276,7 +269,6 @@ pocl_cuda_probe (struct pocl_device_ops *ops)
       probe_count = env_count;
     }
 
-  next_cuda_device = 0;
   return probe_count;
 }
 

--- a/lib/CL/devices/cuda/pocl-ptx-gen.cc
+++ b/lib/CL/devices/cuda/pocl-ptx-gen.cc
@@ -517,7 +517,10 @@ int findLibDevice(char LibDevicePath[PATH_MAX], const char *Arch) {
   char *End;
   unsigned long SM = strtoul(Arch + 3, &End, 10);
   if (!SM || strlen(End))
-    POCL_ABORT("[CUDA] invalid GPU architecture %s\n", Arch);
+    {
+      POCL_MSG_ERR ("[CUDA] invalid GPU architecture %s\n", Arch);
+      return 1;
+    }
 
   // This mapping from SM version to libdevice library version is given here:
   // http://docs.nvidia.com/cuda/libdevice-users-guide/basic-usage.html#version-selection

--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -274,7 +274,7 @@ pocl_init_devices()
              a shared global memory. */
           pocl_devices[dev_index].global_mem_id = dev_index;
 
-          pocl_device_ops[i].init_device_infos(&pocl_devices[dev_index]);
+          pocl_device_ops[i].init_device_infos(j, &pocl_devices[dev_index]);
 
           pocl_device_common_init(&pocl_devices[dev_index]);
 
@@ -286,7 +286,7 @@ pocl_init_devices()
               POCL_MSG_ERR("Unable to generate the env string.");
               return CL_OUT_OF_HOST_MEMORY;
             }
-          pocl_devices[dev_index].ops->init(&pocl_devices[dev_index], getenv(env_name));
+          pocl_devices[dev_index].ops->init (j, &pocl_devices[dev_index], getenv(env_name));
 
           if (dev_index == 0)
             pocl_devices[dev_index].type |= CL_DEVICE_TYPE_DEFAULT;

--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -266,6 +266,7 @@ pocl_init_devices()
       assert(pocl_device_ops[i].init);
       for (j = 0; j < device_count[i]; ++j)
         {
+          cl_int ret = CL_SUCCESS;
           pocl_devices[dev_index].ops = &pocl_device_ops[i];
           pocl_devices[dev_index].dev_id = dev_index;
           /* The default value for the global memory space identifier is
@@ -286,7 +287,16 @@ pocl_init_devices()
               POCL_MSG_ERR("Unable to generate the env string.");
               return CL_OUT_OF_HOST_MEMORY;
             }
-          pocl_devices[dev_index].ops->init (j, &pocl_devices[dev_index], getenv(env_name));
+          ret = pocl_devices[dev_index].ops->init (j, &pocl_devices[dev_index], getenv(env_name));
+          switch (ret)
+          {
+          case CL_OUT_OF_HOST_MEMORY:
+            return ret;
+          case CL_SUCCESS:
+            break;
+          default:
+            pocl_devices[dev_index].available = 0;
+          }
 
           if (dev_index == 0)
             pocl_devices[dev_index].type |= CL_DEVICE_TYPE_DEFAULT;

--- a/lib/CL/devices/devices.h
+++ b/lib/CL/devices/devices.h
@@ -45,7 +45,7 @@ extern unsigned int pocl_num_devices;
  * The devices are shared across contexts, thus must implement resource
  * management internally also across multiple contexts.
  */
-void pocl_init_devices();
+cl_int pocl_init_devices();
 
 /**
  * \brief Get the count of devices for a specific type

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -599,7 +599,7 @@ hsa_queue_callback(hsa_status_t status, hsa_queue_t *q, void* data) {
 /* driver pthread prototype */
 void * pocl_hsa_driver_pthread (void *cldev);
 
-void
+cl_int
 pocl_hsa_init (unsigned j, cl_device_id device, const char* parameters)
 {
   pocl_hsa_device_data_t *d;
@@ -696,6 +696,7 @@ pocl_hsa_init (unsigned j, cl_device_id device, const char* parameters)
   d->exit_driver_thread = 0;
   PTHREAD_CHECK(pthread_create(&d->driver_pthread_id, NULL,
                  &pocl_hsa_driver_pthread, device));
+  return CL_SUCCESS;
 }
 
 static void*

--- a/lib/CL/devices/prototypes.inc
+++ b/lib/CL/devices/prototypes.inc
@@ -42,7 +42,7 @@
   void pocl_##__DRV__##_init_device_infos(unsigned j, struct _cl_device_id* dev);  \
   void pocl_##__DRV__##_init_device_ops(struct pocl_device_ops* ops);  \
   void pocl_##__DRV__##_uninit (cl_device_id device);                   \
-  void pocl_##__DRV__##_init (unsigned j, cl_device_id device, const char* parameters); \
+  cl_int pocl_##__DRV__##_init (unsigned j, cl_device_id device, const char* parameters); \
   unsigned int pocl_##__DRV__##_probe (struct pocl_device_ops *ops); \
   cl_int pocl_##__DRV__##_alloc_mem_obj (cl_device_id device, cl_mem mem_obj, \
                                          void* host_ptr); \

--- a/lib/CL/devices/prototypes.inc
+++ b/lib/CL/devices/prototypes.inc
@@ -39,10 +39,10 @@
   void pocl_##__DRV__##_wait_event (cl_device_id device, cl_event event); \
   void pocl_##__DRV__##_update_event (cl_device_id device, cl_event event, cl_int status); \
   void pocl_##__DRV__##_free_event_data (cl_event event); \
-  void pocl_##__DRV__##_init_device_infos(struct _cl_device_id* dev);  \
+  void pocl_##__DRV__##_init_device_infos(unsigned j, struct _cl_device_id* dev);  \
   void pocl_##__DRV__##_init_device_ops(struct pocl_device_ops* ops);  \
   void pocl_##__DRV__##_uninit (cl_device_id device);                   \
-  void pocl_##__DRV__##_init (cl_device_id device, const char* parameters); \
+  void pocl_##__DRV__##_init (unsigned j, cl_device_id device, const char* parameters); \
   unsigned int pocl_##__DRV__##_probe (struct pocl_device_ops *ops); \
   cl_int pocl_##__DRV__##_alloc_mem_obj (cl_device_id device, cl_mem mem_obj, \
                                          void* host_ptr); \

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -178,7 +178,7 @@ pocl_pthread_init_device_infos(unsigned j, struct _cl_device_id* dev)
 }
 
 
-void
+cl_int
 pocl_pthread_init (unsigned j, cl_device_id device, const char* parameters)
 {
   struct data *d;
@@ -192,7 +192,7 @@ pocl_pthread_init (unsigned j, cl_device_id device, const char* parameters)
   // Should we instead have a separate bool field in device, or do the
   // initialization at library startup time with __attribute__((constructor))?
   if (device->data!=NULL)
-    return;
+    return CL_SUCCESS;
 
   d = (struct data *) calloc (1, sizeof (struct data));
 
@@ -266,6 +266,7 @@ pocl_pthread_init (unsigned j, cl_device_id device, const char* parameters)
     }
   /* system mem as global memory */
   device->global_mem_id = 0;
+  return CL_SUCCESS;
 }
 
 void

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -172,16 +172,15 @@ pocl_pthread_probe(struct pocl_device_ops *ops)
 }
 
 void
-pocl_pthread_init_device_infos(struct _cl_device_id* dev)
+pocl_pthread_init_device_infos(unsigned j, struct _cl_device_id* dev)
 {
-  pocl_basic_init_device_infos(dev);
+  pocl_basic_init_device_infos(j, dev);
 }
 
 
 void
-pocl_pthread_init (cl_device_id device, const char* parameters)
+pocl_pthread_init (unsigned j, cl_device_id device, const char* parameters)
 {
-  static int device_number = 0;
   struct data *d;
   static char scheduler_initialized = 0;
 #ifdef CUSTOM_BUFFER_ALLOCATOR
@@ -236,8 +235,7 @@ pocl_pthread_init (cl_device_id device, const char* parameters)
     device->vendor_id =
       magic[0] | magic[1] << 8 | magic[2] << 16 | magic[3] << 24;
 
-  device->vendor_id += device_number;
-  device_number++;
+  device->vendor_id += j;
 
   // pthread has elementary partitioning support
   device->max_sub_devices = device->max_compute_units;

--- a/lib/CL/devices/tce/ttasim/ttasim.cc
+++ b/lib/CL/devices/tce/ttasim/ttasim.cc
@@ -103,7 +103,7 @@ pocl_ttasim_init_device_ops(struct pocl_device_ops *ops)
 
 
 void
-pocl_ttasim_init_device_infos(struct _cl_device_id* dev)
+pocl_ttasim_init_device_infos(unsigned j, struct _cl_device_id* dev)
 {
   dev->type = CL_DEVICE_TYPE_GPU;
   dev->max_compute_units = 1;
@@ -531,7 +531,7 @@ private:
 
 
 void
-pocl_ttasim_init (cl_device_id device, const char* parameters)
+pocl_ttasim_init (unsigned j, cl_device_id device, const char* parameters)
 {
   if (parameters == NULL)
     POCL_ABORT("The tta device requires the adf file as a device parameter.\n"

--- a/lib/CL/devices/tce/ttasim/ttasim.cc
+++ b/lib/CL/devices/tce/ttasim/ttasim.cc
@@ -530,14 +530,15 @@ private:
 };
 
 
-void
+cl_int
 pocl_ttasim_init (unsigned j, cl_device_id device, const char* parameters)
 {
   if (parameters == NULL)
     POCL_ABORT("The tta device requires the adf file as a device parameter.\n"
                "Set it with POCL_TTASIMn_PARAMETERS=\"path/to/themachine.adf\".\n");
-  
-  new TTASimDevice(device, parameters); 
+
+  new TTASimDevice(device, parameters);
+  return CL_SUCCESS;
 }
 
 void

--- a/lib/CL/devices/topology/pocl_topology.h
+++ b/lib/CL/devices/topology/pocl_topology.h
@@ -37,7 +37,7 @@
 #pragma GCC visibility push(hidden)
 #endif
 
-void pocl_topology_detect_device_info(cl_device_id device);
+int pocl_topology_detect_device_info(cl_device_id device);
 
 #ifdef __GNUC__
 #pragma GCC visibility pop

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -211,7 +211,7 @@ typedef struct pocl_argument_info {
 struct pocl_device_ops {
   const char *device_name;
   void *shared_data; /* data to be shared by a devices of same type */
-  void (*init_device_infos) (struct _cl_device_id*);
+  void (*init_device_infos) (unsigned j, struct _cl_device_id*);
   /* implementation */
 
   /* New driver api extension for out-of-order execution and
@@ -263,7 +263,12 @@ struct pocl_device_ops {
 
   void (*uninit) (cl_device_id device);
   unsigned int (*probe) (struct pocl_device_ops *ops);
-  void (*init) (cl_device_id device, const char *parameters);
+  /* Device initialization. Parameters:
+   *  j : progressive index for the devices of the same type
+   *  device : struct to initialize
+   *  parameters : optional environment with device-specific parameters
+   */
+  void (*init) (unsigned j, cl_device_id device, const char *parameters);
   cl_int (*alloc_mem_obj) (cl_device_id device, cl_mem mem_obj, void* host_ptr);
   void *(*create_sub_buffer) (void *data, void* buffer, size_t origin, size_t size);
   void (*free) (cl_device_id device, cl_mem mem_obj);

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -268,7 +268,7 @@ struct pocl_device_ops {
    *  device : struct to initialize
    *  parameters : optional environment with device-specific parameters
    */
-  void (*init) (unsigned j, cl_device_id device, const char *parameters);
+  cl_int (*init) (unsigned j, cl_device_id device, const char *parameters);
   cl_int (*alloc_mem_obj) (cl_device_id device, cl_mem mem_obj, void* host_ptr);
   void *(*create_sub_buffer) (void *data, void* buffer, size_t origin, size_t size);
   void (*free) (cl_device_id device, cl_mem mem_obj);


### PR DESCRIPTION
I dislike it when platforms `abort()` on error, since this prevents the invoking application from properly handling error conditions. This is particularly damning on initialization, which is actually one of the easiest situations to handle (for example by changing platform).

This patch series proposes a method to handle error condition during initialization (essentially, marking problematic devices as unavailable instead of simply killing everything). It is not complete, since I'm not particularly familiar with the TCE and HSA code and I'm not in the condition to test things.