### PR TITLE
Fix pthread fission (fixes #554)

### DIFF
--- a/lib/CL/clCreateSubDevices.c
+++ b/lib/CL/clCreateSubDevices.c
@@ -120,7 +120,10 @@ POname(clCreateSubDevices)(cl_device_id in_device,
        char what[1024];
        snprintf (what, 1024, "Device-reported partition type 0x%x",
                  (unsigned int)properties[0]);
-       POCL_ABORT_UNIMPLEMENTED (what);
+       POCL_GOTO_ERROR_ON (1, CL_INVALID_VALUE,
+                           "Device reported partition type 0x%x "
+                           "is not supported by Pocl\n",
+                           (unsigned int)properties[0]);
      }
 
    // num_devices must match count_devices if non-zero
@@ -130,6 +133,7 @@ POname(clCreateSubDevices)(cl_device_id in_device,
      // we allocate our own array of devices to simplify management
      new_devs = calloc(count_devices, sizeof(cl_device_id));
      POCL_GOTO_ERROR_COND((!new_devs), CL_OUT_OF_HOST_MEMORY);
+     unsigned sum = 0;
 
      for (i = 0; i < count_devices; ++i) {
        new_devs[i] = calloc(1, sizeof(struct _cl_device_id));
@@ -164,6 +168,12 @@ POname(clCreateSubDevices)(cl_device_id in_device,
        memcpy(new_devs[i]->partition_type, properties, num_props*sizeof(*properties));
        new_devs[i]->num_partition_types = num_props;
 
+       new_devs[i]->core_count = new_devs[i]->max_compute_units;
+       if (in_device->parent_device)
+          new_devs[i]->core_start = in_device->core_start + sum;
+       else
+          new_devs[i]->core_start = sum;
+       sum += new_devs[i]->core_count; 
      }
 
      memcpy(out_devices, new_devs, count_devices*sizeof(cl_device_id));

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -244,6 +244,8 @@ pocl_basic_init_device_infos(unsigned j, struct _cl_device_id* dev)
   dev->platform = 0;
 
   dev->parent_device = NULL;
+  dev->core_count = 0;
+  dev->core_start = 0;
   // basic does not support partitioning
   dev->max_sub_devices = 1;
   dev->num_partition_properties = 1;

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -187,8 +187,8 @@ int pthread_scheduler_get_work (thread_data *td, _cl_command_node **cmd_ptr)
       if ((subd = run_cmd->device->parent_device))
         {
           // subdevice
-          if (!((td->index >= subd->core_start)
-              || (td->index < (subd->core_start + subd->core_count))))
+          if (!((td->index >= run_cmd->device->core_start)
+              && (td->index < (run_cmd->device->core_start + run_cmd->device->core_count))))
               should_ignore = 1;
         }
       if (!should_ignore) {

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -448,7 +448,10 @@ struct _cl_device_id {
   char *short_name;
   char *long_name;
   char *cache_dir_name;
+  // for subdevices
   cl_device_id parent_device;
+  unsigned core_start;
+  unsigned core_count;
 
   const char *vendor;
   const char *driver_version;


### PR DESCRIPTION
Based on @franz's commit in #554, this actually fixes pthread fission such that only the specified number of cores are used:

>platform: pocl  num cores: 1    elapsed time: 9.107037e+04
platform: pocl  num cores: 2    elapsed time: 8.403694e+03
platform: pocl  num cores: 4    elapsed time: 3.124852e+03
platform: pocl  num cores: 8    elapsed time: 2.900043e+03
platform: pocl  num cores: 16   elapsed time: 2.692863e+03
platform: Intel num cores: 1    elapsed time: 2.157060e+03
platform: Intel num cores: 2    elapsed time: 2.378027e+03
platform: Intel num cores: 4    elapsed time: 9.416270e+02
platform: Intel num cores: 8    elapsed time: 6.949500e+02
platform: Intel num cores: 16   elapsed time: 6.701760e+02

I'm not convinced this is the _best_ solution -- on my system I still see very high CPU usage -- presumably due to many threads being stuck in the spin-lock (potentially accounting for the large performance jump between 1 -> 2 threads)?  I'm not entirely sure what the structure of the scheduler is, but I think it would be better to only wake up the required number of threads in `pocl_pthread_notify` ?