### PR TITLE
Create global offset 0 specialized WG functions.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,10 @@ Changes updated until commit 8cb33c3399a (April 4 2019).
 1.4 unreleased
 ==============
 
+Kernel Compiler
+---------------
+- Specialize work-group functions for global offset (0,0,0).
+
 1.3 April 2019
 ==============
 

--- a/doc/sphinx/source/development.rst
+++ b/doc/sphinx/source/development.rst
@@ -84,11 +84,14 @@ Coding Style
 ------------
 
 The code base of pocl consists most of pure C sources and C++ sources (mostly
-the kernel compiler).
+the kernel compiler an).
 
-1) In the C sources, follow the GNU style.
+1) In the C sources, follow the GNU C style, but with spaces for indent.
 
-   http://www.gnu.org/prep/standards/html_node/Writing-C.html
+   The GNU C style guide is here: http://www.gnu.org/prep/standards/html_node/Writing-C.html
+
+   This guide should be followed except please use 2 spaces instead of the
+   confusing "smart" mix of tabs and spaces for indentation.
 
 2) In the C++ sources (mostly the LLVM passes), follow the LLVM coding
    guidelines so it is easier to upstream general code to the LLVM project
@@ -96,9 +99,35 @@ the kernel compiler).
 
    http://llvm.org/docs/CodingStandards.html
 
-It's acknowledged that the pocl code base does fully not adhere to these
-principles at the moment, but the aim is to gradually fix the style and any
-new code merged to master should adhere to them.
+It's acknowledged that the pocl code base does not fully adhere to these
+principles at the moment, but the aim is to gradually fix the style with
+every new commit improving the style.
+
+An example emacs configuration to help get the pocl code style correct::
+
+  (setq default-tab-width 2)
+  (setq-default indent-tabs-mode nil)
+  (setq-default show-trailing-whitespace t)
+  
+  (defun my-c-mode-common-hook ()
+    (c-set-style "gnu")
+    (setq tab-width 2)
+    (setq c-basic-offset 2)
+  )
+  (add-hook 'c-mode-common-hook 'my-c-mode-common-hook)
+  
+  (defun my-cpp-mode-common-hook ()
+    (c-set-style "stroustrup")
+    (setq tab-width 2)
+    (setq c-basic-offset 2)
+    )
+  (add-hook 'c++-mode-hook 'my-cpp-mode-common-hook)
+  
+  (add-to-list 'auto-mode-alist '("\\.cl$" . c-mode))
+  (add-to-list 'auto-mode-alist '("\\.icc$" . c++-mode))
+  (add-to-list 'auto-mode-alist '("\\.cc$" . c++-mode))
+
+
 
 Khronos ICD Loader
 ------------------

--- a/doc/sphinx/source/faq.rst
+++ b/doc/sphinx/source/faq.rst
@@ -105,14 +105,15 @@ pocl source code
 Why C99 in host library?
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The kernel compiler passes are in C++11 and it's much faster to implement
-things in C++11. Why use C99 in the host library?
+The kernel compiler passes and some of the driver implementations are in C++11
+and it's much faster to implement things in C++11. Why require using C99 in
+the host library?
 
 pocl is meant to be very portable to various type of devices, also
-to those with very little resources (no operating systems at all, simple
-runtime libraries). C has better portability to low end CPUs.
+to those with very little resources (no operating system at all and with pruned
+runtime libraries). C has better portability to low end CPUs and VMs.
 
 Thus, in order for a CPU to act as an OpenCL host without online kernel
-compilation support, now only C99 support is required from the target,
-no C++ compiler or C++ runtime is needed. Also, C programs are said to produce
-more "lightweight" binaries, but that is debatable.
+compilation support, only C99 support is required from the target,
+no C++ compiler, runtime or STL is needed. Also, C programs are said to
+sometimes produce more "lightweight" binaries, but that is debatable.

--- a/examples/vecadd/CMakeLists.txt
+++ b/examples/vecadd/CMakeLists.txt
@@ -34,6 +34,8 @@ target_link_libraries("vecadd" ${POCLU_LINK_OPTIONS})
 
 add_test("examples/vecadd" "vecadd")
 
