### PR TITLE
internal API changes

### DIFF
--- a/include/pocl.h
+++ b/include/pocl.h
@@ -113,15 +113,13 @@ typedef struct
   void *args;
   size_t cb_args;
   void (*user_func)(void *);
-  cl_mem *mem_list;
-  unsigned num_mem_objects;
 } _cl_command_native;
 
 // clEnqueueReadBuffer
 typedef struct
 {
   void *__restrict__ dst_host_ptr;
-  void *__restrict__ src_device_ptr;
+  pocl_mem_identifier *src_mem_id;
   size_t offset;
   size_t size;
 } _cl_command_read;
@@ -130,7 +128,7 @@ typedef struct
 typedef struct
 {
   const void *__restrict__ src_host_ptr;
-  void *__restrict__ dst_device_ptr;
+  pocl_mem_identifier *dst_mem_id;
   size_t offset;
   size_t size;
 } _cl_command_write;
@@ -138,8 +136,8 @@ typedef struct
 // clEnqueueCopyBuffer
 typedef struct
 {
-  void *__restrict__ src_device_ptr;
-  void *__restrict__ dst_device_ptr;
+  pocl_mem_identifier *src_mem_id;
+  pocl_mem_identifier *dst_mem_id;
   size_t src_offset;
   size_t dst_offset;
   size_t size;
@@ -149,7 +147,7 @@ typedef struct
 typedef struct
 {
   void *__restrict__ dst_host_ptr;
-  void *__restrict__ src_device_ptr;
+  pocl_mem_identifier *src_mem_id;
   size_t buffer_origin[3];
   size_t host_origin[3];
   size_t region[3];
@@ -163,7 +161,7 @@ typedef struct
 typedef struct
 {
   const void *__restrict__ src_host_ptr;
-  void *__restrict__ dst_device_ptr;
+  pocl_mem_identifier *dst_mem_id;
   size_t buffer_origin[3];
   size_t host_origin[3];
   size_t region[3];
@@ -176,8 +174,8 @@ typedef struct
 // clEnqueueCopyBufferRect
 typedef struct
 {
-  void *__restrict__ src_device_ptr;
-  void *__restrict__ dst_device_ptr;
+  pocl_mem_identifier *src_mem_id;
+  pocl_mem_identifier *dst_mem_id;
   size_t dst_origin[3];
   size_t src_origin[3];
   size_t region[3];
@@ -190,7 +188,6 @@ typedef struct
 // clEnqueueMapBuffer
 typedef struct
 {
-  cl_mem memobj;
   pocl_mem_identifier *mem_id;
   mem_mapping_t *mapping;
 } _cl_command_map;
@@ -198,7 +195,6 @@ typedef struct
 /* clEnqueueUnMapMemObject */
 typedef struct
 {
-  cl_mem memobj;
   pocl_mem_identifier *mem_id;
   mem_mapping_t *mapping;
 } _cl_command_unmap;
@@ -206,7 +202,7 @@ typedef struct
 /* clEnqueueFillBuffer */
 typedef struct
 {
-  void *__restrict__ device_ptr;
+  pocl_mem_identifier *dst_mem_id;
   size_t size;
   size_t offset;
   void *__restrict__ pattern;
@@ -216,7 +212,6 @@ typedef struct
 /* clEnqueue(Write/Read)Image */
 typedef struct
 {
-  cl_mem src_image;
   pocl_mem_identifier *src_mem_id;
   void *__restrict__ dst_host_ptr;
   pocl_mem_identifier *dst_mem_id;
@@ -229,7 +224,6 @@ typedef struct
 
 typedef struct
 {
-  cl_mem dst_image;
   pocl_mem_identifier *dst_mem_id;
   const void *__restrict__ src_host_ptr;
   pocl_mem_identifier *src_mem_id;
@@ -242,8 +236,6 @@ typedef struct
 
 typedef struct
 {
-  cl_mem src_image;
-  cl_mem dst_image;
   pocl_mem_identifier *src_mem_id;
   pocl_mem_identifier *dst_mem_id;
   size_t dst_origin[3];
@@ -254,7 +246,6 @@ typedef struct
 /* clEnqueueFillImage */
 typedef struct
 {
-  cl_mem image;
   pocl_mem_identifier *mem_id;
   size_t origin[3];
   size_t region[3];
@@ -307,7 +298,7 @@ typedef struct
 
 typedef struct
 {
-  void *src;
+  const void *src;
   void* dst;
   size_t size;
 } _cl_command_svm_cpy;

--- a/lib/CL/clCreateBuffer.c
+++ b/lib/CL/clCreateBuffer.c
@@ -116,7 +116,6 @@ POname(clCreateBuffer)(cl_context   context,
   mem->type = CL_MEM_OBJECT_BUFFER;
   mem->flags = flags;
   mem->is_image = CL_FALSE;
-  mem->latest_event = NULL;
   mem->owning_device = NULL;
   mem->is_pipe = 0;
   mem->pipe_packet_size = 0;

--- a/lib/CL/clCreateBuffer.c
+++ b/lib/CL/clCreateBuffer.c
@@ -127,11 +127,7 @@ POname(clCreateBuffer)(cl_context   context,
   mem->device_ptrs =
     (pocl_mem_identifier*) calloc(pocl_num_devices,
                                   sizeof(pocl_mem_identifier));
-  if (mem->device_ptrs == NULL)
-    {
-      errcode = CL_OUT_OF_HOST_MEMORY;
-      goto ERROR;
-    }
+  POCL_GOTO_ERROR_COND((mem->device_ptrs == NULL), CL_OUT_OF_HOST_MEMORY);
 
   /* init dev pointer structure to ease inter device pointer sharing
      in ops->alloc_mem_obj */

--- a/lib/CL/clCreateImage.c
+++ b/lib/CL/clCreateImage.c
@@ -203,6 +203,22 @@ CL_API_SUFFIX__VERSION_1_2
                                        &errcode);
         POCL_GOTO_ERROR_ON ((mem == NULL), CL_OUT_OF_HOST_MEMORY,
                             "clCreateBuffer (for backing the image) failed\n");
+
+        for (i = 0; i < context->num_devices; i++)
+          {
+            cl_device_id dev = context->devices[i];
+            if (!dev->image_support)
+              {
+                continue;
+              } // image_data[i] = NULL
+            if (dev->ops->create_image)
+              mem->device_ptrs[dev->dev_id].image_data
+                  = dev->ops->create_image (dev, image_format, image_desc, mem,
+                                            &errcode);
+            if (errcode)
+              goto ERROR;
+          }
+
         mem->buffer = NULL;
       }
 

--- a/lib/CL/clCreateSampler.c
+++ b/lib/CL/clCreateSampler.c
@@ -21,10 +21,9 @@
    THE SOFTWARE.
 */
 
-
+#include "devices.h"
 #include "pocl_cl.h"
 #include "pocl_icd.h"
-
 
 extern CL_API_ENTRY cl_sampler CL_API_CALL
 POname(clCreateSampler)(cl_context          context,
@@ -66,6 +65,14 @@ CL_API_SUFFIX__VERSION_1_0
   sampler->normalized_coords = normalized_coords;
   sampler->addressing_mode = addressing_mode;
   sampler->filter_mode = filter_mode;
+  sampler->device_data = (void **)calloc (pocl_num_devices, sizeof (void *));
+  for (i = 0; i < context->num_devices; ++i)
+    {
+      cl_device_id dev = context->devices[i];
+      if (dev->image_support == CL_TRUE && dev->ops->create_sampler)
+        sampler->device_data[dev->dev_id]
+            = dev->ops->create_sampler (dev->data, sampler, &errcode);
+    }
 
 ERROR:
   if(errcode_ret)

--- a/lib/CL/clCreateSubBuffer.c
+++ b/lib/CL/clCreateSubBuffer.c
@@ -74,7 +74,6 @@ POname(clCreateSubBuffer)(cl_mem                   buffer,
   mem->size = info->size;
   mem->origin = info->origin;
   mem->context = buffer->context;
-  mem->latest_event = NULL;
   mem->owning_device = buffer->owning_device;
   mem->is_pipe = CL_FALSE;
   mem->mem_host_ptr = NULL;

--- a/lib/CL/clCreateSubBuffer.c
+++ b/lib/CL/clCreateSubBuffer.c
@@ -38,9 +38,11 @@ POname(clCreateSubBuffer)(cl_mem                   buffer,
   int errcode;
   unsigned i;
 
-  HANDLE_IMAGE1D_BUFFER (buffer);
-
   POCL_GOTO_ERROR_COND((buffer == NULL), CL_INVALID_MEM_OBJECT);
+
+  POCL_GOTO_ERROR_ON ((buffer->is_image || IS_IMAGE1D_BUFFER (buffer)),
+                      CL_INVALID_MEM_OBJECT,
+                      "subbuffers on images not supported\n");
 
   POCL_GOTO_ERROR_ON((buffer->parent != NULL), CL_INVALID_MEM_OBJECT,
     "buffer is already a sub-buffer\n");

--- a/lib/CL/clEnqueueCopyBuffer.c
+++ b/lib/CL/clEnqueueCopyBuffer.c
@@ -81,31 +81,18 @@ CL_API_SUFFIX__VERSION_1_0
   if (errcode != CL_SUCCESS)
     return errcode;
 
-  cmd->command.copy.src_buffer = src_buffer;
-  cmd->command.copy.src_offset = src_offset;
-  cmd->command.copy.src_dev = src_buffer->owning_device;
-
-  cmd->command.copy.dst_buffer = dst_buffer;
-  cmd->command.copy.dst_offset = dst_offset;
-  if (dst_buffer->owning_device)
-    cmd->command.copy.dst_dev = dst_buffer->owning_device;
-  else
-    cmd->command.copy.dst_dev = device;
-
-  cmd->command.copy.data = device->data;
-
-  cmd->command.copy.src_ptr = 
-    (char*)src_buffer->device_ptrs[device->dev_id].mem_ptr;
+  cmd->command.copy.src_device_ptr
+      = src_buffer->device_ptrs[device->dev_id].mem_ptr;
   cmd->command.copy.src_offset = src_offset;
 
-  cmd->command.copy.dst_ptr = 
-    (char*)dst_buffer->device_ptrs[device->dev_id].mem_ptr;
+  cmd->command.copy.dst_device_ptr
+      = dst_buffer->device_ptrs[device->dev_id].mem_ptr;
   cmd->command.copy.dst_offset = dst_offset;
-  cmd->command.copy.cb = size;
+  cmd->command.copy.size = size;
 
   POname(clRetainMemObject)(src_buffer);
+  src_buffer->owning_device = command_queue->device;
   POname(clRetainMemObject)(dst_buffer);
-
   dst_buffer->owning_device = command_queue->device;
   
   pocl_command_enqueue(command_queue, cmd);

--- a/lib/CL/clEnqueueCopyBuffer.c
+++ b/lib/CL/clEnqueueCopyBuffer.c
@@ -81,12 +81,10 @@ CL_API_SUFFIX__VERSION_1_0
   if (errcode != CL_SUCCESS)
     return errcode;
 
-  cmd->command.copy.src_device_ptr
-      = src_buffer->device_ptrs[device->dev_id].mem_ptr;
+  cmd->command.copy.src_mem_id = &src_buffer->device_ptrs[device->dev_id];
   cmd->command.copy.src_offset = src_offset;
 
-  cmd->command.copy.dst_device_ptr
-      = dst_buffer->device_ptrs[device->dev_id].mem_ptr;
+  cmd->command.copy.dst_mem_id = &dst_buffer->device_ptrs[device->dev_id];
   cmd->command.copy.dst_offset = dst_offset;
   cmd->command.copy.size = size;
 

--- a/lib/CL/clEnqueueCopyBufferRect.c
+++ b/lib/CL/clEnqueueCopyBufferRect.c
@@ -59,10 +59,8 @@ POname(clEnqueueCopyBufferRect)(cl_command_queue command_queue,
     return err;
 
   cl_device_id dev = command_queue->device;
-  cmd->command.copy_rect.src_device_ptr
-      = src_buffer->device_ptrs[dev->dev_id].mem_ptr;
-  cmd->command.copy_rect.dst_device_ptr
-      = dst_buffer->device_ptrs[dev->dev_id].mem_ptr;
+  cmd->command.copy_rect.src_mem_id = &src_buffer->device_ptrs[dev->dev_id];
+  cmd->command.copy_rect.dst_mem_id = &dst_buffer->device_ptrs[dev->dev_id];
 
   cmd->command.copy_rect.src_origin[0] = src_origin[0];
   cmd->command.copy_rect.src_origin[1] = src_origin[1];

--- a/lib/CL/clEnqueueCopyBufferToImage.c
+++ b/lib/CL/clEnqueueCopyBufferToImage.c
@@ -20,6 +20,20 @@ CL_API_SUFFIX__VERSION_1_0
 
   POCL_RETURN_ERROR_COND ((dst_image == NULL), CL_INVALID_MEM_OBJECT);
 
+  if (IS_IMAGE1D_BUFFER (dst_image))
+    {
+      /* If src_image is a 1D image or 1D image buffer object, src_origin[1]
+       * and src_origin[2] must be 0 If src_image is a 1D image or 1D image
+       * buffer object, region[1] and region[2] must be 1. */
+      IMAGE1D_ORIG_REG_TO_BYTES (dst_image, dst_origin, region);
+      return POname (clEnqueueCopyBufferRect (
+          command_queue, src_buffer, dst_image->buffer,
+          src_origin, i1d_origin, i1d_region,
+          dst_image->image_row_pitch, 0,
+          dst_image->image_row_pitch, 0,
+          num_events_in_wait_list, event_wait_list, event));
+    }
+
   cl_int err = pocl_rect_copy(
     command_queue,
     CL_COMMAND_COPY_BUFFER_TO_IMAGE,

--- a/lib/CL/clEnqueueCopyBufferToImage.c
+++ b/lib/CL/clEnqueueCopyBufferToImage.c
@@ -36,9 +36,8 @@ CL_API_SUFFIX__VERSION_1_0
     return err;
 
   cl_device_id dev = command_queue->device;
-  cmd->command.write_image.dst_image = dst_image;
-  cmd->command.write_image.dst_mem_id = &dst_image->device_ptrs[dev->dev_id];
 
+  cmd->command.write_image.dst_mem_id = &dst_image->device_ptrs[dev->dev_id];
   cmd->command.write_image.src_host_ptr = NULL;
   cmd->command.write_image.src_mem_id = &src_buffer->device_ptrs[dev->dev_id];
 

--- a/lib/CL/clEnqueueCopyBufferToImage.c
+++ b/lib/CL/clEnqueueCopyBufferToImage.c
@@ -1,9 +1,11 @@
+#include "pocl_util.h"
 #include "pocl_shared.h"
+#include "pocl_image_util.h"
 
 extern CL_API_ENTRY cl_int CL_API_CALL
 POname(clEnqueueCopyBufferToImage)(cl_command_queue  command_queue,
-                                   cl_mem            buffer,
-                                   cl_mem            image,
+                                   cl_mem            src_buffer,
+                                   cl_mem            dst_image,
                                    size_t            src_offset,
                                    const size_t *    dst_origin, /*[3]*/
                                    const size_t *    region,  /*[3]*/
@@ -12,15 +14,53 @@ POname(clEnqueueCopyBufferToImage)(cl_command_queue  command_queue,
                                    cl_event *        event )
 CL_API_SUFFIX__VERSION_1_0
 {
+  _cl_command_node *cmd = NULL;
   /* pass src_origin through in a format pocl_rect_copy understands */
   const size_t src_origin[3] = { src_offset, 0, 0};
-  return pocl_rect_copy(command_queue, CL_COMMAND_COPY_BUFFER_TO_IMAGE,
-    buffer, CL_FALSE,
-    image, CL_TRUE,
+
+  POCL_RETURN_ERROR_COND ((dst_image == NULL), CL_INVALID_MEM_OBJECT);
+
+  cl_int err = pocl_rect_copy(
+    command_queue,
+    CL_COMMAND_COPY_BUFFER_TO_IMAGE,
+    src_buffer, CL_FALSE,
+    dst_image, CL_TRUE,
     src_origin, dst_origin, region,
     0, 0,
     0, 0,
     num_events_in_wait_list, event_wait_list,
-    event);
+    event,
+    &cmd);
+
+  if (err != CL_SUCCESS)
+    return err;
+
+  cl_device_id dev = command_queue->device;
+  cmd->command.write_image.dst_image = dst_image;
+  cmd->command.write_image.dst_mem_id = &dst_image->device_ptrs[dev->dev_id];
+
+  cmd->command.write_image.src_host_ptr = NULL;
+  cmd->command.write_image.src_mem_id = &src_buffer->device_ptrs[dev->dev_id];
+
+  // TODO
+  cmd->command.write_image.src_row_pitch = 0;   // dst_image->image_row_pitch;
+  cmd->command.write_image.src_slice_pitch = 0; // dst_image->image_slice_pitch;
+  cmd->command.write_image.src_offset = src_offset;
+
+  cmd->command.write_image.origin[0] = dst_origin[0];
+  cmd->command.write_image.origin[1] = dst_origin[1];
+  cmd->command.write_image.origin[2] = dst_origin[2];
+  cmd->command.write_image.region[0] = region[0];
+  cmd->command.write_image.region[1] = region[1];
+  cmd->command.write_image.region[2] = region[2];
+
+  POname (clRetainMemObject) (dst_image);
+  dst_image->owning_device = dev;
+  POname (clRetainMemObject) (src_buffer);
+  src_buffer->owning_device = dev;
+
+  pocl_command_enqueue (command_queue, cmd);
+
+  return CL_SUCCESS;
 }
 POsym(clEnqueueCopyBufferToImage)

--- a/lib/CL/clEnqueueCopyImage.c
+++ b/lib/CL/clEnqueueCopyImage.c
@@ -20,6 +20,13 @@ POname(clEnqueueCopyImage)(cl_command_queue      command_queue ,
   POCL_RETURN_ERROR_COND ((src_image == NULL), CL_INVALID_MEM_OBJECT);
   POCL_RETURN_ERROR_COND ((dst_image == NULL), CL_INVALID_MEM_OBJECT);
 
+  /* src_image, dst_image: Can be 1D, 2D, 3D image or a 1D, 2D image array
+   * objects allowing us to perform the following actions */
+  POCL_RETURN_ERROR_ON (
+      (IS_IMAGE1D_BUFFER (src_image) || IS_IMAGE1D_BUFFER (dst_image)),
+      CL_INVALID_MEM_OBJECT,
+      "clEnqueueCopyImage cannot be called on image 1D buffers!\n");
+
   POCL_CHECK_DEV_IN_CMDQ;
 
   cl_int err = pocl_rect_copy(

--- a/lib/CL/clEnqueueCopyImage.c
+++ b/lib/CL/clEnqueueCopyImage.c
@@ -37,8 +37,6 @@ POname(clEnqueueCopyImage)(cl_command_queue      command_queue ,
   if (err != CL_SUCCESS)
     return err;
 
-  cmd->command.copy_image.src_image = src_image;
-  cmd->command.copy_image.dst_image = dst_image;
   cmd->command.copy_image.src_mem_id = &src_image->device_ptrs[device->dev_id];
   cmd->command.copy_image.dst_mem_id = &dst_image->device_ptrs[device->dev_id];
 

--- a/lib/CL/clEnqueueCopyImageToBuffer.c
+++ b/lib/CL/clEnqueueCopyImageToBuffer.c
@@ -36,9 +36,7 @@ POname(clEnqueueCopyImageToBuffer)(cl_command_queue  command_queue ,
 
   cl_device_id dev = command_queue->device;
 
-  cmd->command.read_image.src_image = src_image;
   cmd->command.read_image.src_mem_id = &src_image->device_ptrs[dev->dev_id];
-
   cmd->command.read_image.dst_host_ptr = NULL;
   cmd->command.read_image.dst_mem_id = &dst_buffer->device_ptrs[dev->dev_id];
 

--- a/lib/CL/clEnqueueCopyImageToBuffer.c
+++ b/lib/CL/clEnqueueCopyImageToBuffer.c
@@ -19,6 +19,20 @@ POname(clEnqueueCopyImageToBuffer)(cl_command_queue  command_queue ,
 
   POCL_RETURN_ERROR_COND ((src_image == NULL), CL_INVALID_MEM_OBJECT);
 
+  if (IS_IMAGE1D_BUFFER (src_image))
+    {
+      /* If src_image is a 1D image or 1D image buffer object, src_origin[1]
+       * and src_origin[2] must be 0 If src_image is a 1D image or 1D image
+       * buffer object, region[1] and region[2] must be 1. */
+      IMAGE1D_ORIG_REG_TO_BYTES (src_image, src_origin, region);
+      return POname (clEnqueueCopyBufferRect (
+          command_queue, src_image->buffer, dst_buffer,
+          i1d_origin, dst_origin, i1d_region,
+          src_image->image_row_pitch, 0,
+          src_image->image_row_pitch, 0,
+          num_events_in_wait_list, event_wait_list, event));
+    }
+
   cl_int err = pocl_rect_copy(
     command_queue,
     CL_COMMAND_COPY_IMAGE_TO_BUFFER,

--- a/lib/CL/clEnqueueCopyImageToBuffer.c
+++ b/lib/CL/clEnqueueCopyImageToBuffer.c
@@ -1,4 +1,6 @@
+#include "pocl_util.h"
 #include "pocl_shared.h"
+#include "pocl_image_util.h"
 
 CL_API_ENTRY cl_int CL_API_CALL
 POname(clEnqueueCopyImageToBuffer)(cl_command_queue  command_queue ,
@@ -11,16 +13,54 @@ POname(clEnqueueCopyImageToBuffer)(cl_command_queue  command_queue ,
                            const cl_event *  event_wait_list ,
                            cl_event *        event ) CL_API_SUFFIX__VERSION_1_0
 {
+  _cl_command_node *cmd = NULL;
   /* pass dst_origin through in a format pocl_rect_copy understands */
   const size_t dst_origin[3] = { dst_offset, 0, 0};
-  return pocl_rect_copy(command_queue, CL_COMMAND_COPY_IMAGE_TO_BUFFER,
+
+  POCL_RETURN_ERROR_COND ((src_image == NULL), CL_INVALID_MEM_OBJECT);
+
+  cl_int err = pocl_rect_copy(
+    command_queue,
+    CL_COMMAND_COPY_IMAGE_TO_BUFFER,
     src_image, CL_TRUE,
     dst_buffer, CL_FALSE,
     src_origin, dst_origin, region,
     0, 0,
     0, 0,
     num_events_in_wait_list, event_wait_list,
-    event);
+    event,
+    &cmd);
+
+  if (err != CL_SUCCESS)
+    return err;
+
+  cl_device_id dev = command_queue->device;
+
+  cmd->command.read_image.src_image = src_image;
+  cmd->command.read_image.src_mem_id = &src_image->device_ptrs[dev->dev_id];
+
+  cmd->command.read_image.dst_host_ptr = NULL;
+  cmd->command.read_image.dst_mem_id = &dst_buffer->device_ptrs[dev->dev_id];
+
+  cmd->command.read_image.origin[0] = src_origin[0];
+  cmd->command.read_image.origin[1] = src_origin[1];
+  cmd->command.read_image.origin[2] = src_origin[2];
+  cmd->command.read_image.region[0] = region[0];
+  cmd->command.read_image.region[1] = region[1];
+  cmd->command.read_image.region[2] = region[2];
+  // TODO
+  cmd->command.read_image.dst_row_pitch = 0;   // src_image->image_row_pitch;
+  cmd->command.read_image.dst_slice_pitch = 0; // src_image->image_slice_pitch;
+  cmd->command.read_image.dst_offset = dst_offset;
+
+  POname (clRetainMemObject) (src_image);
+  src_image->owning_device = dev;
+  POname (clRetainMemObject) (dst_buffer);
+  dst_buffer->owning_device = dev;
+
+  pocl_command_enqueue (command_queue, cmd);
+
+  return CL_SUCCESS;
 }
 POsym(clEnqueueCopyImageToBuffer)
 

--- a/lib/CL/clEnqueueFillBuffer.c
+++ b/lib/CL/clEnqueueFillBuffer.c
@@ -86,19 +86,20 @@ CL_API_SUFFIX__VERSION_1_2
   if (errcode != CL_SUCCESS)
     return errcode;
 
-  cmd->command.memfill.buffer = buffer;
-  cmd->command.memfill.ptr =
-      buffer->device_ptrs[command_queue->device->dev_id].mem_ptr;
+  cmd->command.memfill.device_ptr
+      = buffer->device_ptrs[command_queue->device->dev_id].mem_ptr;
   cmd->command.memfill.size = size;
   cmd->command.memfill.offset = offset;
   void *p = pocl_aligned_malloc(pattern_size, pattern_size);
   memcpy(p, pattern, pattern_size);
   cmd->command.memfill.pattern = p;
   cmd->command.memfill.pattern_size = pattern_size;
+  // cmd->command.memfill.buffer = buffer;
 
   POname(clRetainMemObject) (buffer);
+  // TODO
   buffer->owning_device = command_queue->device;
-  
+
   pocl_command_enqueue(command_queue, cmd);
 
   return CL_SUCCESS;

--- a/lib/CL/clEnqueueFillBuffer.c
+++ b/lib/CL/clEnqueueFillBuffer.c
@@ -86,18 +86,16 @@ CL_API_SUFFIX__VERSION_1_2
   if (errcode != CL_SUCCESS)
     return errcode;
 
-  cmd->command.memfill.device_ptr
-      = buffer->device_ptrs[command_queue->device->dev_id].mem_ptr;
+  cmd->command.memfill.dst_mem_id
+      = &buffer->device_ptrs[command_queue->device->dev_id];
   cmd->command.memfill.size = size;
   cmd->command.memfill.offset = offset;
   void *p = pocl_aligned_malloc(pattern_size, pattern_size);
   memcpy(p, pattern, pattern_size);
   cmd->command.memfill.pattern = p;
   cmd->command.memfill.pattern_size = pattern_size;
-  // cmd->command.memfill.buffer = buffer;
 
   POname(clRetainMemObject) (buffer);
-  // TODO
   buffer->owning_device = command_queue->device;
 
   pocl_command_enqueue(command_queue, cmd);

--- a/lib/CL/clEnqueueFillImage.c
+++ b/lib/CL/clEnqueueFillImage.c
@@ -104,7 +104,6 @@ CL_API_SUFFIX__VERSION_1_2
   cmd->command.fill_image.pixel_size
       = image->image_elem_size * image->image_channels;
 
-  cmd->command.fill_image.image = image;
   cmd->command.fill_image.mem_id
       = &image->device_ptrs[command_queue->device->dev_id];
 

--- a/lib/CL/clEnqueueFillImage.c
+++ b/lib/CL/clEnqueueFillImage.c
@@ -90,8 +90,8 @@ CL_API_SUFFIX__VERSION_1_2
   pocl_write_pixel_zero (fill_pixel, fill_color, image->image_channel_order,
                          image->image_elem_size,
                          image->image_channel_data_type);
-
-  cl_mem saved_image = image;
+  // TODO
+  // cl_mem saved_image = image;
   HANDLE_IMAGE1D_BUFFER (image);
 
   errcode = pocl_create_command (&cmd, command_queue, CL_COMMAND_FILL_IMAGE,
@@ -100,22 +100,25 @@ CL_API_SUFFIX__VERSION_1_2
   if (errcode != CL_SUCCESS)
     goto ERROR_CLEAN;
 
-  cmd->command.fill_image.rowpitch = saved_image->image_row_pitch;
-  cmd->command.fill_image.slicepitch = saved_image->image_slice_pitch;
   cmd->command.fill_image.fill_pixel = fill_pixel;
   cmd->command.fill_image.pixel_size
-      = saved_image->image_elem_size * saved_image->image_channels;
-  cmd->command.fill_image.data = command_queue->device->data;
-  cmd->command.fill_image.device_ptr = 
-    image->device_ptrs[command_queue->device->dev_id].mem_ptr;
-  memcpy (&(cmd->command.fill_image.buffer_origin), origin, 
-          3*sizeof(size_t));
-  memcpy (&(cmd->command.fill_image.region), region, 3*sizeof(size_t));
+      = image->image_elem_size * image->image_channels;
+
+  cmd->command.fill_image.image = image;
+  cmd->command.fill_image.mem_id
+      = &image->device_ptrs[command_queue->device->dev_id];
+
+  cmd->command.fill_image.origin[0] = origin[0];
+  cmd->command.fill_image.origin[1] = origin[1];
+  cmd->command.fill_image.origin[2] = origin[2];
+  cmd->command.fill_image.region[0] = region[0];
+  cmd->command.fill_image.region[1] = region[1];
+  cmd->command.fill_image.region[2] = region[2];
 
   POname(clRetainMemObject) (image);
   image->owning_device = command_queue->device;
   pocl_command_enqueue(command_queue, cmd);
-  
+
   return errcode;
   
  ERROR_CLEAN:

--- a/lib/CL/clEnqueueFillImage.c
+++ b/lib/CL/clEnqueueFillImage.c
@@ -90,9 +90,19 @@ CL_API_SUFFIX__VERSION_1_2
   pocl_write_pixel_zero (fill_pixel, fill_color, image->image_channel_order,
                          image->image_elem_size,
                          image->image_channel_data_type);
-  // TODO
-  // cl_mem saved_image = image;
-  HANDLE_IMAGE1D_BUFFER (image);
+
+  size_t px = image->image_elem_size * image->image_channels;
+
+  if (IS_IMAGE1D_BUFFER (image))
+    {
+      return POname (clEnqueueFillBuffer) (
+          command_queue,
+          image->buffer,
+          fill_pixel, 16,
+          origin[0] * px,
+          region[0] * px,
+          num_events_in_wait_list, event_wait_list, event);
+    }
 
   errcode = pocl_create_command (&cmd, command_queue, CL_COMMAND_FILL_IMAGE,
                                  event, num_events_in_wait_list,
@@ -101,8 +111,7 @@ CL_API_SUFFIX__VERSION_1_2
     goto ERROR_CLEAN;
 
   cmd->command.fill_image.fill_pixel = fill_pixel;
-  cmd->command.fill_image.pixel_size
-      = image->image_elem_size * image->image_channels;
+  cmd->command.fill_image.pixel_size = px;
 
   cmd->command.fill_image.mem_id
       = &image->device_ptrs[command_queue->device->dev_id];

--- a/lib/CL/clEnqueueMapBuffer.c
+++ b/lib/CL/clEnqueueMapBuffer.c
@@ -41,7 +41,6 @@ POname(clEnqueueMapBuffer)(cl_command_queue command_queue,
 {
   cl_int errcode = CL_SUCCESS;
   cl_device_id device;
-  void *host_ptr = NULL;
   cl_int mapping_result = CL_FAILED;
   mem_mapping_t *mapping_info = NULL;
   unsigned i;
@@ -100,8 +99,7 @@ POname(clEnqueueMapBuffer)(cl_command_queue command_queue,
       /* In this case it should use the given host_ptr + offset as
          the mapping area in the host memory. */   
       assert (buffer->mem_host_ptr != NULL);
-      host_ptr = (char*)buffer->mem_host_ptr + offset;
-      mapping_info->host_ptr = host_ptr;
+      mapping_info->host_ptr = (char*)buffer->mem_host_ptr + offset;
     }
   else
     {

--- a/lib/CL/clEnqueueMapBuffer.c
+++ b/lib/CL/clEnqueueMapBuffer.c
@@ -112,7 +112,8 @@ POname(clEnqueueMapBuffer)(cl_command_queue command_queue,
       mapping_info->host_ptr = NULL;
       mapping_result = device->ops->map_mem (
           device->data,
-          buffer->device_ptrs[device->dev_id].mem_ptr,
+          &buffer->device_ptrs[device->dev_id],
+          buffer,
           mapping_info);
     }
 
@@ -126,7 +127,6 @@ POname(clEnqueueMapBuffer)(cl_command_queue command_queue,
   if (errcode != CL_SUCCESS)
       goto ERROR;
 
-  cmd->command.map.memobj = buffer;
   cmd->command.map.mem_id = &buffer->device_ptrs[device->dev_id];
   cmd->command.map.mapping = mapping_info;
 
@@ -156,7 +156,8 @@ ERROR:
     POname(clReleaseMemObject)(buffer);
   if (mapping_result == CL_SUCCESS)
     device->ops->unmap_mem (device->data,
-                            buffer->device_ptrs[device->dev_id].mem_ptr,
+                            &buffer->device_ptrs[device->dev_id],
+                            buffer,
                             mapping_info);
   POCL_MEM_FREE(mapping_info);
   POCL_MEM_FREE (cmd);

--- a/lib/CL/clEnqueueMapImage.c
+++ b/lib/CL/clEnqueueMapImage.c
@@ -65,6 +65,17 @@ CL_API_SUFFIX__VERSION_1_0
 
   POCL_GOTO_ERROR_COND((image == NULL), CL_INVALID_MEM_OBJECT);
 
+  if (IS_IMAGE1D_BUFFER (image))
+    {
+      IMAGE1D_ORIG_REG_TO_BYTES (image, origin, region)
+      return POname (clEnqueueMapBuffer) (
+          command_queue, image,
+          blocking_map, map_flags,
+          i1d_origin[0], i1d_region[0],
+          num_events_in_wait_list, event_wait_list, event,
+          errcode_ret);
+    }
+
   POCL_GOTO_ERROR_ON((!image->is_image), CL_INVALID_MEM_OBJECT,
     "image argument is not an image type cl_mem\n");
 
@@ -113,8 +124,6 @@ CL_API_SUFFIX__VERSION_1_0
   mapping_info->offset = origin[2] * mapping_info->slice_pitch
                          + origin[1] * mapping_info->row_pitch
                          + origin[0] * px;
-
-  HANDLE_IMAGE1D_BUFFER (image);
 
   /* CL_INVALID_OPERATION if buffer has been created with
    * CL_MEM_HOST_WRITE_ONLY

--- a/lib/CL/clEnqueueMapImage.c
+++ b/lib/CL/clEnqueueMapImage.c
@@ -150,9 +150,11 @@ CL_API_SUFFIX__VERSION_1_0
          When return value (mapping_info->host_ptr) is non-NULL, the
          buffer will be mapped there (assumed it will succeed).  */
       mapping_info->host_ptr = NULL;
-      mapping_result = device->ops->map_image (
-          device->data, image, &image->device_ptrs[device->dev_id],
-          mapping_info);
+      mapping_result = device->ops->map_image
+        (device->data,
+         &image->device_ptrs[device->dev_id],
+         image,
+         mapping_info);
     }
 
   retval = mapping_info->host_ptr;
@@ -164,7 +166,6 @@ CL_API_SUFFIX__VERSION_1_0
   if (errcode != CL_SUCCESS)
     goto ERROR;
 
-  cmd->command.map.memobj = image;
   cmd->command.map.mem_id = &image->device_ptrs[device->dev_id];
   cmd->command.map.mapping = mapping_info;
 

--- a/lib/CL/clEnqueueMigrateMemObjects.c
+++ b/lib/CL/clEnqueueMigrateMemObjects.c
@@ -79,7 +79,7 @@ POname(clEnqueueMigrateMemObjects) (cl_command_queue command_queue,
 
   for (i = 0; i < num_mem_objects; ++i)
     {
-      HANDLE_IMAGE1D_BUFFER (new_mem_objects[i]);
+      IMAGE1D_TO_BUFFER (new_mem_objects[i]);
       POname (clRetainMemObject) (new_mem_objects[i]);
       cmd->command.migrate.source_devices[i]
           = new_mem_objects[i]->owning_device;

--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -525,7 +525,6 @@ if (local_##c1 > 1 && local_##c1 <= local_##c2 && local_##c1 <= local_##c3 && \
   pc.global_offset[2] = offset_z;
 
   command_node->type = CL_COMMAND_NDRANGE_KERNEL;
-  command_node->command.run.data = command_queue->device->data;
   command_node->command.run.tmp_dir = strdup (cachedir);
   command_node->command.run.kernel = kernel;
   command_node->command.run.pc = pc;

--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -493,10 +493,8 @@ if (local_##c1 > 1 && local_##c1 <= local_##c2 && local_##c1 <= local_##c3 && \
                      buf->owning_device->global_mem_id,
                      command_queue->device->global_mem_id);
 #endif
-              cl_event mem_event = buf->latest_event;
               POname(clEnqueueMigrateMemObjects)
-                (command_queue, 1, &buf, 0, (mem_event ? 1 : 0),
-                 (mem_event ? &mem_event : NULL),
+                (command_queue, 1, &buf, 0, 0, NULL,
                  &new_event_wait_list[b_migrate_count++]);
             }
           buf->owning_device = realdev;

--- a/lib/CL/clEnqueueNativeKernel.c
+++ b/lib/CL/clEnqueueNativeKernel.c
@@ -21,7 +21,6 @@ POname(clEnqueueNativeKernel)(cl_command_queue   command_queue ,
 {
   cl_uint i = 0;
   _cl_command_node *command_node = NULL;
-  cl_mem *mem_list_copy = NULL;
   void *args_copy = NULL;
   cl_int errcode;
 
@@ -57,7 +56,6 @@ POname(clEnqueueNativeKernel)(cl_command_queue   command_queue ,
   if (errcode != CL_SUCCESS)
     return errcode;
 
-  command_node->command.native.num_mem_objects = num_mem_objects;
   command_node->command.native.user_func = user_func;
 
   /* Specification specifies that args passed to user_func is a copy of the
@@ -73,20 +71,6 @@ POname(clEnqueueNativeKernel)(cl_command_queue   command_queue ,
       memcpy (args_copy, args, cb_args);
     }
 
-  /* recopy the cl_mem object list to free them easily after run */
-  if (num_mem_objects)
-    {
-      mem_list_copy = (cl_mem*) malloc(num_mem_objects * sizeof(cl_mem));
-      if (mem_list_copy == NULL)
-      {
-        POCL_MEM_FREE(args_copy);
-        POCL_MEM_FREE(command_node);
-        return CL_OUT_OF_HOST_MEMORY;
-      }
-      memcpy (mem_list_copy, mem_list, num_mem_objects * sizeof(cl_mem));
-    }
-  command_node->command.native.mem_list = mem_list_copy;
-
   for (i = 0; i < num_mem_objects; i++)
     {
       void *buf;
@@ -96,7 +80,6 @@ POname(clEnqueueNativeKernel)(cl_command_queue   command_queue ,
       if (mem_list[i] == NULL)
         {
           POCL_MEM_FREE(args_copy);
-          POCL_MEM_FREE(mem_list_copy);
           POCL_MEM_FREE(command_node);
           return CL_INVALID_MEM_OBJECT;
         }

--- a/lib/CL/clEnqueueNativeKernel.c
+++ b/lib/CL/clEnqueueNativeKernel.c
@@ -57,7 +57,6 @@ POname(clEnqueueNativeKernel)(cl_command_queue   command_queue ,
   if (errcode != CL_SUCCESS)
     return errcode;
 
-  command_node->command.native.data = command_queue->device->data;
   command_node->command.native.num_mem_objects = num_mem_objects;
   command_node->command.native.user_func = user_func;
 

--- a/lib/CL/clEnqueueReadBuffer.c
+++ b/lib/CL/clEnqueueReadBuffer.c
@@ -73,8 +73,7 @@ POname(clEnqueueReadBuffer)(cl_command_queue command_queue,
     return errcode;
 
   cmd->command.read.dst_host_ptr = ptr;
-  cmd->command.read.src_device_ptr
-      = buffer->device_ptrs[device->dev_id].mem_ptr;
+  cmd->command.read.src_mem_id = &buffer->device_ptrs[device->dev_id];
   cmd->command.read.offset = offset;
   cmd->command.read.size = size;
 

--- a/lib/CL/clEnqueueReadBuffer.c
+++ b/lib/CL/clEnqueueReadBuffer.c
@@ -31,7 +31,7 @@ POname(clEnqueueReadBuffer)(cl_command_queue command_queue,
                     cl_mem buffer,
                     cl_bool blocking_read,
                     size_t offset,
-                    size_t cb, 
+                    size_t size,
                     void *ptr,
                     cl_uint num_events_in_wait_list,
                     const cl_event *event_wait_list,
@@ -56,7 +56,7 @@ POname(clEnqueueReadBuffer)(cl_command_queue command_queue,
       "or CL_MEM_HOST_NO_ACCESS\n");
 
   POCL_RETURN_ERROR_COND((ptr == NULL), CL_INVALID_VALUE);
-  if (pocl_buffer_boundcheck(buffer, offset, cb) != CL_SUCCESS)
+  if (pocl_buffer_boundcheck (buffer, offset, size) != CL_SUCCESS)
     return CL_INVALID_VALUE;
 
   errcode = pocl_check_event_wait_list (command_queue, num_events_in_wait_list,
@@ -71,15 +71,16 @@ POname(clEnqueueReadBuffer)(cl_command_queue command_queue,
                                  event_wait_list, 1, &buffer);
   if (errcode != CL_SUCCESS)
     return errcode;
-  
-  cmd->command.read.host_ptr = ptr;
-  cmd->command.read.device_ptr = (char*)
-    buffer->device_ptrs[device->dev_id].mem_ptr;
+
+  cmd->command.read.dst_host_ptr = ptr;
+  cmd->command.read.src_device_ptr
+      = buffer->device_ptrs[device->dev_id].mem_ptr;
   cmd->command.read.offset = offset;
-  cmd->command.read.cb = cb;
-  cmd->command.read.buffer = buffer;
+  cmd->command.read.size = size;
+
   POname(clRetainMemObject) (buffer);
   buffer->owning_device = command_queue->device;
+
   pocl_command_enqueue(command_queue, cmd);
 
   if (blocking_read)

--- a/lib/CL/clEnqueueReadBufferRect.c
+++ b/lib/CL/clEnqueueReadBufferRect.c
@@ -92,25 +92,32 @@ POname(clEnqueueReadBufferRect)(cl_command_queue command_queue,
                       (unsigned long)buffer_row_pitch, (unsigned long)buffer_slice_pitch, 
                       (unsigned long)host_row_pitch, (unsigned long)host_slice_pitch);
   
-  POname(clRetainMemObject) (buffer);
-  
   pocl_create_command (&cmd, command_queue, CL_COMMAND_READ_BUFFER_RECT,
                        event, num_events_in_wait_list, event_wait_list, 1, 
                        &buffer);
 
-  cmd->command.read_image.device_ptr = 
-    buffer->device_ptrs[device->dev_id].mem_ptr;
-  cmd->command.read_image.host_ptr = ptr;
-  memcpy (&cmd->command.read_image.origin, buffer_origin, sizeof (size_t) * 3);
-  memcpy (&cmd->command.read_image.h_origin, host_origin, sizeof (size_t) * 3);
-  memcpy (&cmd->command.read_image.region, region, sizeof (size_t) * 3);
-  cmd->command.read_image.h_rowpitch = host_row_pitch;
-  cmd->command.read_image.h_slicepitch = host_slice_pitch;
-  cmd->command.read_image.b_rowpitch = buffer_row_pitch;
-  cmd->command.read_image.b_slicepitch = buffer_slice_pitch;
-  cmd->command.read_image.buffer = buffer;
+  cmd->command.read_rect.src_device_ptr
+      = buffer->device_ptrs[device->dev_id].mem_ptr;
+  cmd->command.read_rect.dst_host_ptr = ptr;
 
-  buffer->owning_device = command_queue->device;
+  cmd->command.read_rect.host_origin[0] = host_origin[0];
+  cmd->command.read_rect.host_origin[1] = host_origin[1];
+  cmd->command.read_rect.host_origin[2] = host_origin[2];
+  cmd->command.read_rect.buffer_origin[0] = buffer_origin[0];
+  cmd->command.read_rect.buffer_origin[1] = buffer_origin[1];
+  cmd->command.read_rect.buffer_origin[2] = buffer_origin[2];
+  cmd->command.read_rect.region[0] = region[0];
+  cmd->command.read_rect.region[1] = region[1];
+  cmd->command.read_rect.region[2] = region[2];
+
+  cmd->command.read_rect.host_row_pitch = host_row_pitch;
+  cmd->command.read_rect.host_slice_pitch = host_slice_pitch;
+  cmd->command.read_rect.buffer_row_pitch = buffer_row_pitch;
+  cmd->command.read_rect.buffer_slice_pitch = buffer_slice_pitch;
+
+  POname (clRetainMemObject) (buffer);
+  buffer->owning_device = device;
+
   pocl_command_enqueue (command_queue, cmd);
 
   if (blocking_read)

--- a/lib/CL/clEnqueueReadBufferRect.c
+++ b/lib/CL/clEnqueueReadBufferRect.c
@@ -96,8 +96,7 @@ POname(clEnqueueReadBufferRect)(cl_command_queue command_queue,
                        event, num_events_in_wait_list, event_wait_list, 1, 
                        &buffer);
 
-  cmd->command.read_rect.src_device_ptr
-      = buffer->device_ptrs[device->dev_id].mem_ptr;
+  cmd->command.read_rect.src_mem_id = &buffer->device_ptrs[device->dev_id];
   cmd->command.read_rect.dst_host_ptr = ptr;
 
   cmd->command.read_rect.host_origin[0] = host_origin[0];

--- a/lib/CL/clEnqueueReadImage.c
+++ b/lib/CL/clEnqueueReadImage.c
@@ -49,6 +49,17 @@ CL_API_SUFFIX__VERSION_1_0
 
   POCL_RETURN_ERROR_COND((ptr == NULL), CL_INVALID_VALUE);
 
+  if (IS_IMAGE1D_BUFFER (image))
+    {
+      IMAGE1D_ORIG_REG_TO_BYTES (image, origin, region);
+      return POname (clEnqueueReadBuffer) (
+          command_queue, image,
+          blocking_read,
+          i1d_origin[0], i1d_region[0],
+          ptr,
+          num_events_in_wait_list, event_wait_list, event);
+    }
+
   POCL_RETURN_ERROR_ON((command_queue->context != image->context),
     CL_INVALID_CONTEXT, "image and command_queue are not from the same context\n");
 
@@ -90,8 +101,6 @@ CL_API_SUFFIX__VERSION_1_0
       POCL_MEM_FREE(cmd);
       return errcode;
     }
-
-  HANDLE_IMAGE1D_BUFFER (image);
 
   cl_device_id dev = command_queue->device;
   cmd->command.read_image.src_mem_id = &image->device_ptrs[dev->dev_id];

--- a/lib/CL/clEnqueueReadImage.c
+++ b/lib/CL/clEnqueueReadImage.c
@@ -94,9 +94,7 @@ CL_API_SUFFIX__VERSION_1_0
   HANDLE_IMAGE1D_BUFFER (image);
 
   cl_device_id dev = command_queue->device;
-  cmd->command.read_image.src_image = image;
   cmd->command.read_image.src_mem_id = &image->device_ptrs[dev->dev_id];
-
   cmd->command.read_image.dst_host_ptr = ptr;
   cmd->command.read_image.dst_mem_id = NULL;
 

--- a/lib/CL/clEnqueueSVMMemFill.c
+++ b/lib/CL/clEnqueueSVMMemFill.c
@@ -79,7 +79,7 @@ POname(clEnqueueSVMMemFill) (cl_command_queue command_queue,
       return errcode;
     }
 
-  cmd->command.memfill.ptr = svm_ptr;
+  cmd->command.memfill.device_ptr = svm_ptr;
   cmd->command.memfill.offset = 0;
   cmd->command.memfill.size = size;
   void *p = pocl_aligned_malloc(pattern_size, pattern_size);

--- a/lib/CL/clEnqueueSVMMemFill.c
+++ b/lib/CL/clEnqueueSVMMemFill.c
@@ -79,7 +79,8 @@ POname(clEnqueueSVMMemFill) (cl_command_queue command_queue,
       return errcode;
     }
 
-  cmd->command.memfill.device_ptr = svm_ptr;
+  // TODO FIX
+  cmd->command.memfill.dst_mem_id = (pocl_mem_identifier *)svm_ptr;
   cmd->command.memfill.offset = 0;
   cmd->command.memfill.size = size;
   void *p = pocl_aligned_malloc(pattern_size, pattern_size);

--- a/lib/CL/clEnqueueUnmapMemObject.c
+++ b/lib/CL/clEnqueueUnmapMemObject.c
@@ -54,8 +54,6 @@ POname(clEnqueueUnmapMemObject)(cl_command_queue command_queue,
 
   POCL_CHECK_DEV_IN_CMDQ;
 
-  HANDLE_IMAGE1D_BUFFER (memobj);
-
   POCL_RETURN_ERROR_ON ((memobj->flags & CL_MEM_HOST_NO_ACCESS),
                         CL_INVALID_OPERATION,
                         "buffer has been created with "

--- a/lib/CL/clEnqueueUnmapMemObject.c
+++ b/lib/CL/clEnqueueUnmapMemObject.c
@@ -79,16 +79,16 @@ POname(clEnqueueUnmapMemObject)(cl_command_queue command_queue,
       "Could not find mapping of this memobj\n");
 
   errcode = pocl_create_command (&cmd, command_queue, 
-                                 CL_COMMAND_UNMAP_MEM_OBJECT, 
+                                 CL_COMMAND_UNMAP_MEM_OBJECT,
                                  event, num_events_in_wait_list, 
                                  event_wait_list, 1, &memobj);
 
   if (errcode != CL_SUCCESS)
     goto ERROR;
 
-  cmd->command.unmap.data = command_queue->device->data;
   cmd->command.unmap.memobj = memobj;
   cmd->command.unmap.mapping = mapping;
+  cmd->command.unmap.mem_id = &memobj->device_ptrs[device->dev_id];
 
   POname(clRetainMemObject) (memobj);
   memobj->owning_device = command_queue->device;

--- a/lib/CL/clEnqueueUnmapMemObject.c
+++ b/lib/CL/clEnqueueUnmapMemObject.c
@@ -86,7 +86,6 @@ POname(clEnqueueUnmapMemObject)(cl_command_queue command_queue,
   if (errcode != CL_SUCCESS)
     goto ERROR;
 
-  cmd->command.unmap.memobj = memobj;
   cmd->command.unmap.mapping = mapping;
   cmd->command.unmap.mem_id = &memobj->device_ptrs[device->dev_id];
 

--- a/lib/CL/clEnqueueWriteBuffer.c
+++ b/lib/CL/clEnqueueWriteBuffer.c
@@ -75,8 +75,7 @@ POname(clEnqueueWriteBuffer)(cl_command_queue command_queue,
     return errcode;
 
   cmd->command.write.src_host_ptr = ptr;
-  cmd->command.write.dst_device_ptr
-      = buffer->device_ptrs[device->dev_id].mem_ptr;
+  cmd->command.write.dst_mem_id = &buffer->device_ptrs[device->dev_id];
   cmd->command.write.offset = offset;
   cmd->command.write.size = size;
 

--- a/lib/CL/clEnqueueWriteBuffer.c
+++ b/lib/CL/clEnqueueWriteBuffer.c
@@ -31,7 +31,7 @@ POname(clEnqueueWriteBuffer)(cl_command_queue command_queue,
                      cl_mem buffer,
                      cl_bool blocking_write,
                      size_t offset,
-                     size_t cb, 
+                     size_t size,
                      const void *ptr,
                      cl_uint num_events_in_wait_list,
                      const cl_event *event_wait_list,
@@ -57,7 +57,7 @@ POname(clEnqueueWriteBuffer)(cl_command_queue command_queue,
 
   POCL_RETURN_ERROR_COND((ptr == NULL), CL_INVALID_VALUE);
 
-  if (pocl_buffer_boundcheck(buffer, offset, cb) != CL_SUCCESS)
+  if (pocl_buffer_boundcheck (buffer, offset, size) != CL_SUCCESS)
     return CL_INVALID_VALUE;
 
   errcode = pocl_check_event_wait_list (command_queue, num_events_in_wait_list,
@@ -74,15 +74,15 @@ POname(clEnqueueWriteBuffer)(cl_command_queue command_queue,
   if (errcode != CL_SUCCESS)
     return errcode;
 
-  cmd->command.write.host_ptr = ptr;
-  cmd->command.write.device_ptr =
-    (char*)buffer->device_ptrs[device->dev_id].mem_ptr;
+  cmd->command.write.src_host_ptr = ptr;
+  cmd->command.write.dst_device_ptr
+      = buffer->device_ptrs[device->dev_id].mem_ptr;
   cmd->command.write.offset = offset;
-  cmd->command.write.cb = cb;
-  cmd->command.write.buffer = buffer;
+  cmd->command.write.size = size;
 
   POname(clRetainMemObject) (buffer);
   buffer->owning_device = command_queue->device;
+
   pocl_command_enqueue(command_queue, cmd);
 
   if (blocking_write)

--- a/lib/CL/clEnqueueWriteBufferRect.c
+++ b/lib/CL/clEnqueueWriteBufferRect.c
@@ -85,8 +85,7 @@ POname(clEnqueueWriteBufferRect)(cl_command_queue command_queue,
                        event, num_events_in_wait_list, event_wait_list, 1,
                        &buffer);
 
-  cmd->command.write_rect.dst_device_ptr
-      = buffer->device_ptrs[device->dev_id].mem_ptr;
+  cmd->command.write_rect.dst_mem_id = &buffer->device_ptrs[device->dev_id];
   cmd->command.write_rect.src_host_ptr = ptr;
 
   cmd->command.write_rect.host_origin[0] = host_origin[0];

--- a/lib/CL/clEnqueueWriteBufferRect.c
+++ b/lib/CL/clEnqueueWriteBufferRect.c
@@ -81,27 +81,32 @@ POname(clEnqueueWriteBufferRect)(cl_command_queue command_queue,
 
   POCL_CHECK_DEV_IN_CMDQ;
 
-  POname(clRetainMemObject) (buffer);
-
   pocl_create_command (&cmd, command_queue, CL_COMMAND_WRITE_BUFFER_RECT,
                        event, num_events_in_wait_list, event_wait_list, 1,
                        &buffer);
 
-  cmd->command.write_image.device_ptr =
-    buffer->device_ptrs[device->dev_id].mem_ptr;
-  cmd->command.write_image.host_ptr = ptr;
-  memcpy (&cmd->command.write_image.origin,
-          buffer_origin, sizeof (size_t) * 3);
-  memcpy (&cmd->command.write_image.h_origin,
-          host_origin, sizeof (size_t) * 3);
-  memcpy (&cmd->command.write_image.region, region, sizeof (size_t) * 3);
-  cmd->command.write_image.h_rowpitch = host_row_pitch;
-  cmd->command.write_image.h_slicepitch = host_slice_pitch;
-  cmd->command.write_image.b_rowpitch = buffer_row_pitch;
-  cmd->command.write_image.b_slicepitch = buffer_slice_pitch;
-  cmd->command.write_image.buffer = buffer;
+  cmd->command.write_rect.dst_device_ptr
+      = buffer->device_ptrs[device->dev_id].mem_ptr;
+  cmd->command.write_rect.src_host_ptr = ptr;
 
-  buffer->owning_device = command_queue->device;
+  cmd->command.write_rect.host_origin[0] = host_origin[0];
+  cmd->command.write_rect.host_origin[1] = host_origin[1];
+  cmd->command.write_rect.host_origin[2] = host_origin[2];
+  cmd->command.write_rect.buffer_origin[0] = buffer_origin[0];
+  cmd->command.write_rect.buffer_origin[1] = buffer_origin[1];
+  cmd->command.write_rect.buffer_origin[2] = buffer_origin[2];
+  cmd->command.write_rect.region[0] = region[0];
+  cmd->command.write_rect.region[1] = region[1];
+  cmd->command.write_rect.region[2] = region[2];
+
+  cmd->command.write_rect.host_row_pitch = host_row_pitch;
+  cmd->command.write_rect.host_slice_pitch = host_slice_pitch;
+  cmd->command.write_rect.buffer_row_pitch = buffer_row_pitch;
+  cmd->command.write_rect.buffer_slice_pitch = buffer_slice_pitch;
+
+  POname (clRetainMemObject) (buffer);
+  buffer->owning_device = device;
+
   pocl_command_enqueue (command_queue, cmd);
 
   if (blocking_write)

--- a/lib/CL/clEnqueueWriteImage.c
+++ b/lib/CL/clEnqueueWriteImage.c
@@ -23,6 +23,17 @@ POname(clEnqueueWriteImage)(cl_command_queue    command_queue,
 
   POCL_RETURN_ERROR_COND((ptr == NULL), CL_INVALID_VALUE);
 
+  if (IS_IMAGE1D_BUFFER (image))
+    {
+      IMAGE1D_ORIG_REG_TO_BYTES (image, origin, region);
+      return POname (clEnqueueWriteBuffer) (
+          command_queue, image,
+          blocking_write,
+          i1d_origin[0], i1d_region[0],
+          ptr,
+          num_events_in_wait_list, event_wait_list, event);
+    }
+
   POCL_RETURN_ERROR_ON((command_queue->context != image->context),
     CL_INVALID_CONTEXT, "image and command_queue are not from the same context\n");
 
@@ -61,7 +72,6 @@ POname(clEnqueueWriteImage)(cl_command_queue    command_queue,
       return errcode;
     }  
 
-  HANDLE_IMAGE1D_BUFFER (image);
 
   cl_device_id dev = command_queue->device;
 

--- a/lib/CL/clEnqueueWriteImage.c
+++ b/lib/CL/clEnqueueWriteImage.c
@@ -64,9 +64,8 @@ POname(clEnqueueWriteImage)(cl_command_queue    command_queue,
   HANDLE_IMAGE1D_BUFFER (image);
 
   cl_device_id dev = command_queue->device;
-  cmd->command.write_image.dst_image = image;
-  cmd->command.write_image.dst_mem_id = &image->device_ptrs[dev->dev_id];
 
+  cmd->command.write_image.dst_mem_id = &image->device_ptrs[dev->dev_id];
   cmd->command.write_image.src_host_ptr = ptr;
   cmd->command.write_image.src_mem_id = NULL;
 

--- a/lib/CL/clGetSupportedImageFormats.c
+++ b/lib/CL/clGetSupportedImageFormats.c
@@ -79,12 +79,15 @@ CL_API_SUFFIX__VERSION_1_0
   for (i = 0; i < context->num_devices; ++i)
     {    
       device_id = context->devices[i];
-      errcode = device_id->ops->get_supported_image_formats 
-        (flags, dev_image_formats+i, (cl_uint*)(dev_num_image_formats + i));
-      
-      if (errcode != CL_SUCCESS)
-        goto CLEAN_MEM_AND_RETURN;
-      
+      if (device_id->image_support == CL_TRUE)
+        {
+          errcode = device_id->ops->get_supported_image_formats (
+              flags, dev_image_formats + i,
+              (cl_uint *)(dev_num_image_formats + i));
+          if (errcode != CL_SUCCESS)
+            goto CLEAN_MEM_AND_RETURN;
+        }
+
       if (dev_num_image_formats[i] == 0) {
         /* this device supports no image formats. since we have to
          * present the intersection of all supported image formats

--- a/lib/CL/clReleaseCommandQueue.c
+++ b/lib/CL/clReleaseCommandQueue.c
@@ -46,10 +46,11 @@ POname(clReleaseCommandQueue)(cl_command_queue command_queue) CL_API_SUFFIX__VER
       POCL_DESTROY_OBJECT (command_queue);
       POCL_MEM_FREE(command_queue);
 
-      POname(clReleaseContext)(context);
+      POCL_RELEASE_OBJECT (context, new_refcount);
+      POCL_MSG_PRINT_REFCOUNTS ("Context refs after freeing CmdQueue: %d\n",
+                                new_refcount);
       POname(clReleaseDevice)(device);
 
-      POCL_MSG_PRINT_REFCOUNTS ("Context refs after freeing CmdQueue: %d\n", context->pocl_refcount);
     }
   return CL_SUCCESS;
 }

--- a/lib/CL/clReleaseKernel.c
+++ b/lib/CL/clReleaseKernel.c
@@ -60,9 +60,11 @@ POname(clReleaseKernel)(cl_kernel kernel) CL_API_SUFFIX__VERSION_1_0
           /* Remove the kernel from the program's linked list of
              kernels */
           *pk = (*pk)->next;
+          POCL_RELEASE_OBJECT_UNLOCKED (program, new_refcount);
+          POCL_MSG_PRINT_REFCOUNTS ("Released non-default kernel kernel %p, "
+                                    "program %p now has refs: %d \n",
+                                    kernel, kernel->program, new_refcount);
           POCL_UNLOCK_OBJ (program);
-          POname (clReleaseProgram) (program);
-          POCL_MSG_PRINT_REFCOUNTS ("Released non-default kernel kernel %p, program %p now has refs: %d \n", kernel, kernel->program, kernel->program->pocl_refcount);
         }
 
       POCL_MEM_FREE (kernel->name);

--- a/lib/CL/clSetKernelArgSVMPointer.c
+++ b/lib/CL/clSetKernelArgSVMPointer.c
@@ -45,7 +45,6 @@ POname(clSetKernelArgSVMPointer)(cl_kernel kernel,
   mem->type = CL_MEM_OBJECT_BUFFER;
   mem->flags = CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE;
   mem->device_ptrs = NULL;
-  mem->latest_event = NULL;
   mem->owning_device = NULL;
   mem->is_image = CL_FALSE;
   mem->is_pipe = 0;

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -282,7 +282,7 @@ fill_dev_image_t (dev_image_t* di, struct pocl_argument* parg,
                               mem->image_channel_data_type,
                               &(di->_num_channels), &(di->_elem_size));
 
-  HANDLE_IMAGE1D_BUFFER (mem);
+  IMAGE1D_TO_BUFFER (mem);
   di->_data = (mem->device_ptrs[device->dev_id].mem_ptr);
 }
 
@@ -638,7 +638,8 @@ pocl_exec_command (_cl_command_node * volatile node)
     case CL_COMMAND_UNMAP_MEM_OBJECT:
       POCL_UPDATE_EVENT_RUNNING(event);
       POCL_LOCK_OBJ (event->mem_objs[0]);
-      if (event->mem_objs[0]->is_image == CL_FALSE) // TODO handle 1d-buffer
+      if (event->mem_objs[0]->is_image == CL_FALSE
+          || IS_IMAGE1D_BUFFER (event->mem_objs[0]))
         {
           assert (dev->ops->unmap_mem != NULL);
           dev->ops->unmap_mem (dev->data,

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -382,7 +382,7 @@ pocl_mem_objs_cleanup (cl_event event)
 }
 
 /**
- * executes given command.
+ * executes given command. Call with node->event UNLOCKED.
  */
 void
 pocl_exec_command (_cl_command_node * volatile node)
@@ -757,6 +757,7 @@ pocl_exec_command (_cl_command_node * volatile node)
   pocl_mem_manager_free_command (node);
 }
 
+/* call with brc_event UNLOCKED. */
 void
 pocl_broadcast (cl_event brc_event)
 {

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -377,10 +377,6 @@ pocl_mem_objs_cleanup (cl_event event)
   for (i = 0; i < event->num_buffers; ++i)
     {
       assert(event->mem_objs[i] != NULL);
-      POCL_LOCK_OBJ (event->mem_objs[i]);
-      if (event->mem_objs[i]->latest_event == event)
-        event->mem_objs[i]->latest_event = NULL;
-      POCL_UNLOCK_OBJ (event->mem_objs[i]);
       POname(clReleaseMemObject) (event->mem_objs[i]);
     }
   free (event->mem_objs);

--- a/lib/CL/devices/common.h
+++ b/lib/CL/devices/common.h
@@ -33,8 +33,6 @@
 #undef __CBUILD__
 
 #define XSETUP_DEVICE_CL_VERSION(A, B)             \
-  dev->cl_version_major = A;                      \
-  dev->cl_version_minor = B;                      \
   dev->cl_version_int = (A * 100) + (B * 10);     \
   dev->cl_version_std = "CL" # A "." # B;         \
   dev->version = "OpenCL " # A "." # B " pocl";
@@ -76,7 +74,7 @@ void fill_dev_image_t (dev_image_t* di, struct pocl_argument* parg,
 
 void fill_dev_sampler_t (dev_sampler_t *ds, struct pocl_argument *parg);
 
-void pocl_copy_mem_object (cl_device_id dest_dev, cl_mem dest, 
+void pocl_copy_mem_object (cl_device_id dest_dev, cl_mem dest,
                            size_t dest_offset,
                            cl_device_id source_dev, cl_mem source,
                            size_t source_offset, size_t cb);

--- a/lib/CL/devices/common.h
+++ b/lib/CL/devices/common.h
@@ -87,7 +87,6 @@ void pocl_scheduler (_cl_command_node * volatile * ready_list,
 void pocl_exec_command (_cl_command_node * volatile node);
 
 void pocl_ndrange_node_cleanup(_cl_command_node *node);
-void pocl_native_kernel_cleanup(_cl_command_node *node);
 void pocl_mem_objs_cleanup (cl_event event);
 
 void pocl_broadcast (cl_event event);

--- a/lib/CL/devices/common.h
+++ b/lib/CL/devices/common.h
@@ -66,6 +66,8 @@ extern "C" {
 #pragma GCC visibility push(hidden)
 #endif
 
+void pocl_init_cpu_device_infos (cl_device_id dev);
+
 char *llvm_codegen (const char *tmpdir, cl_kernel kernel, cl_device_id device,
                     size_t local_x, size_t local_y, size_t local_z);
 

--- a/lib/CL/devices/cpuinfo.c
+++ b/lib/CL/devices/cpuinfo.c
@@ -427,6 +427,19 @@ pocl_cpuinfo_get_cpu_name_and_vendor(cl_device_id device)
   device->long_name = new_name;
 }
 
+/*
+ * Expects:
+ *   short name
+ *
+ * Sets up:
+ *   vendor_id
+ *   vendor (name)
+ *   long name
+ *
+ *   max compute units IF NOT SET ALREADY
+ *   max clock freq
+ */
+
 void
 pocl_cpuinfo_detect_device_info(cl_device_id device) 
 {

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -130,7 +130,6 @@ pocl_cuda_init_device_ops (struct pocl_device_ops *ops)
   pocl_basic_init_device_ops (ops);
 
   ops->device_name = "CUDA";
-  ops->init_device_infos = pocl_cuda_init_device_infos;
   ops->build_hash = pocl_cuda_build_hash;
   ops->probe = pocl_cuda_probe;
   ops->uninit = pocl_cuda_uninit;
@@ -173,6 +172,29 @@ pocl_cuda_init (unsigned j, cl_device_id dev, const char *parameters)
 
   if (dev->data)
     return ret;
+
+  pocl_init_cpu_device_infos (dev);
+
+  dev->vendor = "NVIDIA Corporation";
+  dev->vendor_id = 0x10de; /* the PCIID for NVIDIA */
+
+  dev->type = CL_DEVICE_TYPE_GPU;
+  dev->address_bits = (sizeof (void *) * 8);
+
+  dev->llvm_target_triplet = (sizeof (void *) == 8) ? "nvptx64" : "nvptx";
+
+  dev->spmd = CL_TRUE;
+  dev->workgroup_pass = CL_FALSE;
+  dev->execution_capabilities = CL_EXEC_KERNEL;
+
+  dev->global_as_id = 1;
+  dev->local_as_id = 3;
+  dev->constant_as_id = 1;
+
+  /* TODO: Get images working */
+  dev->image_support = CL_FALSE;
+
+  dev->has_64bit_long = 1;
 
   pocl_cuda_device_data_t *data = calloc (1, sizeof (pocl_cuda_device_data_t));
   result = cuDeviceGet (&data->device, j);
@@ -383,33 +405,6 @@ pocl_cuda_build_hash (cl_device_id device)
   char *res = calloc (1000, sizeof (char));
   snprintf (res, 1000, "CUDA-%s", device->llvm_cpu);
   return res;
-}
-
-void
-pocl_cuda_init_device_infos (unsigned j, struct _cl_device_id *dev)
-{
-  pocl_basic_init_device_infos (j, dev);
-
-  dev->vendor = "NVIDIA Corporation";
-  dev->vendor_id = 0x10de; /* the PCIID for NVIDIA */
-
-  dev->type = CL_DEVICE_TYPE_GPU;
-  dev->address_bits = (sizeof (void *) * 8);
-
-  dev->llvm_target_triplet = (sizeof (void *) == 8) ? "nvptx64" : "nvptx";
-
-  dev->spmd = CL_TRUE;
-  dev->workgroup_pass = CL_FALSE;
-  dev->execution_capabilities = CL_EXEC_KERNEL;
-
-  dev->global_as_id = 1;
-  dev->local_as_id = 3;
-  dev->constant_as_id = 1;
-
-  /* TODO: Get images working */
-  dev->image_support = CL_FALSE;
-
-  dev->has_64bit_long = 1;
 }
 
 unsigned int

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -205,13 +205,13 @@ pocl_hsa_init_device_ops(struct pocl_device_ops *ops)
   ops->init = pocl_hsa_init;
   ops->alloc_mem_obj = pocl_hsa_alloc_mem_obj;
   ops->free = pocl_hsa_free;
-  //ops->run = pocl_hsa_run;
-  ops->read = pocl_basic_read;
-  ops->read_rect = pocl_basic_read_rect;
-  ops->write = pocl_basic_write;
-  ops->write_rect = pocl_basic_write_rect;
+  ops->run = NULL;
+  //  ops->read = pocl_basic_read;
+  //  ops->read_rect = pocl_basic_read_rect;
+  //  ops->write = pocl_basic_write;
+  //  ops->write_rect = pocl_basic_write_rect;
   ops->copy = pocl_hsa_copy;
-  ops->copy_rect = pocl_basic_copy_rect;
+  //  ops->copy_rect = pocl_basic_copy_rect;
   ops->get_timer_value = pocl_hsa_get_timer_value;
 
   // new driver api (out-of-order)
@@ -225,11 +225,8 @@ pocl_hsa_init_device_ops(struct pocl_device_ops *ops)
   ops->update_event = pocl_hsa_update_event;
   ops->free_event_data = pocl_hsa_free_event_data;
   ops->init_target_machine = NULL;
-  ops->run = NULL;
   ops->wait_event = pocl_hsa_wait_event;
   ops->update_event = pocl_hsa_update_event;
-  ops->free_event_data = NULL;
-
   ops->build_hash = pocl_hsa_build_hash;
 }
 
@@ -778,12 +775,16 @@ pocl_hsa_free (cl_device_id device, cl_mem memobj)
 }
 
 void
-pocl_hsa_copy (void *data, const void *src_ptr, size_t src_offset,
-               void *__restrict__ dst_ptr, size_t dst_offset, size_t cb)
+pocl_hsa_copy (void *data,
+               void *__restrict__ dst_ptr,
+               void *__restrict__ src_ptr,
+               size_t dst_offset,
+               size_t src_offset,
+               size_t size)
 {
   assert(src_offset == 0);
   assert(dst_offset == 0);
-  HSA_CHECK(hsa_memory_copy(dst_ptr, src_ptr, cb));
+  HSA_CHECK (hsa_memory_copy (dst_ptr, src_ptr, size));
 }
 
 cl_int

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -776,12 +776,16 @@ pocl_hsa_free (cl_device_id device, cl_mem memobj)
 
 void
 pocl_hsa_copy (void *data,
-               void *__restrict__ dst_ptr,
-               void *__restrict__ src_ptr,
+               pocl_mem_identifier * dst_mem_id,
+               cl_mem dst_buf,
+               pocl_mem_identifier * src_mem_id,
+               cl_mem src_buf,
                size_t dst_offset,
                size_t src_offset,
                size_t size)
 {
+  void *__restrict__ dst_ptr = dst_mem_id->mem_ptr;
+  void *__restrict__ src_ptr = src_mem_id->mem_ptr;
   assert(src_offset == 0);
   assert(dst_offset == 0);
   HSA_CHECK (hsa_memory_copy (dst_ptr, src_ptr, size));

--- a/lib/CL/devices/prototypes.inc
+++ b/lib/CL/devices/prototypes.inc
@@ -29,92 +29,110 @@
 #  define POP_VISIBILITY_HIDDEN _Pragma ("GCC visibility pop")
 #endif
 
-#define GEN_PROTOTYPES(__DRV__)                                         \
-  PUSH_VISIBILITY_HIDDEN                               \
+#define GEN_PROTOTYPES(__DRV__)                                               \
+  PUSH_VISIBILITY_HIDDEN                                                      \
   void pocl_##__DRV__##_submit (_cl_command_node *node, cl_command_queue cq); \
-  void pocl_##__DRV__##_join (cl_device_id device, cl_command_queue cq); \
-  void pocl_##__DRV__##_flush (cl_device_id device, cl_command_queue cq); \
-  void pocl_##__DRV__##_notify (cl_device_id device, cl_event event, cl_event finished);  \
-  void pocl_##__DRV__##_broadcast (cl_event event);                    \
-  void pocl_##__DRV__##_wait_event (cl_device_id device, cl_event event); \
-  void pocl_##__DRV__##_update_event (cl_device_id device, cl_event event, cl_int status); \
-  void pocl_##__DRV__##_free_event_data (cl_event event); \
-  void pocl_##__DRV__##_init_device_ops(struct pocl_device_ops* ops);  \
-  cl_int pocl_##__DRV__##_uninit (cl_device_id device);                   \
-  cl_int pocl_##__DRV__##_reinit (cl_device_id device);                   \
-  cl_int pocl_##__DRV__##_init (unsigned j, cl_device_id device, const char* parameters); \
-  unsigned int pocl_##__DRV__##_probe (struct pocl_device_ops *ops); \
-  cl_int pocl_##__DRV__##_init_queue (cl_command_queue queue); \
-  void pocl_##__DRV__##_free_queue (cl_command_queue queue); \
+  void pocl_##__DRV__##_join (cl_device_id device, cl_command_queue cq);      \
+  void pocl_##__DRV__##_flush (cl_device_id device, cl_command_queue cq);     \
+  void pocl_##__DRV__##_notify (cl_device_id device, cl_event event,          \
+                                cl_event finished);                           \
+  void pocl_##__DRV__##_broadcast (cl_event event);                           \
+  void pocl_##__DRV__##_wait_event (cl_device_id device, cl_event event);     \
+  void pocl_##__DRV__##_update_event (cl_device_id device, cl_event event,    \
+                                      cl_int status);                         \
+  void pocl_##__DRV__##_free_event_data (cl_event event);                     \
+  void pocl_##__DRV__##_init_device_ops (struct pocl_device_ops *ops);        \
+  cl_int pocl_##__DRV__##_uninit (cl_device_id device);                       \
+  cl_int pocl_##__DRV__##_reinit (cl_device_id device);                       \
+  cl_int pocl_##__DRV__##_init (unsigned j, cl_device_id device,              \
+                                const char *parameters);                      \
+  unsigned int pocl_##__DRV__##_probe (struct pocl_device_ops *ops);          \
+  cl_int pocl_##__DRV__##_init_queue (cl_command_queue queue);                \
+  void pocl_##__DRV__##_free_queue (cl_command_queue queue);                  \
   cl_int pocl_##__DRV__##_alloc_mem_obj (cl_device_id device, cl_mem mem_obj, \
-                                         void* host_ptr); \
-  void *pocl_##__DRV__##_create_sub_buffer (void *device_data, void* buffer, \
-                                            size_t origin, size_t size); \
-  void pocl_##__DRV__##_free (cl_device_id device, cl_mem mem_obj);   \
-  void pocl_##__DRV__##_free_ptr (cl_device_id device, void* mem_ptr);   \
-  void pocl_##__DRV__##_read (void *data, void *host_ptr,                   \
-                          const void *device_ptr, size_t offset, size_t cb); \
-  void pocl_##__DRV__##_read_rect (void *data, void *host_ptr,          \
-                               void *device_ptr,                        \
-                               const size_t *buffer_origin,             \
-                               const size_t *host_origin,               \
-                               const size_t *region,                    \
-                               size_t buffer_row_pitch,                 \
-                               size_t buffer_slice_pitch,               \
-                               size_t host_row_pitch,                   \
-                               size_t host_slice_pitch);                \
-  void pocl_##__DRV__##_write (void *data, const void *host_ptr,        \
-                               void *device_ptr, size_t offset, size_t cb); \
-  void pocl_##__DRV__##_write_rect (void *data, const void *host_ptr,  \
-                                void *device_ptr,                       \
-                                const size_t *buffer_origin,            \
-                                const size_t *host_origin,              \
-                                const size_t *region,                   \
-                                size_t buffer_row_pitch,                \
-                                size_t buffer_slice_pitch,              \
-                                size_t host_row_pitch,                  \
-                                size_t host_slice_pitch);               \
-  void pocl_##__DRV__##_copy (void *data, const void *src_ptr, \
-                             size_t src_offset, void *__restrict__ dst_ptr, \
-                             size_t dst_offset, size_t cb);       \
-  void pocl_##__DRV__##_copy_rect (void *data, const void *src_ptr,         \
-                               void *dst_ptr,                           \
-                               const size_t *src_origin,                \
-                               const size_t *dst_origin,                \
-                               const size_t *region,                    \
-                               size_t src_row_pitch,                    \
-                               size_t src_slice_pitch,                  \
-                               size_t dst_row_pitch,                    \
-                               size_t dst_slice_pitch);                 \
-  void pocl_##__DRV__##_fill_rect (void *data,           \
-                           void *__restrict__ const device_ptr, \
-                           const size_t *__restrict__ const buffer_origin,  \
-                           const size_t *__restrict__ const region,         \
-                           size_t const buffer_row_pitch,      \
-                           size_t const buffer_slice_pitch,    \
-                           void *fill_pixel,    \
-                           size_t pixel_size);  \
-  void pocl_##__DRV__##_compile_kernel (_cl_command_node *node, \
-                                        cl_kernel kernel, \
-                                        cl_device_id device);  \
-  void pocl_##__DRV__##_memfill (void *ptr,           \
-                            size_t size,              \
-                            size_t offset,            \
-                            const void* pattern,      \
-                            size_t pattern_size);     \
-  void pocl_##__DRV__##_run (void *data, _cl_command_node* cmd);        \
-  void pocl_##__DRV__##_run_native (void *data, _cl_command_node* cmd); \
-  void* pocl_##__DRV__##_map_mem (void *data, void *buf_ptr,         \
-                        size_t offset, size_t size, void *host_ptr); \
-  void* pocl_##__DRV__##_unmap_mem (void *data, void *host_ptr, \
-                                    void *device_start_ptr, size_t offset, \
-                                    size_t size); \
-  cl_ulong pocl_##__DRV__##_get_timer_value(void *data); \
-  char* pocl_##__DRV__##_init_build (void *data); \
-  char* pocl_##__DRV__##_build_hash (cl_device_id device); \
-  void pocl_##__DRV__##_init_target_machine (void *data, void* target_machine);\
-  cl_int pocl_##__DRV__##_get_supported_image_formats (cl_mem_flags flags,\
-                                         const cl_image_format **image_formats,\
-                                         cl_uint *num_image_formats);\
-
-POP_VISIBILITY_HIDDEN
+                                         void *host_ptr);                     \
+  void *pocl_##__DRV__##_create_sub_buffer (void *device_data, void *buffer,  \
+                                            size_t origin, size_t size);      \
+  void pocl_##__DRV__##_free (cl_device_id device, cl_mem mem_obj);           \
+  void pocl_##__DRV__##_free_ptr (cl_device_id device, void *mem_ptr);        \
+  void pocl_##__DRV__##_read (void *data, void *__restrict__ dst_host_ptr,    \
+                              void *__restrict__ src_device_ptr,              \
+                              size_t offset, size_t size);                    \
+  void pocl_##__DRV__##_read_rect (                                           \
+      void *data, void *__restrict__ dst_host_ptr,                            \
+      void *__restrict__ src_device_ptr, const size_t *buffer_origin,         \
+      const size_t *host_origin, const size_t *region,                        \
+      size_t buffer_row_pitch, size_t buffer_slice_pitch,                     \
+      size_t host_row_pitch, size_t host_slice_pitch);                        \
+  void pocl_##__DRV__##_write (                                               \
+      void *data, const void *__restrict__ src_host_ptr,                      \
+      void *__restrict__ dst_device_ptr, size_t offset, size_t size);         \
+  void pocl_##__DRV__##_write_rect (                                          \
+      void *data, const void *__restrict__ src_host_ptr,                      \
+      void *__restrict__ dst_device_ptr, const size_t *buffer_origin,         \
+      const size_t *host_origin, const size_t *region,                        \
+      size_t buffer_row_pitch, size_t buffer_slice_pitch,                     \
+      size_t host_row_pitch, size_t host_slice_pitch);                        \
+  void pocl_##__DRV__##_copy (void *data, void *__restrict__ dst_device_ptr,  \
+                              void *__restrict__ src_device_ptr,              \
+                              size_t dst_offset, size_t src_offset,           \
+                              size_t size);                                   \
+  void pocl_##__DRV__##_copy_rect (                                           \
+      void *data, void *__restrict__ dst_device_ptr,                          \
+      void *__restrict__ src_device_ptr, const size_t *dst_origin,            \
+      const size_t *src_origin, const size_t *region, size_t dst_row_pitch,   \
+      size_t dst_slice_pitch, size_t src_row_pitch, size_t src_slice_pitch);  \
+  void pocl_##__DRV__##_compile_kernel (                                      \
+      _cl_command_node *node, cl_kernel kernel, cl_device_id device);         \
+  void pocl_##__DRV__##_memfill (                                             \
+      void *data, void *__restrict__ device_ptr, size_t size, size_t offset,  \
+      const void *__restrict__ pattern, size_t pattern_size);                 \
+  void pocl_##__DRV__##_run (void *data, _cl_command_node *cmd);              \
+  void pocl_##__DRV__##_run_native (void *data, _cl_command_node *cmd);       \
+  cl_int pocl_##__DRV__##_map_mem (                                           \
+      void *data, void *__restrict__ src_device_ptr, mem_mapping_t *map);     \
+  cl_int pocl_##__DRV__##_unmap_mem (                                         \
+      void *data, void *__restrict__ dst_device_ptr, mem_mapping_t *map);     \
+  cl_ulong pocl_##__DRV__##_get_timer_value (void *data);                     \
+  char *pocl_##__DRV__##_init_build (void *data);                             \
+  char *pocl_##__DRV__##_build_hash (cl_device_id device);                    \
+  void pocl_##__DRV__##_init_target_machine (void *data,                      \
+                                             void *target_machine);           \
+  cl_int pocl_##__DRV__##_get_supported_image_formats (                       \
+      cl_mem_flags flags, const cl_image_format **image_formats,              \
+      cl_uint *num_image_formats);                                            \
+  void *pocl_##__DRV__##_create_image (                                       \
+      void *data, const cl_image_format *image_format,                        \
+      const cl_image_desc *image_desc, cl_mem image, cl_int *err);            \
+  cl_int pocl_##__DRV__##_free_image (void *data, cl_mem image,               \
+                                      void *mem_id);                          \
+  void *pocl_##__DRV__##_create_sampler (void *data, cl_sampler samp,         \
+                                         cl_int *err);                        \
+  cl_int pocl_##__DRV__##_free_sampler (void *data, cl_sampler samp,          \
+                                        void *sampler_data);                  \
+  cl_int pocl_##__DRV__##_copy_image_rect (                                   \
+      void *data, cl_mem src_image, cl_mem dst_image,                         \
+      pocl_mem_identifier *src_mem_id, pocl_mem_identifier *dst_mem_id,       \
+      const size_t *src_origin, const size_t *dst_origin,                     \
+      const size_t *region);                                                  \
+  cl_int pocl_##__DRV__##_write_image_rect (                                  \
+      void *data, cl_mem dst_image, pocl_mem_identifier *dst_mem_id,          \
+      const void *__restrict__ src_host_ptr, pocl_mem_identifier *src_mem_id, \
+      const size_t *origin, const size_t *region, size_t src_row_pitch,       \
+      size_t src_slice_pitch, size_t src_offset);                             \
+  cl_int pocl_##__DRV__##_read_image_rect (                                   \
+      void *data, cl_mem src_image, pocl_mem_identifier *src_mem_id,          \
+      void *__restrict__ dst_host_ptr, pocl_mem_identifier *dst_mem_id,       \
+      const size_t *origin, const size_t *region, size_t dst_row_pitch,       \
+      size_t dst_slice_pitch, size_t dst_offset);                             \
+  cl_int pocl_##__DRV__##_map_image (void *data, cl_mem src_image,            \
+                                     pocl_mem_identifier *mem_id,             \
+                                     mem_mapping_t *map);                     \
+  cl_int pocl_##__DRV__##_unmap_image (void *data, cl_mem dst_image,          \
+                                       pocl_mem_identifier *mem_id,           \
+                                       mem_mapping_t *map);                   \
+  cl_int pocl_##__DRV__##_fill_image (                                        \
+      void *data, cl_mem image, pocl_mem_identifier *mem_id,                  \
+      const size_t *origin, const size_t *region,                             \
+      const void *__restrict__ fill_pixel, size_t pixel_size);                \
+  POP_VISIBILITY_HIDDEN

--- a/lib/CL/devices/prototypes.inc
+++ b/lib/CL/devices/prototypes.inc
@@ -56,43 +56,50 @@
   void pocl_##__DRV__##_free (cl_device_id device, cl_mem mem_obj);           \
   void pocl_##__DRV__##_free_ptr (cl_device_id device, void *mem_ptr);        \
   void pocl_##__DRV__##_read (void *data, void *__restrict__ dst_host_ptr,    \
-                              void *__restrict__ src_device_ptr,              \
-                              size_t offset, size_t size);                    \
+                              pocl_mem_identifier *src_mem_id,                \
+                              cl_mem src_buf, size_t offset, size_t size);    \
   void pocl_##__DRV__##_read_rect (                                           \
       void *data, void *__restrict__ dst_host_ptr,                            \
-      void *__restrict__ src_device_ptr, const size_t *buffer_origin,         \
-      const size_t *host_origin, const size_t *region,                        \
-      size_t buffer_row_pitch, size_t buffer_slice_pitch,                     \
-      size_t host_row_pitch, size_t host_slice_pitch);                        \
-  void pocl_##__DRV__##_write (                                               \
-      void *data, const void *__restrict__ src_host_ptr,                      \
-      void *__restrict__ dst_device_ptr, size_t offset, size_t size);         \
+      pocl_mem_identifier *src_mem_id, cl_mem src_buf,                        \
+      const size_t *buffer_origin, const size_t *host_origin,                 \
+      const size_t *region, size_t buffer_row_pitch,                          \
+      size_t buffer_slice_pitch, size_t host_row_pitch,                       \
+      size_t host_slice_pitch);                                               \
+  void pocl_##__DRV__##_write (void *data,                                    \
+                               const void *__restrict__ src_host_ptr,         \
+                               pocl_mem_identifier *dst_mem_id,               \
+                               cl_mem dst_buf, size_t offset, size_t size);   \
   void pocl_##__DRV__##_write_rect (                                          \
       void *data, const void *__restrict__ src_host_ptr,                      \
-      void *__restrict__ dst_device_ptr, const size_t *buffer_origin,         \
-      const size_t *host_origin, const size_t *region,                        \
-      size_t buffer_row_pitch, size_t buffer_slice_pitch,                     \
-      size_t host_row_pitch, size_t host_slice_pitch);                        \
-  void pocl_##__DRV__##_copy (void *data, void *__restrict__ dst_device_ptr,  \
-                              void *__restrict__ src_device_ptr,              \
-                              size_t dst_offset, size_t src_offset,           \
-                              size_t size);                                   \
+      pocl_mem_identifier *dst_mem_id, cl_mem dst_buf,                        \
+      const size_t *buffer_origin, const size_t *host_origin,                 \
+      const size_t *region, size_t buffer_row_pitch,                          \
+      size_t buffer_slice_pitch, size_t host_row_pitch,                       \
+      size_t host_slice_pitch);                                               \
+  void pocl_##__DRV__##_copy (                                                \
+      void *data, pocl_mem_identifier *dst_mem_id, cl_mem dst_buf,            \
+      pocl_mem_identifier *src_mem_id, cl_mem src_buf, size_t dst_offset,     \
+      size_t src_offset, size_t size);                                        \
   void pocl_##__DRV__##_copy_rect (                                           \
-      void *data, void *__restrict__ dst_device_ptr,                          \
-      void *__restrict__ src_device_ptr, const size_t *dst_origin,            \
-      const size_t *src_origin, const size_t *region, size_t dst_row_pitch,   \
-      size_t dst_slice_pitch, size_t src_row_pitch, size_t src_slice_pitch);  \
+      void *data, pocl_mem_identifier *dst_mem_id, cl_mem dst_buf,            \
+      pocl_mem_identifier *src_mem_id, cl_mem src_buf,                        \
+      const size_t *dst_origin, const size_t *src_origin,                     \
+      const size_t *region, size_t dst_row_pitch, size_t dst_slice_pitch,     \
+      size_t src_row_pitch, size_t src_slice_pitch);                          \
   void pocl_##__DRV__##_compile_kernel (                                      \
       _cl_command_node *node, cl_kernel kernel, cl_device_id device);         \
