### PR TITLE
[CUDA] Add POCL_CUDA_VERIFY_MODULE environment variable

### DIFF
--- a/doc/sphinx/source/cuda.rst
+++ b/doc/sphinx/source/cuda.rst
@@ -44,7 +44,9 @@ Building pocl with CUDA support
 
 4) Configuration
 ~~~~~~~~~~~~~~~~
-  Use ``POCL_DEVICES=CUDA`` to select only CUDA devices.
+  Use ``POCL_DEVICES=CUDA`` to select only CUDA devices. If the system has more
+  than one GPU, specify the ``CUDA`` device multiple times (e.g.
+  ``POCL_DEVICES=CUDA,CUDA`` for two GPUs).
 
   The CUDA backend currently has a runtime dependency on the CUDA toolkit. If
   you receive errors regarding a failure to load ``libdevice``, you may need

--- a/doc/sphinx/source/cuda.rst
+++ b/doc/sphinx/source/cuda.rst
@@ -57,6 +57,9 @@ Building pocl with CUDA support
   target GPU architecture (e.g. ``POCL_CUDA_GPU_ARCH=sm_35``), which may be
   necessary in cases where LLVM doesn't yet support the architecture.
 
+  The ``POCL_CUDA_VERIFY_MODULE`` environment variable can be set to ``1`` to
+  verify that the LLVM module produced by the CUDA backend is well formed.
+
   The ``POCL_CUDA_DUMP_NVVM`` environment variable can be set to ``1`` to
   dump the LLVM IR that is fed into the NVPTX backend for debugging purposes
   (requires ``POCL_DEBUG=1``).

--- a/lib/CL/devices/cuda/pocl-ptx-gen.cc
+++ b/lib/CL/devices/cuda/pocl-ptx-gen.cc
@@ -99,12 +99,15 @@ int pocl_ptx_gen(const char *BitcodeFilename, const char *PTXFilename,
     POCL_MSG_PRINT_INFO("NVVM module:\n%s\n", ModuleString.c_str());
   }
 
-  // Verify module.
   std::string Error;
-  llvm::raw_string_ostream Errs(Error);
-  if (llvm::verifyModule(*Module->get(), &Errs)) {
-    POCL_MSG_ERR("\n%s\n", Error.c_str());
-    POCL_ABORT("[CUDA] ptx-gen: module verification failed\n");
+
+  // Verify module.
+  if (pocl_get_bool_option("POCL_CUDA_VERIFY_MODULE", 0)) {
+    llvm::raw_string_ostream Errs(Error);
+    if (llvm::verifyModule(*Module->get(), &Errs)) {
+      POCL_MSG_ERR("\n%s\n", Error.c_str());
+      POCL_ABORT("[CUDA] ptx-gen: module verification failed\n");
+    }
   }
 
   llvm::StringRef Triple =


### PR DESCRIPTION
Make module verifiation opt-in, since the pocl linker currently
generates invalid metadata.

This is a workaround for #525, to make the CUDA backend work with LLVM 5+.