+add_test("examples/vecadd_large_grid" "vecadd" "128000" "128" "10000" "100" "1" "1")
+
 set_tests_properties( "examples/vecadd"
   PROPERTIES
     COST 3.0

--- a/examples/vecadd/vecadd_exec.c
+++ b/examples/vecadd/vecadd_exec.c
@@ -10,9 +10,9 @@ extern "C" {
 
 int
 exec_vecadd_kernel (cl_context context, cl_device_id device,
-		    cl_command_queue cmd_queue, cl_program program,
-		    int n, cl_float *srcA, cl_float *srcB,
-		    cl_float *dst)
+                    cl_command_queue cmd_queue, cl_program program, int n,
+                    int wg_size,
+                    cl_float *srcA, cl_float *srcB, cl_float *dst)
 {
   cl_kernel kernel = NULL;
   cl_mem memobjs[3] = { 0, 0, 0 };
@@ -51,7 +51,7 @@ exec_vecadd_kernel (cl_context context, cl_device_id device,
   CHECK_CL_ERROR2 (err);
 
   global_work_size[0] = n;
-  local_work_size[0] = 128;
+  local_work_size[0] = wg_size;
 
   err = clEnqueueNDRangeKernel (cmd_queue, kernel, 1, NULL, global_work_size,
 				local_work_size, 0, NULL, NULL);

--- a/include/pocl_cache.h
+++ b/include/pocl_cache.h
@@ -94,7 +94,8 @@ void pocl_cache_kernel_cachedir_path (char* kernel_cachedir_path,
                                       const char* append_str,
                                       size_t local_x,
                                       size_t local_y,
-                                      size_t local_z);
+                                      size_t local_z,
+				      int assume_zero_global_offset);
 
 
 int pocl_cache_write_kernel_parallel_bc(void*        bc,
@@ -103,7 +104,8 @@ int pocl_cache_write_kernel_parallel_bc(void*        bc,
                                         cl_kernel    kernel,
                                         size_t       local_x,
                                         size_t       local_y,
-                                        size_t       local_z);
+                                        size_t       local_z,
+					int assume_zero_global_offset);
 
 
 // required by pocl_binary.c
@@ -121,14 +123,20 @@ void pocl_cache_program_bc_path(char*       program_bc_path,
                                cl_program   program,
                                unsigned     device_i);
 
-void pocl_cache_work_group_function_path(char* parallel_bc_path, cl_program program,
-                              unsigned device_i, cl_kernel kernel,
-                              size_t local_x, size_t local_y, size_t local_z);
+void pocl_cache_work_group_function_path(char* parallel_bc_path,
+					 cl_program program,
+					 unsigned device_i,
+					 cl_kernel kernel,
+					 size_t local_x, size_t local_y,
+					 size_t local_z,
+					 int assume_zero_global_offset);
 
-void pocl_cache_final_binary_path(char* final_binary_path, cl_program program,
-                               unsigned device_i, cl_kernel kernel,
-                               size_t local_x, size_t local_y,
-                               size_t local_z);
+void pocl_cache_final_binary_path(char* final_binary_path,
+				  cl_program program,
+				  unsigned device_i, cl_kernel kernel,
+				  size_t local_x, size_t local_y,
+				  size_t local_z,
+				  int assume_zero_global_offset);
 
 #ifdef __GNUC__
 #pragma GCC visibility pop

--- a/lib/CL/clGetProgramInfo.c
+++ b/lib/CL/clGetProgramInfo.c
@@ -28,15 +28,12 @@
 #include "pocl_binary.h"
 #include "pocl_shared.h"
 
-cl_int program_compile_dynamic_wg_binaries (cl_program program,
-                                            int only_spmd_devices);
-
 /******************************************************************************/
 
 static void get_binary_sizes(cl_program program, size_t *sizes)
 {
 #ifdef OCS_AVAILABLE
-  if (program_compile_dynamic_wg_binaries (program, 0) != CL_SUCCESS)
+  if (program_compile_dynamic_wg_binaries (program) != CL_SUCCESS)
     {
       memset(sizes, 0, program->num_devices * sizeof(size_t));
       return;
@@ -57,7 +54,7 @@ static void get_binary_sizes(cl_program program, size_t *sizes)
 static void get_binaries(cl_program program, unsigned char **binaries)
 {
 #ifdef OCS_AVAILABLE
-  if (program_compile_dynamic_wg_binaries (program, 0) != CL_SUCCESS)
+  if (program_compile_dynamic_wg_binaries (program) != CL_SUCCESS)
     {
       memset(binaries, 0, program->num_devices * sizeof(unsigned char*));
       return;

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -82,7 +82,7 @@
 int
 llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
               cl_device_id device, size_t local_x, size_t local_y,
-              size_t local_z)
+              size_t local_z, int assume_zero_global_offset)
 {
   POCL_MEASURE_START (llvm_codegen);
   int error = 0;
@@ -101,12 +101,14 @@ llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
   /* $/parallel.bc */
   char parallel_bc_path[POCL_FILENAME_LENGTH];
   pocl_cache_work_group_function_path (parallel_bc_path, program, device_i,
-                                       kernel, local_x, local_y, local_z);
+                                       kernel, local_x, local_y, local_z,
+				       assume_zero_global_offset);
 
   /* $/kernel.so */
   char final_binary_path[POCL_FILENAME_LENGTH];
   pocl_cache_final_binary_path (final_binary_path, program, device_i, kernel,
-                                local_x, local_y, local_z);
+                                local_x, local_y, local_z,
+				assume_zero_global_offset);
 
   if (pocl_exists (final_binary_path))
     goto FINISH;
@@ -114,7 +116,8 @@ llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
   assert (strlen (final_binary_path) < (POCL_FILENAME_LENGTH - 3));
 
   error = pocl_llvm_generate_workgroup_function_nowrite (
-      device_i, device, kernel, local_x, local_y, local_z, &llvm_module);
+      device_i, device, kernel, local_x, local_y, local_z,
+      assume_zero_global_offset, &llvm_module);
   if (error)
     {
       POCL_MSG_PRINT_LLVM ("pocl_llvm_generate_workgroup_function() failed"
@@ -127,20 +130,22 @@ llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
   if (pocl_get_bool_option ("POCL_LEAVE_KERNEL_COMPILER_TEMP_FILES", 0))
     {
       POCL_MSG_PRINT_LLVM ("Writing parallel.bc to %s.\n", parallel_bc_path);
-      error = pocl_cache_write_kernel_parallel_bc (
-          llvm_module, program, device_i, kernel, local_x, local_y, local_z);
+      error =
+	pocl_cache_write_kernel_parallel_bc
+	(llvm_module, program, device_i, kernel, local_x, local_y, local_z,
+	 assume_zero_global_offset);
     }
   else
     {
       char kernel_parallel_path[POCL_FILENAME_LENGTH];
       pocl_cache_kernel_cachedir_path (kernel_parallel_path, program, device_i,
-                                       kernel, "", local_x, local_y, local_z);
+                                       kernel, "", local_x, local_y, local_z,
+				       assume_zero_global_offset);
       error = pocl_mkdir_p (kernel_parallel_path);
     }
   if (error)
     {
-      POCL_MSG_PRINT_GENERAL ("writing parallel.bc failed"
-                              " for kernel %s\n",
+      POCL_MSG_PRINT_GENERAL ("writing parallel.bc failed for kernel %s\n",
                               kernel->name);
       goto FINISH;
     }
@@ -941,13 +946,23 @@ pocl_check_kernel_disk_cache (_cl_command_node *cmd)
   size_t y = cmd->command.run.local_y;
   size_t z = cmd->command.run.local_z;
 
+  /* First try to find a static WG binary for the local size as they
+     are always more efficient than the dynamic ones.  Also, in case
+     of reqd_wg_size, there might not be a dynamic sized one at all.  */
+
+  int global_offset_is_zero =
+    cmd->command.run.pc.global_offset[0] == 0 &&
+    cmd->command.run.pc.global_offset[1] == 0 &&
+    cmd->command.run.pc.global_offset[2] == 0;
+
   module_fn = malloc (POCL_FILENAME_LENGTH);
-  pocl_cache_final_binary_path (module_fn, p, dev_i, k, x, y, z);
+  pocl_cache_final_binary_path (module_fn, p, dev_i, k, x, y, z,
+				global_offset_is_zero);
   if (pocl_exists (module_fn))
     {
       POCL_MSG_PRINT_INFO (
-          "For %zu x %zu x %zu, using static WG size binary: %s\n", x, y, z,
-          module_fn);
+          "For %zu x %zu x %zu goffs0 %d, using static WG size binary: %s\n",
+	  x, y, z, global_offset_is_zero, module_fn);
       return module_fn;
     }
 
@@ -957,7 +972,7 @@ pocl_check_kernel_disk_cache (_cl_command_node *cmd)
 
       POCL_LOCK (pocl_llvm_codegen_lock);
       int error = llvm_codegen (module_fn, dev_i, cmd->command.run.kernel,
-                                cmd->device, x, y, z);
+                                cmd->device, x, y, z, global_offset_is_zero);
       POCL_UNLOCK (pocl_llvm_codegen_lock);
       if (error)
         {
@@ -973,17 +988,19 @@ pocl_check_kernel_disk_cache (_cl_command_node *cmd)
                     " cannot compile LLVM IRs to machine code\n");
 #endif
     }
-
-  // pocl_binaries must exist
   assert (p->pocl_binaries[dev_i]);
 
-  pocl_cache_final_binary_path (module_fn, p, dev_i, k, 0, 0, 0);
   if (!pocl_exists (module_fn))
-    POCL_ABORT ("Can't find either static or dynamic WG size binary!\n");
-
-  POCL_MSG_PRINT_INFO (
-      "For %zu x %zu x %zu, using dynamic WG size binary: %s\n", x, y, z,
-      module_fn);
+    {
+      pocl_cache_final_binary_path (module_fn, p, dev_i, k, 0, 0, 0, 0);
+      if (!pocl_exists (module_fn))
+        POCL_ABORT("Dynamic WG size binary does not exist\n");
+      POCL_MSG_PRINT_INFO("Using dynamic local size binary: %s\n",
+			  module_fn);
+    }
+  else
+    POCL_MSG_PRINT_INFO("Using static local size binary: %s\n",
+			module_fn);
   return module_fn;
 }
 

