### PR TITLE
Field program->compiler_options is not free-ed in clReleaseProgram

### DIFF
--- a/lib/CL/clBuildProgram.c
+++ b/lib/CL/clBuildProgram.c
@@ -596,7 +596,6 @@ ERROR:
   POCL_MEM_FREE(unique_devlist);
   pocl_cache_release_lock(write_cache_lock);
 ERROR_CLEAN_OPTIONS:
-  POCL_MEM_FREE(modded_options);
   program->build_status = CL_BUILD_ERROR;
 
   POCL_UNLOCK_OBJ(program);

--- a/lib/CL/clReleaseProgram.c
+++ b/lib/CL/clReleaseProgram.c
@@ -97,10 +97,7 @@ POname(clReleaseProgram)(cl_program program) CL_API_SUFFIX__VERSION_1_0
         }
 
       POCL_MEM_FREE(program->build_hash);
-      if (program->compiler_options)
-        {
-          POCL_MEM_FREE(program->compiler_options);
-        }
+      POCL_MEM_FREE(program->compiler_options);
       POCL_MEM_FREE(program->llvm_irs);
       POCL_MEM_FREE(program);
 

--- a/lib/CL/clReleaseProgram.c
+++ b/lib/CL/clReleaseProgram.c
@@ -97,6 +97,10 @@ POname(clReleaseProgram)(cl_program program) CL_API_SUFFIX__VERSION_1_0
         }
 
       POCL_MEM_FREE(program->build_hash);
+      if (program->compiler_options)
+        {
+          POCL_MEM_FREE(program->compiler_options);
+        }
       POCL_MEM_FREE(program->llvm_irs);
       POCL_MEM_FREE(program);
 


### PR DESCRIPTION
`program->compiler_options` is set to `modded_options` in `clBuildProgram`, when `modded_options` is result of a sequence of calloc and realloc in the `APPEND_TOKEN` macro. 