### PR TITLE
Add a minimally intrusive and easy-to-use kernel execution time profiler

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,22 @@
+Changes updated until commit 7288619eb1b (May 25, 2019).
+
 1.5 unreleased
 ==============
 
+Notable User Facing Changes
+---------------------------
+- POCL_TRACE_EVENT, POCL_TRACE_EVENT_OPT and POCL_TRACE_EVENT_FILTER
+  environment variables were renamed to
+  POCL_TRACING, POCL_TRACING_OPT and POCL_TRACING_FILTER, respectively.
+
+Usability
+---------
+- A simple per-kernel execution time statistics atexit() for quick and easy
+  low-impact per-device profiling purposes (relies on event time stamps purely).
+  It can be enabled by setting POCL_TRACING env to 'cq'.
+
 1.4 September 2019
-==============
+==================
 
 Highlights
 ----------

--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -74,7 +74,7 @@
 
 
 
-#ifdef ENABLE_HOST_CPU_DEVICES
+#if defined(BUILD_BASIC) || defined(BUILD_PTHREAD)
 
 #define HOST_AS_FLAGS  "@HOST_AS_FLAGS@"
 

--- a/doc/sphinx/source/using.rst
+++ b/doc/sphinx/source/using.rst
@@ -246,18 +246,24 @@ pocl.
   Default 0. If set to an integer N > 0, libpocl will make a pause of N seconds
   once, when it's loading. Useful e.g. to set up a LTTNG tracing session.
 
-- **POCL_TRACE_EVENT**, **POCL_TRACE_EVENT_OPT** and **POCL_TRACE_EVENT_FILTER**
+- **POCL_TRACING**, **POCL_TRACING_OPT** and **POCL_TRACING_FILTER**
 
- If POCL_TRACE_EVENT is set to some tracer name, then all events
+ If POCL_TRACING is set to some tracer name, then all events
  will be traced automatically. Depending on the backend, traces
- may be output in different formats.
- POCL_TRACE_EVENT_FILTER is a comma separated list of string to
+ may be output in different formats and collected in a different way.
+ POCL_TRACING_FILTER is a comma separated list of string to
  indicate which event status should be filtered. For instance to trace
- complete and running events POCL_TRACE_EVENT_FILTER should be set
+ complete and running events POCL_TRACING_FILTER should be set
  to "complete,running". Default behavior is to trace all events.
 
+    cq -- Dumps a simple per-kernel execution time statistics at the
+          program exit time which is collected from command queue
+          start and finish time stamps. Useful for quick and easy profiling
+          purposes with accurate kernel execution time stamps produced
+          in a per device way. Currently only tracks kernel timings, and
+          POCL_TRACING_FILTER has no effect.
     text   -- Basic text logger for each events state
-              Use POCL_TRACE_EVENT_OPT=<file> to set the
+              Use POCL_TRACING_OPT=<file> to set the
               output file. If not specified, it defaults to
               pocl_trace_event.log
     lttng  -- LTTNG tracepoint support. When activated, a lttng session

--- a/lib/CL/CMakeLists.txt
+++ b/lib/CL/CMakeLists.txt
@@ -138,7 +138,7 @@ set(POCL_LIB_SOURCES  "clCreateContextFromType.c"
                    "clEnqueueSVMMap.c" "clEnqueueSVMUnmap.c"
                    "clEnqueueSVMMemcpy.c" "clEnqueueSVMMemFill.c"
                    "clSetKernelArgSVMPointer.c" "clSetKernelExecInfo.c"
-                   "pocl_binary.c" "pocl_opengl.c")
+                   "pocl_binary.c" "pocl_opengl.c" "pocl_cq_profiling.c")
 
 if(ANDROID)
   list(APPEND POCL_LIB_SOURCES "pocl_mkstemp.c")

--- a/lib/CL/clCreateCommandQueue.c
+++ b/lib/CL/clCreateCommandQueue.c
@@ -8,10 +8,10 @@
    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
    copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
-   
+
    The above copyright notice and this permission notice shall be included in
    all copies or substantial portions of the Software.
-   
+
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,6 +22,7 @@
 */
 
 #include "pocl_cl.h"
+#include "pocl_cq_profiling.h"
 #include "pocl_util.h"
 
 CL_API_ENTRY cl_command_queue CL_API_CALL
