### PR TITLE
pthread: broadcast event updates with pthread_cond_broadcast()

### DIFF
--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -447,7 +447,7 @@ void pocl_pthread_update_event (cl_device_id device, cl_event event, cl_int stat
       pocl_update_command_queue (event, pthread_scheduler_release_host);
       POCL_LOCK_OBJ (event);
 
-      pthread_cond_signal(&e_d->event_cond);
+      pthread_cond_broadcast(&e_d->event_cond);
       break;
 
     default:
@@ -465,7 +465,7 @@ void pocl_pthread_update_event (cl_device_id device, cl_event event, cl_int stat
       pocl_update_command_queue (event, pthread_scheduler_release_host);
       POCL_LOCK_OBJ (event);
 
-      pthread_cond_signal (&e_d->event_cond);
+      pthread_cond_broadcast (&e_d->event_cond);
       break;
     }
 }


### PR DESCRIPTION
pocl_pthread_update_event() notifies event waiters about changes of status. It should use pthread_cond_broadcast() rather than pthread_cond_signal() so all waiters get notified in case multiple threads are waiting on the event.