--- a/lib/CL/devices/common.h
+++ b/lib/CL/devices/common.h
@@ -1,8 +1,8 @@
-/* common.h - common code that can be reused between device driver 
+/* common.h - common code that can be reused between device driver
               implementations
 
-   Copyright (c) 2012 Pekka Jääskeläinen / Tampere University of Technology
-   
+   Copyright (c) 2012-2018 Pekka Jääskeläinen
+
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
    in the Software without restriction, including without limitation the rights
@@ -68,7 +68,7 @@ void pocl_init_cpu_device_infos (cl_device_id dev);
 
 int llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
                   cl_device_id device, size_t local_x, size_t local_y,
-                  size_t local_z);
+                  size_t local_z, int assume_zero_global_offset);
 
 void fill_dev_image_t (dev_image_t* di, struct pocl_argument* parg, 
                        cl_device_id device);

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -1096,7 +1096,7 @@ compile_parallel_bc_to_brig (char *brigfile, cl_kernel kernel,
   char parallel_bc_path[POCL_FILENAME_LENGTH];
 
   pocl_cache_work_group_function_path (parallel_bc_path, kernel->program,
-				       device_i, kernel, 0, 0, 0);
+				       device_i, kernel, 0, 0, 0, 0);
 
   strcpy (brigfile, parallel_bc_path);
   strncat (brigfile, ".brig", POCL_FILENAME_LENGTH-1);
@@ -1300,7 +1300,7 @@ pocl_hsa_compile_kernel_hsail (_cl_command_node *cmd, cl_kernel kernel,
 
   int error = pocl_llvm_generate_workgroup_function (
       cmd->command.run.device_i, device, kernel, cmd->command.run.local_x,
-      cmd->command.run.local_y, cmd->command.run.local_z);
+      cmd->command.run.local_y, cmd->command.run.local_z, 0);
   if (error)
     {
       POCL_MSG_PRINT_GENERAL ("HSA: pocl_llvm_generate_workgroup_function()"

--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -457,10 +457,14 @@ pocl_tce_compile_kernel(_cl_command_node *cmd,
   if (!device)
     device = cmd->device;
 
+  int goffs_is_zero =
+      cmd->command.run.pc.global_offset[0] == 0 &&
+      cmd->command.run.pc.global_offset[1] == 0 &&
+      cmd->command.run.pc.global_offset[2] == 0;
   POCL_LOCK(d->tce_compile_lock);
   int error = pocl_llvm_generate_workgroup_function(
       cmd->command.run.device_i, device, kernel, cmd->command.run.local_x,
-      cmd->command.run.local_y, cmd->command.run.local_z);
+      cmd->command.run.local_y, cmd->command.run.local_z, goffs_is_zero);
 
   if (error) {
     POCL_UNLOCK(d->tce_compile_lock);
@@ -480,7 +484,8 @@ pocl_tce_compile_kernel(_cl_command_node *cmd,
                                   cmd->command.run.device_i, kernel, "",
                                   cmd->command.run.local_x,
                                   cmd->command.run.local_y,
-                                  cmd->command.run.local_z);
+                                  cmd->command.run.local_z,
+                                  goffs_is_zero);
   cmd->command.run.device_data = strdup(cachedir);
 
   if (d->isNewKernel(&(cmd->command.run))) {

--- a/lib/CL/pocl_llvm.h
+++ b/lib/CL/pocl_llvm.h
@@ -73,13 +73,15 @@ int pocl_llvm_get_kernels_metadata(cl_program program, unsigned device_i);
  * control the compilation. We should enforce only one compilations is done
  * at a time or control the options through thread safe methods.
  */
