### PR TITLE
Fix num devices check

### DIFF
--- a/examples/EinsteinToolkit/EinsteinToolkit.c
+++ b/examples/EinsteinToolkit/EinsteinToolkit.c
@@ -533,7 +533,7 @@ void setup(const char* program_source1, const char* program_source2)
       cl_device_id subdevs[128];
       cl_uint retval;
       int err
-          = clCreateSubDevices (main_device_id, props, 2, subdevs, &retval);
+          = clCreateSubDevices (main_device_id, props, 128, subdevs, &retval);
       assert (err == CL_SUCCESS);
       device_id = subdevs[0];
     }

--- a/lib/CL/clCreateSubDevices.c
+++ b/lib/CL/clCreateSubDevices.c
@@ -122,8 +122,8 @@ POname(clCreateSubDevices)(cl_device_id in_device,
                            (unsigned int)properties[0]);
      }
 
-   // num_devices must match count_devices if non-zero
-   POCL_GOTO_ERROR_COND((num_devices && count_devices != num_devices), CL_INVALID_VALUE);
+   // num_devices must be greater than or equal to count_devices if non-zero
+   POCL_GOTO_ERROR_COND((num_devices && num_devices < count_devices), CL_INVALID_VALUE);
 
    if (out_devices) {
      // we allocate our own array of devices to simplify management


### PR DESCRIPTION
Migrated from #554 -- note, the segfault went away after a clean rebuild.  Instead I just had a failing test.

---

The relevant part of the spec is:

>CL_INVALID_VALUE if out_devices is not NULL and **num_devices is less than the number of sub-devices** created by the partition scheme.

instead, it was checking for exact equality (`clCreateSubDevices.c::126`).

On my 40 core server, this manifested as an error in the `EinsteinToolkit_subDev` test, as it would split `40 / 2 -> 20 != 2` passed in `clCreateSubDevices (main_device_id, props, 2, subdevs, &retval);`

Instead that should be the size of the full sub device array (128).

