### PR TITLE
[WIP] Clang/LLVM 7.0 ToT

### DIFF
--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -36,6 +36,7 @@ else()
   # search for any version
   find_program(LLVM_CONFIG
     NAMES "llvm-config"
+      "llvm-config-mp-7.0" "llvm-config-7.0" "llvm-config70"
       "llvm-config-mp-6.0" "llvm-config-6.0" "llvm-config60"
       "llvm-config-mp-5.0" "llvm-config-5.0" "llvm-config50"
       "llvm-config-mp-4.0" "llvm-config-4.0" "llvm-config40"
@@ -175,18 +176,25 @@ if(LLVM_VERSION MATCHES "3[.]([0-9]+)")
   set(LLVM_OLDER_THAN_4_0 1)
   set(LLVM_OLDER_THAN_5_0 1)
   set(LLVM_OLDER_THAN_6_0 1)
+  set(LLVM_OLDER_THAN_7_0 1)
 elseif(LLVM_VERSION MATCHES "4[.]0")
   set(LLVM_MAJOR 4)
   set(LLVM_4_0 1)
   set(LLVM_OLDER_THAN_5_0 1)
   set(LLVM_OLDER_THAN_6_0 1)
+  set(LLVM_OLDER_THAN_7_0 1)
 elseif(LLVM_VERSION MATCHES "5[.]0")
   set(LLVM_MAJOR 5)
-  set(LLVM_OLDER_THAN_6_0 1)
   set(LLVM_5_0 1)
+  set(LLVM_OLDER_THAN_6_0 1)
+  set(LLVM_OLDER_THAN_7_0 1)
 elseif(LLVM_VERSION MATCHES "6[.]0")
   set(LLVM_MAJOR 6)
   set(LLVM_6_0 1)
+  set(LLVM_OLDER_THAN_7_0 1)
+elseif(LLVM_VERSION MATCHES "7[.]0")
+  set(LLVM_MAJOR 7)
+  set(LLVM_7_0 1)
 else()
   message(FATAL_ERROR "LLVM version between 3.7 and 6.0 required, found: ${LLVM_VERSION}")
 endif()

--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -113,6 +113,9 @@
 /* "Using LLVM 6.0" */
 #cmakedefine LLVM_6_0
 
+/* "Using LLVM 7.0" */
+#cmakedefine LLVM_7_0
+
 #cmakedefine LLVM_BUILD_MODE_DEBUG
 
 #ifndef LLVM_VERSION

--- a/include/_kernel_c.h
+++ b/include/_kernel_c.h
@@ -60,11 +60,19 @@
 # undef LLVM_6_0
 # define LLVM_6_0
 
+#elif (__clang_major__ == 7)
+
+# undef LLVM_7_0
+# define LLVM_7_0
+
 #else
 
 #error Unsupported Clang/LLVM version.
 
 #endif
+
+#ifndef LLVM_7_0
+#define LLVM_OLDER_THAN_7_0 1
 
 #ifndef LLVM_6_0
 #define LLVM_OLDER_THAN_6_0 1
@@ -87,6 +95,7 @@
 #ifndef LLVM_3_6
 #define LLVM_OLDER_THAN_3_6 1
 
+#endif
 #endif
 #endif
 #endif

--- a/include/pocl.h
+++ b/include/pocl.h
@@ -309,6 +309,9 @@ struct _cl_command_node
   volatile cl_int ready;
 };
 
+#ifndef LLVM_7_0
+#define LLVM_OLDER_THAN_7_0 1
+
 #ifndef LLVM_6_0
 #define LLVM_OLDER_THAN_6_0 1
 
@@ -330,6 +333,7 @@ struct _cl_command_node
 #ifndef LLVM_3_6
 #define LLVM_OLDER_THAN_3_6 1
 
+#endif
 #endif
 #endif
 #endif

--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -654,8 +654,10 @@ int pocl_llvm_link_program(cl_program program, unsigned device_i,
 #ifdef LLVM_OLDER_THAN_3_8
     if (Linker::LinkModules(mod, llvm::CloneModule(p))) {
       delete mod;
-#else
+#elif LLVM_OLDER_THAN_7_0
     if (Linker::linkModules(*mod, llvm::CloneModule(p))) {
+#else
+    if (Linker::linkModules(*mod, llvm::CloneModule(*p))) {
 #endif
       std::string msg = getDiagString();
       appendToProgramBuildLog(program, device_i, msg);

--- a/lib/CL/pocl_llvm_utils.cc
+++ b/lib/CL/pocl_llvm_utils.cc
@@ -83,7 +83,11 @@ llvm::Module *parseModuleIR(const char *path) {
 
 void writeModuleIR(const Module *mod, std::string &str) {
   llvm::raw_string_ostream sos(str);
+#ifdef LLVM_OLDER_THAN_7_0
   WriteBitcodeToFile(mod, sos);
+#else
+  WriteBitcodeToFile(*mod, sos);
+#endif
   sos.str(); // flush
 }
 

--- a/lib/llvmopencl/BarrierTailReplication.cc
+++ b/lib/llvmopencl/BarrierTailReplication.cc
@@ -93,7 +93,11 @@ BarrierTailReplication::runOnFunction(Function &F)
 
   bool changed = ProcessFunction(F);
 
+
+  // In LLVM 7+, it is replaced by some assert(verify()) in LLVM itself
+#ifdef LLVM_OLDER_THAN_7_0
   DT->verifyDomTree();
+#endif
 
   LI->verifyAnalysis();
   /* The created tails might contain PHI nodes with operands 

--- a/lib/llvmopencl/LLVMFileUtils.cc
+++ b/lib/llvmopencl/LLVMFileUtils.cc
@@ -380,7 +380,11 @@ int pocl_write_module(void *module, const char* path, int dont_rewrite) {
     raw_fd_ostream os(fd, 1, sys::fs::F_RW | sys::fs::F_Excl);
     RETURN_IF_EC;
 
+#ifdef LLVM_OLDER_THAN_7_0
     WriteBitcodeToFile((llvm::Module*)module, os);
+#else
+    WriteBitcodeToFile(*(llvm::Module*)module, os);
+#endif
 
     os.flush();
 #ifdef HAVE_FDATASYNC


### PR DESCRIPTION
This is a development branch to have PoCL working with ToT Clang/LLVM.
It is not intended to be merged for now but mostly to have an `llvm-7.0` branch Khronos and others can work with and contribute, towards the great unification around ToT OpenCL/SPIR/SPIR-V/SYCL...

On my laptop the `ctest -j1`seems good:
```
99% tests passed, 1 tests failed out of 121

Label Time Summary:
EinsteinToolkit    =   5.42 sec (2 tests)
cuda               =   3.94 sec (49 tests)
hsa                =   0.22 sec (3 tests)
internal           =  15.46 sec (107 tests)
kernel             =   2.65 sec (29 tests)
regression         =   2.42 sec (35 tests)
runtime            =   8.71 sec (21 tests)
spir               =   0.48 sec (1 test)
tce                =   0.56 sec (8 tests)
workgroup          =   1.45 sec (19 tests)

Total Test time (real) =  22.35 sec

The following tests FAILED:
	121 - EinsteinToolkit_SubDev (OTHER_FAULT)
Errors while running CTest
```