### PR TITLE
Device-side allocation of local memory to stack

### DIFF
--- a/include/pocl.h
+++ b/include/pocl.h
@@ -44,6 +44,12 @@
 
 #define POCL_FILENAME_LENGTH 1024
 
+#define SPIR_ADDRESS_SPACE_PRIVATE 0
+#define SPIR_ADDRESS_SPACE_GLOBAL 1
+#define SPIR_ADDRESS_SPACE_CONSTANT 2
+#define SPIR_ADDRESS_SPACE_LOCAL 3
+#define SPIR_ADDRESS_SPACE_GENERIC 4
+
 typedef struct _mem_mapping mem_mapping_t;
 /* represents a single buffer to host memory mapping */
 struct _mem_mapping {

--- a/include/pocl.h
+++ b/include/pocl.h
@@ -1,7 +1,7 @@
 /* pocl.h - global pocl declarations for the host side runtime.
 
    Copyright (c) 2011 Universidad Rey Juan Carlos
-                 2011-2018 Pekka Jääskeläinen / Tampere University of Technology
+                 2011-2019 Pekka Jääskeläinen
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -43,12 +43,6 @@
 #include "pocl_compiler_features.h"
 
 #define POCL_FILENAME_LENGTH 1024
-
-#define SPIR_ADDRESS_SPACE_PRIVATE 0
-#define SPIR_ADDRESS_SPACE_GLOBAL 1
-#define SPIR_ADDRESS_SPACE_CONSTANT 2
-#define SPIR_ADDRESS_SPACE_LOCAL 3
-#define SPIR_ADDRESS_SPACE_GENERIC 4
 
 typedef struct _mem_mapping mem_mapping_t;
 /* represents a single buffer to host memory mapping */

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -4,10 +4,10 @@
                  2011-2019 Pekka Jääskeläinen
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -17,9 +17,9 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #include "config.h"
@@ -554,10 +554,8 @@ pocl_basic_write (void *data,
   memcpy ((char *)device_ptr + offset, host_ptr, size);
 }
 
-
 void
-pocl_basic_run (void *data,
-		_cl_command_node* cmd)
+pocl_basic_run (void *data, _cl_command_node *cmd)
 {
   struct data *d;
   struct pocl_argument *al;
@@ -621,8 +619,8 @@ pocl_basic_run (void *data,
           dev_image_t di;
           fill_dev_image_t (&di, al, cmd->device);
 
-          void* devptr =
-	    pocl_aligned_malloc(MAX_EXTENDED_ALIGNMENT, sizeof(dev_image_t));
+          void *devptr = pocl_aligned_malloc (MAX_EXTENDED_ALIGNMENT,
+                                              sizeof (dev_image_t));
           arguments[i] = malloc (sizeof (void *));
           *(void **)(arguments[i]) = devptr;
           memcpy (devptr, &di, sizeof (dev_image_t));
@@ -721,8 +719,7 @@ pocl_basic_run (void *data,
 }
 
 void
-pocl_basic_run_native (void *data,
-		       _cl_command_node* cmd)
+pocl_basic_run_native (void *data, _cl_command_node *cmd)
 {
   cmd->command.native.user_func(cmd->command.native.args);
 }

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -1,7 +1,7 @@
 /* basic.c - a minimalistic pocl device driver layer implementation
 
    Copyright (c) 2011-2013 Universidad Rey Juan Carlos and
-                 2011-2018 Pekka Jääskeläinen / Tampere University of Technology
+                 2011-2019 Pekka Jääskeläinen
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -57,7 +57,7 @@ struct data {
   cl_kernel current_kernel;
   /* Loaded kernel dynamic library handle. */
   lt_dlhandle current_dlhandle;
-  
+
   /* List of commands ready to be executed */
   _cl_command_node * volatile ready_list;
   /* List of commands not yet ready to be executed */
@@ -555,9 +555,8 @@ pocl_basic_write (void *data,
 
 
 void
-pocl_basic_run 
-(void *data, 
- _cl_command_node* cmd)
+pocl_basic_run (void *data,
+		_cl_command_node* cmd)
 {
   struct data *d;
   struct pocl_argument *al;
@@ -576,7 +575,7 @@ pocl_basic_run
                                       * (meta->num_args + meta->num_locals));
 
   /* Process the kernel arguments. Convert the opaque buffer
-     pointers to real device pointers, allocate dynamic local 
+     pointers to real device pointers, allocate dynamic local
      memory buffers, etc. */
   for (i = 0; i < meta->num_args; ++i)
     {
@@ -588,7 +587,7 @@ pocl_basic_run
         }
       else if (meta->arg_info[i].type == POCL_ARG_TYPE_POINTER)
         {
-          /* It's legal to pass a NULL pointer to clSetKernelArguments. In 
+          /* It's legal to pass a NULL pointer to clSetKernelArguments. In
              that case we must pass the same NULL forward to the kernel.
              Otherwise, the user must have created a buffer with per device
              pointers stored in the cl_mem. */
@@ -697,9 +696,8 @@ pocl_basic_run
 }
 
 void
-pocl_basic_run_native 
-(void *data, 
- _cl_command_node* cmd)
+pocl_basic_run_native (void *data,
+		       _cl_command_node* cmd)
 {
   cmd->command.native.user_func(cmd->command.native.args);
 }

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -658,7 +658,7 @@ pocl_hsa_init (unsigned j, cl_device_id dev, const char *parameters)
   dev->autolocals_to_args = CL_FALSE;
   dev->device_alloca_locals = CL_FALSE;
 
-  dev->global_as_id = SPIR_ADDRESS_SPACE_GLOBAL;
+  dev->context_as_id = dev->global_as_id = SPIR_ADDRESS_SPACE_GLOBAL;
   dev->local_as_id = SPIR_ADDRESS_SPACE_LOCAL;
   dev->constant_as_id = SPIR_ADDRESS_SPACE_CONSTANT;
 

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -9,10 +9,10 @@
    the HSA runtime library sources (c) 2014 HSA Foundation Inc.
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -22,31 +22,33 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
-/* Some example code snippets copied verbatim from vector_copy.c of HSA-Runtime-AMD: */
+/* Some example code snippets copied verbatim from vector_copy.c of
+ * HSA-Runtime-AMD: */
 /* Copyright 2014 HSA Foundation Inc.  All Rights Reserved.
  *
  * HSAF is granting you permission to use this software and documentation (if
  * any) (collectively, the "Materials") pursuant to the terms and conditions
  * of the Software License Agreement included with the Materials.  If you do
- * not have a copy of the Software License Agreement, contact the  HSA Foundation for a copy.
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ * not have a copy of the Software License Agreement, contact the  HSA
+ * Foundation for a copy. Redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided that the following
+ * conditions are met:
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
- * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
  * CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * WITH THE SOFTWARE.
  */
 
 #ifndef _BSD_SOURCE
@@ -357,77 +359,70 @@ static const char *phsa_native_device_aux_funcs[] =
 
 #define AMD_VENDOR_ID 0x1002
 
-static struct _cl_device_id
-supported_hsa_devices[HSA_NUM_KNOWN_HSA_AGENTS] =
-{
-  [0] =
-  {
-    .long_name = "Spectre",
-    .llvm_cpu = (HSAIL_ENABLED ? NULL : "kaveri"),
-    .llvm_target_triplet = (HSAIL_ENABLED ? "hsail64" : "amdgcn--amdhsa"),
-    .spmd = CL_TRUE,
-    .autolocals_to_args = CL_FALSE,
-    .device_alloca_locals = CL_FALSE,
-    .has_64bit_long = 1,
-    .vendor_id = AMD_VENDOR_ID,
-    .global_mem_cache_type = CL_READ_WRITE_CACHE,
-    .max_constant_buffer_size = 65536,
-    .local_mem_type = CL_LOCAL,
-    .endian_little = CL_TRUE,
-    .extensions = HSA_DEVICE_EXTENSIONS,
-    .device_side_printf = !HSAIL_ENABLED,
-    .printf_buffer_size = 16 * 1024 * 1024,
-    .preferred_wg_size_multiple = 64, // wavefront size on Kaveri
-    .preferred_vector_width_char = 4,
-    .preferred_vector_width_short = 2,
-    .preferred_vector_width_int = 1,
-    .preferred_vector_width_long = 1,
-    .preferred_vector_width_float = 1,
-    .preferred_vector_width_double = 1,
-    .native_vector_width_char = 4,
-    .native_vector_width_short = 2,
-    .native_vector_width_int = 1,
-    .native_vector_width_long = 1,
-    .native_vector_width_float = 1,
-    .native_vector_width_double = 1
-  },
-  [1] =
-  { .long_name = "phsa generic CPU agent",
-    .llvm_cpu = NULL,
-    .llvm_target_triplet = (HSAIL_ENABLED ? "hsail64" : NULL),
-    .spmd = CL_FALSE,
-    .autolocals_to_args = !HSAIL_ENABLED,
-    .device_alloca_locals = CL_TRUE,
-    .has_64bit_long = 1,
-    .vendor_id = 0xffff,
-    .global_mem_cache_type = CL_READ_WRITE_CACHE,
-    .max_constant_buffer_size = 65536,
-    .local_mem_type = CL_LOCAL,
-    .endian_little = !(WORDS_BIGENDIAN),
-    .extensions = HSA_DEVICE_EXTENSIONS,
-    .device_side_printf = !HSAIL_ENABLED,
-    .printf_buffer_size = 16 * 1024 * 1024,
-    .preferred_wg_size_multiple = 1,
-    /* We want to exploit the widest vector types in HSAIL
-       for the CPUs assuming they have some sort of SIMD ISE
-       which the finalizer than can more readily utilize.  */
-    .preferred_vector_width_char = 16,
-    .preferred_vector_width_short = 16,
-    .preferred_vector_width_int = 16,
-    .preferred_vector_width_long = 16,
-    .preferred_vector_width_float = 16,
-    .preferred_vector_width_double = 16,
-    .native_vector_width_char = 16,
-    .native_vector_width_short = 16,
-    .native_vector_width_int = 16,
-    .native_vector_width_long = 16,
-    .native_vector_width_float = 16,
-    .native_vector_width_double = 16,
-    .final_linkage_flags = default_native_final_linkage_flags,
-    .device_aux_functions =
-    (HSAIL_ENABLED ? NULL : phsa_native_device_aux_funcs)
-  }
-};
+static struct _cl_device_id supported_hsa_devices[HSA_NUM_KNOWN_HSA_AGENTS]
+    = { [0] = { .long_name = "Spectre",
+                .llvm_cpu = (HSAIL_ENABLED ? NULL : "kaveri"),
+                .llvm_target_triplet
+                = (HSAIL_ENABLED ? "hsail64" : "amdgcn--amdhsa"),
+                .spmd = CL_TRUE,
+                .autolocals_to_args = CL_FALSE,
+                .device_alloca_locals = CL_FALSE,
+                .has_64bit_long = 1,
+                .vendor_id = AMD_VENDOR_ID,
+                .global_mem_cache_type = CL_READ_WRITE_CACHE,
+                .max_constant_buffer_size = 65536,
+                .local_mem_type = CL_LOCAL,
+                .endian_little = CL_TRUE,
+                .extensions = HSA_DEVICE_EXTENSIONS,
+                .device_side_printf = !HSAIL_ENABLED,
+                .printf_buffer_size = 16 * 1024 * 1024,
+                .preferred_wg_size_multiple = 64, // wavefront size on Kaveri
+                .preferred_vector_width_char = 4,
+                .preferred_vector_width_short = 2,
+                .preferred_vector_width_int = 1,
+                .preferred_vector_width_long = 1,
+                .preferred_vector_width_float = 1,
+                .preferred_vector_width_double = 1,
+                .native_vector_width_char = 4,
+                .native_vector_width_short = 2,
+                .native_vector_width_int = 1,
+                .native_vector_width_long = 1,
+                .native_vector_width_float = 1,
+                .native_vector_width_double = 1 },
+        [1] = { .long_name = "phsa generic CPU agent",
+                .llvm_cpu = NULL,
+                .llvm_target_triplet = (HSAIL_ENABLED ? "hsail64" : NULL),
+                .spmd = CL_FALSE,
+                .autolocals_to_args = !HSAIL_ENABLED,
+                .device_alloca_locals = CL_TRUE,
+                .has_64bit_long = 1,
+                .vendor_id = 0xffff,
+                .global_mem_cache_type = CL_READ_WRITE_CACHE,
+                .max_constant_buffer_size = 65536,
+                .local_mem_type = CL_LOCAL,
+                .endian_little = !(WORDS_BIGENDIAN),
+                .extensions = HSA_DEVICE_EXTENSIONS,
+                .device_side_printf = !HSAIL_ENABLED,
+                .printf_buffer_size = 16 * 1024 * 1024,
+                .preferred_wg_size_multiple = 1,
+                /* We want to exploit the widest vector types in HSAIL
+                   for the CPUs assuming they have some sort of SIMD ISE
+                   which the finalizer than can more readily utilize.  */
+                .preferred_vector_width_char = 16,
+                .preferred_vector_width_short = 16,
+                .preferred_vector_width_int = 16,
+                .preferred_vector_width_long = 16,
+                .preferred_vector_width_float = 16,
+                .preferred_vector_width_double = 16,
+                .native_vector_width_char = 16,
+                .native_vector_width_short = 16,
+                .native_vector_width_int = 16,
+                .native_vector_width_long = 16,
+                .native_vector_width_float = 16,
+                .native_vector_width_double = 16,
+                .final_linkage_flags = default_native_final_linkage_flags,
+                .device_aux_functions
+                = (HSAIL_ENABLED ? NULL : phsa_native_device_aux_funcs) } };
 
 char *
 pocl_hsa_build_hash (cl_device_id device)
@@ -460,16 +455,17 @@ get_hsa_device_features(char* dev_name, struct _cl_device_id* dev)
 	  COPY_ATTR (llvm_target_triplet);
 	  COPY_ATTR (spmd);
 	  COPY_ATTR (autolocals_to_args);
-	  COPY_ATTR (device_alloca_locals);
-	  if (!HSAIL_ENABLED) {
-	    /* TODO: Add a CMake variable or HSA description string
-	       autodetection to control these. */
-	    if (dev->llvm_cpu == NULL)
-	      dev->llvm_cpu = get_llvm_cpu_name ();
-	    if (dev->llvm_target_triplet == NULL)
-	      dev->llvm_target_triplet = OCL_KERNEL_TARGET;
-	    dev->arg_buffer_launcher = CL_TRUE;
-	  }
+          COPY_ATTR (device_alloca_locals);
+          if (!HSAIL_ENABLED)
+            {
+              /* TODO: Add a CMake variable or HSA description string
+                 autodetection to control these. */
+              if (dev->llvm_cpu == NULL)
+                dev->llvm_cpu = get_llvm_cpu_name ();
+              if (dev->llvm_target_triplet == NULL)
+                dev->llvm_target_triplet = OCL_KERNEL_TARGET;
+              dev->arg_buffer_launcher = CL_TRUE;
+            }
           COPY_ATTR (has_64bit_long);
           COPY_ATTR (vendor_id);
           COPY_ATTR (global_mem_cache_type);
@@ -988,25 +984,25 @@ setup_kernel_args (pocl_hsa_device_data_t *d,
         {
 	  size_t buf_size = ARG_IS_LOCAL (meta->arg_info[i]) ?
 	    al->size : meta->local_sizes[i - meta->num_args];
-	  if (d->device->device_alloca_locals)
-	    {
-	      /* Local buffers are allocated in the device side work-group
-		 launcher. Let's pass only the sizes of the local args in
-		 the arg buffer. */
-	      assert(sizeof (size_t) == 8);
-	      CHECK_AND_ALIGN_SPACE(sizeof (size_t));
-	      memcpy (write_pos, &buf_size, sizeof (size_t));
-	      write_pos += sizeof (size_t);
-	    }
-	  else if (HSAIL_ENABLED)
-	    {
-	      CHECK_AND_ALIGN_SPACE(sizeof (uint32_t));
-	      memcpy (write_pos, total_group_size, sizeof (uint32_t));
-	      *total_group_size += (uint32_t)buf_size;
-	      write_pos += sizeof (uint32_t);
-	    }
-	  else
-	    assert (0 && "Unsupported local mem allocation scheme.");
+          if (d->device->device_alloca_locals)
+            {
+              /* Local buffers are allocated in the device side work-group
+                 launcher. Let's pass only the sizes of the local args in
+                 the arg buffer. */
+              assert (sizeof (size_t) == 8);
+              CHECK_AND_ALIGN_SPACE (sizeof (size_t));
+              memcpy (write_pos, &buf_size, sizeof (size_t));
+              write_pos += sizeof (size_t);
+            }
+          else if (HSAIL_ENABLED)
+            {
+              CHECK_AND_ALIGN_SPACE (sizeof (uint32_t));
+              memcpy (write_pos, total_group_size, sizeof (uint32_t));
+              *total_group_size += (uint32_t)buf_size;
+              write_pos += sizeof (uint32_t);
+            }
+          else
+            assert (0 && "Unsupported local mem allocation scheme.");
         }
       else if (meta->arg_info[i].type == POCL_ARG_TYPE_POINTER)
         {

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -1,6 +1,6 @@
 /* pocl-hsa.c - driver for HSA supported devices.
 
-   Copyright (c) 2015-2018 Pekka Jääskeläinen <pekka.jaaskelainen@tut.fi>
+   Copyright (c) 2015-2019 Pekka Jääskeläinen
                  2015 Charles Chen <ccchen@pllab.cs.nthu.edu.tw>
                       Shao-chung Wang <scwang@pllab.cs.nthu.edu.tw>
                  2015-2018 Michal Babej <michal.babej@tut.fi>

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -658,7 +658,8 @@ pocl_hsa_init (unsigned j, cl_device_id dev, const char *parameters)
   dev->autolocals_to_args = CL_FALSE;
   dev->device_alloca_locals = CL_FALSE;
 
-  dev->context_as_id = dev->global_as_id = SPIR_ADDRESS_SPACE_GLOBAL;
+  dev->args_as_id = dev->context_as_id = dev->global_as_id =
+    SPIR_ADDRESS_SPACE_GLOBAL;
   dev->local_as_id = SPIR_ADDRESS_SPACE_LOCAL;
   dev->constant_as_id = SPIR_ADDRESS_SPACE_CONSTANT;
 

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -4,10 +4,10 @@
                  2011-2019 Pekka Jääskeläinen
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -17,9 +17,9 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #define _GNU_SOURCE

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -1,18 +1,18 @@
 /* OpenCL native pthreaded device implementation.
 
-   Copyright (c) 2011-2012 Universidad Rey Juan Carlos and
-                           Pekka Jääskeläinen / Tampere Univ. of Technology
-   
+   Copyright (c) 2011-2012 Universidad Rey Juan Carlos
+                 2011-2019 Pekka Jääskeläinen
+
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
    in the Software without restriction, including without limitation the rights
    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
    copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
-   
+
    The above copyright notice and this permission notice shall be included in
    all copies or substantial portions of the Software.
-   
+
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/lib/CL/devices/tce/ttasim/ttasim.cc
+++ b/lib/CL/devices/tce/ttasim/ttasim.cc
@@ -566,6 +566,7 @@ pocl_ttasim_init (unsigned j, cl_device_id dev, const char* parameters)
   dev->global_as_id = TTA_ASID_GLOBAL;
   dev->local_as_id = TTA_ASID_LOCAL;
   dev->constant_as_id = TTA_ASID_CONSTANT;
+  dev->context_as_id = 0;
 
   SETUP_DEVICE_CL_VERSION (TCE_DEVICE_CL_VERSION_MAJOR,
                            TCE_DEVICE_CL_VERSION_MINOR);

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -717,6 +717,10 @@ struct _cl_device_id {
   int has_64bit_long;  /* Does the device have 64bit longs */
   /* Convert automatic local variables to kernel arguments? */
   int autolocals_to_args;
+  /* Allocate local buffers device side in the work-group launcher instead of
+     having a disjoint physical local memory per work-group or having the
+     runtime/driver allocate the local space. */
+  int device_alloca_locals;
 
   /* Device-specific linker flags that should be appended to the clang's
      argument list for a final linkage call when producing the final binary

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -743,8 +743,12 @@ struct _cl_device_id {
   unsigned local_as_id;
   unsigned constant_as_id;
 
+  /* The address space where the argument data is passed. */
+  unsigned args_as_id;
+
   /* The address space where the grid context data is passed. */
   unsigned context_as_id;
+
 
   /* True if the device supports SVM. Then it has the responsibility of
      allocating shared buffers residing in Shared Virtual Memory areas. */

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -743,6 +743,9 @@ struct _cl_device_id {
   unsigned local_as_id;
   unsigned constant_as_id;
 
+  /* The address space where the grid context data is passed. */
+  unsigned context_as_id;
+
   /* True if the device supports SVM. Then it has the responsibility of
      allocating shared buffers residing in Shared Virtual Memory areas. */
   cl_bool should_allocate_svm;

--- a/lib/llvmopencl/AutomaticLocals.cc
+++ b/lib/llvmopencl/AutomaticLocals.cc
@@ -161,6 +161,7 @@ AutomaticLocals::processAutomaticLocals(Function *F) {
     FuncName = F->getName().str();
     if (isAutomaticLocal(FuncName, *i)) {
       Locals.push_back(&*i);
+
       // Add the parameters to the end of the function parameter list.
       Parameters.push_back(i->getType());
 

--- a/lib/llvmopencl/AutomaticLocals.cc
+++ b/lib/llvmopencl/AutomaticLocals.cc
@@ -205,8 +205,8 @@ AutomaticLocals::processAutomaticLocals(Function *F) {
   CloneFunctionInto(NewKernel, F, VV, true, RI);
 
   for (size_t i = 0; i < Locals.size(); ++i) {
-    setFuncArgAddressSpaceMD(
-      NewKernel, F->arg_size() + i, SPIR_ADDRESS_SPACE_LOCAL);
+    setFuncArgAddressSpaceMD(NewKernel, F->arg_size() + i,
+                             SPIR_ADDRESS_SPACE_LOCAL);
   }
   return NewKernel;
 }

--- a/lib/llvmopencl/AutomaticLocals.cc
+++ b/lib/llvmopencl/AutomaticLocals.cc
@@ -204,6 +204,10 @@ AutomaticLocals::processAutomaticLocals(Function *F) {
   // the other.  For some reason it doesn't want to reuse the old ones.
   CloneFunctionInto(NewKernel, F, VV, true, RI);
 
+  for (size_t i = 0; i < Locals.size(); ++i) {
+    setFuncArgAddressSpaceMD(
+      NewKernel, F->arg_size() + i, SPIR_ADDRESS_SPACE_LOCAL);
+  }
   return NewKernel;
 }
 

--- a/lib/llvmopencl/LLVMUtils.cc
+++ b/lib/llvmopencl/LLVMUtils.cc
@@ -109,4 +109,50 @@ void eraseFunctionAndCallers(llvm::Function *Function) {
   Function->eraseFromParent();
 }
 
+int
+getConstantIntMDValue(Metadata *MD) {
+  ConstantInt *CI = mdconst::extract<ConstantInt>(MD);
+  return CI->getLimitedValue();
+}
+
+llvm::Metadata*
+createConstantIntMD(llvm::LLVMContext &C, int32_t Val) {
+  IntegerType *I32Type = IntegerType::get(C, 32);
+  return ConstantAsMetadata::get(ConstantInt::get(I32Type, Val));
+}
+
+bool
+isLocalMemFunctionArg(llvm::Function *F, unsigned ArgIndex) {
+
+  MDNode *MD = F->getMetadata("kernel_arg_addr_space");
+
+  if (MD == nullptr || MD->getNumOperands() <= ArgIndex)
+    return false;
+  else
+    return getConstantIntMDValue(MD->getOperand(ArgIndex)) ==
+      SPIR_ADDRESS_SPACE_LOCAL;
+}
+
+void
+setFuncArgAddressSpaceMD(
+  llvm::Function *F, unsigned ArgIndex, unsigned AS) {
+
+  unsigned MDKind = F->getContext().getMDKindID("kernel_arg_addr_space");
+  MDNode *OldMD = F->getMetadata(MDKind);
+
+  assert (OldMD == nullptr || OldMD->getNumOperands() >= ArgIndex);
+
+  LLVMContext &C = F->getContext();
+
+  llvm::SmallVector<llvm::Metadata *, 8> AddressQuals;
+  for (unsigned i = 0; i < ArgIndex; ++i) {
+    AddressQuals.push_back(
+      createConstantIntMD(C, OldMD != nullptr ?
+                          getConstantIntMDValue(OldMD->getOperand(i)) :
+                          SPIR_ADDRESS_SPACE_GLOBAL));
+  }
+  AddressQuals.push_back(createConstantIntMD(C, AS));
+  F->setMetadata(MDKind, MDNode::get(F->getContext(), AddressQuals));
+}
+
 }

--- a/lib/llvmopencl/LLVMUtils.cc
+++ b/lib/llvmopencl/LLVMUtils.cc
@@ -1,17 +1,17 @@
 // Implementation of LLVMUtils, useful common LLVM-related functionality.
-// 
-// Copyright (c) 2013 Pekka Jääskeläinen / TUT
-// 
+//
+// Copyright (c) 2013-2019 Pekka Jääskeläinen
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/lib/llvmopencl/LLVMUtils.cc
+++ b/lib/llvmopencl/LLVMUtils.cc
@@ -109,20 +109,17 @@ void eraseFunctionAndCallers(llvm::Function *Function) {
   Function->eraseFromParent();
 }
 
-int
-getConstantIntMDValue(Metadata *MD) {
+int getConstantIntMDValue(Metadata *MD) {
   ConstantInt *CI = mdconst::extract<ConstantInt>(MD);
   return CI->getLimitedValue();
 }
 
-llvm::Metadata*
-createConstantIntMD(llvm::LLVMContext &C, int32_t Val) {
+llvm::Metadata *createConstantIntMD(llvm::LLVMContext &C, int32_t Val) {
   IntegerType *I32Type = IntegerType::get(C, 32);
   return ConstantAsMetadata::get(ConstantInt::get(I32Type, Val));
 }
 
-bool
-isLocalMemFunctionArg(llvm::Function *F, unsigned ArgIndex) {
+bool isLocalMemFunctionArg(llvm::Function *F, unsigned ArgIndex) {
 
   MDNode *MD = F->getMetadata("kernel_arg_addr_space");
 
@@ -130,29 +127,26 @@ isLocalMemFunctionArg(llvm::Function *F, unsigned ArgIndex) {
     return false;
   else
     return getConstantIntMDValue(MD->getOperand(ArgIndex)) ==
-      SPIR_ADDRESS_SPACE_LOCAL;
+           SPIR_ADDRESS_SPACE_LOCAL;
 }
 
-void
-setFuncArgAddressSpaceMD(
-  llvm::Function *F, unsigned ArgIndex, unsigned AS) {
+void setFuncArgAddressSpaceMD(llvm::Function *F, unsigned ArgIndex,
+                              unsigned AS) {
 
   unsigned MDKind = F->getContext().getMDKindID("kernel_arg_addr_space");
   MDNode *OldMD = F->getMetadata(MDKind);
 
-  assert (OldMD == nullptr || OldMD->getNumOperands() >= ArgIndex);
+  assert(OldMD == nullptr || OldMD->getNumOperands() >= ArgIndex);
 
   LLVMContext &C = F->getContext();
 
   llvm::SmallVector<llvm::Metadata *, 8> AddressQuals;
   for (unsigned i = 0; i < ArgIndex; ++i) {
-    AddressQuals.push_back(
-      createConstantIntMD(C, OldMD != nullptr ?
-                          getConstantIntMDValue(OldMD->getOperand(i)) :
-                          SPIR_ADDRESS_SPACE_GLOBAL));
+    AddressQuals.push_back(createConstantIntMD(
+        C, OldMD != nullptr ? getConstantIntMDValue(OldMD->getOperand(i))
+                            : SPIR_ADDRESS_SPACE_GLOBAL));
   }
   AddressQuals.push_back(createConstantIntMD(C, AS));
   F->setMetadata(MDKind, MDNode::get(F->getContext(), AddressQuals));
 }
-
 }

--- a/lib/llvmopencl/LLVMUtils.h
+++ b/lib/llvmopencl/LLVMUtils.h
@@ -3,10 +3,10 @@
 // Copyright (c) 2013-2019 Pekka Jääskeläinen
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
 //
 // The above copyright notice and this permission notice shall be included in
@@ -16,9 +16,9 @@
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
 
 #ifndef _POCL_LLVM_UTILS_H
 #define _POCL_LLVM_UTILS_H
@@ -94,19 +94,16 @@ is_sampler_type(const llvm::Type& t)
 }
 
 // Checks if the given argument of Func is a local buffer.
-bool
-isLocalMemFunctionArg(llvm::Function *Func, unsigned ArgIndex);
+bool isLocalMemFunctionArg(llvm::Function *Func, unsigned ArgIndex);
 
 // Sets the address space metadata of the given function argument.
 // Note: The address space ids must be SPIR ids. If it encounters
 // argument indices without address space ids in the list, sets
 // them to globals.
-void
-setFuncArgAddressSpaceMD(llvm::Function *Func, unsigned ArgIndex, unsigned AS);
+void setFuncArgAddressSpaceMD(llvm::Function *Func, unsigned ArgIndex,
+                              unsigned AS);
 
-llvm::Metadata *
-createConstantIntMD(llvm::LLVMContext &C, int32_t Val);
-
+llvm::Metadata *createConstantIntMD(llvm::LLVMContext &C, int32_t Val);
 }
 
 #endif

--- a/lib/llvmopencl/LLVMUtils.h
+++ b/lib/llvmopencl/LLVMUtils.h
@@ -93,6 +93,20 @@ is_sampler_type(const llvm::Type& t)
   return false;
 }
 
+// Checks if the given argument of Func is a local buffer.
+bool
+isLocalMemFunctionArg(llvm::Function *Func, unsigned ArgIndex);
+
+// Sets the address space metadata of the given function argument.
+// Note: The address space ids must be SPIR ids. If it encounters
+// argument indices without address space ids in the list, sets
+// them to globals.
+void
+setFuncArgAddressSpaceMD(llvm::Function *Func, unsigned ArgIndex, unsigned AS);
+
+llvm::Metadata *
+createConstantIntMD(llvm::LLVMContext &C, int32_t Val);
+
 }
 
 #endif

--- a/lib/llvmopencl/LLVMUtils.h
+++ b/lib/llvmopencl/LLVMUtils.h
@@ -1,17 +1,17 @@
 // Header for LLVMUtils, useful common LLVM-related functionality.
-// 
-// Copyright (c) 2013 Pekka Jääskeläinen / TUT
-// 
+//
+// Copyright (c) 2013-2019 Pekka Jääskeläinen
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -226,10 +226,12 @@ Workgroup::runOnModule(Module &M) {
   LauncherFuncT =
     FunctionType::get(
       Type::getVoidTy(*C),
-      {PointerType::get(
-          PointerType::get(Type::getInt8Ty(*C), 0), 0),
-          PointerType::get(PoclContextT, 0),
-          SizeT, SizeT, SizeT}, false);
+      {PointerType::get(PointerType::get(Type::getInt8Ty(*C),
+                                         currentPoclDevice->global_as_id),
+                        0),
+       PointerType::get(PoclContextT, currentPoclDevice->context_as_id), SizeT,
+       SizeT, SizeT},
+      false);
 #endif
 
   assert ((SizeTWidth == 64 || SizeTWidth == 32) &&
@@ -566,7 +568,7 @@ Workgroup::createWrapper(Function *F, FunctionMapping &printfCache) {
   } else {
     // pocl_context
     sv.push_back(
-        PointerType::get(PoclContextT, currentPoclDevice->global_as_id));
+      PointerType::get(PoclContextT, currentPoclDevice->context_as_id));
     // group_x
     sv.push_back(SizeT);
     // group_y

--- a/tools/scripts/format-branch.sh
+++ b/tools/scripts/format-branch.sh
@@ -14,4 +14,4 @@ SCRIPTPATH=$( realpath "$0"  )
 RELPATH=$(dirname "$SCRIPTPATH")
 
 $RELPATH/clang-format-diff.py -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 -style GNU <$PATCHY
-$RELPATH/clang-format-diff.py -regex '.*(\.hh$|\.cc$)' -i -p1 -style LLVM <$PATCHY
+$RELPATH/clang-format-diff.py -regex '(.*(\.hh$|\.cc$))|(lib/llvmopencl/.*\.h)' -i -p1 -style LLVM <$PATCHY

--- a/tools/scripts/format-last-commit.sh
+++ b/tools/scripts/format-last-commit.sh
@@ -14,7 +14,7 @@ SCRIPTPATH=$( realpath "$0"  )
 RELPATH=$(dirname "$SCRIPTPATH")
 
 $RELPATH/clang-format-diff.py -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 -style GNU <$PATCHY
-$RELPATH/clang-format-diff.py -regex '.*(\.hh$|\.cc$)' -i -p1 -style LLVM <$PATCHY
+$RELPATH/clang-format-diff.py -regex '(.*(\.hh$|\.cc$))|(lib/llvmopencl/.*\.h)' -i -p1 -style LLVM <$PATCHY
 
 git diff
 


### PR DESCRIPTION
Allows devices to set "device_alloca_locals" to 1, which causes then Workgroup.cc to generate code that allocates local memory from stack (using the alloca LLVM IR instruction) instead of expecting it to be preallocated by the host launcher. In that case the hidden local args contain the size of the local buffer to allocate instead of the buffer pointer.