@@ -44,7 +45,7 @@ POname(clCreateCommandQueue)(cl_context context,
   POCL_GOTO_ERROR_ON((properties > (1<<2)-1), CL_INVALID_VALUE,
             "Properties must be <= 3 (there are only 2)\n");
 
-  if (POCL_DEBUGGING_ON)
+  if (POCL_DEBUGGING_ON || pocl_cq_profiling_enabled)
     properties |= CL_QUEUE_PROFILING_ENABLE;
 
   for (i=0; i<context->num_devices; i++)

--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -23,13 +23,14 @@
 */
 
 #include "config.h"
+#include "pocl_binary.h"
+#include "pocl_cache.h"
 #include "pocl_cl.h"
+#include "pocl_context.h"
+#include "pocl_cq_profiling.h"
 #include "pocl_llvm.h"
 #include "pocl_util.h"
-#include "pocl_cache.h"
 #include "utlist.h"
-#include "pocl_binary.h"
-#include "pocl_context.h"
 
 #ifndef _MSC_VER
 #  include <unistd.h>
@@ -602,6 +603,13 @@ if (local_##c1 > 1 && local_##c1 <= local_##c2 && local_##c1 <= local_##c3 && \
   command_node->next = NULL;
 
   POname(clRetainKernel) (kernel);
+
+  if (pocl_cq_profiling_enabled)
+    {
+      pocl_cq_profiling_register_event (command_node->event);
+      clRetainKernel (kernel);
+      command_node->event->meta_data->kernel = kernel;
+    }
 
   pocl_command_enqueue (command_queue, command_node);
   errcode = CL_SUCCESS;

--- a/lib/CL/clGetEventInfo.c
+++ b/lib/CL/clGetEventInfo.c
@@ -1,11 +1,34 @@
+/* OpenCL runtime library: clGetEventInfo()
+
+   Copyright (c) 2011-2019 pocl developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
 #include "pocl_util.h"
 
 CL_API_ENTRY cl_int CL_API_CALL
-POname(clGetEventInfo)(cl_event          event ,
-                       cl_event_info     param_name ,
-                       size_t            param_value_size ,
-                       void *            param_value ,
-                       size_t *          param_value_size_ret ) 
+POname(clGetEventInfo)(cl_event          event,
+                       cl_event_info     param_name,
+                       size_t            param_value_size,
+                       void *            param_value,
+                       size_t *          param_value_size_ret)
 CL_API_SUFFIX__VERSION_1_0
 {
   POCL_RETURN_ERROR_COND((event == NULL), CL_INVALID_EVENT);

--- a/lib/CL/clGetEventInfo.c
+++ b/lib/CL/clGetEventInfo.c
@@ -3,10 +3,10 @@
    Copyright (c) 2011-2019 pocl developers
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -16,20 +16,16 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #include "pocl_util.h"
 
-CL_API_ENTRY cl_int CL_API_CALL
-POname(clGetEventInfo)(cl_event          event,
-                       cl_event_info     param_name,
-                       size_t            param_value_size,
-                       void *            param_value,
-                       size_t *          param_value_size_ret)
-CL_API_SUFFIX__VERSION_1_0
+CL_API_ENTRY cl_int CL_API_CALL POname (clGetEventInfo) (
+    cl_event event, cl_event_info param_name, size_t param_value_size,
+    void *param_value, size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
 {
   POCL_RETURN_ERROR_COND((event == NULL), CL_INVALID_EVENT);
   POCL_LOCK_OBJ (event);

--- a/lib/CL/clReleaseContext.c
+++ b/lib/CL/clReleaseContext.c
@@ -4,10 +4,10 @@
                  2011-2019 pocl developers
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -17,14 +17,14 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
+#include "devices/devices.h"
 #include "pocl_cl.h"
 #include "pocl_util.h"
-#include "devices/devices.h"
 
 #include <unistd.h>
 

--- a/lib/CL/clReleaseContext.c
+++ b/lib/CL/clReleaseContext.c
@@ -1,17 +1,18 @@
 /* OpenCL runtime library: clReleaseContext()
 
    Copyright (c) 2011 Universidad Rey Juan Carlos
-   
+                 2011-2019 pocl developers
+
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
    in the Software without restriction, including without limitation the rights
    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
    copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
-   
+
    The above copyright notice and this permission notice shall be included in
    all copies or substantial portions of the Software.
-   
+
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,6 +23,7 @@
 */
 
 #include "pocl_cl.h"
+#include "pocl_util.h"
 #include "devices/devices.h"
 
 #include <unistd.h>
@@ -65,6 +67,7 @@ POname(clReleaseContext)(cl_context context) CL_API_SUFFIX__VERSION_1_0
 
       /* see below on why we don't call uninit_devices here anymore */
       --cl_context_count;
+      POCL_ATOMIC_DEC (cl_context_count);
     }
 
   POCL_UNLOCK (pocl_context_handling_lock);

--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -455,7 +455,7 @@ pocl_init_devices ()
   POCL_GOTO_ERROR_ON ((pocl_cache_init_topdir ()), CL_DEVICE_NOT_FOUND,
                       "Cache directory initialization failed");
 
-  pocl_event_tracing_init ();
+  pocl_tracing_init ();
 
 #ifdef HAVE_SLEEP
   int delay = pocl_get_int_option ("POCL_STARTUP_DELAY", 0);

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -1581,7 +1581,7 @@ pocl_hsa_submit (_cl_command_node *node, cl_command_queue cq)
   pocl_hsa_device_data_t *d = device->data;
   unsigned added_to_readylist = 0;
 
-  PTHREAD_CHECK (pthread_mutex_lock(&d->list_mutex));
+  PTHREAD_CHECK (pthread_mutex_lock (&d->list_mutex));
 
   node->ready = 1;
   if (pocl_command_is_ready (node->event))

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -1581,7 +1581,7 @@ pocl_hsa_submit (_cl_command_node *node, cl_command_queue cq)
   pocl_hsa_device_data_t *d = device->data;
   unsigned added_to_readylist = 0;
 
-  PTHREAD_CHECK(pthread_mutex_lock(&d->list_mutex));
+  PTHREAD_CHECK (pthread_mutex_lock(&d->list_mutex));
 
   node->ready = 1;
   if (pocl_command_is_ready (node->event))

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -1139,6 +1139,14 @@ struct event_node
   event_node * volatile next;
 };
 
