### PR TITLE
[CUDA] Map LLVM math intrinsics to libdevice calls

### DIFF
--- a/lib/CL/devices/cuda/pocl-ptx-gen.cc
+++ b/lib/CL/devices/cuda/pocl-ptx-gen.cc
@@ -795,8 +795,10 @@ void mapLibDeviceCalls(llvm::Module *Module) {
 
 // clang-format off
 #define LDMAP(name) \
-  {name "f", "__nv_" name "f"}, \
-  {name,     "__nv_" name},
+  {        name "f",    "__nv_" name "f"}, \
+  {        name,        "__nv_" name}, \
+  {"llvm." name ".f32", "__nv_" name "f"}, \
+  {"llvm." name ".f64", "__nv_" name},
 
     LDMAP("acos")
     LDMAP("acosh")


### PR DESCRIPTION
Just adds additional entries for the `llvm.*.f{32,64}` intrinsics to the libdevice function map.

Recommend cherry picking to the 1.2 release.
