### PR TITLE
[CUDA] Fix build for LLVM 7.0

### DIFF
--- a/lib/CL/devices/cuda/pocl-ptx-gen.cc
+++ b/lib/CL/devices/cuda/pocl-ptx-gen.cc
@@ -135,6 +135,9 @@ int pocl_ptx_gen(const char *BitcodeFilename, const char *PTXFilename,
   llvm::SmallVector<char, 4096> Data;
   llvm::raw_svector_ostream PTXStream(Data);
   if (Machine->addPassesToEmitFile(Passes, PTXStream,
+#if ! LLVM_OLDER_THAN_7_0
+                                   nullptr,
+#endif
                                    llvm::TargetMachine::CGFT_AssemblyFile)) {
     POCL_MSG_ERR("[CUDA] ptx-gen: failed to add passes\n");
     return 1;


### PR DESCRIPTION
The `addPassesToEmitFile` function has an additional argument.

Recommend cherry picking to the 1.2 release.