### PR TITLE
fix issue #486 (Release MemObject on multi-devices platform)

### DIFF
--- a/lib/CL/clCreateBuffer.c
+++ b/lib/CL/clCreateBuffer.c
@@ -167,8 +167,6 @@ POname(clCreateBuffer)(cl_context   context,
       if (context->svm_allocdev == context->devices[i])
         continue;
 
-      if (i > 0)
-        POname(clRetainMemObject) (mem);
       device = context->devices[i];
       assert (device->ops->alloc_mem_obj != NULL);
       if (device->ops->alloc_mem_obj (device, mem, host_ptr) != CL_SUCCESS)


### PR DESCRIPTION
When we create a buffer on a multi-devices platform, we do not want
any clRetainMemObject on it so that only one clReleaseMemObject is
needed to free the buffer.