### PR TITLE
[CUDA] Improve printf handling

### DIFF
--- a/lib/CL/devices/cuda/pocl-ptx-gen.cc
+++ b/lib/CL/devices/cuda/pocl-ptx-gen.cc
@@ -308,6 +308,15 @@ void fixPrintF(llvm::Module *Module) {
       llvm::Value *Arg = Call->getArgOperand(A + 1);
       llvm::Type *ArgType = Arg->getType();
 
+      // Cast pointers to the generic address space.
+      if (ArgType->isPointerTy() && ArgType->getPointerAddressSpace() != 0) {
+        llvm::CastInst *AddrSpaceCast =llvm::CastInst::CreatePointerCast(
+          Arg, ArgType->getPointerElementType()->getPointerTo());
+        AddrSpaceCast->insertBefore(Call);
+        Arg = AddrSpaceCast;
+        ArgType = Arg->getType();
+      }
+
       // Get pointer to argument in i64 array.
       // TODO: promote arguments that are shorter than 32 bits.
       llvm::Constant *ArgIndex = llvm::ConstantInt::get(I32, A);

--- a/lib/kernel/cuda/printf.c
+++ b/lib/kernel/cuda/printf.c
@@ -70,7 +70,11 @@ __cl_printf(__attribute__((address_space(4))) char* restrict format, ...)
             vprintf("%s", arg_data);
             break;
           }
-          default: goto error;
+          default:
+          {
+            vprintf("<format error>", &ch);
+            break;
+          }
         }
         ch = *++format;
       }
@@ -83,9 +87,4 @@ __cl_printf(__attribute__((address_space(4))) char* restrict format, ...)
 
   va_end(ap);
   return 0;
-
-  error:
-  va_end(ap);
-  vprintf("(printf format string error)", &ch);
-  return -1;
 }

--- a/lib/kernel/cuda/printf.c
+++ b/lib/kernel/cuda/printf.c
@@ -58,6 +58,12 @@ __cl_printf(__attribute__((address_space(4))) char* restrict format, ...)
             vprintf("%d", arg_data);
             break;
           }
+          case 'x':
+          {
+            __cl_va_arg(ap, arg_data, 1);
+            vprintf("%x", arg_data);
+            break;
+          }
           case 'f':
           {
             __cl_va_arg(ap, arg_data, 2);


### PR DESCRIPTION
This fixes a bug that was causing kernels to crash when printing strings using `%s` (as seen in #702), and adds a couple of other improvements that helps when printing errors from pocl's internal tests.

NOTE: #702 is still an issue, it just now actually tells you the test failed rather than crashing