### PR TITLE
Link against libclang-cpp.so when linking with shared libraries

### DIFF
--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -219,10 +219,16 @@ string(REPLACE " -pedantic" "" LLVM_CXXFLAGS "${LLVM_CXXFLAGS}")
 string(REGEX REPLACE "-W[^ ]*" "" LLVM_CXXFLAGS "${LLVM_CXXFLAGS}")
 
 # Llvm-config does not include clang libs
-set(CLANG_LIBNAMES clangCodeGen clangFrontendTool clangFrontend clangDriver clangSerialization
-    clangParse clangSema clangRewrite clangRewriteFrontend
-    clangStaticAnalyzerFrontend clangStaticAnalyzerCheckers
-    clangStaticAnalyzerCore clangAnalysis clangEdit clangAST clangASTMatchers clangLex clangBasic)
+if(8 LESS LLVM_MAJOR AND LLVM_LIB_IS_SHARED MATCHES "shared")
+  # Link against a single shared library instead of multiple component shared
+  # libraries.
+  set(CLANG_LIBNAMES clang-cpp)
+else()
+  set(CLANG_LIBNAMES clangCodeGen clangFrontendTool clangFrontend clangDriver clangSerialization
+      clangParse clangSema clangRewrite clangRewriteFrontend
+      clangStaticAnalyzerFrontend clangStaticAnalyzerCheckers
+      clangStaticAnalyzerCore clangAnalysis clangEdit clangAST clangASTMatchers clangLex clangBasic)
+endif()
 
 foreach(LIBNAME ${CLANG_LIBNAMES})
   find_library(C_LIBFILE_${LIBNAME} NAMES "${LIBNAME}" HINTS "${LLVM_LIBDIR}")


### PR DESCRIPTION
libclang-cpp.so is a new shared object in clang-9.0.0 which
contains all the clang components in one library.  Doing this will
save us from having to update cmake when there is a new clang component
and may provide better performance in LTO builds of clang.