### PR TITLE
Next

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ message(STATUS "Hwloc_CFLAGS ${Hwloc_CFLAGS}")
 
 ######################################################################################
 
-if(NOT CACHELINE_SIZE)
+if(NOT HOST_CPU_CACHELINE_SIZE)
 
   set(CL_SIZE 0)
   if(UNIX)
@@ -217,15 +217,15 @@ if(NOT CACHELINE_SIZE)
         # getconf sometimes just returns zero
         if(NOT (CL_SIZE EQUAL 0))
           message(STATUS "L1D Cacheline size detected: ${CL_SIZE}")
-          set(CACHELINE_SIZE "${CL_SIZE}" CACHE STRING "L1D Cacheline size")
+          set(HOST_CPU_CACHELINE_SIZE "${CL_SIZE}" CACHE STRING "L1D Cacheline size")
         endif()
       endif()
     endif()
   endif()
 
   if(CL_SIZE EQUAL 0)
-    message(WARNING "Unable to detect cacheline size - assuming 64byte cacheline, override with -DCACHELINE_SIZE=<number>")
-    set(CACHELINE_SIZE "64" CACHE STRING "L1D Cacheline size")
+    message(WARNING "Unable to detect cacheline size - assuming 64byte cacheline, override with -DHOST_CPU_CACHELINE_SIZE=<number>")
+    set(HOST_CPU_CACHELINE_SIZE "64" CACHE STRING "L1D Cacheline size")
   endif()
 endif()
 
@@ -1232,4 +1232,4 @@ MESSAGE(STATUS "Kernel caching: ${KERNEL_CACHE_DEFAULT}")
 MESSAGE(STATUS "Kernel library CPU variants: ${KERNELLIB_HOST_CPU_VARIANTS}")
 MESSAGE(STATUS "Kernel library distro build: ${KERNELLIB_HOST_DISTRO_VARIANTS}")
 MESSAGE(STATUS "Use fake address space IDs: ${POCL_USE_FAKE_ADDR_SPACE_IDS}")
