### PR TITLE
fix issue #537 (pocl_binaries are not functionnal)

### DIFF
--- a/lib/CL/clCreateKernel.c
+++ b/lib/CL/clCreateKernel.c
@@ -83,10 +83,10 @@ POname(clCreateKernel)(cl_program program,
 
   for (device_i = 0; device_i < program->num_devices; ++device_i)
     {
+#ifdef OCS_AVAILABLE
       if (program->binaries[device_i] &&
           pocl_cache_device_cachedir_exists(program, device_i))
         {
-#ifdef OCS_AVAILABLE
           pocl_llvm_get_kernel_metadata (program, kernel, device_i,
                                          kernel_name, &errcode);
           cl_device_id device = program->devices[device_i];
@@ -118,12 +118,14 @@ POname(clCreateKernel)(cl_program program,
 
               device->ops->compile_kernel (&cmd, kernel, device);
             }
-#endif
         }
       /* If the program was created with a pocl binary, we won't be able to
          get the metadata for the cl_kernel from an IR file, so we call pocl
          binary function to initialize the cl_kernel data */
       else if (program->pocl_binaries[device_i])
+#else
+      if (program->pocl_binaries[device_i])
+#endif
         {
           errcode
             = pocl_binary_get_kernel_metadata (program->pocl_binaries[device_i],

--- a/lib/CL/pocl_binary.c
+++ b/lib/CL/pocl_binary.c
@@ -87,9 +87,9 @@ typedef struct pocl_binary_kernel_s
   /* kernel_name string */
   char *kernel_name;
 
-  // number of kernel arguments
+  /* number of kernel arguments */
   uint32_t num_args;
-  // number of kernel local variables
+  /* number of kernel local variables */
   uint32_t num_locals;
 
   /* arguments and argument metadata. Note that not everything is stored
@@ -292,12 +292,12 @@ pocl_binary_get_kernel_names(unsigned char *binary,
   unsigned char *orig_buffer;
   unsigned i, len;
 
-  // skip real path of program.bc
+  /* skip real path of program.bc */
   BUFFER_READ(len, uint32_t);
   assert (len > 0);
   buffer += len;
 
-  // skip content of program.bc
+  /* skip content of program.bc */
   BUFFER_READ(len, uint32_t);
   assert (len > 0);
   buffer += len;
@@ -306,7 +306,7 @@ pocl_binary_get_kernel_names(unsigned char *binary,
   {
     orig_buffer = buffer;
     BUFFER_READ(struct_size, uint64_t);
-    // skip binaries_size & arginfo_size
+    /* skip binaries_size & arginfo_size */
     buffer += sizeof(uint64_t) + sizeof(uint32_t);
     BUFFER_READ_STR2(kernel_names[i], len);
     kernel_names[i][len] = 0;
@@ -714,12 +714,12 @@ pocl_binary_get_kernel_metadata (unsigned char *binary, const char *kernel_name,
                         "for this device.\n");
 
   size_t len;
-  // skip real path of program.bc
+  /* skip real path of program.bc */
   BUFFER_READ(len, uint32_t);
   assert (len > 0);
   buffer += len;
 
-  // skip content of program.bc
+  /* skip content of program.bc */
   BUFFER_READ(len, uint32_t);
   assert (len > 0);
   buffer += len;

--- a/lib/CL/pocl_binary.c
+++ b/lib/CL/pocl_binary.c
@@ -291,6 +291,17 @@ pocl_binary_get_kernel_names(unsigned char *binary,
 
   unsigned char *orig_buffer;
   unsigned i, len;
+
+  // skip real path of program.bc
+  BUFFER_READ(len, uint32_t);
+  assert (len > 0);
+  buffer += len;
+
+  // skip content of program.bc
+  BUFFER_READ(len, uint32_t);
+  assert (len > 0);
+  buffer += len;
+
   for (i=0; i < num_kernels; i++)
   {
     orig_buffer = buffer;
@@ -701,6 +712,17 @@ pocl_binary_get_kernel_metadata (unsigned char *binary, const char *kernel_name,
                         CL_INVALID_PROGRAM,
                         "Deserialized a binary, but it doesn't seem to be "
                         "for this device.\n");
+
+  size_t len;
+  // skip real path of program.bc
+  BUFFER_READ(len, uint32_t);
+  assert (len > 0);
+  buffer += len;
+
+  // skip content of program.bc
+  BUFFER_READ(len, uint32_t);
+  assert (len > 0);
+  buffer += len;
 
   unsigned j;
   assert (b.num_kernels > 0);


### PR DESCRIPTION
We need to skip program.bc in a pocl_binaries when we want to have
information on kernels from the start of a pocl_binaries.
When running POCL offline, we do not need to take care of
program->binaries (even if they are present) as we do not have a
compiler available.