### PR TITLE
Allow SPIR -> PTX conversion in llvm_build

### DIFF
--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -623,6 +623,8 @@ int pocl_llvm_link_program(cl_program program, unsigned device_i,
         POCL_MSG_ERR("Invalid SPIR binary triple\n");
         return CL_LINK_PROGRAM_FAILURE;
       }
+    } else if(triple.getArch() == Triple::nvptx || triple.getArch() == Triple::nvptx64) {
+      POCL_MSG_WARN("Experimental SPIR -> PTX conversion\n");
     } else {
       POCL_MSG_ERR("SPIR is currently only supported on x86(-64)\n");
       return CL_LINK_PROGRAM_FAILURE;


### PR DESCRIPTION
The scenario here is that we are using POCL to provide a OpenCL device that supports SPIR on Nvidia hardware that only natively supports PTX. 
This is useful for higher-level libraries/APIs building on top of OpenCL that emit SPIR.

Without this change, this use case fails with "Invalid SPIR binary triple". With it, we have successfully run several ComputeCPP tests on Nvidia hardware using the POCL CUDA backend.