### PR TITLE
Ensure to not use CPU autodetection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,10 +400,9 @@ if (OCS_AVAILABLE)
 
   if(NOT DEFINED HOST_DEVICE_BUILD_HASH)
     if(KERNELLIB_HOST_CPU_VARIANTS STREQUAL "distro")
-      set(HOST_DEVICE_BUILD_HASH "${LLC_TRIPLE}")
-    else()
-      set(HOST_DEVICE_BUILD_HASH "${LLC_TRIPLE}-${LLC_HOST_CPU}")
+      set(LLC_HOST_CPU "generic")
     endif()
+    set(HOST_DEVICE_BUILD_HASH "${LLC_TRIPLE}-${LLC_HOST_CPU}")
   endif()
 
   if(ARM AND LLVM_3_9)


### PR DESCRIPTION
Ensure to not use CPU autodetection
when building distro packages.

Without this patch, config.h's `OCL_KERNEL_TARGET_CPU` got this value and
lib/CL/devices/basic/basic.c
lib/CL/pocl_llvm_utils.cc
lib/CL/pocl_llvm_build.cc
used the value, creating variations in build results.

Note: I tested that it builds reproducibly on different CPUs, but not that it works.