-  void pocl_##__DRV__##_memfill (                                             \
-      void *data, void *__restrict__ device_ptr, size_t size, size_t offset,  \
-      const void *__restrict__ pattern, size_t pattern_size);                 \
+  void pocl_##__DRV__##_memfill (void *data, pocl_mem_identifier *dst_mem_id, \
+                                 cl_mem dst_buf, size_t size, size_t offset,  \
+                                 const void *__restrict__ pattern,            \
+                                 size_t pattern_size);                        \
   void pocl_##__DRV__##_run (void *data, _cl_command_node *cmd);              \
   void pocl_##__DRV__##_run_native (void *data, _cl_command_node *cmd);       \
-  cl_int pocl_##__DRV__##_map_mem (                                           \
-      void *data, void *__restrict__ src_device_ptr, mem_mapping_t *map);     \
-  cl_int pocl_##__DRV__##_unmap_mem (                                         \
-      void *data, void *__restrict__ dst_device_ptr, mem_mapping_t *map);     \
+  cl_int pocl_##__DRV__##_map_mem (void *data,                                \
+                                   pocl_mem_identifier *src_mem_id,           \
+                                   cl_mem src_buf, mem_mapping_t *map);       \
+  cl_int pocl_##__DRV__##_unmap_mem (void *data,                              \
+                                     pocl_mem_identifier *dst_mem_id,         \
+                                     cl_mem dst_buf, mem_mapping_t *map);     \
   cl_ulong pocl_##__DRV__##_get_timer_value (void *data);                     \
   char *pocl_##__DRV__##_init_build (void *data);                             \
   char *pocl_##__DRV__##_build_hash (cl_device_id device);                    \