+/* Optional metadata for events for improved profile data readability etc. */
+typedef struct _pocl_event_md
+{
+  /* The kernel executed by the NDRange command associated with the event,
+     if any. */
+  cl_kernel kernel;
+} pocl_event_md;
+
 typedef struct _cl_event _cl_event;
 struct _cl_event {
   POCL_ICD_OBJECT
@@ -1169,9 +1177,12 @@ struct _cl_event {
   cl_ulong time_start;  /* the time the command actually started executing */
   cl_ulong time_end;    /* the finish time of the command */
 
-  void *data; /* Device specific data */  
+  void *data; /* Device specific data. */
 
-  /* impicit event = an event for pocl's internal use, not visible to user */
+  /* Additional (optional data) used to make profile data more readable etc. */
+  pocl_event_md *meta_data;
+
+  /* Event for pocl's internal use, not visible to user. */
   int implicit_event;
   _cl_event * volatile next;
   _cl_event * volatile prev;

--- a/lib/CL/pocl_cq_profiling.c
+++ b/lib/CL/pocl_cq_profiling.c
@@ -1,0 +1,138 @@
+/* OpenCL runtime library: integrated command queue profile collecting
+   functionality
+
+   Copyright (c) 2019 Pekka Jääskeläinen
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#include "pocl_cq_profiling.h"
+#include "pocl_cl.h"
+#include "pocl_util.h"
+
+/* Maximum number of events collected. */
+#define POCL_CQ_PROFILING_MAX_EVENTS 1000000
+#define POCL_CQ_PROFILING_MAX_KERNELS 1000
+
+int pocl_cq_profiling_enabled = 0;
+static unsigned cq_events_collected = 0;
+static cl_event *profiled_cq_events = NULL;
+
+struct kernel_stats
+{
+  cl_kernel kernel;
+  unsigned long time;
+  unsigned long launches;
+};
+
+static int
+order_by_time (const void *a, const void *b)
+{
+  if (((struct kernel_stats *)a)->time < ((struct kernel_stats *)b)->time)
+    return 1;
+  else if (((struct kernel_stats *)a)->time > ((struct kernel_stats *)b)->time)
+    return -1;
+  else
+    return 0;
+}
+
+static void
+pocl_atexit ()
+{
+  unsigned long total_time = 0;
+  unsigned long total_commands = 0;
+  unsigned long different_kernels = 0;
+
+  struct kernel_stats kernel_statistics[cq_events_collected];
+  bzero (kernel_statistics, sizeof (kernel_statistics));
+
+  /* First statistics computation round. */
+  for (unsigned i = 0; i < cq_events_collected; ++i)
+    {
+      cl_event e = profiled_cq_events[i];
+      cl_kernel kernel = e->meta_data->kernel;
+      unsigned long kernel_t = e->time_end - e->time_start;
+      total_time += kernel_t;
+      total_commands++;
+
+      unsigned k_i = 0;
+      while (k_i < different_kernels
+             && strcmp (kernel_statistics[k_i].kernel->name, kernel->name)
+                    != 0)
+        ++k_i;
+
+      if (kernel_statistics[k_i].kernel == NULL)
+        {
+          kernel_statistics[k_i].kernel = kernel;
+          different_kernels++;
+        }
+      kernel_statistics[k_i].time += kernel_t;
+      kernel_statistics[k_i].launches++;
+    }
+
+  printf ("\n");
+  printf ("     %-30s %10s %15s %3s  %10s\n", "kernel", "launches", "total us",
+          "", "avg us");
+  qsort (kernel_statistics, different_kernels, sizeof (struct kernel_stats),
+         order_by_time);
+
+  for (int i = 0; i < different_kernels; ++i)
+    {
+      printf ("%3d) %-30s %10lu %15lu %3lu%% %10lu\n", i + 1,
+              kernel_statistics[i].kernel->name, kernel_statistics[i].launches,
+              kernel_statistics[i].time,
+              kernel_statistics[i].time * 100 / total_time,
+              kernel_statistics[i].time / kernel_statistics[i].launches);
+    }
+  printf ("     %-30s %10s %15s %3s %10s\n", "",
+          "==========", "==========", "====", "==========");
+
+  printf ("     %-30s %10lu %15lu %4s %10lu\n", "", total_commands, total_time,
+          "100%", total_time / total_commands);
+
+  /* TODO: Critical path information of the task graph. */
+}
+
+/* Initialize the profiling data structures, if not yet done. */
+
+void
+pocl_cq_profiling_init ()
+{
+  profiled_cq_events
+      = (cl_event *)malloc (sizeof (cl_event *) * POCL_CQ_PROFILING_MAX_EVENTS);
+  atexit (pocl_atexit);
+  pocl_cq_profiling_enabled = 1;
+}
+
+/* Registers the event for profiling. Retains it to keep it alive until stats
+   have been collected.
+*/
+
+void
+pocl_cq_profiling_register_event (cl_event event)
+{
+  clRetainEvent (event);
+  if (event->meta_data == NULL)
+    event->meta_data = (pocl_event_md *)malloc (sizeof (pocl_event_md));
+
+  unsigned cq_events_pos = POCL_ATOMIC_INC (cq_events_collected) - 1;
+  if (cq_events_pos >= POCL_CQ_PROFILING_MAX_EVENTS)
+    POCL_ABORT ("CQ profiler reached the limit on tracked events.");
+  profiled_cq_events[cq_events_pos] = event;
+}

--- a/lib/CL/pocl_cq_profiling.h
+++ b/lib/CL/pocl_cq_profiling.h
@@ -1,0 +1,55 @@
+/* OpenCL runtime library: integrated command queue profile collecting
+   functionality
+
+   Copyright (c) 2019 Pekka Jääskeläinen
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+/* The basic idea of the 'cq' profiler is to move most of the execution profile
+   impact (additional code executed, cache footprints changed etc. due to
+   profiling enabled) to the initialization (CQ creation time) with minimal impact
+   at runtime. This is accomplished by enabling the basic profiling queue feature
+   which is expected to be a minimally intrusive per-device specific way to
+   collect time stamps. The events with the profiling time stamps are just
+   accumulated until there is a "non-intrusive" spot to collect/analyze the data.
+   The default implementation just accumulates all the events and analyzes them
+   atexit() with a simple per kernel execution time printout.
+
+   One thing to keep in mind is that the command queue time stamps are per-device
+   timer stamps, and there is no requirement (AFAIK) to have a synchronized
+   global clock counter across the devices in the system. This means that _differences_
+   between time stamps in the same device does make sense, but in a multi-device
+   platform, the CQ timestamps are not necessarily a robust mechanism to draw
+   a global picture of the overall execution orderings etc. OpenCL 2.1 introduced
+   clGetHostTimer() and clGetDeviceAndHostTimer() which should help.
+*/
+
+#ifndef POCL_CQ_PROFILING_H
+#define POCL_CQ_PROFILING_H
+
+#include "CL/cl.h"
+
+/* This is set to 1 in case the cq profiling was enabled via POCL_TRACING=cq. */
+extern int pocl_cq_profiling_enabled;
+
+void pocl_cq_profiling_init ();
+void pocl_cq_profiling_register_event (cl_event event);
+
+#endif

--- a/lib/CL/pocl_mem_management.c
+++ b/lib/CL/pocl_mem_management.c
@@ -1,17 +1,17 @@
-/* pocl_cl.h - local runtime library declarations.
+/* pocl_mem_management.c - manage allocation of runtime objects
 
    Copyright (c) 2014 Ville Korhonen
-   
+
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
    in the Software without restriction, including without limitation the rights
    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
    copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
-   
+
    The above copyright notice and this permission notice shall be included in
    all copies or substantial portions of the Software.
-   
+
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/lib/CL/pocl_mem_management.c
+++ b/lib/CL/pocl_mem_management.c
@@ -3,10 +3,10 @@
    Copyright (c) 2014 Ville Korhonen
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -16,9 +16,9 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #include "pocl_mem_management.h"

--- a/lib/CL/pocl_mem_management.h
+++ b/lib/CL/pocl_mem_management.h
@@ -3,10 +3,10 @@
    Copyright (c) 2014 Ville Korhonen
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -16,9 +16,9 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #include "pocl_cl.h"

--- a/lib/CL/pocl_mem_management.h
+++ b/lib/CL/pocl_mem_management.h
@@ -1,17 +1,17 @@
-/* pocl_cl.h - local runtime library declarations.
+/* pocl_mem_management.c - manage allocation of runtime objects
 
    Copyright (c) 2014 Ville Korhonen
-   
+
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
    in the Software without restriction, including without limitation the rights
    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
    copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
-   
+
    The above copyright notice and this permission notice shall be included in
    all copies or substantial portions of the Software.
-   
+
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/lib/CL/pocl_runtime_config.h
+++ b/lib/CL/pocl_runtime_config.h
@@ -1,12 +1,13 @@
-/* pocl_runtime_config.h: functions to query pocl runtime configuration settings
+/* pocl_runtime_config.h: functions to query pocl runtime configuration
+   settings
 
    Copyright (c) 2013 Pekka Jääskeläinen
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -16,9 +17,9 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #ifndef _POCL_RUNTIME_CONFIG_H

--- a/lib/CL/pocl_runtime_config.h
+++ b/lib/CL/pocl_runtime_config.h
@@ -1,17 +1,17 @@
 /* pocl_runtime_config.h: functions to query pocl runtime configuration settings
 
    Copyright (c) 2013 Pekka Jääskeläinen
-   
+
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
    in the Software without restriction, including without limitation the rights
    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
    copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
-   
+
    The above copyright notice and this permission notice shall be included in
    all copies or substantial portions of the Software.
-   
+
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/lib/CL/pocl_tracing.h
+++ b/lib/CL/pocl_tracing.h
@@ -38,23 +38,21 @@ extern "C"
 {
 #endif
 
-  void pocl_event_updated (cl_event event, int new_status);
+void pocl_event_updated (cl_event event, int new_status);
 
-/* Initializes event tracing system 
- */
-  void pocl_event_tracing_init ();
+/* Initializes the event tracing system selected with POCL_TRACING. */
+void pocl_tracing_init ();
 
-/* Struct of trace handlers
- */
-  struct pocl_event_tracer
-  {
-    /* Tracer name used to match POCL_TRACE_EVENT=xxx env var */
-    const char *name;
-    /* Init function called when the tracer is matched */
-    void (*init) ();
-    /* Callback called when an event has been updated */
-    void (*event_updated) (cl_event /* event */ , int /* status */ );
-  };
+/* Struct of trace handlers. */
+struct pocl_event_tracer
+{
+  /* Tracer name used to match POCL_TRACING=xxx env var */
+  const char *name;
+  /* Init function called when the tracer is matched */
+  void (*init) ();
+  /* Callback called when an event has been updated */
+  void (*event_updated) (cl_event /* event */ , int /* status */ );
+};
 
 #ifdef __cplusplus
 }

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -395,7 +395,7 @@ cl_int pocl_create_event (cl_event *event, cl_command_queue command_queue,
         POname(clRetainCommandQueue) (command_queue);
 
       (*event)->command_type = command_type;
-      (*event)->id = ATOMIC_INC (event_id_counter);
+      (*event)->id = POCL_ATOMIC_INC (event_id_counter);
       (*event)->num_buffers = num_buffers;
 
       POCL_MSG_PRINT_EVENTS ("created event with id %d\n", (*event)->id);
@@ -406,12 +406,8 @@ cl_int pocl_create_event (cl_event *event, cl_command_queue command_queue,
           memcpy ((*event)->mem_objs, buffers, num_buffers * sizeof(cl_mem));
         }
       (*event)->status = CL_QUEUED;
-
-      /* user events do not have cq */
-      if (!command_queue)
-        return CL_SUCCESS;
-
     }
+
   return CL_SUCCESS;
 }
 
