### PR TITLE
User events handling

### DIFF
--- a/lib/CL/clCreateUserEvent.c
+++ b/lib/CL/clCreateUserEvent.c
@@ -20,6 +20,11 @@ POname(clCreateUserEvent)(cl_context     context ,
       event->pocl_refcount = 1;
       event->status = CL_SUBMITTED;
       event->context = context;
+      pocl_user_event_data *p = malloc (sizeof (pocl_user_event_data));
+      assert (p);
+      pthread_cond_init (&p->wakeup_cond, NULL);
+      pthread_mutex_init (&p->lock, NULL);
+      event->data = p;
     }
 
   if (errcode_ret)

--- a/lib/CL/clReleaseEvent.c
+++ b/lib/CL/clReleaseEvent.c
@@ -36,6 +36,14 @@ POname(clReleaseEvent)(cl_event event) CL_API_SUFFIX__VERSION_1_0
   
   if (new_refcount == 0)
     {
+      event_callback_item *cb_ptr = NULL;
+      event_callback_item *next = NULL;
+      for (cb_ptr = event->callback_list; cb_ptr; cb_ptr = next)
+        {
+          next = cb_ptr->next;
+          POCL_MEM_FREE (cb_ptr);
+        }
+
       POCL_MSG_PRINT_REFCOUNTS ("Free event %d\n", event->id);
       if (event->command_type != CL_COMMAND_USER &&
           event->queue->device->ops->free_event_data)

--- a/lib/CL/clReleaseEvent.c
+++ b/lib/CL/clReleaseEvent.c
@@ -44,6 +44,13 @@ POname(clReleaseEvent)(cl_event event) CL_API_SUFFIX__VERSION_1_0
           POCL_MEM_FREE (cb_ptr);
         }
 
+      if (event->command_type == CL_COMMAND_USER)
+        {
+          pocl_user_event_data *p = event->data;
+          pthread_cond_destroy (&p->wakeup_cond);
+          pthread_mutex_destroy (&p->lock);
+        }
+
       POCL_MSG_PRINT_REFCOUNTS ("Free event %d\n", event->id);
       if (event->command_type != CL_COMMAND_USER &&
           event->queue->device->ops->free_event_data)

--- a/lib/CL/clSetUserEventStatus.c
+++ b/lib/CL/clSetUserEventStatus.c
@@ -29,6 +29,12 @@ CL_API_SUFFIX__VERSION_1_1
       pocl_broadcast (event);
       pocl_event_updated (event, execution_status);
     }
+
+  pocl_user_event_data *p = event->data;
+  POCL_LOCK (p->lock);
+  pthread_cond_broadcast (&p->wakeup_cond);
+  POCL_UNLOCK (p->lock);
+
   return CL_SUCCESS;
 
 ERROR:

--- a/lib/CL/clSetUserEventStatus.c
+++ b/lib/CL/clSetUserEventStatus.c
@@ -24,6 +24,8 @@ CL_API_SUFFIX__VERSION_1_1
 
   if (execution_status <= CL_COMPLETE)
     {
+      POCL_MSG_PRINT_EVENTS ("User event %u completed with status: %i\n",
+                             event->id, execution_status);
       pocl_broadcast (event);
       pocl_event_updated (event, execution_status);
     }

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -917,9 +917,12 @@ pocl_basic_submit (_cl_command_node *node, cl_command_queue cq)
   
   node->device->ops->compile_kernel (node, NULL, NULL);
 
+  POCL_LOCK_OBJ (node->event);
   node->ready = 1;
   POCL_LOCK (d->cq_lock);
   pocl_command_push(node, &d->ready_list, &d->command_list);
+  POCL_UNLOCK_OBJ (node->event);
+
   basic_command_scheduler (d);
   POCL_UNLOCK (d->cq_lock);
 

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -1295,6 +1295,9 @@ pocl_cuda_notify (cl_device_id device, cl_event event, cl_event finished)
   if (finished->queue && finished->queue->device->ops == device->ops)
     return;
 
+  if (event->status == CL_QUEUED)
+    return;
+
   pocl_cuda_event_data_t *event_data = (pocl_cuda_event_data_t *)event->data;
 
   assert (event_data);

--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -887,12 +887,14 @@ pocl_tce_submit (_cl_command_node *node, cl_command_queue /*cq*/)
 {
   TCEDevice *d = (TCEDevice*)node->device->data;
 
+  POCL_LOCK_OBJ(node->event);
   node->ready = 1;
-
-  POCL_LOCK (d->cq_lock);
+  POCL_LOCK(d->cq_lock);
   pocl_command_push(node, &d->ready_list, &d->command_list);
+  POCL_UNLOCK_OBJ(node->event);
+
   tce_command_scheduler (d);
-  POCL_UNLOCK (d->cq_lock);
+  POCL_UNLOCK(d->cq_lock);
 
   return;
 }

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -756,6 +756,11 @@ struct _cl_event {
   _cl_event * volatile prev;
 };
 
+typedef struct _pocl_user_event_data
+{
+  pthread_cond_t wakeup_cond;
+  pthread_mutex_t lock;
+} pocl_user_event_data;
 
 typedef struct _cl_sampler cl_sampler_t;
 struct _cl_sampler {

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -879,6 +879,8 @@ struct _cl_sampler {
             {                                                                 \
               pocl_mem_objs_cleanup (__event);                                \
               POCL_LOCK_OBJ (__event);                                        \
+              if ((__event)->status > CL_COMPLETE)                            \
+                (__event)->status = CL_FAILED;                                \
               if ((__cq)->properties & CL_QUEUE_PROFILING_ENABLE)             \
                 {                                                             \
                   (__event)->time_end                                         \

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -567,6 +567,7 @@ pocl_command_push (_cl_command_node *node,
   POCL_LOCK_OBJ (node->event);
   if (pocl_command_is_ready(node->event))
     {
+      POCL_UPDATE_EVENT_SUBMITTED (node->event);
       CDL_PREPEND ((*ready_list), node);
     }
   else

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -564,7 +564,6 @@ pocl_command_push (_cl_command_node *node,
       CDL_PREPEND ((*pending_list), node);
       return;
     }
-  POCL_LOCK_OBJ (node->event);
   if (pocl_command_is_ready(node->event))
     {
       POCL_UPDATE_EVENT_SUBMITTED (node->event);
@@ -574,7 +573,6 @@ pocl_command_push (_cl_command_node *node,
     {
       CDL_PREPEND ((*pending_list), node);
     }
-  POCL_UNLOCK_OBJ (node->event);
 }
 
 int pocl_update_command_queue (cl_event event)


### PR DESCRIPTION
Already described at pocl-devel, so only shortly:

This PR attempts to fix the remaining issues with user events.
 
In particular, pocl_broadcast() now calls notify on events also in
CL_QUEUED state, and also calls notify on events which depend on failed
*user* events. Some problems remain:
 
1) i've updated all drivers except CUDA which seems to have its own way
of handling events.
 
2) after any event fails, the state is "implementation defined". Code in this PR just sets all dependent events to failed.