@@ -125,12 +132,11 @@
       void *__restrict__ dst_host_ptr, pocl_mem_identifier *dst_mem_id,       \
       const size_t *origin, const size_t *region, size_t dst_row_pitch,       \
       size_t dst_slice_pitch, size_t dst_offset);                             \
-  cl_int pocl_##__DRV__##_map_image (void *data, cl_mem src_image,            \
-                                     pocl_mem_identifier *mem_id,             \
-                                     mem_mapping_t *map);                     \
-  cl_int pocl_##__DRV__##_unmap_image (void *data, cl_mem dst_image,          \
+  cl_int pocl_##__DRV__##_map_image (void *data, pocl_mem_identifier *mem_id, \
+                                     cl_mem src_image, mem_mapping_t *map);   \
+  cl_int pocl_##__DRV__##_unmap_image (void *data,                            \
                                        pocl_mem_identifier *mem_id,           \
-                                       mem_mapping_t *map);                   \
+                                       cl_mem dst_image, mem_mapping_t *map); \
   cl_int pocl_##__DRV__##_fill_image (                                        \
       void *data, cl_mem image, pocl_mem_identifier *mem_id,                  \
       const size_t *origin, const size_t *region,                             \

--- a/lib/CL/devices/prototypes.inc
+++ b/lib/CL/devices/prototypes.inc
@@ -39,7 +39,6 @@
   void pocl_##__DRV__##_wait_event (cl_device_id device, cl_event event); \
   void pocl_##__DRV__##_update_event (cl_device_id device, cl_event event, cl_int status); \
   void pocl_##__DRV__##_free_event_data (cl_event event); \
