### PR TITLE
tests/kernel: test_shuffle_* pass on arm64

### DIFF
--- a/tests/kernel/CMakeLists.txt
+++ b/tests/kernel/CMakeLists.txt
@@ -208,16 +208,6 @@ set_tests_properties("kernel/test_shuffle_char" "kernel/test_shuffle_short"
     DEPENDS "pocl_version_check"
     LABELS "internal;kernel")
 
-# interestingly, long/ulong/double do not fail
-if(ARM64)
-  set_tests_properties("kernel/test_shuffle_char"
-    "kernel/test_shuffle_short" "kernel/test_shuffle_ushort"
-    "kernel/test_shuffle_uint" "kernel/test_shuffle_int"
-    "kernel/test_shuffle_float" ${HALF_TEST}
-  PROPERTIES
-    WILL_FAIL 1)
-endif()
-
 ######################################################################
 
 


### PR DESCRIPTION
The test shuffle_* tests pass on arm64 but fail the build as they are
expected to fail. Fix this by dropping the hunk marking the tests as
failing.

Fixes #610