### PR TITLE
Determine CLANG resources dir at runtime

### DIFF
--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -438,7 +438,16 @@ int pocl_llvm_build_program(cl_program program,
   po.Includes.push_back(BuiltinRenamesH);
 #ifndef LLVM_OLDER_THAN_4_0
   // Use Clang's opencl-c.h header.
-  po.Includes.push_back(CLANG_RESOURCE_DIR "/include/opencl-c.h");
+  {
+#if (!defined(LLVM_OLDER_THAN_8_0)) && (!defined(LLVM_8_0))
+      std::string ClangResourcesDir = driver::Driver::GetResourcesPath(CLANG);
+#else
+      DiagnosticsEngine Diags{new DiagnosticIDs, new DiagnosticOptions};
+      driver::Driver TheDriver(CLANG, "", Diags);
+      std::string ClangResourcesDir = TheDriver.ResourceDir;
+#endif
+      po.Includes.push_back(ClangResourcesDir + "/include/opencl-c.h");
+  }
 #endif
   po.Includes.push_back(KernelH);
   clang::TargetOptions &ta = pocl_build.getTargetOpts();


### PR DESCRIPTION
When the resources dir is determined at compile time, it also includes
the full version (e.g. /usr/lib64/clang/8.0.0/include/opencl-c.h). If
clang gets a minor version update later (e.g. from 8.0.0 to 8.0.1), pocl
will still add the obsolete path for the header lookup.

Determine the path at runtime instead. LLVM 9.0 adds a static method
llvm::driver::Driver::GetResourcesPath(...) which can be used, LLVM 8.0
and older have to use a dummy Driver instance.

Fixes #747.

This targets the release_1_3 branch, as thats the one I have tested. The
code around ClangResourcesDir has changed a little bit, but a forward
port should be trivial.