-  void pocl_##__DRV__##_init_device_infos(unsigned j, struct _cl_device_id* dev);  \
   void pocl_##__DRV__##_init_device_ops(struct pocl_device_ops* ops);  \
   cl_int pocl_##__DRV__##_uninit (cl_device_id device);                   \
   cl_int pocl_##__DRV__##_reinit (cl_device_id device);                   \
@@ -117,4 +116,5 @@
   cl_int pocl_##__DRV__##_get_supported_image_formats (cl_mem_flags flags,\
                                          const cl_image_format **image_formats,\
                                          cl_uint *num_image_formats);\
+
 POP_VISIBILITY_HIDDEN

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -117,21 +117,14 @@ pocl_pthread_init_device_ops(struct pocl_device_ops *ops)
 
   ops->device_name = "pthread";
 
-  /* implementation */
+  /* implementation that differs from basic */
   ops->probe = pocl_pthread_probe;
   ops->uninit = pocl_pthread_uninit;
   ops->reinit = pocl_pthread_reinit;
   ops->init = pocl_pthread_init;
-  ops->alloc_mem_obj = pocl_basic_alloc_mem_obj;
-  ops->free = pocl_basic_free;
-  ops->read = pocl_pthread_read;
-  ops->write = pocl_pthread_write;
-  ops->copy = pocl_pthread_copy;
-  ops->copy_rect = pocl_basic_copy_rect;
   ops->run = pocl_pthread_run;
   ops->join = pocl_pthread_join;
   ops->submit = pocl_pthread_submit;
