### PR TITLE
[CMake] Use LLVM_LIBDIR to construct CLANG_RESOURCE_DIR

### DIFF
--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -712,7 +712,7 @@ else()
 endif()
 
 if(LLVM_OLDER_THAN_5_0)
-  set(CLANG_RESOURCE_DIR "${LLVM_PREFIX}/lib/clang/${LLVM_VERSION_FULL}")
+  set(CLANG_RESOURCE_DIR "${LLVM_LIBDIR}/clang/${LLVM_VERSION_FULL}")
 else()
   execute_process(COMMAND "${CLANG}" "--print-resource-dir" OUTPUT_VARIABLE CLANG_RESOURCE_DIR)
   string(STRIP "${CLANG_RESOURCE_DIR}" CLANG_RESOURCE_DIR)


### PR DESCRIPTION
CLANG_RESOURCE_DIR did not account for LLVM_LIBDIR_SUFFIX.
LLVM_LIBDIR is derived from llvm-config which takes care of this.