### PR TITLE
[CUDA] Implement proper async work-group copies

### DIFF
--- a/lib/kernel/cuda/CMakeLists.txt
+++ b/lib/kernel/cuda/CMakeLists.txt
@@ -32,6 +32,7 @@ foreach(FILE atomics.cl)
 endforeach()
 
 foreach(FILE
+  async_work_group_copy.cl async_work_group_strided_copy.cl
   atomic_add.ll atomic_and.ll atomic_cmpxchg.ll atomic_dec.ll atomic_inc.ll
   atomic_min.ll atomic_max.ll atomic_or.ll atomic_sub.ll atomic_xchg.ll
   atomic_xor.ll barrier.ll
@@ -39,6 +40,7 @@ foreach(FILE
   get_local_id.c get_local_size.c get_num_groups.c
   get_global_offset.c
   printf.c
+  wait_group_events.cl
   )
   list(REMOVE_ITEM KERNEL_SOURCES "${FILE}")
   list(APPEND KERNEL_SOURCES "cuda/${FILE}")

--- a/lib/kernel/cuda/async_work_group_copy.cl
+++ b/lib/kernel/cuda/async_work_group_copy.cl
@@ -1,0 +1,78 @@
+/* OpenCL built-in library: async_work_group_copy()
+
+   Copyright (c) 2018 pocl developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+// TODO: Use get_local_linear_id() when available
+#define IMPLEMENT_ASYNC_COPY_FUNCS_SINGLE(GENTYPE)                          \
+  __attribute__((overloadable))                                             \
+  event_t async_work_group_copy(__local GENTYPE *dst,                       \
+                                const __global GENTYPE *src,                \
+                                size_t num_gentypes,                        \
+                                event_t event)                              \
+  {                                                                         \
+    size_t lid =                                                            \
+      get_local_id(0) +                                                     \
+      (get_local_id(1) +                                                    \
+       (get_local_id(2) * get_local_size(1))) * get_local_size(0);          \
+    size_t lsz = get_local_size(0) * get_local_size(1) * get_local_size(2); \
+    for (size_t i = lid; i < num_gentypes; i+=lsz)                          \
+      dst[i] = src[i];                                                      \
+    return event;                                                           \
+  }                                                                         \
+                                                                            \
+  __attribute__((overloadable))                                             \
+  event_t async_work_group_copy(__global GENTYPE *dst,                      \
+                                const __local GENTYPE *src,                 \
+                                size_t num_gentypes,                        \
+                                event_t event)                              \
+  {                                                                         \
+    size_t lid =                                                            \
+      get_local_id(0) +                                                     \
+      (get_local_id(1) +                                                    \
+       (get_local_id(2) * get_local_size(1))) * get_local_size(0);          \
+    size_t lsz = get_local_size(0) * get_local_size(1) * get_local_size(2); \
+    for (size_t i = lid; i < num_gentypes; i+=lsz)                          \
+      dst[i] = src[i];                                                      \
+    return event;                                                           \
+  }
+
+
+#define IMPLEMENT_ASYNC_COPY_FUNCS(GENTYPE)             \
+  IMPLEMENT_ASYNC_COPY_FUNCS_SINGLE(GENTYPE)            \
+  IMPLEMENT_ASYNC_COPY_FUNCS_SINGLE(GENTYPE##2)         \
+  IMPLEMENT_ASYNC_COPY_FUNCS_SINGLE(GENTYPE##3)         \
+  IMPLEMENT_ASYNC_COPY_FUNCS_SINGLE(GENTYPE##4)         \
+  IMPLEMENT_ASYNC_COPY_FUNCS_SINGLE(GENTYPE##8)         \
+  IMPLEMENT_ASYNC_COPY_FUNCS_SINGLE(GENTYPE##16)
+
+IMPLEMENT_ASYNC_COPY_FUNCS(char);
+IMPLEMENT_ASYNC_COPY_FUNCS(uchar);
+IMPLEMENT_ASYNC_COPY_FUNCS(short);
+IMPLEMENT_ASYNC_COPY_FUNCS(ushort);
+IMPLEMENT_ASYNC_COPY_FUNCS(int);
+IMPLEMENT_ASYNC_COPY_FUNCS(uint);
+__IF_INT64(IMPLEMENT_ASYNC_COPY_FUNCS(long));
+__IF_INT64(IMPLEMENT_ASYNC_COPY_FUNCS(ulong));
+
+IMPLEMENT_ASYNC_COPY_FUNCS(float);
+__IF_FP64(IMPLEMENT_ASYNC_COPY_FUNCS(double));
+__IF_FP16 (IMPLEMENT_ASYNC_COPY_FUNCS (half));

--- a/lib/kernel/cuda/async_work_group_strided_copy.cl
+++ b/lib/kernel/cuda/async_work_group_strided_copy.cl
@@ -1,0 +1,73 @@
+/* OpenCL built-in library: async_work_group_strided_copy()
+
+   Copyright (c) 2018 pocl developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+// TODO: Use get_local_linear_id() when available
+#define IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS_SINGLE(GENTYPE)                    \
+  __attribute__ ((overloadable)) event_t async_work_group_strided_copy (      \
+    __local GENTYPE *dst, const __global GENTYPE *src, size_t num_gentypes,   \
+    size_t src_stride, event_t event)                                         \
+  {                                                                           \
+    size_t lid =                                                              \
+      get_local_id(0) +                                                       \
+      (get_local_id(1) +                                                      \
+       (get_local_id(2) * get_local_size(1))) * get_local_size(0);            \
+    size_t lsz = get_local_size(0) * get_local_size(1) * get_local_size(2);   \
+    for (size_t i = lid; i < num_gentypes; i+=lsz)                            \
+      dst[i] = src[i * src_stride];                                           \
+    return event;                                                             \
+  }                                                                           \
+                                                                              \
+  __attribute__ ((overloadable)) event_t async_work_group_strided_copy (      \
+      __global GENTYPE *dst, const __local GENTYPE *src, size_t num_gentypes, \
+      size_t dst_stride, event_t event)                                       \
+  {                                                                           \
+    size_t lid =                                                              \
+      get_local_id(0) +                                                       \
+      (get_local_id(1) +                                                      \
+       (get_local_id(2) * get_local_size(1))) * get_local_size(0);            \
+    size_t lsz = get_local_size(0) * get_local_size(1) * get_local_size(2);   \
+    for (size_t i = lid; i < num_gentypes; i+=lsz)                            \
+      dst[i * dst_stride] = src[i];                                           \
+    return event;                                                             \
+  }
+
+#define IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS(GENTYPE)                           \
+  IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS_SINGLE (GENTYPE)                         \
+  IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS_SINGLE (GENTYPE##2)                      \
+  IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS_SINGLE (GENTYPE##3)                      \
+  IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS_SINGLE (GENTYPE##4)                      \
+  IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS_SINGLE (GENTYPE##8)                      \
+  IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS_SINGLE (GENTYPE##16)
+
+IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS (char);
+IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS (uchar);
+IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS (short);
+IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS (ushort);
+IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS (int);
+IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS (uint);
+__IF_INT64 (IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS (long));
+__IF_INT64 (IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS (ulong));
+
+__IF_FP16 (IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS (half));
+IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS (float);
+__IF_FP64 (IMPLEMENT_ASYNC_STRIDED_COPY_FUNCS (double));

--- a/lib/kernel/cuda/wait_group_events.cl
+++ b/lib/kernel/cuda/wait_group_events.cl
@@ -1,0 +1,28 @@
+/* OpenCL built-in library: wait_group_events()
+
+   Copyright (c) 2018 pocl developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+void _CL_OVERLOADABLE wait_group_events (int num_events,
+                                         event_t *event_list)
+{
+  barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE);
+}


### PR DESCRIPTION
Use a blocked copy, with a barrier in wait_group_events().

This gets the `basic` conformance test suite passing with CUDA again.