@@ -484,7 +480,7 @@ cl_int pocl_create_command (_cl_command_node **cmd,
 
   (*cmd)->type = command_type;
 
-  /* Even if user does not provide event pointer, create event anyway */
+  /* If user does not provide an event pointer, create an implicit one. */
   event = &((*cmd)->event);
   err = pocl_create_event (event, command_queue, 0, num_buffers, buffers,
                            command_queue->context);

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -51,6 +51,8 @@ extern "C" {
 /* See: https://gcc.gnu.org/onlinedocs/gcc-4.1.2/gcc/Atomic-Builtins.html */
 #define POCL_ATOMIC_INC(x) __sync_add_and_fetch (&x, 1)
 #define POCL_ATOMIC_DEC(x) __sync_sub_and_fetch (&x, 1)
+#define POCL_ATOMIC_CAS(ptr, oldval, newval)                                  \
+  __sync_val_compare_and_swap (ptr, oldval, newval)
 
 #else
 #error Need basic atomics builtin support in the compiler.

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -46,9 +46,14 @@ extern "C" {
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)
-#define ATOMIC_INC(x) __sync_add_and_fetch(&x, 1)
+
+/* These return the new value. */
+/* See: https://gcc.gnu.org/onlinedocs/gcc-4.1.2/gcc/Atomic-Builtins.html */
+#define POCL_ATOMIC_INC(x) __sync_add_and_fetch (&x, 1)
+#define POCL_ATOMIC_DEC(x) __sync_sub_and_fetch (&x, 1)
+
 #else
-#error Need atomic_inc() builtin for this compiler
+#error Need basic atomics builtin support in the compiler.
 #endif
 
 uint32_t byteswap_uint32_t (uint32_t word, char should_swap);

--- a/lib/llvmopencl/WorkitemHandler.cc
+++ b/lib/llvmopencl/WorkitemHandler.cc
@@ -54,7 +54,7 @@ using namespace llvm;
 /* These are used to communicate the work-group function specialization
    properites of the currently compiled kernel command.
 
-   TODO: Something cleaner than a global value. */
+   TODO: Something cleaner than global values. */
 
 bool WGDynamicLocalSize = false;
 size_t WGLocalSizeX = 1;


### PR DESCRIPTION
Setting POCL_PROFILING=1 collects kernel execution times and dumps stats atexit(). The purpose of this feature is to enable implementation of minimally intrusive profile collection; the profile data collector can choose the occasions when it gathers the time stamp data from the events. The impact to the observed execution profile is minimized by avoiding writing any logs, copying objects or such while collecting the data during execution.

It relies on the standard event timestamps to enable devices update them as (and when) they see fit during the execution.

The drawback is accumulation of cl_object garbage, which should be taken in account in the data collection interval; the collector should release the events and the extra data objects they hold often enough to avoid memory consumption to become a problem.

The current version does not perform garbage collection, but assumes the alive OpenCL objects that are kept until the exit is a non-problem, which is clearly the case with most of the OpenCL programs which are rather simple; not long running, nor launch a lot of commands over their lifetime.

The default profile data collector counts only kernel commands at the moment. Collecting stats of data transfers would be a useful addition.

+ a few smaller fixes