### PR TITLE
pocl_buffer_boundcheck_3d off by 1

### DIFF
--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -691,7 +691,7 @@ int pocl_buffer_boundcheck_3d(const size_t buffer_size,
                origin[1] * rp +
                origin[0];
 
-  size_t byte_offset_end = origin[0] + region[0]-1 +
+  size_t byte_offset_end = origin[0] + region[0] +
        rp * (origin[1] + region[1]-1) +
        sp * (origin[2] + region[2]-1);
 

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -691,14 +691,14 @@ int pocl_buffer_boundcheck_3d(const size_t buffer_size,
                origin[1] * rp +
                origin[0];
 
-  size_t byte_offset_end = origin[0] + region[0] +
+  size_t byte_offset_end = origin[0] + region[0]-1 +
        rp * (origin[1] + region[1]-1) +
        sp * (origin[2] + region[2]-1);
 
 
   POCL_RETURN_ERROR_ON((byte_offset_begin > buffer_size), CL_INVALID_VALUE,
             "%sorigin is outside the %sbuffer", prefix, prefix);
-  POCL_RETURN_ERROR_ON((byte_offset_end > buffer_size), CL_INVALID_VALUE,
+  POCL_RETURN_ERROR_ON((byte_offset_end >= buffer_size), CL_INVALID_VALUE,
             "%sorigin+region is outside the %sbuffer", prefix, prefix);
   return CL_SUCCESS;
 }


### PR DESCRIPTION
So i believe this is a small bug, I could be wrong though I think negating region[0] by 1 was always yielding a byte size 1 byte smaller than intended. For example a 2D region where we wish to specify a buffer of 1600 bytes would yield 1599 (sorry for the bad pseudo-code):

```
int origin[3] = {0, 0, 0}
int region[3] = {80, 20, 1}; // z always has to be 1 for spec conformance
int rp = region[0]; // 80
int sp = region[1] * rp; // 20 * 80 = 1600 
```

Old formula:
`origin[0] + region[0]-1 + rp * (origin[1] + region[1]-1) + sp * (origin[2] + region[2]-1);`
**0 + 80 - 1 + 80 * (0 + 20 - 1) + 1600 * (0 + 1 - 1) = 1599**

Updated formula:
`origin[0] + region[0] + rp * (origin[1] + region[1]-1) + sp * (origin[2] + region[2]-1);`
**0 + 80 + 80 * (0 + 20 - 1) + 1600 * (0 + 1 - 1) = 1600**

I think the general idea was to offset the fact that the region values always have to be a minimum of 1 in the OpenCL (at least 1.2) specification and it throws off the calculation a little. So just negate by 1. I don't think region[0] has to be negated by 1 though as it's not multiplied by a value in this case that's always set (and by default if not specified by a user), but I could be missing the bigger picture and be wrong in this case (sorry if I am).