-int pocl_llvm_generate_workgroup_function(unsigned device_i, cl_device_id device,
+int pocl_llvm_generate_workgroup_function(unsigned device_i,
+					  cl_device_id device,
                                           cl_kernel kernel, size_t local_x,
-                                          size_t local_y, size_t local_z);
+                                          size_t local_y, size_t local_z,
+					  int assume_zero_global_offset);
 
 int pocl_llvm_generate_workgroup_function_nowrite(unsigned device_i,
     cl_device_id device, cl_kernel kernel, size_t local_x, size_t local_y,
-    size_t local_z, void **output);
+    size_t local_z, int assume_zero_global_offset, void **output);
 /**
  * Free the LLVM IR of a program for a given device
  */

--- a/lib/CL/pocl_llvm_wg.cc
+++ b/lib/CL/pocl_llvm_wg.cc
@@ -376,14 +376,17 @@ namespace pocl {
 extern size_t WGLocalSizeX;
 extern size_t WGLocalSizeY;
 extern size_t WGLocalSizeZ;
+extern bool WGAssumeZeroGlobalOffset;
 extern bool WGDynamicLocalSize;
 }
 
 int pocl_update_program_llvm_irs_unlocked(cl_program program,
                                           unsigned device_i);
 
-int pocl_llvm_generate_workgroup_function_nowrite(unsigned device_i, cl_device_id device,
-  cl_kernel kernel, size_t local_x, size_t local_y, size_t local_z, void **output) {
+int pocl_llvm_generate_workgroup_function_nowrite(
+  unsigned device_i, cl_device_id device,
+  cl_kernel kernel, size_t local_x, size_t local_y, size_t local_z,
+  int assume_zero_global_offset, void **output) {
 
   cl_program program = kernel->program;
 
@@ -415,11 +418,14 @@ int pocl_llvm_generate_workgroup_function_nowrite(unsigned device_i, cl_device_i
 
   copyKernelFromBitcode(kernel->name, parallel_bc, program_bc);
 
-  /* Now finally run the set of passes assembled above
-   * TODO pass these as parameters instead, this is not thread safe! */
+  // Now finally run the set of passes assembled above.
+  // Parameter passing to the WG function passes via global variables.
+  // TODO: Figure out if there's a better way. Probably not by much
+  // as we want to reuse the passes for multiple kernels.
   pocl::WGLocalSizeX = local_x;
   pocl::WGLocalSizeY = local_y;
   pocl::WGLocalSizeZ = local_z;
+  pocl::WGAssumeZeroGlobalOffset = assume_zero_global_offset;
   KernelName = kernel->name;
 
 #ifdef LLVM_OLDER_THAN_3_7
@@ -439,34 +445,39 @@ int pocl_llvm_generate_workgroup_function_nowrite(unsigned device_i, cl_device_i
 }
 
 
-int pocl_llvm_generate_workgroup_function(unsigned device_i, cl_device_id device, cl_kernel kernel,
-                                          size_t local_x, size_t local_y,
-                                          size_t local_z) {
+int pocl_llvm_generate_workgroup_function(
+  unsigned device_i, cl_device_id device, cl_kernel kernel,
+  size_t local_x, size_t local_y, size_t local_z,
+  int assume_zero_global_offset) {
 
   void *modp = NULL;
 
   char parallel_bc_path[POCL_FILENAME_LENGTH];
   pocl_cache_work_group_function_path(parallel_bc_path, kernel->program,
                                       device_i, kernel, local_x, local_y,
-                                      local_z);
+                                      local_z, assume_zero_global_offset);
 
   if (pocl_exists(parallel_bc_path))
     return CL_SUCCESS;
 
   char final_binary_path[POCL_FILENAME_LENGTH];
   pocl_cache_final_binary_path(final_binary_path, kernel->program, device_i,
-                               kernel, local_x, local_y, local_z);
+                               kernel, local_x, local_y, local_z,
+                               assume_zero_global_offset);
 
   if (pocl_exists(final_binary_path))
     return CL_SUCCESS;
 
   int error = pocl_llvm_generate_workgroup_function_nowrite(
-      device_i, device, kernel, local_x, local_y, local_z, &modp);
+      device_i, device, kernel, local_x, local_y, local_z,
+      assume_zero_global_offset, &modp);
   if (error)
     return error;
 
   error = pocl_cache_write_kernel_parallel_bc(
-      modp, kernel->program, device_i, kernel, local_x, local_y, local_z);
+    modp, kernel->program, device_i, kernel, local_x, local_y, local_z,
+    assume_zero_global_offset);
+
 
   if (error)
     {

--- a/lib/CL/pocl_shared.h
+++ b/lib/CL/pocl_shared.h
@@ -52,8 +52,7 @@ cl_int pocl_rect_copy(cl_command_queue command_queue,
                       cl_event *event,
                       _cl_command_node **cmd);
 
-cl_int program_compile_dynamic_wg_binaries (cl_program program,
-                                            int only_spmd_devices);
+cl_int program_compile_dynamic_wg_binaries (cl_program program);
 
 cl_program create_program_skeleton (cl_context context, cl_uint num_devices,
                                     const cl_device_id *device_list,

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -849,12 +849,20 @@ Workgroup::privatizeContext(Function *F)
   privatizeGlobals(
     F, Builder, {"_group_id_x", "_group_id_y", "_group_id_z"}, GroupIdArgs);
 
-  privatizeGlobals(
-    F, Builder,
-    {"_global_offset_x", "_global_offset_y", "_global_offset_z"},
+  if (WGAssumeZeroGlobalOffset) {
+    privatizeGlobals(
+      F, Builder,
+      {"_global_offset_x", "_global_offset_y", "_global_offset_z"},
+      {ConstantInt::get(SizeT, 0), ConstantInt::get(SizeT, 0),
+          ConstantInt::get(SizeT, 0)});
+  } else {
+    privatizeGlobals(
+      F, Builder,
+      {"_global_offset_x", "_global_offset_y", "_global_offset_z"},
     globalHandlesToContextStructLoads(
       Builder, {"_global_offset_x", "_global_offset_y", "_global_offset_z"},
       PC_GLOBAL_OFFSET));
+  }
 
   privatizeGlobals(
     F, Builder, {"_work_dim"},

--- a/lib/llvmopencl/WorkitemHandler.cc
+++ b/lib/llvmopencl/WorkitemHandler.cc
@@ -52,13 +52,10 @@ namespace pocl {
 
 using namespace llvm;
 
-/* This is used to communicate the work-group dimensions of the currently
-   compiled kernel command to the workitem loop.
-
-   TODO: Something cleaner than a global value. */
 size_t WGLocalSizeX = 1;
 size_t WGLocalSizeY = 1;
 size_t WGLocalSizeZ = 1;
+bool WGAssumeZeroGlobalOffset = false;
 bool WGDynamicLocalSize = false;
 
 cl::opt<bool>

--- a/lib/llvmopencl/WorkitemHandler.h
+++ b/lib/llvmopencl/WorkitemHandler.h
@@ -1,7 +1,7 @@
 // Header for WorkitemHandler, a parent class for all implementations of
 // work item handling.
 // 
-// Copyright (c) 2012 Pekka Jääskeläinen / TUT
+// Copyright (c) 2012-2018 Pekka Jääskeläinen
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -73,9 +73,14 @@ namespace pocl {
   extern llvm::cl::opt<bool> AddWIMetadata;
   extern llvm::cl::opt<int> LockStepSIMDWidth;
 
+  // Used to communicate the work-group dimensions of the currently
+  // compiled kernel command to the workitem loop.
+  // TODO: Something cleaner than a global value.
   extern size_t WGLocalSizeX;
   extern size_t WGLocalSizeY;
   extern size_t WGLocalSizeZ;
+  // Set to true to generate a global offset 0 specialized WG function.
+  extern bool WGAssumeZeroGlobalOffset;
   extern bool WGDynamicLocalSize;
 }
 


### PR DESCRIPTION
It seems to be rare to use the global offset in kernel commands, which means useless address computation which complicates AA and even incures a little runtime overhead.

This creates a special version of the WG which assumes the global offset is 0 and uses that in case that's the case.

This needs to be pulled in before the following PRs which will be done on top of it.