-MESSAGE(STATUS "L1d cacheline size: ${CACHELINE_SIZE}")
+MESSAGE(STATUS "L1d cacheline size: ${HOST_CPU_CACHELINE_SIZE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,35 @@ message(STATUS "Hwloc_LDFLAGS ${Hwloc_LDFLAGS}")
 message(STATUS "Hwloc_CFLAGS ${Hwloc_CFLAGS}")
 
 ######################################################################################
+
+if(NOT CACHELINE_SIZE)
+
+  set(CL_SIZE 0)
+  if(UNIX)
+    find_program(GETCONF "getconf")
+    if(GETCONF)
+      execute_process(COMMAND "getconf" "LEVEL1_DCACHE_LINESIZE"
+                      RESULT_VARIABLE RES OUTPUT_VARIABLE CL_SIZE)
+      if(RES)
+        message(WARNING "getconf exited with nonzero status!")
+        set(CL_SIZE 0)
+      else()
+        # getconf sometimes just returns zero
+        if(NOT (CL_SIZE EQUAL 0))
+          message(STATUS "L1D Cacheline size detected: ${CL_SIZE}")
+          set(CACHELINE_SIZE "${CL_SIZE}" CACHE STRING "L1D Cacheline size")
+        endif()
+      endif()
+    endif()
+  endif()
+
+  if(CL_SIZE EQUAL 0)
+    message(WARNING "Unable to detect cacheline size - assuming 64byte cacheline, override with -DCACHELINE_SIZE=<number>")
+    set(CACHELINE_SIZE "64" CACHE STRING "L1D Cacheline size")
+  endif()
+endif()
+
+######################################################################################
 #
 # Find executables to few tools required during build 
 #
@@ -1203,3 +1232,4 @@ MESSAGE(STATUS "Kernel caching: ${KERNEL_CACHE_DEFAULT}")
 MESSAGE(STATUS "Kernel library CPU variants: ${KERNELLIB_HOST_CPU_VARIANTS}")
 MESSAGE(STATUS "Kernel library distro build: ${KERNELLIB_HOST_DISTRO_VARIANTS}")
 MESSAGE(STATUS "Use fake address space IDs: ${POCL_USE_FAKE_ADDR_SPACE_IDS}")
+MESSAGE(STATUS "L1d cacheline size: ${CACHELINE_SIZE}")

--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -36,9 +36,11 @@ else()
   # search for any version
   find_program(LLVM_CONFIG
     NAMES "llvm-config"
+      "llvm-config-mp-5.0" "llvm-config-5.0" "llvm-config50"
+      "llvm-config-mp-4.0" "llvm-config-4.0" "llvm-config40"
+      "llvm-config-mp-3.9" "llvm-config-3.9" "llvm-config39"
       "llvm-config-mp-3.8" "llvm-config-3.8" "llvm-config38"
       "llvm-config-mp-3.7" "llvm-config-3.7" "llvm-config37"
-      "llvm-config-mp-3.9" "llvm-config-3.9" "llvm-config39"
     DOC "llvm-config executable")
 endif()
 

--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -12,7 +12,7 @@
 /* "Build with ICD" */
 #cmakedefine BUILD_ICD
 
-#define CACHELINE_SIZE @CACHELINE_SIZE@
+#define HOST_CPU_CACHELINE_SIZE @HOST_CPU_CACHELINE_SIZE@
 
 #cmakedefine CLANG_IS_PATCHED_FOR_SPIR_CC
 

--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -12,6 +12,8 @@
 /* "Build with ICD" */
 #cmakedefine BUILD_ICD
 
+#define CACHELINE_SIZE 64
+
 #cmakedefine CLANG_IS_PATCHED_FOR_SPIR_CC
 
 #define CLANG "@CLANG@"

--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -12,7 +12,7 @@
 /* "Build with ICD" */
 #cmakedefine BUILD_ICD
 
-#define CACHELINE_SIZE 64
+#define CACHELINE_SIZE @CACHELINE_SIZE@
 
 #cmakedefine CLANG_IS_PATCHED_FOR_SPIR_CC
 

--- a/examples/ASL/CMakeLists.txt
+++ b/examples/ASL/CMakeLists.txt
@@ -74,8 +74,9 @@ if ((NOT "${CMAKE_VERSION}" VERSION_LESS "3.0.2")
            COMMAND "${TS_BUILDDIR}/test/testACL/testOperators")
   add_test(NAME ASL_testKernelMerger
            COMMAND "${TS_BUILDDIR}/test/testACL/testKernelMerger")
-  add_test(NAME ASL_testPrivateVar
-           COMMAND "${TS_BUILDDIR}/test/testACL/testPrivateVar")
+# takes too long
+#  add_test(NAME ASL_testPrivateVar
+#           COMMAND "${TS_BUILDDIR}/test/testACL/testPrivateVar")
   add_test(NAME ASL_testASLData
            COMMAND "${TS_BUILDDIR}/test/testMath/testASLData")
   add_test(NAME ASL_testDistanceFunction
@@ -147,7 +148,7 @@ if ((NOT "${CMAKE_VERSION}" VERSION_LESS "3.0.2")
     ASL_testKernel
     ASL_testOperators
     ASL_testKernelMerger
-    ASL_testPrivateVar
+#    ASL_testPrivateVar
     ASL_testASLData
     ASL_testDistanceFunction
     ASL_testReductionFunction

--- a/examples/arrayfire/CMakeLists.txt
+++ b/examples/arrayfire/CMakeLists.txt
@@ -225,9 +225,10 @@ if(LAPACK_FOUND AND
   add_test(NAME arrayfire_tests_medfilt_opencl
            COMMAND "${TS_BUILDDIR}/test/medfilt_opencl"
            WORKING_DIRECTORY "${TS_BUILDDIR}/test")
-  add_test(NAME arrayfire_tests_median_opencl
-           COMMAND "${TS_BUILDDIR}/test/median_opencl"
-           WORKING_DIRECTORY "${TS_BUILDDIR}/test")
+# takes too long
+#  add_test(NAME arrayfire_tests_median_opencl
+#           COMMAND "${TS_BUILDDIR}/test/median_opencl"
+#           WORKING_DIRECTORY "${TS_BUILDDIR}/test")
   add_test(NAME arrayfire_tests_memory_lock_opencl
            COMMAND "${TS_BUILDDIR}/test/memory_lock_opencl"
            WORKING_DIRECTORY "${TS_BUILDDIR}/test")
@@ -371,33 +372,34 @@ if(LAPACK_FOUND AND
   add_test(NAME arrayfire_examples_filters_opencl
            COMMAND "${TS_BUILDDIR}/examples/image_processing/filters_opencl"
            WORKING_DIRECTORY "${TS_BUILDDIR}/examples/image_processing")
-  add_test(NAME arrayfire_examples_deep_belief_net_opencl
-           COMMAND "${TS_BUILDDIR}/examples/machine_learning/deep_belief_net_opencl"
-           WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
-  add_test(NAME arrayfire_examples_kmeans_opencl
-           COMMAND "${TS_BUILDDIR}/examples/machine_learning/kmeans_opencl"
-           WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
+# these tests are commented out b/c they take too much time on CPU.
+#  add_test(NAME arrayfire_examples_deep_belief_net_opencl
+#           COMMAND "${TS_BUILDDIR}/examples/machine_learning/deep_belief_net_opencl"
+#           WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
+#  add_test(NAME arrayfire_examples_kmeans_opencl
+#           COMMAND "${TS_BUILDDIR}/examples/machine_learning/kmeans_opencl"
+#           WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
   add_test(NAME arrayfire_examples_knn_opencl
            COMMAND "${TS_BUILDDIR}/examples/machine_learning/knn_opencl"
            WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
-  add_test(NAME arrayfire_examples_logistic_regression_opencl
-           COMMAND "${TS_BUILDDIR}/examples/machine_learning/logistic_regression_opencl"
-           WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
+#  add_test(NAME arrayfire_examples_logistic_regression_opencl
+#           COMMAND "${TS_BUILDDIR}/examples/machine_learning/logistic_regression_opencl"
+#           WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
   add_test(NAME arrayfire_examples_naive_bayes_opencl
            COMMAND "${TS_BUILDDIR}/examples/machine_learning/naive_bayes_opencl"
            WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
-  add_test(NAME arrayfire_examples_neural_network_opencl
-           COMMAND "${TS_BUILDDIR}/examples/machine_learning/neural_network_opencl"
-           WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
-  add_test(NAME arrayfire_examples_perceptron_opencl
-           COMMAND "${TS_BUILDDIR}/examples/machine_learning/perceptron_opencl"
-           WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
-  add_test(NAME arrayfire_examples_rbm_opencl
-           COMMAND "${TS_BUILDDIR}/examples/machine_learning/rbm_opencl"
-           WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
-  add_test(NAME arrayfire_examples_softmax_regression_opencl
-           COMMAND "${TS_BUILDDIR}/examples/machine_learning/softmax_regression_opencl"
-           WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
+#  add_test(NAME arrayfire_examples_neural_network_opencl
+#           COMMAND "${TS_BUILDDIR}/examples/machine_learning/neural_network_opencl"
+#           WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
+#  add_test(NAME arrayfire_examples_perceptron_opencl
+#           COMMAND "${TS_BUILDDIR}/examples/machine_learning/perceptron_opencl"
+#           WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
+#  add_test(NAME arrayfire_examples_rbm_opencl
+#           COMMAND "${TS_BUILDDIR}/examples/machine_learning/rbm_opencl"
+#           WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
+#  add_test(NAME arrayfire_examples_softmax_regression_opencl
+#           COMMAND "${TS_BUILDDIR}/examples/machine_learning/softmax_regression_opencl"
+#           WORKING_DIRECTORY "${TS_BUILDDIR}/examples/machine_learning")
   add_test(NAME arrayfire_examples_basic_opencl
            COMMAND "${TS_BUILDDIR}/examples/unified/basic_opencl"
            WORKING_DIRECTORY "${TS_BUILDDIR}/examples/unified")
@@ -586,7 +588,7 @@ if(LAPACK_FOUND AND
     arrayfire_tests_mean_opencl
     arrayfire_tests_meanshift_opencl
     arrayfire_tests_medfilt_opencl
-    arrayfire_tests_median_opencl
+#    arrayfire_tests_median_opencl
     arrayfire_tests_memory_lock_opencl
     arrayfire_tests_memory_opencl
     arrayfire_tests_missing_opencl
@@ -643,15 +645,15 @@ if(LAPACK_FOUND AND
     arrayfire_examples_binary_thresholding_opencl
     arrayfire_examples_brain_segmentation_opencl
     arrayfire_examples_filters_opencl
-    arrayfire_examples_deep_belief_net_opencl
-    arrayfire_examples_kmeans_opencl
+#    arrayfire_examples_deep_belief_net_opencl
+#    arrayfire_examples_kmeans_opencl
     arrayfire_examples_knn_opencl
-    arrayfire_examples_logistic_regression_opencl
+#    arrayfire_examples_logistic_regression_opencl
     arrayfire_examples_naive_bayes_opencl
-    arrayfire_examples_neural_network_opencl
-    arrayfire_examples_perceptron_opencl
-    arrayfire_examples_rbm_opencl
-    arrayfire_examples_softmax_regression_opencl
+#    arrayfire_examples_neural_network_opencl
+#    arrayfire_examples_perceptron_opencl
+#    arrayfire_examples_rbm_opencl
+#    arrayfire_examples_softmax_regression_opencl
     arrayfire_examples_basic_opencl
     arrayfire_examples_black_scholes_options_opencl
     arrayfire_examples_heston_model_opencl

--- a/examples/conformance/CMakeLists.txt
+++ b/examples/conformance/CMakeLists.txt
@@ -925,7 +925,6 @@ set_tests_properties(
     "${TS_NAME}_select_long_long"
     "${TS_NAME}_thread_dimensions_quick"
     "${TS_NAME}_thread_dimensions_full"
-    "${TS_NAME}_vecalign"
     "${TS_NAME}_vecstep"
   PROPERTIES
     LABELS "conformance_suite;conformance_suite_short"

--- a/include/pocl_cache.h
+++ b/include/pocl_cache.h
@@ -61,7 +61,7 @@ void pocl_cache_release_lock(void* lock);
 int pocl_cl_device_to_index(cl_program   program,
                             cl_device_id device);
 
-void pocl_cache_mk_temp_name(char* path);
+void pocl_cache_tempname (char *path_template, const char *suffix, int *fd);
 
 int pocl_cache_create_tempdir(char* path);
 

--- a/lib/CL/clCreateSubDevices.c
+++ b/lib/CL/clCreateSubDevices.c
@@ -53,54 +53,75 @@ POname(clCreateSubDevices)(cl_device_id in_device,
    POCL_GOTO_ERROR_COND((num_devices && !out_devices), CL_INVALID_VALUE);
    POCL_GOTO_ERROR_COND((!num_devices && out_devices), CL_INVALID_VALUE);
 
+   POCL_GOTO_ERROR_ON (
+       (in_device->max_sub_devices == 0), CL_DEVICE_PARTITION_FAILED,
+       "Device %s cannot be further partitioned\n", in_device->short_name);
+
    /* check that the partition property is supported by the device */
-   errcode = CL_INVALID_VALUE;
+   POCL_GOTO_ERROR_ON ((in_device->num_partition_properties == 0),
+                       CL_INVALID_VALUE,
+                       "Device %s does not support any partition property\n",
+                       in_device->short_name);
+
    for (i = 0; i < in_device->num_partition_properties; ++i) {
      if (properties[0] == in_device->partition_properties[i]) {
-       errcode = CL_SUCCESS;
        break;
      }
    }
-   if (errcode != CL_SUCCESS)
-     goto ERROR;
+
+   POCL_GOTO_ERROR_ON (
+       (i == in_device->num_partition_properties), CL_INVALID_VALUE,
+       "Device %s does not support the requested partition property\n",
+       in_device->short_name);
 
    /* Ok, it's a supported partition property, count the number of devices; currently,
     * we only support EQUALLY and BY_COUNTS, which enumerate the number of devices
     * differently */
-   if (properties[0] == CL_DEVICE_PARTITION_EQUALLY) {
-     // error out if the number of CUs per device is 0 or bigger than the number of
-     // CUs of in_device
-     POCL_GOTO_ERROR_COND(
-       (properties[1] == 0 || (cl_uint)properties[1] > in_device->max_compute_units),
-       CL_INVALID_VALUE);
-     // error out if properties isn't zero-terminated
-     POCL_GOTO_ERROR_COND(properties[2] != 0, CL_INVALID_VALUE);
+   if (properties[0] == CL_DEVICE_PARTITION_EQUALLY)
+     {
+       /* error out if the number of CUs per device is 0 or bigger than the
+        * number of CUs of in_device */
+       POCL_GOTO_ERROR_COND (
+           (properties[1] == 0
+            || (cl_uint)properties[1] > in_device->max_compute_units),
+           CL_INVALID_VALUE);
+       // error out if properties isn't zero-terminated
+       POCL_GOTO_ERROR_COND (properties[2] != 0, CL_INVALID_VALUE);
 
-     count_devices = in_device->max_compute_units / properties[1];
-     num_props = 3; // partition type, CUs per device, terminating 0
-   } else if (properties[0] == CL_DEVICE_PARTITION_BY_COUNTS) {
-     cl_uint total_cus = 0;
-     i = 1;
-     while (properties[i] != 0) {
-       count_devices++;
-       total_cus += properties[i];
-       ++i;
+       count_devices = in_device->max_compute_units / properties[1];
+       num_props = 3; // partition type, CUs per device, terminating 0
      }
-     // error out if the total number of CUs surpasses the number of device CUs,
-     // or if we have to many subdevices
-     POCL_GOTO_ERROR_COND(
-       (total_cus == 0 || total_cus > in_device->max_compute_units ||
-        count_devices > in_device->max_sub_devices),
-       CL_INVALID_DEVICE_PARTITION_COUNT);
-     num_props = count_devices + 2; // partition type, one spec per device, terminating 0
-   } else {
-     // we end here if some of our devices claim to support a different
-     // partition type, but this function was not updated accordingly
+   else if (properties[0] == CL_DEVICE_PARTITION_BY_COUNTS)
+     {
+       cl_uint total_cus = 0;
+       i = 1;
+       while (properties[i] != 0)
+         {
+           count_devices++;
+           total_cus += properties[i];
+           ++i;
+         }
+       /* error out if the total number of CUs surpasses the number of device
+        * CUs, or if we have to many subdevices */
+       POCL_GOTO_ERROR_COND ((total_cus == 0),
+                             CL_INVALID_DEVICE_PARTITION_COUNT);
+       POCL_GOTO_ERROR_COND ((total_cus > in_device->max_compute_units),
+                             CL_INVALID_DEVICE_PARTITION_COUNT);
+       POCL_GOTO_ERROR_COND ((count_devices > in_device->max_sub_devices),
+                             CL_INVALID_DEVICE_PARTITION_COUNT);
+       num_props = count_devices
+                   + 2; /* partition type, one spec per device, terminating 0 */
+     }
+   else
+     {
+       /* we end here if some of our devices claim to support a different
+        * partition type, but this function was not updated accordingly */
 
-     char what[1024];
-     snprintf(what, 1024, "Device-reported partition type 0x%x", (unsigned int)properties[0]);
-     POCL_ABORT_UNIMPLEMENTED(what);
-   }
+       char what[1024];
+       snprintf (what, 1024, "Device-reported partition type 0x%x",
+                 (unsigned int)properties[0]);
+       POCL_ABORT_UNIMPLEMENTED (what);
+     }
 
    // num_devices must match count_devices if non-zero
    POCL_GOTO_ERROR_COND((num_devices && count_devices != num_devices), CL_INVALID_VALUE);
@@ -118,18 +139,29 @@ POname(clCreateSubDevices)(cl_device_id in_device,
        // clone in_device
        memcpy(new_devs[i], in_device, sizeof(struct _cl_device_id));
 
-       // override the fields: partition type, parent, max_compute_units,
-       // max_sub_devices
+       new_devs[i]->parent_device = in_device;
+
+       new_devs[i]->max_sub_devices = new_devs[i]->max_compute_units
+           = (properties[0] == CL_DEVICE_PARTITION_EQUALLY
+                  ? properties[1]
+                  : properties[i + 1]);
+
+       /* for devices with 1 CU, report zero subdevices and
+        * no partitioning support. */
+       if (new_devs[i]->max_compute_units == 1)
+         {
+           new_devs[i]->max_sub_devices = 0;
+           new_devs[i]->num_partition_properties = 0;
+           new_devs[i]->partition_properties = NULL;
+         }
+
+       /* copy the partition type argument, for clGetDeviceInfo() */
        new_devs[i]->partition_type = calloc(num_props, sizeof(*properties));
        POCL_GOTO_ERROR_COND((new_devs[i]->partition_type == NULL),
          CL_OUT_OF_HOST_MEMORY);
        memcpy(new_devs[i]->partition_type, properties, num_props*sizeof(*properties));
        new_devs[i]->num_partition_types = num_props;
 
-       new_devs[i]->parent_device = in_device;
-       new_devs[i]->max_sub_devices = new_devs[i]->max_compute_units =
-         (properties[0] == CL_DEVICE_PARTITION_EQUALLY ? properties[1] :
-          properties[i+1]);
      }
 
      memcpy(out_devices, new_devs, count_devices*sizeof(cl_device_id));

--- a/lib/CL/clEnqueueMapImage.c
+++ b/lib/CL/clEnqueueMapImage.c
@@ -145,7 +145,7 @@ CL_API_SUFFIX__VERSION_1_0
 
   if (map == NULL)
     {
-      POCL_UPDATE_EVENT_COMPLETE(event);
+      POCL_UPDATE_EVENT_COMPLETE (*event);
       errcode = CL_MAP_FAILURE;
       goto ERROR;
     }

--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -235,12 +235,9 @@ POname(clEnqueueNDRangeKernel)(cl_command_queue command_queue,
        * trying to respect the preferred WG size multiple (for better SIMD
        * instruction utilization).
       */
-      size_t preferred_wg_multiple; cl_int prop_err =
-        POname(clGetKernelWorkGroupInfo) (kernel, command_queue->device,
-          CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE, sizeof (size_t),
-          &preferred_wg_multiple, NULL);
+      size_t preferred_wg_multiple = realdev->preferred_wg_size_multiple;
 
-      if (prop_err != CL_SUCCESS) /* unlikely */
+      if (!preferred_wg_multiple) /* unlikely */
         preferred_wg_multiple = 1;
 
       POCL_MSG_PRINT_INFO("Preferred WG size multiple %zu\n",

--- a/lib/CL/clGetDeviceInfo.c
+++ b/lib/CL/clGetDeviceInfo.c
@@ -254,27 +254,38 @@ POname(clGetDeviceInfo)(cl_device_id   device,
    * that it is not actually supported */
   case CL_DEVICE_PARENT_DEVICE                     :
     POCL_RETURN_GETINFO(cl_device_id, device->parent_device);
+
   case CL_DEVICE_PARTITION_MAX_SUB_DEVICES         :
     POCL_RETURN_GETINFO(cl_uint, device->max_sub_devices);
+
   case CL_DEVICE_PARTITION_PROPERTIES              :
-    POCL_RETURN_GETINFO_ARRAY(cl_device_partition_property,
-      device->num_partition_properties, device->partition_properties);
+    if (device->num_partition_properties)
+      POCL_RETURN_GETINFO_ARRAY (cl_device_partition_property,
+                                 device->num_partition_properties,
+                                 device->partition_properties);
+    else
+      POCL_RETURN_GETINFO (cl_device_partition_property, 0);
+
   case CL_DEVICE_PARTITION_TYPE                    :
-    POCL_RETURN_GETINFO_ARRAY(cl_device_partition_property,
-      device->num_partition_types, device->partition_type);
+    if (device->num_partition_types)
+      POCL_RETURN_GETINFO_ARRAY (cl_device_partition_property,
+                                 device->num_partition_types,
+                                 device->partition_type);
+    else
+      POCL_RETURN_GETINFO (cl_device_partition_property, 0);
+
   case CL_DEVICE_PARTITION_AFFINITY_DOMAIN         :
     POCL_RETURN_GETINFO(cl_device_affinity_domain, 0);
 
   case CL_DEVICE_PREFERRED_INTEROP_USER_SYNC       :
     POCL_RETURN_GETINFO(cl_bool, CL_TRUE);
+
   case CL_DEVICE_PRINTF_BUFFER_SIZE                :
     POCL_RETURN_DEVICE_INFO_WITH_IMPL_CHECK(size_t, device->printf_buffer_size);
+
   case CL_DEVICE_REFERENCE_COUNT:
     POCL_RETURN_DEVICE_INFO_WITH_IMPL_CHECK(cl_uint, 
                                             (cl_uint)device->pocl_refcount)
-
-
-
 
   case CL_DEVICE_SVM_CAPABILITIES:
     POCL_RETURN_GETINFO(cl_device_svm_capabilities, device->svm_caps);

--- a/lib/CL/clReleaseCommandQueue.c
+++ b/lib/CL/clReleaseCommandQueue.c
@@ -45,6 +45,7 @@ POname(clReleaseCommandQueue)(cl_command_queue command_queue) CL_API_SUFFIX__VER
       if (command_queue->device->ops->free_queue)
         command_queue->device->ops->free_queue (command_queue);
       pocl_queue_list_delete(command_queue);
+      POCL_DESTROY_OBJECT (command_queue);
       POCL_MEM_FREE(command_queue);
 
       POname(clReleaseContext)(context);

--- a/lib/CL/clReleaseContext.c
+++ b/lib/CL/clReleaseContext.c
@@ -51,6 +51,7 @@ POname(clReleaseContext)(cl_context context) CL_API_SUFFIX__VERSION_1_0
         }   
       POCL_MEM_FREE(context->devices);
       POCL_MEM_FREE(context->properties);
+      POCL_DESTROY_OBJECT (context);
       POCL_MEM_FREE(context);
     }
   return CL_SUCCESS;

--- a/lib/CL/clReleaseDevice.c
+++ b/lib/CL/clReleaseDevice.c
@@ -34,6 +34,7 @@ POname(clReleaseDevice)(cl_device_id device) CL_API_SUFFIX__VERSION_1_2
 
   if (new_refcount == 0)
     {
+      POCL_DESTROY_OBJECT (device);
       POCL_MEM_FREE(device);
       POCL_MSG_PRINT_REFCOUNTS ("Free Device %p\n", device);
     }

--- a/lib/CL/clReleaseEvent.c
+++ b/lib/CL/clReleaseEvent.c
@@ -45,6 +45,7 @@ POname(clReleaseEvent)(cl_event event) CL_API_SUFFIX__VERSION_1_0
       if (event->queue)
         POname(clReleaseCommandQueue) (event->queue);
 
+      POCL_DESTROY_OBJECT (event);
       pocl_mem_manager_free_event (event);
     }
 

--- a/lib/CL/clReleaseKernel.c
+++ b/lib/CL/clReleaseKernel.c
@@ -83,6 +83,7 @@ POname(clReleaseKernel)(cl_kernel kernel) CL_API_SUFFIX__VERSION_1_0
       POCL_MEM_FREE (kernel->arg_info);
       POCL_MEM_FREE (kernel->dyn_arguments);
       POCL_MEM_FREE (kernel->reqd_wg_size);
+      POCL_DESTROY_OBJECT (kernel);
       POCL_MEM_FREE (kernel);
     }
   

--- a/lib/CL/clReleaseMemObject.c
+++ b/lib/CL/clReleaseMemObject.c
@@ -104,6 +104,7 @@ POname(clReleaseMemObject)(cl_mem memobj) CL_API_SUFFIX__VERSION_1_0
         callback = next_callback;
       }
 
+      POCL_DESTROY_OBJECT (memobj);
       POCL_MEM_FREE(memobj);
 
       if (parent)

--- a/lib/CL/clReleaseProgram.c
+++ b/lib/CL/clReleaseProgram.c
@@ -102,6 +102,7 @@ POname(clReleaseProgram)(cl_program program) CL_API_SUFFIX__VERSION_1_0
       POCL_MEM_FREE(program->build_hash);
       POCL_MEM_FREE(program->compiler_options);
       POCL_MEM_FREE(program->llvm_irs);
+      POCL_DESTROY_OBJECT (program);
       POCL_MEM_FREE(program);
 
       POname(clReleaseContext)(context);

--- a/lib/CL/clReleaseSampler.c
+++ b/lib/CL/clReleaseSampler.c
@@ -37,6 +37,7 @@ CL_API_SUFFIX__VERSION_1_0
   if (new_refcount == 0)
     {
       POname (clReleaseContext) (sampler->context);
+      POCL_DESTROY_OBJECT (sampler);
       POCL_MEM_FREE (sampler);
     }
 

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -908,11 +908,10 @@ void
 pocl_basic_submit (_cl_command_node *node, cl_command_queue cq)
 {
   struct data *d = node->device->data;
-  cl_event *event = &(node->event);
   
   node->device->ops->compile_kernel (node, NULL, NULL);
   POCL_LOCK (d->cq_lock);
-  POCL_UPDATE_EVENT_SUBMITTED(event);
+  POCL_UPDATE_EVENT_SUBMITTED (node->event);
   pocl_command_push(node, &d->ready_list, &d->command_list);
   
   basic_command_scheduler (d);

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -958,11 +958,9 @@ pocl_basic_notify (cl_device_id device, cl_event event, cl_event finished)
   struct data *d = (struct data*)device->data;
   _cl_command_node * volatile node = event->command;
   
-  POCL_LOCK_OBJ (event);
   if (!(node->ready) && pocl_command_is_ready(node->event))
     {
       node->ready = 1;
-      POCL_UNLOCK_OBJ (event);
       if (node->event->status == CL_SUBMITTED)
         {
           POCL_LOCK (d->cq_lock);
@@ -973,7 +971,6 @@ pocl_basic_notify (cl_device_id device, cl_event event, cl_event finished)
         }
       return;
     }
-  POCL_UNLOCK_OBJ (event);
 }
 
 void

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -199,8 +199,10 @@ pocl_basic_init_device_infos(unsigned j, struct _cl_device_id* dev)
   dev->single_fp_config = CL_FP_ROUND_TO_NEAREST | CL_FP_INF_NAN;
 #ifdef __x86_64__
   dev->single_fp_config |= (CL_FP_DENORM | CL_FP_ROUND_TO_INF | CL_FP_ROUND_TO_ZERO);
+#ifdef OCS_AVAILABLE
   if (cpu_has_fma())
     dev->single_fp_config |= CL_FP_FMA;
+#endif
 #endif
   dev->double_fp_config = CL_FP_FMA | CL_FP_ROUND_TO_NEAREST
                           | CL_FP_ROUND_TO_ZERO | CL_FP_ROUND_TO_INF

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -159,8 +159,8 @@ pocl_basic_init_device_infos(unsigned j, struct _cl_device_id* dev)
     the SIMD lanes times the vector units, but not more than
     that to avoid stack overflow and cache trashing.
   */
-  dev->max_work_item_sizes[0] = dev->max_work_item_sizes[1] =
-	  dev->max_work_item_sizes[2] = dev->max_work_group_size = 1024*4;
+  dev->max_work_item_sizes[0] = dev->max_work_item_sizes[1]
+      = dev->max_work_item_sizes[2] = dev->max_work_group_size = 1024 * 4;
 
   dev->preferred_wg_size_multiple = 8;
   dev->preferred_vector_width_char = POCL_DEVICES_PREFERRED_VECTOR_WIDTH_CHAR;

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -196,10 +196,11 @@ pocl_basic_init_device_infos(unsigned j, struct _cl_device_id* dev)
   dev->min_data_type_align_size = MAX_EXTENDED_ALIGNMENT; // this is in bytes
   dev->mem_base_addr_align = MAX_EXTENDED_ALIGNMENT*8; // this is in bits
   dev->half_fp_config = 0;
-#ifdef __x86_64__
-  dev->single_fp_config = CL_FP_ROUND_TO_NEAREST | CL_FP_INF_NAN | CL_FP_DENORM;
-#else
   dev->single_fp_config = CL_FP_ROUND_TO_NEAREST | CL_FP_INF_NAN;
+#ifdef __x86_64__
+  dev->single_fp_config |= (CL_FP_DENORM | CL_FP_ROUND_TO_INF | CL_FP_ROUND_TO_ZERO);
+  if (cpu_has_fma())
+    dev->single_fp_config |= CL_FP_FMA;
 #endif
   dev->double_fp_config = CL_FP_FMA | CL_FP_ROUND_TO_NEAREST
                           | CL_FP_ROUND_TO_ZERO | CL_FP_ROUND_TO_INF

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -632,7 +632,7 @@ pocl_broadcast (cl_event brc_event)
   event_node *tmp;
   while ((target = brc_event->notify_list))
     {
-      POCL_LOCK_OBJ (target->event);
+      pocl_lock_events_inorder (brc_event, target->event);
       /* remove event from wait list */
       LL_FOREACH (target->event->wait_list, tmp)
         {
@@ -645,14 +645,12 @@ pocl_broadcast (cl_event brc_event)
         }
       if (target->event->status == CL_SUBMITTED)
         {
-          POCL_UNLOCK_OBJ (target->event);
           target->event->command->device->ops->notify
             (target->event->command->device, target->event, brc_event);
         }
-      else 
-        POCL_UNLOCK_OBJ (target->event);
       
       LL_DELETE (brc_event->notify_list, target);
+      pocl_unlock_events_inorder (brc_event, target->event);
       pocl_mem_manager_free_event_node (target);
     }
 }

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -294,7 +294,7 @@ pocl_exec_command (_cl_command_node * volatile node)
 {
   unsigned i;
   /* because of POCL_UPDATE_EVENT_ */
-  cl_event *event = &(node->event);
+  cl_event event = node->event;
   switch (node->type)
     {
     case CL_COMMAND_READ_BUFFER:
@@ -513,7 +513,7 @@ pocl_exec_command (_cl_command_node * volatile node)
       break;
     case CL_COMMAND_NDRANGE_KERNEL:
       POCL_UPDATE_EVENT_RUNNING(event);
-      assert (*event == node->event);
+      assert (event == node->event);
       node->device->ops->run(node->command.run.data, node);
       POCL_UPDATE_EVENT_COMPLETE(event);
       POCL_DEBUG_EVENT_TIME(event, "Enqueue NDRange       ");

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -22,14 +22,17 @@
    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
    THE SOFTWARE.
 */
+
+#define _GNU_SOURCE
+
 #include "common.h"
 #include "pocl_shared.h"
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <utlist.h>
-#include <assert.h>
 
 #ifndef _MSC_VER
 #  include <sys/time.h>
@@ -74,87 +77,152 @@ char*
 llvm_codegen (const char* tmpdir, cl_kernel kernel, cl_device_id device,
               size_t local_x, size_t local_y, size_t local_z)
 {
+  int error = 0;
+  void *write_lock = NULL;
+  void *llvm_module = NULL;
 
-  char bytecode[POCL_FILENAME_LENGTH];
-  char objfile[POCL_FILENAME_LENGTH];
-  /* strlen of / .so 4+1 */
-  int file_name_alloc_size = 
-    min(POCL_FILENAME_LENGTH, strlen(tmpdir) + strlen(kernel->name) + 5);
-  char* module = (char*) malloc(file_name_alloc_size); 
-  /* To avoid corrupted .so files, create a tmp file first
-     and then rename it. */
-  char tmp_module[file_name_alloc_size + 4]; /* .tmp postfix */
-  int error;
+  char tmp_module[POCL_FILENAME_LENGTH];
 
-  error = snprintf(module, POCL_FILENAME_LENGTH,
-                   "%s/%s.so", tmpdir, kernel->name);
+  char objfile_path[POCL_FILENAME_LENGTH];
+  char *objfile = NULL;
+  size_t objfile_size = 0;
 
-  assert (error >= 0);
+  cl_program program = kernel->program;
 
-  error = snprintf(objfile, POCL_FILENAME_LENGTH,
-                   "%s/%s.so.o", tmpdir, kernel->name);
-  assert (error >= 0);
+  int device_i = pocl_cl_device_to_index (program, device);
+  assert (device_i >= 0);
 
-  if (pocl_exists(module))
-    return module;
+  /* $/parallel.bc */
+  char parallel_bc_path[POCL_FILENAME_LENGTH];
+  pocl_cache_work_group_function_path (parallel_bc_path, program, device_i,
+                                       kernel, local_x, local_y, local_z);
 
-  memcpy (tmp_module, module, file_name_alloc_size);
-  strcat (tmp_module, ".tmp");
+  /* $/kernel.so */
+  char final_binary_path[POCL_FILENAME_LENGTH];
+  pocl_cache_final_binary_path (final_binary_path, program, device_i, kernel,
+                                local_x, local_y, local_z);
 
-  void* write_lock = pocl_cache_acquire_writer_lock(kernel->program, device);
-  assert(write_lock);
+  if (pocl_exists (final_binary_path))
+    goto FINISH;
 
-  error = pocl_llvm_generate_workgroup_function (device, kernel,
-                                                 local_x, local_y, local_z);
+  /* $/kernel.so.o */
+  assert (strlen (final_binary_path) < (POCL_FILENAME_LENGTH - 3));
+  strcpy (objfile_path, final_binary_path);
+  strcat (objfile_path, ".o");
+
+  error = pocl_llvm_generate_workgroup_function_nowrite (
+      device, kernel, local_x, local_y, local_z, &llvm_module);
   if (error)
     {
       POCL_MSG_PRINT_GENERAL ("pocl_llvm_generate_workgroup_function() failed"
-                              " for kernel %s\n", kernel->name);
-      assert (error == 0);
+                              " for kernel %s\n",
+                              kernel->name);
+      goto FINISH;
+    }
+  assert (llvm_module != NULL);
+
+  /* may happen if another thread is building the same program & wins
+   * the llvm lock. */
+  if (pocl_exists (final_binary_path))
+    goto FINISH;
+
+  error = pocl_llvm_codegen (kernel, device, llvm_module, &objfile,
+                             &objfile_size);
+  if (error)
+    {
+      POCL_MSG_PRINT_GENERAL ("pocl_llvm_codegen() failed"
+                              " for kernel %s\n",
+                              kernel->name);
+      goto FINISH;
     }
 
-  error = snprintf (bytecode, POCL_FILENAME_LENGTH,
-		    "%s%s", tmpdir, POCL_PARALLEL_BC_FILENAME);
-  assert (error >= 0);
+  if (pocl_exists (final_binary_path))
+    goto FINISH;
 
-  error = pocl_llvm_codegen( kernel, device, bytecode, objfile);
-  assert (error == 0);
+  /**************************************************************************/
+  write_lock = pocl_cache_acquire_writer_lock (kernel->program, device);
+  assert (write_lock);
 
-  /* clang is used as the linker driver in LINK_CMD */
+  /* write parallel.bc only if we want to leave compiler files*/
+  if (pocl_get_bool_option ("POCL_LEAVE_KERNEL_COMPILER_TEMP_FILES", 0))
+    {
+      POCL_MSG_PRINT_LLVM ("Writing parallel.bc to %s.\n", parallel_bc_path);
+      error = pocl_cache_write_kernel_parallel_bc (
+          llvm_module, program, device_i, kernel, local_x, local_y, local_z);
+    }
+  else
+    {
+      char kernel_parallel_path[POCL_FILENAME_LENGTH];
+      pocl_cache_kernel_cachedir_path (kernel_parallel_path, program, device_i,
+                                       kernel, "", local_x, local_y, local_z);
+      error = pocl_mkdir_p (kernel_parallel_path);
+    }
+  if (error)
+    {
+      POCL_MSG_PRINT_GENERAL ("writing parallel.bc failed"
+                              " for kernel %s\n",
+                              kernel->name);
+      goto FINISH;
+    }
 
+  /* write krenel.so.o always, required for linking step. */
+  POCL_MSG_PRINT_LLVM ("Writing code gen output to %s.\n", objfile_path);
+  error = pocl_write_file (objfile_path, objfile, objfile_size, 0, 0);
+  if (error)
+    {
+      POCL_MSG_PRINT_GENERAL ("writing kernel.so.o failed"
+                              " for kernel %s\n",
+                              kernel->name);
+      goto FINISH;
+    }
+  else
+    {
+      POCL_MSG_PRINT_GENERAL ("written kernel.so.o size %zu\n", objfile_size);
+    }
+
+  /* create a temporary filename */
+  pocl_cache_tempname (tmp_module, ".so", NULL);
+  assert (pocl_exists (tmp_module) > 0);
+
+  /* clang is used as the linker driver for ANDROID, otherwise GNU ld is used
+   */
   POCL_MSG_PRINT_INFO ("Linking final module\n");
   char *const args1[]
 #ifndef POCL_ANDROID
-      = { LINK_COMMAND,
-          HOST_LD_FLAGS_ARRAY,
-          "-o",
-          tmp_module,
-          objfile,
-          NULL };
+      = { LINK_COMMAND, HOST_LD_FLAGS_ARRAY, "-o",
+          tmp_module,   objfile_path,        NULL };
 #else
       = { POCL_ANDROID_PREFIX "/bin/ld",
           HOST_LD_FLAGS_ARRAY,
           "-o",
           tmp_module,
-          objfile,
+          objfile_path,
           NULL };
 #endif
   error = pocl_run_command (args1);
-  assert (error == 0);
+  if (error)
+    goto FINISH;
 
-  error = pocl_rename (tmp_module, module);
-  assert (error == 0);
+  error = pocl_rename (tmp_module, final_binary_path);
+  if (error)
+    goto FINISH;
 
   /* Save space in kernel cache */
   if (!pocl_get_bool_option("POCL_LEAVE_KERNEL_COMPILER_TEMP_FILES", 0))
     {
-      pocl_remove(objfile);
-      pocl_remove(bytecode);
+      pocl_remove (objfile_path);
     }
 
-  pocl_cache_release_lock(write_lock);
+  pocl_cache_release_lock (write_lock);
 
-  return module;
+FINISH:
+  pocl_destroy_llvm_module (llvm_module);
+  POCL_MEM_FREE (objfile);
+
+  if (error)
+    return NULL;
+  else
+    return strdup (final_binary_path);
 }
 #endif
 

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -1093,7 +1093,7 @@ pocl_cuda_submit_node (_cl_command_node *node, cl_command_queue cq)
       CUDA_CHECK (result, "cuEventRecord");
     }
 
-  POCL_UPDATE_EVENT_SUBMITTED (&node->event);
+  POCL_UPDATE_EVENT_SUBMITTED (node->event);
 
   POCL_UNLOCK_OBJ (node->event);
 
@@ -1366,8 +1366,8 @@ pocl_cuda_finalize_command (cl_device_id device, cl_event event)
       return;
     }
 
-  POCL_UPDATE_EVENT_RUNNING (&event);
-  POCL_UPDATE_EVENT_COMPLETE (&event);
+  POCL_UPDATE_EVENT_RUNNING (event);
+  POCL_UPDATE_EVENT_COMPLETE (event);
 }
 
 void

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -1428,8 +1428,8 @@ pocl_cuda_update_event (cl_device_id device, cl_event event, cl_int status)
 
       POCL_LOCK_OBJ (event);
       event->status = CL_COMPLETE;
-      device->ops->broadcast (event);
       POCL_UNLOCK_OBJ (event);
+      device->ops->broadcast (event);
 
       pocl_update_command_queue (event);
 

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -1193,7 +1193,7 @@ pocl_hsa_submit (_cl_command_node *node, cl_command_queue cq)
 
   POCL_LOCK_OBJ (node->event);
   PTHREAD_CHECK(pthread_mutex_lock(&d->list_mutex));
-  POCL_UPDATE_EVENT_SUBMITTED(&node->event);
+  POCL_UPDATE_EVENT_SUBMITTED (node->event);
 
   /* this "ready" consept to ensure that command is pushed only once */
   if (!(node->ready) && pocl_command_is_ready(node->event))
@@ -1444,7 +1444,7 @@ pocl_hsa_launch(pocl_hsa_device_data_t *d, cl_event event)
     }
 
   POCL_UNLOCK_OBJ (event);
-  POCL_UPDATE_EVENT_RUNNING(&event);
+  POCL_UPDATE_EVENT_RUNNING (event);
 }
 
 static void
@@ -1478,7 +1478,7 @@ pocl_hsa_ndrange_event_finished (pocl_hsa_device_data_t *d, size_t i)
   hsa_memory_free(event_data->actual_kernargs);
 
   POCL_UNLOCK_OBJ (event);
-  POCL_UPDATE_EVENT_COMPLETE(&event);
+  POCL_UPDATE_EVENT_COMPLETE (event);
 
   uint64_t ns = event->time_end - event->time_start;
   pocl_debug_print_duration(__func__,__LINE__,

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -1264,7 +1264,6 @@ void
 pocl_hsa_notify (cl_device_id device, cl_event event, cl_event finished)
 {
   pocl_hsa_device_data_t *d = device->data;
-  POCL_LOCK_OBJ (event);
   _cl_command_node *node = event->command;
   int added_to_readylist = 0;
   POCL_MSG_PRINT_INFO("pocl-hsa: notify on event %u \n", event->id);
@@ -1298,7 +1297,6 @@ pocl_hsa_notify (cl_device_id device, cl_event event, cl_event finished)
         POCL_MSG_WARN("node->ready was 0 but event %u is"
                       " not submitted!\n", event->id);
     }
-  POCL_UNLOCK_OBJ (event);
 
   if (added_to_readylist)
     hsa_signal_subtract_relaxed(d->nudge_driver_thread, 1);
@@ -1698,11 +1696,10 @@ pocl_hsa_update_event (cl_device_id device, cl_event event, cl_int status)
 
       POCL_LOCK_OBJ (event);
       event->status = CL_COMPLETE;
-
       pthread_cond_signal(&e_d->event_cond);
+      POCL_UNLOCK_OBJ (event);
 
       device->ops->broadcast (event);
-      POCL_UNLOCK_OBJ (event);
       break;
     default:
       assert("Invalid event status\n");

--- a/lib/CL/devices/pthread/pocl-pthread_utils.h
+++ b/lib/CL/devices/pthread/pocl-pthread_utils.h
@@ -28,21 +28,26 @@ struct kernel_run_command
   void *data;
   cl_kernel kernel;
   cl_device_id device;
-  struct pocl_context pc;
   _cl_command_node *cmd;
-  pthread_mutex_t lock;
   unsigned lock_counter;
   volatile unsigned group_idx[3];
-  volatile unsigned remaining_wgs;
-  volatile unsigned wgs_dealt;
   pocl_workgroup workgroup;
   struct pocl_argument *kernel_args;
-  volatile int ref_count;
   kernel_run_command *volatile next;
+  volatile int ref_count;
+
 #ifdef POCL_PTHREAD_CACHE_MONITORING
   pocl_cache_data cache_data;
 #endif
-};
+
+  pthread_mutex_t lock __attribute__ ((aligned (CACHELINE_SIZE)));
+
+  volatile unsigned remaining_wgs __attribute__ ((aligned (CACHELINE_SIZE)));
+  volatile unsigned wgs_dealt;
+
+  struct pocl_context pc __attribute__ ((aligned (CACHELINE_SIZE)));
+
+} __attribute__ ((aligned (CACHELINE_SIZE)));
 
 void pocl_init_kernel_run_command_manager (void);
 void pocl_init_thread_argument_manager ();

--- a/lib/CL/devices/pthread/pocl-pthread_utils.h
+++ b/lib/CL/devices/pthread/pocl-pthread_utils.h
@@ -29,8 +29,6 @@ struct kernel_run_command
   cl_kernel kernel;
   cl_device_id device;
   _cl_command_node *cmd;
-  unsigned lock_counter;
-  volatile unsigned group_idx[3];
   pocl_workgroup workgroup;
   struct pocl_argument *kernel_args;
   kernel_run_command *volatile next;

--- a/lib/CL/devices/pthread/pocl-pthread_utils.h
+++ b/lib/CL/devices/pthread/pocl-pthread_utils.h
@@ -38,14 +38,14 @@ struct kernel_run_command
   pocl_cache_data cache_data;
 #endif
 
-  pthread_mutex_t lock __attribute__ ((aligned (CACHELINE_SIZE)));
+  pthread_mutex_t lock __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
 
-  volatile unsigned remaining_wgs __attribute__ ((aligned (CACHELINE_SIZE)));
+  volatile unsigned remaining_wgs __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
   volatile unsigned wgs_dealt;
 
-  struct pocl_context pc __attribute__ ((aligned (CACHELINE_SIZE)));
+  struct pocl_context pc __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
 
-} __attribute__ ((aligned (CACHELINE_SIZE)));
+} __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
 
 void pocl_init_kernel_run_command_manager (void);
 void pocl_init_thread_argument_manager ();

--- a/lib/CL/devices/pthread/pocl-pthread_utils.h
+++ b/lib/CL/devices/pthread/pocl-pthread_utils.h
@@ -4,15 +4,19 @@
 #include "pocl_cl.h"
 
 /* locking macros */
-#define PTHREAD_LOCK(__lock , __counter)        \
-  do {                                          \
-    if ((__counter))                            \
-      ++(*((unsigned*)(__counter)));            \
-  }while (pthread_mutex_trylock((__lock)))
+#define PTHREAD_LOCK(__lock)                                                  \
+  do                                                                          \
+    {                                                                         \
+      pthread_mutex_lock ((__lock));                                          \
+    }                                                                         \
+  while (0)
 
-//#define PTHREAD_LOCK(__lock, __counter) do {pthread_mutex_lock((__lock__));} while (0)
-
-#define PTHREAD_UNLOCK(__lock) do { pthread_mutex_unlock((__lock)); }while(0)
+#define PTHREAD_UNLOCK(__lock)                                                \
+  do                                                                          \
+    {                                                                         \
+      pthread_mutex_unlock ((__lock));                                        \
+    }                                                                         \
+  while (0)
 
 #ifdef __GNUC__
 #pragma GCC visibility push(hidden)

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -377,7 +377,7 @@ pocl_pthread_submit (_cl_command_node *node, cl_command_queue cq)
     }
   else
     {
-      PTHREAD_LOCK (&d->cq_lock, NULL);
+      PTHREAD_LOCK (&d->cq_lock);
       DL_PREPEND (d->command_list, node);
       PTHREAD_UNLOCK (&d->cq_lock);
     }
@@ -412,7 +412,7 @@ pocl_pthread_notify (cl_device_id device, cl_event event, cl_event finished)
       node->ready = 1;
       if (event->status == CL_SUBMITTED)
         {
-          PTHREAD_LOCK (&d->cq_lock, NULL);
+          PTHREAD_LOCK (&d->cq_lock);
           assert (d->command_list != NULL);
           DL_DELETE (d->command_list, node);
           PTHREAD_UNLOCK (&d->cq_lock);

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -114,7 +114,7 @@ struct data {
 #endif
 
   /* Lock for command list related operations */
-  pthread_mutex_t cq_lock __attribute__ ((aligned (CACHELINE_SIZE)));
+  pthread_mutex_t cq_lock __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
   /* List of commands waiting to be enqueued */
   _cl_command_node *volatile command_list;
 };

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -471,9 +471,9 @@ void pocl_pthread_update_event (cl_device_id device, cl_event event, cl_int stat
 
       POCL_LOCK_OBJ (event);
       event->status = CL_COMPLETE;
-
       pthread_cond_signal(&e_d->event_cond);
       POCL_UNLOCK_OBJ (event);
+
       if (cq_ready)
         pthread_scheduler_release_host ();
 
@@ -503,6 +503,5 @@ void pocl_pthread_free_event_data (cl_event event)
   assert(event->data != NULL);
   free(event->data);
   event->data = NULL;
-
 }
 

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -105,10 +105,6 @@ struct data {
   cl_kernel current_kernel;
   /* Loaded kernel dynamic library handle. */
   lt_dlhandle current_dlhandle;
-
-  /* List of commands waiting to be enqueued */
-  _cl_command_node * volatile command_list;
-  pthread_mutex_t cq_lock;      /* Lock for command list related operations */
   volatile uint64_t total_cmd_exec_time;
 
 #ifdef CUSTOM_BUFFER_ALLOCATOR
@@ -117,6 +113,10 @@ struct data {
   mem_regions_management* mem_regions;
 #endif
 
+  /* Lock for command list related operations */
+  pthread_mutex_t cq_lock __attribute__ ((aligned (CACHELINE_SIZE)));
+  /* List of commands waiting to be enqueued */
+  _cl_command_node *volatile command_list;
 };
 
 static size_t get_max_thread_count();

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -405,7 +405,6 @@ pocl_pthread_notify (cl_device_id device, cl_event event, cl_event finished)
    int wake_thread = 0;
   _cl_command_node * volatile node = event->command;
 
-  POCL_LOCK_OBJ (event);
   /* this "ready" consept to ensure that command is pushed only once */
   if (!(node->ready) && pocl_command_is_ready(node->event))
     {
@@ -419,7 +418,6 @@ pocl_pthread_notify (cl_device_id device, cl_event event, cl_event finished)
           wake_thread = 1;
         }
     }
-  POCL_UNLOCK_OBJ (event);
 
   if (wake_thread)
     {
@@ -477,9 +475,9 @@ void pocl_pthread_update_event (cl_device_id device, cl_event event, cl_int stat
       pthread_cond_signal(&e_d->event_cond);
       if (cq_ready)
         pthread_scheduler_release_host ();
+      POCL_UNLOCK_OBJ (event);
 
       device->ops->broadcast (event);
-      POCL_UNLOCK_OBJ (event);
       break;
     default:
       assert("Invalid event status\n");

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -368,7 +368,7 @@ pocl_pthread_submit (_cl_command_node *node, cl_command_queue cq)
   struct data *d = device->data;
 
   POCL_LOCK_OBJ (node->event);
-  POCL_UPDATE_EVENT_SUBMITTED(&node->event);
+  POCL_UPDATE_EVENT_SUBMITTED (node->event);
   /* this "ready" consept to ensure that command is pushed only once */
   if (!(node->ready) && pocl_command_is_ready(node->event))
     {

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -473,9 +473,9 @@ void pocl_pthread_update_event (cl_device_id device, cl_event event, cl_int stat
       event->status = CL_COMPLETE;
 
       pthread_cond_signal(&e_d->event_cond);
+      POCL_UNLOCK_OBJ (event);
       if (cq_ready)
         pthread_scheduler_release_host ();
-      POCL_UNLOCK_OBJ (event);
 
       device->ops->broadcast (event);
       break;

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -323,7 +323,7 @@ void finalize_kernel_command (struct pool_thread_data *thread_data,
 #endif
 
   pocl_ndrange_node_cleanup (k->cmd);
-  POCL_UPDATE_EVENT_COMPLETE (&k->cmd->event);
+  POCL_UPDATE_EVENT_COMPLETE (k->cmd->event);
 
   pocl_mem_manager_free_command (k->cmd);
 
@@ -383,7 +383,7 @@ pocl_pthread_exec_command (_cl_command_node * volatile cmd,
 {
   if(cmd->type == CL_COMMAND_NDRANGE_KERNEL)
     {
-      POCL_UPDATE_EVENT_RUNNING(&(cmd->event));
+      POCL_UPDATE_EVENT_RUNNING (cmd->event);
       pocl_pthread_prepare_kernel (cmd->command.run.data, cmd);
     }
   else

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <pthread.h>
 #include <time.h>
+#include <signal.h>
 
 #include "pocl-pthread_scheduler.h"
 #include "pocl_cl.h"
@@ -57,6 +58,13 @@ void pthread_scheduler_init (size_t num_worker_threads)
     (num_worker_threads, sizeof (struct pool_thread_data));
   scheduler.num_threads = num_worker_threads;
 
+  /* let the main pocl thread handle SIGFPE */
+  sigset_t set, oldset;
+  sigemptyset (&set);
+  sigaddset (&set, SIGFPE);
+  int res = pthread_sigmask (SIG_BLOCK, &set, &oldset);
+  assert (res == 0);
+
   for (i = 0; i < num_worker_threads; ++i)
     {
       pthread_cond_init (&scheduler.thread_pool[i].wakeup_cond, NULL);
@@ -65,6 +73,9 @@ void pthread_scheduler_init (size_t num_worker_threads)
                       pocl_pthread_driver_thread,
                       (void*)&scheduler.thread_pool[i]);
     }
+
+  res = pthread_sigmask (SIG_SETMASK, &oldset, NULL);
+  assert (res == 0);
 
 }
 

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -175,15 +175,11 @@ int pthread_scheduler_get_work (thread_data *td, _cl_command_node **cmd_ptr)
         {
           PTHREAD_UNLOCK (&scheduler.wq_lock);
           finalize_kernel_command (td, run_cmd);
+          PTHREAD_LOCK (&scheduler.wq_lock);
         }
-      else
-        PTHREAD_UNLOCK (&scheduler.wq_lock);
     }
-  else
-    PTHREAD_UNLOCK (&scheduler.wq_lock);
 
   // execute a command if available
-  PTHREAD_LOCK (&scheduler.wq_lock);
   if ((cmd = scheduler.work_queue))
     {
       DL_DELETE (scheduler.work_queue, cmd);

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -16,15 +16,15 @@ static void* pocl_pthread_driver_thread (void *p);
 
 struct pool_thread_data
 {
-  pthread_cond_t wakeup_cond __attribute__ ((aligned (CACHELINE_SIZE)));
-  pthread_mutex_t lock __attribute__ ((aligned (CACHELINE_SIZE)));
+  pthread_cond_t wakeup_cond __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+  pthread_mutex_t lock __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
 
-  pthread_t thread __attribute__ ((aligned (CACHELINE_SIZE)));
+  pthread_t thread __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
   volatile long executed_commands;
   volatile unsigned current_ftz;
   unsigned num_threads;
 
-} __attribute__ ((aligned (CACHELINE_SIZE)));
+} __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
 
 typedef struct scheduler_data_
 {
@@ -32,17 +32,17 @@ typedef struct scheduler_data_
   struct pool_thread_data *thread_pool;
 
   _cl_command_node *volatile work_queue
-      __attribute__ ((aligned (CACHELINE_SIZE)));
+      __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
   kernel_run_command *volatile kernel_queue;
 
-  pthread_cond_t wake_pool __attribute__ ((aligned (CACHELINE_SIZE)));
-  pthread_mutex_t wq_lock __attribute__ ((aligned (CACHELINE_SIZE)));
+  pthread_cond_t wake_pool __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+  pthread_mutex_t wq_lock __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
 
-  pthread_cond_t cq_finished_cond __attribute__ ((aligned (CACHELINE_SIZE)));
-  pthread_mutex_t cq_finished_lock __attribute__ ((aligned (CACHELINE_SIZE)));
+  pthread_cond_t cq_finished_cond __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+  pthread_mutex_t cq_finished_lock __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
 
   volatile int thread_pool_shutdown_requested;
-} scheduler_data __attribute__ ((aligned (CACHELINE_SIZE)));
+} scheduler_data __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
 
 static scheduler_data scheduler;
 

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -283,15 +283,10 @@ work_group_scheduler (kernel_run_command *k,
                  pc.group_id[1], pc.group_id[2]);
 #endif
 
-          unsigned rm = pocl_save_rm ();
           pocl_set_default_rm ();
-          unsigned ftz = pocl_save_ftz ();
           pocl_set_ftz (k->kernel->program->flush_denorms);
 
           k->workgroup (arguments, &pc);
-
-          pocl_restore_rm (rm);
-          pocl_restore_ftz (ftz);
 
         }
 

--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -886,10 +886,9 @@ void
 pocl_tce_submit (_cl_command_node *node, cl_command_queue /*cq*/)
 {
   TCEDevice *d = (TCEDevice*)node->device->data;
-  cl_event *event = &(node->event);
 
   POCL_LOCK (d->cq_lock);
-  POCL_UPDATE_EVENT_SUBMITTED(event);
+  POCL_UPDATE_EVENT_SUBMITTED (node->event);
   pocl_command_push(node, &d->ready_list, &d->command_list);
 
   tce_command_scheduler (d);

--- a/lib/CL/pocl_build.c
+++ b/lib/CL/pocl_build.c
@@ -577,6 +577,7 @@ compile_and_link_program(int compile_program,
         }
       else if (link_program && (num_input_programs > 0))
         {
+#ifdef OCS_AVAILABLE
           /* just link binaries. */
           unsigned char *cur_device_binaries[num_input_programs];
           size_t cur_device_binary_sizes[num_input_programs];
@@ -602,6 +603,12 @@ compile_and_link_program(int compile_program,
               cur_device_binaries, cur_device_binary_sizes, cur_llvm_irs);
           POCL_GOTO_ERROR_ON ((error != CL_SUCCESS), CL_LINK_PROGRAM_FAILURE,
                               "pocl_llvm_link_program() failed\n");
+#else
+          POCL_GOTO_ERROR_ON ((1), CL_LINK_PROGRAM_FAILURE,
+                              "clCompileProgram/clLinkProgram/clBuildProgram"
+                              " require a pocl built with LLVM\n");
+
+#endif
         }
       else
         {

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -765,84 +765,102 @@ struct _cl_sampler {
   cl_filter_mode      filter_mode;
 };
 
-#define POCL_UPDATE_EVENT_QUEUED(__event)                               \
-  do {                                                                  \
-    if ((__event) != NULL && (*(__event)) != NULL)                      \
-      {                                                                 \
-        cl_command_queue __cq = (*(__event))->queue;                    \
-        if ((__cq)->device->ops->update_event)                   \
-          (__cq)->device->ops->update_event((__cq)->device, (*__event), CL_QUEUED);    \
-        else {                                                          \
-          (*(__event))->status = CL_QUEUED;                             \
-          if (__cq && __cq->properties & CL_QUEUE_PROFILING_ENABLE)     \
-            (*(__event))->time_queue =                                  \
-              __cq->device->ops->get_timer_value(__cq->device->data);   \
-        }                                                               \
-        pocl_event_updated(*(__event), CL_QUEUED);                      \
-      }                                                                 \
-  } while (0)                                                           \
+#define POCL_UPDATE_EVENT_QUEUED(__event)                                     \
+  do                                                                          \
+    {                                                                         \
+      if ((__event) != NULL)                                                  \
+        {                                                                     \
+          cl_command_queue __cq = (__event)->queue;                           \
+          if ((__cq)->device->ops->update_event)                              \
+            (__cq)->device->ops->update_event ((__cq)->device, (__event),     \
+                                               CL_QUEUED);                    \
+          else                                                                \
+            {                                                                 \
+              (__event)->status = CL_QUEUED;                                  \
+              if (__cq && __cq->properties & CL_QUEUE_PROFILING_ENABLE)       \
+                (__event)->time_queue = __cq->device->ops->get_timer_value (  \
+                    __cq->device->data);                                      \
+            }                                                                 \
+          pocl_event_updated (__event, CL_QUEUED);                            \
+        }                                                                     \
+    }                                                                         \
+  while (0)
 
-#define POCL_UPDATE_EVENT_SUBMITTED(__event)                            \
-  do {                                                                  \
-    if ((__event) != NULL && (*(__event)) != NULL)                      \
-      {                                                                 \
-        assert((*(__event))->status == CL_QUEUED);                      \
-         cl_command_queue __cq = (*(__event))->queue;                    \
-        if ((__cq)->device->ops->update_event)                   \
-          (__cq)->device->ops->update_event((__cq)->device, (*(__event)), CL_SUBMITTED);    \
-        else {                                                          \
-          (*(__event))->status = CL_SUBMITTED;                          \
-          if (__cq && __cq->properties & CL_QUEUE_PROFILING_ENABLE)     \
-            (*(__event))->time_submit =                                 \
-              __cq->device->ops->get_timer_value(__cq->device->data);   \
-        }                                                               \
-        pocl_event_updated(*(__event), CL_SUBMITTED);                   \
-      }                                                                 \
-  } while (0)                                                           \
+#define POCL_UPDATE_EVENT_SUBMITTED(__event)                                  \
+  do                                                                          \
+    {                                                                         \
+      if ((__event) != NULL)                                                  \
+        {                                                                     \
+          assert ((__event)->status == CL_QUEUED);                            \
+          cl_command_queue __cq = (__event)->queue;                           \
+          if ((__cq)->device->ops->update_event)                              \
+            (__cq)->device->ops->update_event ((__cq)->device, (__event),     \
+                                               CL_SUBMITTED);                 \
+          else                                                                \
+            {                                                                 \
+              (__event)->status = CL_SUBMITTED;                               \
+              if (__cq && __cq->properties & CL_QUEUE_PROFILING_ENABLE)       \
+                (__event)->time_submit = __cq->device->ops->get_timer_value ( \
+                    __cq->device->data);                                      \
+            }                                                                 \
+          pocl_event_updated (__event, CL_SUBMITTED);                         \
+        }                                                                     \
+    }                                                                         \
+  while (0)
 
-#define POCL_UPDATE_EVENT_RUNNING(__event)                              \
-  do {                                                                  \
-    if (__event != NULL && (*(__event)) != NULL)                        \
-      {                                                                 \
-        assert((*(__event))->status == CL_SUBMITTED);                   \
-        cl_command_queue __cq = (*(__event))->queue;                    \
-        if ((__cq)->device->ops->update_event)                   \
-          (__cq)->device->ops->update_event((__cq)->device, (*(__event)), CL_RUNNING);    \
-        else {                                                          \
-          (*(__event))->status = CL_RUNNING;                            \
-          if (__cq && __cq->properties & CL_QUEUE_PROFILING_ENABLE)     \
-            (*(__event))->time_start =                                  \
-              __cq->device->ops->get_timer_value(__cq->device->data);   \
-        }                                                               \
-        pocl_event_updated(*(__event), CL_RUNNING);                     \
-      }                                                                 \
-  } while (0)                                                           \
+#define POCL_UPDATE_EVENT_RUNNING(__event)                                    \
+  do                                                                          \
+    {                                                                         \
+      if (__event != NULL)                                                    \
+        {                                                                     \
+          assert ((__event)->status == CL_SUBMITTED);                         \
+          cl_command_queue __cq = (__event)->queue;                           \
+          if ((__cq)->device->ops->update_event)                              \
+            (__cq)->device->ops->update_event ((__cq)->device, (__event),     \
+                                               CL_RUNNING);                   \
+          else                                                                \
+            {                                                                 \
+              (__event)->status = CL_RUNNING;                                 \
+              if (__cq && __cq->properties & CL_QUEUE_PROFILING_ENABLE)       \
+                (__event)->time_start = __cq->device->ops->get_timer_value (  \
+                    __cq->device->data);                                      \
+            }                                                                 \
+          pocl_event_updated (__event, CL_RUNNING);                           \
+        }                                                                     \
+    }                                                                         \
+  while (0)
 
-#define POCL_UPDATE_EVENT_COMPLETE(__event)                             \
-  do {                                                                  \
-    if ((__event) != NULL && (*(__event)) != NULL)                      \
-      {                                                                 \
-        assert((*(__event))->status == CL_RUNNING);                     \
-        cl_command_queue __cq = (*(__event))->queue;                    \
-        assert((*(__event))->status == CL_RUNNING);                     \
-        if ((__cq)->device->ops->update_event)                          \
-          (__cq)->device->ops->update_event((__cq)->device, (*(__event)), CL_COMPLETE); \
-        else{                                                           \
-          pocl_mem_objs_cleanup ((*__event));                           \
-          POCL_LOCK_OBJ (*(__event));                                   \
-          (*(__event))->status = CL_COMPLETE;                           \
-          if ((__cq)->properties & CL_QUEUE_PROFILING_ENABLE){          \
-            (*(__event))->time_end =                                    \
-            (__cq)->device->ops->get_timer_value((__cq)->device->data); \
-          }                                                             \
-          (__cq)->device->ops->broadcast(*(__event));                   \
-          POCL_UNLOCK_OBJ (*(__event));                                 \
-          pocl_update_command_queue(*(__event));                        \
-        }                                                               \
-        pocl_event_updated(*(__event), CL_COMPLETE);                    \
-        POname(clReleaseEvent) (*(__event));                            \
-      }                                                                 \
-  } while (0)                                                           \
+#define POCL_UPDATE_EVENT_COMPLETE(__event)                                   \
+  do                                                                          \
+    {                                                                         \
+      if ((__event) != NULL)                                                  \
+        {                                                                     \
+          assert ((__event)->status == CL_RUNNING);                           \
+          cl_command_queue __cq = (__event)->queue;                           \
+          assert ((__event)->status == CL_RUNNING);                           \
+          if ((__cq)->device->ops->update_event)                              \
+            (__cq)->device->ops->update_event ((__cq)->device, (__event),     \
+                                               CL_COMPLETE);                  \
+          else                                                                \
+            {                                                                 \
+              pocl_mem_objs_cleanup (__event);                                \
+              POCL_LOCK_OBJ (__event);                                        \
+              (__event)->status = CL_COMPLETE;                                \
+              if ((__cq)->properties & CL_QUEUE_PROFILING_ENABLE)             \
+                {                                                             \
+                  (__event)->time_end                                         \
+                      = (__cq)->device->ops->get_timer_value (                \
+                          (__cq)->device->data);                              \
+                }                                                             \
+              (__cq)->device->ops->broadcast (__event);                       \
+              POCL_UNLOCK_OBJ (__event);                                      \
+              pocl_update_command_queue (__event);                            \
+            }                                                                 \
+          pocl_event_updated (__event, CL_COMPLETE);                          \
+          POname (clReleaseEvent) (__event);                                  \
+        }                                                                     \
+    }                                                                         \
+  while (0)
 
 #ifndef __cplusplus
 

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -114,6 +114,13 @@ typedef pthread_mutex_t pocl_lock_t;
       POCL_INIT_OBJECT_NO_ICD(__OBJ__)
 #endif
 
+#define POCL_DESTROY_OBJECT(__OBJ__)                                          \
+  do                                                                          \
+    {                                                                         \
+      POCL_DESTROY_LOCK ((__OBJ__)->pocl_lock);                               \
+    }                                                                         \
+  while (0);
+
 /* Declares the generic pocl object attributes inside a struct. */
 #define POCL_OBJECT \
   pocl_lock_t pocl_lock; \

--- a/lib/CL/pocl_debug.h
+++ b/lib/CL/pocl_debug.h
@@ -207,8 +207,10 @@ extern int pocl_aborting;
     #define POCL_MSG_PRINT_GENERAL2(errcode, ...) POCL_MSG_PRINT_INFO_F(GENERAL, errcode, __VA_ARGS__)
     #define POCL_MSG_PRINT_GENERAL(...) POCL_MSG_PRINT_INFO_F(GENERAL, "", __VA_ARGS__)
 
-    #define POCL_DEBUG_EVENT_TIME(eventp, msg) \
-        pocl_debug_print_duration(__func__, __LINE__, "Event " msg, (uint64_t)((*eventp)->time_end - (*eventp)->time_start))
+#define POCL_DEBUG_EVENT_TIME(eventp, msg)                                    \
+  pocl_debug_print_duration (                                                 \
+      __func__, __LINE__, "Event " msg,                                       \
+      (uint64_t) ((eventp)->time_end - (eventp)->time_start))
 
 #else
 

--- a/lib/CL/pocl_llvm.h
+++ b/lib/CL/pocl_llvm.h
@@ -75,10 +75,16 @@ int pocl_llvm_generate_workgroup_function(cl_device_id device,
                                           cl_kernel kernel, size_t local_x,
                                           size_t local_y, size_t local_z);
 
+int pocl_llvm_generate_workgroup_function_nowrite(
+    cl_device_id device, cl_kernel kernel, size_t local_x, size_t local_y,
+    size_t local_z, void **output);
 /**
  * Free the LLVM IR of a program for a given device
  */
 void pocl_free_llvm_irs(cl_program program, int device_i);
+
+/* calls delete on the module. */
+void pocl_destroy_llvm_module(void *modp);
 
 /**
  * Update the program->binaries[] representation of the kernels
@@ -109,10 +115,8 @@ unsigned pocl_llvm_get_kernel_names( cl_program program, char **knames, unsigned
 /** Compile the kernel in infile from LLVM bitcode to native object file for
  * device, into outfile.
  */
-int pocl_llvm_codegen ( cl_kernel kernel,
-                        cl_device_id device,
-                        const char *infile,
-                        const char *outfile);
+int pocl_llvm_codegen(cl_kernel kernel, cl_device_id device, void *modp,
+                      char **output, size_t *output_size);
 
 /* Parse program file and populate program's llvm_irs */
 int

--- a/lib/CL/pocl_llvm.h
+++ b/lib/CL/pocl_llvm.h
@@ -35,6 +35,8 @@ extern "C" {
 
 /* Returns the cpu name as reported by LLVM. */
 char* get_cpu_name();
+/* Returns if the cpu supports FMA instruction (uses LLVM). */
+int cpu_has_fma();
 
 /* Compiles an .cl file into LLVM IR.
  */

--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -308,6 +308,7 @@ int pocl_llvm_build_program(cl_program program,
 
   llvm::StringRef extensions(device->extensions);
 
+  std::string cl_ext;
   if (extensions.size() > 0) {
     size_t e_start = 0, e_end = 0;
     while (e_end < std::string::npos) {
@@ -316,11 +317,18 @@ int pocl_llvm_build_program(cl_program program,
       e_start = e_end + 1;
       ss << "-D" << tok.str() << " ";
 #ifndef LLVM_OLDER_THAN_4_0
-      ss << "-cl-ext=" << tok.str() << " ";
+      cl_ext += "+";
+      cl_ext += tok.str();
+      cl_ext += ",";
 #endif
     }
   }
-
+#ifndef LLVM_OLDER_THAN_4_0
+  if (!cl_ext.empty()) {
+    cl_ext.back() = ' '; // replace last "," with space
+    ss << "-cl-ext=-all," << cl_ext;
+  }
+#endif
   /* temp dir takes preference */
   if (num_input_headers > 0)
     ss << "-I" << temp_include_dir << " ";

--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -398,7 +398,7 @@ int pocl_llvm_build_program(cl_program program,
   if (device->llvm_cpu != NULL)
     ss << "-target-cpu " << device->llvm_cpu << " ";
 
-  POCL_MSG_PRINT_INFO("all build options: %s\n", ss.str().c_str());
+  POCL_MSG_PRINT_LLVM("all build options: %s\n", ss.str().c_str());
 
   std::istream_iterator<std::string> begin(ss);
   std::istream_iterator<std::string> end;
@@ -577,7 +577,7 @@ int pocl_llvm_build_program(cl_program program,
   write_lock = pocl_cache_acquire_writer_lock_i(program, device_i);
   assert(write_lock);
 
-  POCL_MSG_PRINT_INFO("Writing program.bc to %s.\n", program_bc_path);
+  POCL_MSG_PRINT_LLVM("Writing program.bc to %s.\n", program_bc_path);
 
   /* Always retain program.bc. Its required in clBuildProgram */
   error = pocl_write_module(*mod, program_bc_path, 0);
@@ -674,7 +674,7 @@ int pocl_llvm_link_program(cl_program program,
   write_lock = pocl_cache_acquire_writer_lock_i(program, device_i);
   assert(write_lock);
 
-  POCL_MSG_PRINT_INFO("Writing program.bc to %s.\n", program_bc_path);
+  POCL_MSG_PRINT_LLVM("Writing program.bc to %s.\n", program_bc_path);
 
   /* Always retain program.bc. Its required in clBuildProgram */
   error = pocl_write_module(linked_module, program_bc_path, 0);
@@ -1112,7 +1112,7 @@ int pocl_llvm_get_kernel_metadata(cl_program program,
     std::string funcName = "";
     funcName = KernelFunction->getName().str();
     if (pocl::isAutomaticLocal(funcName, *i)) {
-      POCL_MSG_PRINT_INFO("Automatic local detected: %s\n",
+      POCL_MSG_PRINT_LLVM("Automatic local detected: %s\n",
                           i->getName().str().c_str());
       locals.push_back(&*i);
     }
@@ -1838,7 +1838,7 @@ kernel_library
 
   if (pocl_exists(kernellib.c_str()))
     {
-      POCL_MSG_PRINT_INFO("Using %s as the built-in lib.\n", kernellib.c_str());
+      POCL_MSG_PRINT_LLVM("Using %s as the built-in lib.\n", kernellib.c_str());
       lib = ParseIRFile(kernellib.c_str(), Err, *GlobalContext());
     }
   else
@@ -2162,7 +2162,7 @@ pocl_llvm_codegen(cl_kernel kernel,
 
     PM.run(*input);
     std::string o = sos.str(); // flush
-    POCL_MSG_PRINT_INFO("Writing code gen output to %s.\n", outfilename);
+    POCL_MSG_PRINT_LLVM("Writing code gen output to %s.\n", outfilename);
 
     return pocl_write_file(outfilename, o.c_str(), o.size(), 0, 0);
 }

--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -1294,6 +1294,13 @@ char* get_cpu_name() {
   return cpu_name;
 }
 
+int cpu_has_fma() {
+  StringMap<bool> features;
+  bool res = llvm::sys::getHostCPUFeatures(features);
+  assert(res);
+  return ((features["fma"] || features["fma4"]) ? 1 : 0);
+}
+
 /* helpers copied from LLVM opt START */
 
 /* FIXME: these options should come from the cl_device, and

--- a/lib/CL/pocl_llvm_api.cc
+++ b/lib/CL/pocl_llvm_api.cc
@@ -1587,7 +1587,9 @@ kernel_compiler_passes(cl_device_id device, llvm::Module *input,
       POCL_MSG_PRINT_LLVM(
           "Module references images, using flatten-globals-only\n");
       passes.push_back("flatten-globals");
+#ifndef LLVM_3_9
       passes.push_back("inline");
+#endif
     } else {
       passes.push_back("flatten-inline-all");
     }

--- a/lib/CL/pocl_mem_management.c
+++ b/lib/CL/pocl_mem_management.c
@@ -69,6 +69,7 @@ cl_event pocl_mem_manager_new_event ()
     {
       LL_DELETE (mm->event_list, ev);
       POCL_UNLOCK (mm->event_lock);
+      POCL_INIT_OBJECT (ev); /* reinit the pocl_lock mutex */
       return ev;
     }
   POCL_UNLOCK (mm->event_lock);

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -143,7 +143,9 @@ void
 pocl_set_default_rm ()
 {
 #if defined(__x86_64__) && defined(__GNUC__) && defined(_MM_ROUND_NEAREST)
-  _MM_SET_ROUNDING_MODE (_MM_ROUND_NEAREST);
+  unsigned rm = _MM_GET_ROUNDING_MODE ();
+  if (rm != _MM_ROUND_NEAREST)
+    _MM_SET_ROUNDING_MODE (_MM_ROUND_NEAREST);
 #endif
 }
 

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -539,7 +539,7 @@ void pocl_command_enqueue (cl_command_queue command_queue,
   command_queue->last_event.event_id = node->event->id;
   POCL_UNLOCK_OBJ (command_queue);
 
-  POCL_UPDATE_EVENT_QUEUED (&node->event);
+  POCL_UPDATE_EVENT_QUEUED (node->event);
 
   command_queue->device->ops->submit(node, command_queue);
 #ifdef POCL_DEBUG_BUILD

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -73,6 +73,12 @@ void *pocl_aligned_malloc(size_t alignment, size_t size);
 void pocl_aligned_free(void* ptr);
 #endif
 
+/* locks / unlocks two events in order of their event-id.
+ * This avoids any potential deadlocks of threads should
+ * they try to lock events in opposite order. */
+void pocl_lock_events_inorder (cl_event ev1, cl_event ev2);
+void pocl_unlock_events_inorder (cl_event ev1, cl_event ev2);
+
 /* Function for creating events */
 cl_int pocl_create_event (cl_event *event, cl_command_queue command_queue,
                           cl_command_type command_type, int num_buffers,

--- a/lib/kernel/CMakeLists.txt
+++ b/lib/kernel/CMakeLists.txt
@@ -82,6 +82,7 @@ get_global_id.c
 get_global_offset.c
 get_global_size.c
 get_group_id.c
+get_image_array_size.cl
 get_image_channel_data_type.cl
 get_image_channel_order.cl
 get_image_depth.cl
@@ -208,6 +209,7 @@ get_global_id.c
 get_global_offset.c
 get_global_size.c
 get_group_id.c
+get_image_array_size.cl
 get_image_channel_data_type.cl
 get_image_channel_order.cl
 get_image_depth.cl

--- a/lib/kernel/get_image_array_size.cl
+++ b/lib/kernel/get_image_array_size.cl
@@ -1,0 +1,50 @@
+/* OpenCL built-in library: get_image_array_size()
+
+   Copyright (c) 2017 Michal Babej / Tampere University of Technology
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+#include "templates.h"
+
+#ifndef LLVM_OLDER_THAN_3_8
+
+#define IMPLEMENT_GET_IMAGE_ARRAY_SIZE(__IMGTYPE__)             \
+size_t _CL_OVERLOADABLE get_image_array_size(__IMGTYPE__ image) \
+{                                                               \
+  global dev_image_t* img =                                     \
+    __builtin_astype (image, global dev_image_t*);              \
+  return (size_t)(img->_image_array_size);                      \
+}
+
+IMPLEMENT_GET_IMAGE_ARRAY_SIZE (IMG_RO_AQ image1d_array_t)
+IMPLEMENT_GET_IMAGE_ARRAY_SIZE (IMG_RO_AQ image2d_array_t)
+
+#ifdef CLANG_HAS_IMAGE_AS
+IMPLEMENT_GET_IMAGE_ARRAY_SIZE (IMG_WO_AQ image1d_array_t)
+IMPLEMENT_GET_IMAGE_ARRAY_SIZE (IMG_WO_AQ image2d_array_t)
+#endif
+
+#ifdef CLANG_HAS_RW_IMAGES
+IMPLEMENT_GET_IMAGE_ARRAY_SIZE (IMG_RW_AQ image1d_array_t)
+IMPLEMENT_GET_IMAGE_ARRAY_SIZE (IMG_RW_AQ image2d_array_t)
+#endif
+
+
+#endif

--- a/lib/kernel/read_image.cl
+++ b/lib/kernel/read_image.cl
@@ -287,7 +287,7 @@ get_image_array_offset2 (global dev_image_t *img, int4 uvw_after_rint,
 
 /* RET: (int4) (img.x{,y,z}, array_size, 0 {,0 ...} ) */
 static int4
-get_image_array_size (global dev_image_t *img)
+pocl_get_image_array_size (global dev_image_t *img)
 {
   int4 imgsize = (int4) (img->_width, img->_height, img->_depth, 0);
   if (img->_image_array_size > 0)
@@ -1204,7 +1204,7 @@ nonrepeat_filter (global dev_image_t *img, float4 orig_coord,
   float4 coord = orig_coord;
   if (samp & CLK_NORMALIZED_COORDS_TRUE)
     {
-      float4 imgsize = convert_float4 (get_image_array_size (img));
+      float4 imgsize = convert_float4 (pocl_get_image_array_size (img));
       coord *= imgsize;
     }
 
@@ -1285,7 +1285,7 @@ repeat_filter (global dev_image_t *img, float4 coord, dev_sampler_t samp)
            ijk = ijk – whd
          ... same for 3 coords
       */
-      int4 maxcoord = get_image_array_size (img);
+      int4 maxcoord = pocl_get_image_array_size (img);
       float4 whd = convert_float4 (maxcoord);
       float4 uvw = (coord - floor (coord)) * whd;
       int4 ijk = convert_int4 (floor (uvw));
@@ -1380,7 +1380,7 @@ mirrored_repeat_filter (global dev_image_t *img, float4 coord,
 
       float4 ss = (float4) (2.0f) * rint ((float4) (0.5f) * coord);
       ss = fabs (coord - ss);
-      int4 maxcoord = get_image_array_size (img);
+      int4 maxcoord = pocl_get_image_array_size (img);
       float4 whd = convert_float4 (maxcoord);
       float4 uvw = ss * whd;
       int4 ijk = convert_int4 (floor (uvw));

--- a/tests/kernel/CMakeLists.txt
+++ b/tests/kernel/CMakeLists.txt
@@ -77,7 +77,16 @@ set_tests_properties( "kernel/test_as_type" "kernel/test_bitselect"
     FAIL_REGULAR_EXPRESSION "FAIL"
     PASS_REGULAR_EXPRESSION "\nOK\n"
     PROCESSORS 1
-    DEPENDS "pocl_version_check")
+    DEPENDS "pocl_version_check"
+    LABELS "kernel")
+
+# convert_type_{4,8,16} on some machines takes >1 hour,
+# so only add convert_type_1/2 to internal tests to keep them reasonably fast.
+
+set_tests_properties( "kernel/test_as_type" "kernel/test_bitselect"
+  "kernel/test_convert_type_1" "kernel/test_convert_type_2"
+  PROPERTIES
+    LABELS "internal;kernel")
 
 set_tests_properties("kernel/test_hadd_loops"
   PROPERTIES ENVIRONMENT "POCL_WORK_GROUP_METHOD=loops")

--- a/tests/runtime/test_clCreateSubDevices.c
+++ b/tests/runtime/test_clCreateSubDevices.c
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
     *eqdev = alldevs + 1,
     *countdev = alldevs + 3;
   cl_uint max_cus, max_subs;
-  cl_uint i;
+  cl_uint i, j;
 
   cl_int err = poclu_get_any_device(&ctx, &rootdev, &q);
   CHECK_OPENCL_ERROR_IN("poclu_get_any_device");
@@ -163,15 +163,16 @@ int main(int argc, char **argv)
     dev_pt_size, dev_pt, NULL);
   CHECK_OPENCL_ERROR_IN("CL_DEVICE_PARTITION_PROPERTIES");
 
-  dev_pt_size /= sizeof(*dev_pt); // number of partition types
+  j = dev_pt_size / sizeof (*dev_pt); // number of partition types
 
   // check that partition types EQUALLY and BY_COUNTS are supported
   int found = 0;
-  for (i = 0; i < dev_pt_size; ++i) {
-    if (dev_pt[i] == CL_DEVICE_PARTITION_EQUALLY ||
-        dev_pt[i] == CL_DEVICE_PARTITION_BY_COUNTS)
-      ++found;
-  }
+  for (i = 0; i < j; ++i)
+    {
+      if (dev_pt[i] == CL_DEVICE_PARTITION_EQUALLY
+          || dev_pt[i] == CL_DEVICE_PARTITION_BY_COUNTS)
+        ++found;
+    }
 
   TEST_ASSERT(found == 2);
 
@@ -371,6 +372,8 @@ int main(int argc, char **argv)
   CHECK_OPENCL_ERROR_IN("clCreateContext");
   TEST_ASSERT( test_context(ctx, prog_src_two, -1, NUMDEVS - 1, alldevs + 1)
     == CL_SUCCESS );
+
+  printf ("OK\n");
 
   return 0;
 }


### PR DESCRIPTION
* properly handle -cl-ext for LLVM 4+
* implement get_image_array_size
* cmake: disable tests that take too long on CPU, enable some kernel tests (convert_type) that should be enabled
* subdevices now pass conformance tests
* partially revert the flatten-only-globals pass since it was causing significant performance regressions. We still need the globals-only for images, so detect image reads/writes and don't flatten programs with those.
* refactor pocl llvm codegen / gen wg function. The way they were written, they were holding a write lock during entire gen_wg()+codegen(), which was causing some heavily threaded tests to timeout on acquire-lock. I've changed the code to build everything in memory, and write out all files just before linking.
* some performance tuning (focused on better scaling for multicore machines).

Some benchmarks on AMD SDK 3.0, relative to pocl 0.14 _ceteris partybus_ (8C/16T cpu, llvm 4.0, kernel 4.11) (+improvement, -regression):

BitonicSort +116%
FastWalshTransform -2%
FloydWarshall +350% kernel, +136% total
MatrixTranspose +1%
MatrixMultiplication +11%
NBody +42%
RadixSort +140%
SimpleConvolution Separable Filter +44%

CPU power management is too clever these days, even with performance governor, so results might be few % off. Worst regression seems to be FastWalshTransform (-2%) so far, but i haven't run the full AMD SDK tests yet.
