### PR TITLE
CUDA device code is not hosted

### DIFF
--- a/lib/kernel/cuda/CMakeLists.txt
+++ b/lib/kernel/cuda/CMakeLists.txt
@@ -56,7 +56,7 @@ else( CMAKE_SIZEOF_VOID_P EQUAL 8 )
 endif( CMAKE_SIZEOF_VOID_P EQUAL 8 )
 
 
-set(CLANG_FLAGS "-emit-llvm" "-target" "${LLVM_TARGET}" "-D_CL_DISABLE_HALF")
+set(CLANG_FLAGS "-ffreestanding" "-emit-llvm" "-target" "${LLVM_TARGET}" "-D_CL_DISABLE_HALF")
 
 if(POCL_USE_FAKE_ADDR_SPACE_IDS)
   list(APPEND CLANG_FLAGS "-Xclang" "-ffake-address-space-map" "-DPOCL_USE_FAKE_ADDR_SPACE_IDS")


### PR DESCRIPTION
When building the cuda driver with LLVM 7, compilation of the device
functions may fail with the error:

/usr/include/stdint.h:26:10: fatal error: 'bits/libc-header-start.h' file not found

Adding `-ffreestanding` to the compilation flags for the cuda driver
avoids attempts to access the host include files.

Fixes #671.