### PR TITLE
Add option to disable installing of OpenCL headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -837,7 +837,7 @@ message(STATUS "Run tests with ICD: ${TESTS_USE_ICD}")
 if(INSTALL_OPENCL_HEADERS)
   message(STATUS "Install POCL's OpenCL headers: ${INSTALL_OPENCL_HEADERS}")
 elseif(DEFINED INSTALL_OPENCL_HEADERS AND NOT INSTALL_OPENCL_HEADERS)
-  message(STATUS "Not install POCL's OpenCL headers: ${INSTALL_OPENCL_HEADERS}")
+  message(STATUS "Not installing OpenCL headers.")
 else() # Undefined = auto -> check
   find_file(OPENCL_H opencl.h PATH_SUFFIXES CL OpenCL)
   if(OPENCL_H)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -834,8 +834,10 @@ message(STATUS "Run tests with ICD: ${TESTS_USE_ICD}")
 
 ######################################################################################
 
-if(DEFINED INSTALL_OPENCL_HEADERS)
+if(INSTALL_OPENCL_HEADERS)
   message(STATUS "Install POCL's OpenCL headers: ${INSTALL_OPENCL_HEADERS}")
+elseif(DEFINED INSTALL_OPENCL_HEADERS AND NOT INSTALL_OPENCL_HEADERS)
+  message(STATUS "Not install POCL's OpenCL headers: ${INSTALL_OPENCL_HEADERS}")
 else() # Undefined = auto -> check
   find_file(OPENCL_H opencl.h PATH_SUFFIXES CL OpenCL)
   if(OPENCL_H)


### PR DESCRIPTION
Currently only installing or auto detection of OpenCL headers is possible. 
With this patch it is possible to install (cmake -DINSTALL_OPENCL_HEADERS=1/YES), not install (cmake -DINSTALL_OPENCL_HEADERS=0/NO) or auto detect (cmake). 
With no option set, it behaves like before. 