-  ops->compile_kernel = pocl_basic_compile_kernel;
   ops->notify = pocl_pthread_notify;
   ops->broadcast = pocl_broadcast;
   ops->flush = pocl_pthread_flush;
@@ -304,36 +297,6 @@ pocl_pthread_reinit (cl_device_id device)
   pthread_scheduler_init (device);
 
   return CL_SUCCESS;
-}
-
-void
-pocl_pthread_read (void *data, void *host_ptr, const void *device_ptr,
-                   size_t offset, size_t cb)
-{
-  if (host_ptr == device_ptr)
-    return;
-
-  memcpy (host_ptr, (char*)device_ptr + offset, cb);
-}
-
-void
-pocl_pthread_write (void *data, const void *host_ptr, void *device_ptr,
-                    size_t offset, size_t cb)
-{
-  if (host_ptr == device_ptr)
-    return;
-
-  memcpy ((char*)device_ptr + offset, host_ptr, cb);
-}
-
-void
-pocl_pthread_copy (void *data, const void *src_ptr, size_t src_offset,
-                   void *__restrict__ dst_ptr, size_t dst_offset, size_t cb)
-{
-  if (src_ptr == dst_ptr)
-    return;
-
-  memcpy ((char*)dst_ptr + dst_offset, (char*)src_ptr + src_offset, cb);
 }
 
 void

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -502,7 +502,7 @@ pocl_pthread_exec_command (_cl_command_node *cmd,
 {
   if(cmd->type == CL_COMMAND_NDRANGE_KERNEL)
     {
-      pocl_pthread_prepare_kernel (cmd->command.run.data, cmd);
+      pocl_pthread_prepare_kernel (cmd->device->data, cmd);
     }
   else
     {

--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -354,28 +354,33 @@ pocl_tce_alloc_mem_obj (cl_device_id device, cl_mem mem_obj, void* host_ptr)
 }
 
 void
-pocl_tce_write (void *data, const void *host_ptr, void *device_ptr, 
-                size_t offset, size_t cb)
+pocl_tce_write (void *data,
+                void *__restrict__ host_ptr,
+                void *__restrict__ device_ptr,
+                size_t offset, size_t size)
 {
   TCEDevice *d = (TCEDevice*)data;
   chunk_info_t *chunk = (chunk_info_t*)device_ptr;
 #ifdef DEBUG_TTA_DRIVER
-  printf("host: write %x %x %u\n", host_ptr, chunk->start_address + offset, cb);
+  printf ("host: write %x %x %u\n", host_ptr, chunk->start_address + offset,
+          size);
 #endif
-  d->copyHostToDevice(host_ptr, chunk->start_address + offset, cb);
+  d->copyHostToDevice (host_ptr, chunk->start_address + offset, size);
 }
 
 void
-pocl_tce_read (void *data, void *host_ptr, const void *device_ptr, 
-               size_t offset, size_t cb)
+pocl_tce_read (void *data,
+               const void *__restrict__ host_ptr,
+               void *__restrict__ device_ptr,
+               size_t offset, size_t size)
 {
   TCEDevice* d = (TCEDevice*)data;
   chunk_info_t *chunk = (chunk_info_t*)device_ptr;
 #ifdef DEBUG_TTA_DRIVER
-  printf("host: read to %x (host) from %d (device) %u\n", host_ptr,
-         chunk->start_address + offset, cb);
+  printf ("host: read to %x (host) from %d (device) %u\n", host_ptr,
+          chunk->start_address + offset, size);
 #endif
-  d->copyDeviceToHost(chunk->start_address + offset, host_ptr, cb);
+  d->copyDeviceToHost (chunk->start_address + offset, host_ptr, size);
 }
 
 void *
@@ -756,27 +761,31 @@ pocl_tce_build_hash (cl_device_id device)
 }
 
 void
-pocl_tce_copy (void */*data*/, const void *src_ptr, size_t /*src_offset*/,
-               void *__restrict__ dst_ptr, size_t /*dst_offset*/, size_t cb)
+pocl_tce_copy (void */*data*/,
+               void *__restrict__ dst_ptr,
+               void *__restrict__ src_ptr,
+               size_t dst_offset,
+               size_t src_offset,
+               size_t size)
 {
   POCL_ABORT_UNIMPLEMENTED("Copy not yet supported in TCE driver.");
   if (src_ptr == dst_ptr)
     return;
 
-  memcpy (dst_ptr, src_ptr, cb);
+  memcpy (dst_ptr, src_ptr, size);
 }
 
 void
 pocl_tce_copy_rect (void */*data*/,
-                    const void *__restrict const src_ptr,
                     void *__restrict__ const dst_ptr,
+                    const void *__restrict const src_ptr,
+                    const size_t *__restrict__ const dst_origin,
                     const size_t *__restrict__ const src_origin,
-                    const size_t *__restrict__ const dst_origin, 
                     const size_t *__restrict__ const region,
-                    size_t const src_row_pitch,
-                    size_t const src_slice_pitch,
                     size_t const dst_row_pitch,
-                    size_t const dst_slice_pitch)
+                    size_t const dst_slice_pitch,
+                    size_t const src_row_pitch,
+                    size_t const src_slice_pitch)
 {
   char const *__restrict const adjusted_src_ptr = 
     (char const*)src_ptr +

--- a/lib/CL/devices/tce/tce_common.h
+++ b/lib/CL/devices/tce/tce_common.h
@@ -55,6 +55,9 @@ class TCEDevice {
   virtual void copyDeviceToHost
     (uint32_t src_addr, const void *host_ptr, size_t count) = 0;
 
+  virtual void copyDeviceToDevice
+    (uint32_t src_addr, uint32_t dst_addr, size_t count) = 0;
+
   virtual void loadProgramToDevice(const std::string& asmFileName) = 0;
   /* Restarts the device to start the program from the beginning. */
   virtual void restartProgram() = 0;

--- a/lib/CL/devices/tce/ttasim/ttasim.cc
+++ b/lib/CL/devices/tce/ttasim/ttasim.cc
@@ -89,6 +89,7 @@ pocl_ttasim_init_device_ops(struct pocl_device_ops *ops)
   ops->copy = pocl_tce_copy;
   ops->copy_rect = pocl_tce_copy_rect;
   ops->map_mem = pocl_tce_map_mem;
+  ops->unmap_mem = pocl_tce_unmap_mem;
   ops->run = pocl_tce_run;
   ops->get_timer_value = pocl_ttasim_get_timer_value;
   ops->init_build = pocl_tce_init_build;
@@ -170,7 +171,15 @@ public:
       unsigned char val = ((char*)host_ptr)[i];
       globalMem->write (dest_addr + i, (Memory::MAU)(val));
     }
+  }
 
