### PR TITLE
Support older GLIBC

### DIFF
--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -24,7 +24,7 @@
 */
 
 /* for posix_memalign and strdup */
-#define _DEFAULT_SOURCE
+#define _BSD_SOURCE
 #define _POSIX_C_SOURCE 200809L
 
 #include "common.h"

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -1289,6 +1289,28 @@ struct _cl_sampler {
   #include <sys/endian.h>
 #else
   #include <endian.h>
+  #if defined(__GLIBC__) && __GLIBC__ == 2 && \
+      defined(__GLIBC_MINOR__) && __GLIBC_MINOR__ < 9 && \
+      defined(__x86_64__)
+    #ifndef htole64
+      #define htole64(x) (x)
+    #endif
+    #ifndef htole32
+      #define htole32(x) (x)
+    #endif
+    #ifndef htole16
+      #define htole16(x) (x)
+    #endif
+    #ifndef le64toh
+      #define le64toh(x) (x)
+    #endif
+    #ifndef le32toh
+      #define le32toh(x) (x)
+    #endif
+    #ifndef le16toh
+      #define le16toh(x) (x)
+    #endif
+  #endif
 #endif
 
 #endif /* POCL_CL_H */

--- a/lib/poclu/cl_half.c
+++ b/lib/poclu/cl_half.c
@@ -23,6 +23,9 @@
    THE SOFTWARE.
 */
 
+// for exp2
+#define _ISOC99_SOURCE
+
 #include <math.h>
 #include "poclu.h"
 #include <CL/opencl.h>


### PR DESCRIPTION
With this change I can build on a CentOS 5 machine (Needed to build a wheel for pyopencl).

Fixes https://github.com/pocl/pocl/issues/678