+  virtual void copyDeviceToDevice(uint32_t src_addr, uint32_t dest_addr, size_t count) {
+    MemorySystem &mems = simulator.memorySystem();
+    MemorySystem::MemoryPtr globalMem = mems.memory (*global_as);
+    for (std::size_t i = 0; i < count; ++i) {
+      unsigned char val =  globalMem->read (src_addr + i);
+      globalMem->write (dest_addr + i, (Memory::MAU)(val));
+    }
   }
 
   virtual void copyDeviceToHost(uint32_t src_addr, const void *host_ptr, 

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -353,13 +353,15 @@ struct pocl_device_ops {
   /* clEnqReadBuffer */
   void (*read) (void *data,
                 void *__restrict__  dst_host_ptr,
-                void *__restrict__ src_device_ptr,
+                pocl_mem_identifier * src_mem_id,
+                cl_mem src_buf,
                 size_t offset,
                 size_t size);
   /* clEnqReadBufferRect */
   void (*read_rect) (void *data,
                      void *__restrict__ dst_host_ptr,
-                     void *__restrict__ src_device_ptr,
+                     pocl_mem_identifier * src_mem_id,
+                     cl_mem src_buf,
                      const size_t *buffer_origin,
                      const size_t *host_origin, 
                      const size_t *region,
@@ -370,13 +372,15 @@ struct pocl_device_ops {
   /* clEnqWriteBuffer */
   void (*write) (void *data,
                  const void *__restrict__  src_host_ptr,
-                 void *__restrict__  dst_device_ptr,
+                 pocl_mem_identifier * dst_mem_id,
+                 cl_mem dst_buf,
                  size_t offset,
                  size_t size);
   /* clEnqWriteBufferRect */
   void (*write_rect) (void *data,
                       const void *__restrict__ src_host_ptr,
-                      void *__restrict__ dst_device_ptr,
+                      pocl_mem_identifier * dst_mem_id,
+                      cl_mem dst_buf,
                       const size_t *buffer_origin,
                       const size_t *host_origin, 
                       const size_t *region,
@@ -386,15 +390,19 @@ struct pocl_device_ops {
                       size_t host_slice_pitch);
   /* clEnqCopyBuffer */
   void (*copy) (void *data,
-                void *__restrict__ dst_device_ptr,
-                void *__restrict__ src_device_ptr,
+                pocl_mem_identifier * dst_mem_id,
+                cl_mem dst_buf,
+                pocl_mem_identifier * src_mem_id,
+                cl_mem src_buf,
                 size_t dst_offset,
                 size_t src_offset,
                 size_t size);
   /* clEnqCopyBufferRect */
   void (*copy_rect) (void *data,
-                     void *__restrict__ dst_device_ptr,
-                     void *__restrict__ src_device_ptr,
+                     pocl_mem_identifier * dst_mem_id,
+                     cl_mem dst_buf,
+                     pocl_mem_identifier * src_mem_id,
+                     cl_mem src_buf,
                      const size_t *dst_origin,
                      const size_t *src_origin,
                      const size_t *region,
@@ -405,7 +413,8 @@ struct pocl_device_ops {
 
   /* clEnqFillBuffer */
   void (*memfill) (void *data,
-                   void *__restrict__ device_ptr,
+                   pocl_mem_identifier * dst_mem_id,
+                   cl_mem dst_buf,
                    size_t size,
                    size_t offset,
                    const void *__restrict__  pattern,
@@ -415,11 +424,13 @@ struct pocl_device_ops {
      host-accessible memory. This might or might not involve copying 
      the block from the device. */
   cl_int (*map_mem) (void *data,
-                    void *__restrict__ src_device_ptr,
-                    mem_mapping_t *map);
+                     pocl_mem_identifier * src_mem_id,
+                     cl_mem src_buf,
+                     mem_mapping_t *map);
   cl_int (*unmap_mem) (void *data,
-                      void *__restrict__ dst_device_ptr,
-                      mem_mapping_t *map);
+                       pocl_mem_identifier * dst_mem_id,
+                       cl_mem dst_buf,
+                       mem_mapping_t *map);
 
   /* compile the fully linked LLVM IR to target-specific binaries. */
   void (*compile_kernel) (_cl_command_node* cmd, cl_kernel kernel, cl_device_id device);
@@ -518,14 +529,14 @@ struct pocl_device_ops {
 
   /* maps the entire image from device to host */
   cl_int (*map_image) (void *data,
-                       cl_mem src_image,
                        pocl_mem_identifier *mem_id,
+                       cl_mem src_image,
                        mem_mapping_t *map);
 
   /* unmaps the entire image from host to device */
   cl_int (*unmap_image) (void *data,
-                         cl_mem dst_image,
                          pocl_mem_identifier *mem_id,
+                         cl_mem dst_image,
                          mem_mapping_t *map);
 
   /* fill image with pattern */

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -669,8 +669,6 @@ struct _cl_mem {
   cl_device_id shared_mem_allocation_owner;
   /* device where this mem obj resides */
   volatile cl_device_id owning_device;
-  /* latest event assosiated with the buffer, set NULL when event completed */
-  volatile cl_event latest_event;
   /* A linked list of regions of the buffer mapped to the 
      host memory */
   mem_mapping_t *mappings;

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -109,12 +109,17 @@ typedef pthread_mutex_t pocl_lock_t;
     }                                                                         \
   while (0)
 
-#define POCL_RELEASE_OBJECT(__OBJ__, __NEW_REFCOUNT__)                  \
-  do {                                                                  \
-    POCL_LOCK_OBJ (__OBJ__);                                            \
-    __NEW_REFCOUNT__ = --(__OBJ__)->pocl_refcount;                      \
-    POCL_UNLOCK_OBJ (__OBJ__);                                          \
-  } while (0)
+#define POCL_RELEASE_OBJECT_UNLOCKED(__OBJ__, __NEW_REFCOUNT__)               \
+  __NEW_REFCOUNT__ = --(__OBJ__)->pocl_refcount
+
+#define POCL_RELEASE_OBJECT(__OBJ__, __NEW_REFCOUNT__)                        \
+  do                                                                          \
+    {                                                                         \
+      POCL_LOCK_OBJ (__OBJ__);                                                \
+      POCL_RELEASE_OBJECT_UNLOCKED (__OBJ__, __NEW_REFCOUNT__);               \
+      POCL_UNLOCK_OBJ (__OBJ__);                                              \
+    }                                                                         \
+  while (0)
 
 #define POCL_RETAIN_OBJECT_UNLOCKED(__OBJ__)    \
     ++((__OBJ__)->pocl_refcount);

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -265,9 +265,6 @@ typedef struct pocl_argument_info {
 
 struct pocl_device_ops {
   const char *device_name;
-  void *shared_data; /* data to be shared by a devices of same type */
-  void (*init_device_infos) (unsigned j, struct _cl_device_id*);
-  /* implementation */
 
   /* New driver api extension for out-of-order execution and
      asynchronous devices.

--- a/lib/CL/pocl_image_util.c
+++ b/lib/CL/pocl_image_util.c
@@ -26,6 +26,14 @@
 #include "pocl_cl.h"
 #include "pocl_util.h"
 
+void
+origin_to_bytes (cl_mem mem, const size_t *origin, size_t *byte_offset)
+{
+  *byte_offset = origin[0] + origin[1] * mem->image_row_pitch
+                 + origin[2] * mem->image_slice_pitch;
+  *byte_offset *= (mem->image_elem_size * mem->image_channels);
+}
+
 static unsigned
 pocl_get_image_dim (const cl_mem image)
 {

--- a/lib/CL/pocl_image_util.h
+++ b/lib/CL/pocl_image_util.h
@@ -30,6 +30,8 @@
 #pragma GCC visibility push(hidden)
 #endif
 
+void origin_to_bytes (cl_mem mem, const size_t *origin, size_t *byte_offset);
+
 extern cl_int 
 pocl_check_image_origin_region (const cl_mem image, 
                                 const size_t *origin, 

--- a/lib/CL/pocl_llvm.h
+++ b/lib/CL/pocl_llvm.h
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 /* Returns the cpu name as reported by LLVM. */
-char* get_cpu_name();
+char *get_llvm_cpu_name ();
 /* Returns if the cpu supports FMA instruction (uses LLVM). */
 int cpu_has_fma();
 

--- a/lib/CL/pocl_llvm_utils.cc
+++ b/lib/CL/pocl_llvm_utils.cc
@@ -121,7 +121,9 @@ int getModuleTriple(const char *input_stream, size_t size,
   return 0;
 }
 
-char *get_cpu_name() {
+char *
+get_llvm_cpu_name ()
+{
 
   StringRef r = llvm::sys::getHostCPUName();
 

--- a/lib/CL/pocl_llvm_wg.cc
+++ b/lib/CL/pocl_llvm_wg.cc
@@ -629,7 +629,12 @@ int pocl_llvm_codegen(cl_device_id device, void *modp, char **output,
   SmallVector<char, 4096> data;
   llvm::raw_svector_ostream sos(data);
   if (target &&
+#ifdef LLVM_OLDER_THAN_7_0
       target->addPassesToEmitFile(PM, sos, TargetMachine::CGFT_ObjectFile))
+#else
+      target->addPassesToEmitFile(PM, sos, nullptr,
+                                  TargetMachine::CGFT_ObjectFile))
+#endif
     return 1;
 #endif
 

--- a/lib/CL/pocl_shared.h
+++ b/lib/CL/pocl_shared.h
@@ -50,7 +50,8 @@ cl_int pocl_rect_copy(cl_command_queue command_queue,
                       size_t dst_slice_pitch,
                       cl_uint num_events_in_wait_list,
                       const cl_event *event_wait_list,
-                      cl_event *event);
+                      cl_event *event,
+                      _cl_command_node **cmd);
 
 cl_int program_compile_dynamic_wg_binaries(cl_program program);
 

--- a/lib/CL/pocl_tracing.c
+++ b/lib/CL/pocl_tracing.c
@@ -182,17 +182,18 @@ text_tracer_event_updated (cl_event event, int status)
   switch (event->command_type)
     {
     case CL_COMMAND_READ_BUFFER:
-      text_size += sprintf (cur_buf, "size=%"PRIuS", host_ptr=%p\n",
-                            node->command.read.cb,
-                            node->command.read.host_ptr);
+      text_size += sprintf (cur_buf, "size=%" PRIuS ", host_ptr=%p\n",
+                            node->command.read.size,
+                            node->command.read.dst_host_ptr);
       break;
     case CL_COMMAND_WRITE_BUFFER:
-      text_size += sprintf (cur_buf, "size=%"PRIuS", host_ptr=%p\n\n",
-                            node->command.write.cb,
-                            node->command.write.host_ptr);
+      text_size += sprintf (cur_buf, "size=%" PRIuS ", host_ptr=%p\n\n",
+                            node->command.write.size,
+                            node->command.write.src_host_ptr);
       break;
     case CL_COMMAND_COPY_BUFFER:
-      text_size += sprintf (cur_buf, "size=%"PRIuS"\n", node->command.copy.cb);
+      text_size
+          += sprintf (cur_buf, "size=%" PRIuS "\n", node->command.copy.size);
       break;
     case CL_COMMAND_NDRANGE_KERNEL:
       text_size += sprintf (cur_buf, "name=%s\n",

--- a/lib/CL/pocl_tracing.c
+++ b/lib/CL/pocl_tracing.c
@@ -50,6 +50,7 @@ static const struct pocl_event_tracer *pocl_event_tracers[] = {
 
 static const struct pocl_event_tracer *event_tracer = NULL;
 
+/* called with event locked, and must also return with locked event */
 void
 pocl_event_updated (cl_event event, int status)
 {

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -516,6 +516,7 @@ cl_int pocl_create_command (_cl_command_node **cmd,
   return CL_SUCCESS;
 }
 
+/* call with node->event UNLOCKED */
 void pocl_command_enqueue (cl_command_queue command_queue,
                           _cl_command_node *node)
 {
@@ -559,7 +560,7 @@ void pocl_command_enqueue (cl_command_queue command_queue,
     POname(clFinish) (command_queue);
 }
 
-
+/* call (and return) with node->event locked */
 void
 pocl_command_push (_cl_command_node *node, 
                    _cl_command_node *volatile *ready_list, 
@@ -586,6 +587,7 @@ pocl_command_push (_cl_command_node *node,
     }
 }
 
+/* call with both event->queue and event UNLOCKED */
 int pocl_update_command_queue (cl_event event)
 {
   int cq_ready;

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -644,26 +644,6 @@ pocl_cl_mem_inherit_flags (cl_mem mem, cl_mem from_buffer, cl_mem_flags flags)
                | (from_buffer->flags & CL_MEM_COPY_HOST_PTR);
 }
 
-cl_int pocl_update_mem_obj_sync (cl_command_queue cq, _cl_command_node *cmd, 
-                                 cl_mem mem, char operation)
-{
-  int i;
-  POCL_LOCK_OBJ (mem);
-  mem->owning_device = cmd->device;
-  mem->latest_event = cmd->event;
-  POCL_UNLOCK_OBJ (mem);
-
-  for (i = 0; i < cmd->event->num_buffers; ++i)
-    {
-      if (cmd->event->mem_objs[i] == NULL)
-        {
-          cmd->event->mem_objs[i] = mem;
-          break;
-        }
-    }
-  return CL_SUCCESS;
-}
-
 int pocl_buffer_boundcheck(cl_mem buffer, size_t offset, size_t size) {
   POCL_RETURN_ERROR_ON ((offset > buffer->size), CL_INVALID_VALUE,
                         "offset(%zu) > buffer->size(%zu)\n", offset,

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -149,10 +149,6 @@ pocl_update_command_queue (cl_event event);
 void pocl_cl_mem_inherit_flags (cl_mem mem, cl_mem from_buffer,
                                 cl_mem_flags flags);
 
-cl_int 
-pocl_update_mem_obj_sync (cl_command_queue cq, _cl_command_node *cmd, 
-                          cl_mem mem, char operation);
-
 void pocl_setup_context(cl_context context);
 
 /* Helpers for dealing with devices / subdevices */

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -265,9 +265,17 @@ float half_to_float (uint16_t value);
     }                                                                   \
   while (0)
 
-#define HANDLE_IMAGE1D_BUFFER(mem)                                            \
+#define IMAGE1D_TO_BUFFER(mem)                                                \
   mem = ((mem->is_image && (mem->type == CL_MEM_OBJECT_IMAGE1D_BUFFER))       \
              ? mem->buffer                                                    \
              : mem);
+
+#define IS_IMAGE1D_BUFFER(mem)                                                \
+  (mem->is_image && (mem->type == CL_MEM_OBJECT_IMAGE1D_BUFFER))
+
+#define IMAGE1D_ORIG_REG_TO_BYTES(mem, o, r)                                  \
+  size_t px = (mem->image_elem_size * mem->image_channels);                   \
+  size_t i1d_origin[3] = { o[0] * px, o[1], o[2] };                           \
+  size_t i1d_region[3] = { r[0] * px, r[1], r[2] };
 
 #endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 set(SANITIZER_OPTIONS "")
 
 if(ENABLE_ASAN)
-  if("${CMAKE_C_COMPILER_VERSION}" VERSION_LESS "5.1.0")
+  if("${CMAKE_C_COMPILER_VERSION}" VERSION_LESS "6.0.0")
     list(APPEND SANITIZER_OPTIONS "-fsanitize=address")
   else()
     list(APPEND SANITIZER_OPTIONS "-fsanitize=address" "-fsanitize-recover=address")


### PR DESCRIPTION
Small changes:

* remove some old unused code
* few LLVM 7 fixes

Big(ger) changes:

* merges device->init_device_infos() with device->init()
* completely separates image handling from buffer handling in the driver API. Ofc image support is entirely optional. The API should be suitable to implement image support for HSA, CUDA and whatever else (though that is not done in this PR)
* changed the driver API to use pocl_mem_identifiers instead of device memory pointers directly. This is required for the next PR.