### PR TITLE
refactor vector conversions for better autovectorizing codegen

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,10 @@ Notable User Facing Changes
 - POCL_TRACE_EVENT, POCL_TRACE_EVENT_OPT and POCL_TRACE_EVENT_FILTER
   environment variables were renamed to
   POCL_TRACING, POCL_TRACING_OPT and POCL_TRACING_FILTER, respectively.
+- Refactored the implementation of convert_T() OpenCL functions to better meet
+  autovectorization criteria under LLVM, thus utilizing device's SIMD ISA
+  capabilities where available; e.g. on an ARM64 Cortex-A72 convert_int8(short8)
+  is 5.5x faster now when measured in a tight loop.
 
 Usability
 ---------

--- a/lib/kernel/convert_type.cl
+++ b/lib/kernel/convert_type.cl
@@ -42,15 +42,6 @@ char2 convert_char2(char2 x)
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3(char3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char4 convert_char4(char4 x)
 {
   return (char4)(
@@ -96,6 +87,15 @@ char16 convert_char16(char16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3(char3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar(char x)
@@ -109,15 +109,6 @@ uchar2 convert_uchar2(char2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3(char3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -166,6 +157,15 @@ uchar16 convert_uchar16(char16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3(char3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short(char x)
@@ -179,15 +179,6 @@ short2 convert_short2(char2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3(char3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -236,6 +227,15 @@ short16 convert_short16(char16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3(char3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort(char x)
@@ -249,15 +249,6 @@ ushort2 convert_ushort2(char2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3(char3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -306,6 +297,15 @@ ushort16 convert_ushort16(char16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3(char3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int(char x)
@@ -319,15 +319,6 @@ int2 convert_int2(char2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3(char3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -376,6 +367,15 @@ int16 convert_int16(char16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3(char3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint(char x)
@@ -389,15 +389,6 @@ uint2 convert_uint2(char2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3(char3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -446,6 +437,15 @@ uint16 convert_uint16(char16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3(char3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -460,15 +460,6 @@ long2 convert_long2(char2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3(char3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -517,6 +508,15 @@ long16 convert_long16(char16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3(char3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -532,15 +532,6 @@ ulong2 convert_ulong2(char2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3(char3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -589,6 +580,15 @@ ulong16 convert_ulong16(char16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3(char3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -604,15 +604,6 @@ half2 convert_half2(char2 x)
   return (half2)(
     (half)x.s0,
     (half)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half3 convert_half3(char3 x)
-{
-  return (half3)(
-    (half)x.s0,
-    (half)x.s1,
-    (half)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -661,6 +652,15 @@ half16 convert_half16(char16 x)
     (half)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3(char3 x)
+{
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -675,15 +675,6 @@ float2 convert_float2(char2 x)
   return (float2)(
     (float)x.s0,
     (float)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float3 convert_float3(char3 x)
-{
-  return (float3)(
-    (float)x.s0,
-    (float)x.s1,
-    (float)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -732,6 +723,15 @@ float16 convert_float16(char16 x)
     (float)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float3 convert_float3(char3 x)
+{
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
+}
+
 
 #if defined(cl_khr_fp64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -746,15 +746,6 @@ double2 convert_double2(char2 x)
   return (double2)(
     (double)x.s0,
     (double)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double3 convert_double3(char3 x)
-{
-  return (double3)(
-    (double)x.s0,
-    (double)x.s1,
-    (double)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -803,6 +794,15 @@ double16 convert_double16(char16 x)
     (double)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double3 convert_double3(char3 x)
+{
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -817,15 +817,6 @@ char2 convert_char2(uchar2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3(uchar3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -874,6 +865,15 @@ char16 convert_char16(uchar16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3(uchar3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar(uchar x)
@@ -887,15 +887,6 @@ uchar2 convert_uchar2(uchar2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3(uchar3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -944,6 +935,15 @@ uchar16 convert_uchar16(uchar16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3(uchar3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short(uchar x)
@@ -957,15 +957,6 @@ short2 convert_short2(uchar2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3(uchar3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1014,6 +1005,15 @@ short16 convert_short16(uchar16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3(uchar3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort(uchar x)
@@ -1027,15 +1027,6 @@ ushort2 convert_ushort2(uchar2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3(uchar3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1084,6 +1075,15 @@ ushort16 convert_ushort16(uchar16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3(uchar3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int(uchar x)
@@ -1097,15 +1097,6 @@ int2 convert_int2(uchar2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3(uchar3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1154,6 +1145,15 @@ int16 convert_int16(uchar16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3(uchar3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint(uchar x)
@@ -1167,15 +1167,6 @@ uint2 convert_uint2(uchar2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3(uchar3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1224,6 +1215,15 @@ uint16 convert_uint16(uchar16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3(uchar3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1238,15 +1238,6 @@ long2 convert_long2(uchar2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3(uchar3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1295,6 +1286,15 @@ long16 convert_long16(uchar16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3(uchar3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -1310,15 +1310,6 @@ ulong2 convert_ulong2(uchar2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3(uchar3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1367,6 +1358,15 @@ ulong16 convert_ulong16(uchar16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3(uchar3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -1382,15 +1382,6 @@ half2 convert_half2(uchar2 x)
   return (half2)(
     (half)x.s0,
     (half)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half3 convert_half3(uchar3 x)
-{
-  return (half3)(
-    (half)x.s0,
-    (half)x.s1,
-    (half)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1439,6 +1430,15 @@ half16 convert_half16(uchar16 x)
     (half)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3(uchar3 x)
+{
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1453,15 +1453,6 @@ float2 convert_float2(uchar2 x)
   return (float2)(
     (float)x.s0,
     (float)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float3 convert_float3(uchar3 x)
-{
-  return (float3)(
-    (float)x.s0,
-    (float)x.s1,
-    (float)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1510,6 +1501,15 @@ float16 convert_float16(uchar16 x)
     (float)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float3 convert_float3(uchar3 x)
+{
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
+}
+
 
 #if defined(cl_khr_fp64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1524,15 +1524,6 @@ double2 convert_double2(uchar2 x)
   return (double2)(
     (double)x.s0,
     (double)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double3 convert_double3(uchar3 x)
-{
-  return (double3)(
-    (double)x.s0,
-    (double)x.s1,
-    (double)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1581,6 +1572,15 @@ double16 convert_double16(uchar16 x)
     (double)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double3 convert_double3(uchar3 x)
+{
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1595,15 +1595,6 @@ char2 convert_char2(short2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3(short3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1652,6 +1643,15 @@ char16 convert_char16(short16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3(short3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar(short x)
@@ -1665,15 +1665,6 @@ uchar2 convert_uchar2(short2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3(short3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1722,6 +1713,15 @@ uchar16 convert_uchar16(short16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3(short3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short(short x)
@@ -1735,15 +1735,6 @@ short2 convert_short2(short2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3(short3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1792,6 +1783,15 @@ short16 convert_short16(short16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3(short3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort(short x)
@@ -1805,15 +1805,6 @@ ushort2 convert_ushort2(short2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3(short3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1862,6 +1853,15 @@ ushort16 convert_ushort16(short16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3(short3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int(short x)
@@ -1875,15 +1875,6 @@ int2 convert_int2(short2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3(short3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1932,6 +1923,15 @@ int16 convert_int16(short16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3(short3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint(short x)
@@ -1945,15 +1945,6 @@ uint2 convert_uint2(short2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3(short3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2002,6 +1993,15 @@ uint16 convert_uint16(short16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3(short3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2016,15 +2016,6 @@ long2 convert_long2(short2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3(short3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2073,6 +2064,15 @@ long16 convert_long16(short16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3(short3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2088,15 +2088,6 @@ ulong2 convert_ulong2(short2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3(short3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2145,6 +2136,15 @@ ulong16 convert_ulong16(short16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3(short3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -2160,15 +2160,6 @@ half2 convert_half2(short2 x)
   return (half2)(
     (half)x.s0,
     (half)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half3 convert_half3(short3 x)
-{
-  return (half3)(
-    (half)x.s0,
-    (half)x.s1,
-    (half)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2217,6 +2208,15 @@ half16 convert_half16(short16 x)
     (half)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3(short3 x)
+{
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2231,15 +2231,6 @@ float2 convert_float2(short2 x)
   return (float2)(
     (float)x.s0,
     (float)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float3 convert_float3(short3 x)
-{
-  return (float3)(
-    (float)x.s0,
-    (float)x.s1,
-    (float)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2288,6 +2279,15 @@ float16 convert_float16(short16 x)
     (float)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float3 convert_float3(short3 x)
+{
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
+}
+
 
 #if defined(cl_khr_fp64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2302,15 +2302,6 @@ double2 convert_double2(short2 x)
   return (double2)(
     (double)x.s0,
     (double)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double3 convert_double3(short3 x)
-{
-  return (double3)(
-    (double)x.s0,
-    (double)x.s1,
-    (double)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2359,6 +2350,15 @@ double16 convert_double16(short16 x)
     (double)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double3 convert_double3(short3 x)
+{
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2373,15 +2373,6 @@ char2 convert_char2(ushort2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3(ushort3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2430,6 +2421,15 @@ char16 convert_char16(ushort16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3(ushort3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar(ushort x)
@@ -2443,15 +2443,6 @@ uchar2 convert_uchar2(ushort2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3(ushort3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2500,6 +2491,15 @@ uchar16 convert_uchar16(ushort16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3(ushort3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short(ushort x)
@@ -2513,15 +2513,6 @@ short2 convert_short2(ushort2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3(ushort3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2570,6 +2561,15 @@ short16 convert_short16(ushort16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3(ushort3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort(ushort x)
@@ -2583,15 +2583,6 @@ ushort2 convert_ushort2(ushort2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3(ushort3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2640,6 +2631,15 @@ ushort16 convert_ushort16(ushort16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3(ushort3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int(ushort x)
@@ -2653,15 +2653,6 @@ int2 convert_int2(ushort2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3(ushort3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2710,6 +2701,15 @@ int16 convert_int16(ushort16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3(ushort3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint(ushort x)
@@ -2723,15 +2723,6 @@ uint2 convert_uint2(ushort2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3(ushort3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2780,6 +2771,15 @@ uint16 convert_uint16(ushort16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3(ushort3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2794,15 +2794,6 @@ long2 convert_long2(ushort2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3(ushort3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2851,6 +2842,15 @@ long16 convert_long16(ushort16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3(ushort3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2866,15 +2866,6 @@ ulong2 convert_ulong2(ushort2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3(ushort3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2923,6 +2914,15 @@ ulong16 convert_ulong16(ushort16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3(ushort3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -2938,15 +2938,6 @@ half2 convert_half2(ushort2 x)
   return (half2)(
     (half)x.s0,
     (half)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half3 convert_half3(ushort3 x)
-{
-  return (half3)(
-    (half)x.s0,
-    (half)x.s1,
-    (half)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2995,6 +2986,15 @@ half16 convert_half16(ushort16 x)
     (half)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3(ushort3 x)
+{
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3009,15 +3009,6 @@ float2 convert_float2(ushort2 x)
   return (float2)(
     (float)x.s0,
     (float)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float3 convert_float3(ushort3 x)
-{
-  return (float3)(
-    (float)x.s0,
-    (float)x.s1,
-    (float)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3066,6 +3057,15 @@ float16 convert_float16(ushort16 x)
     (float)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float3 convert_float3(ushort3 x)
+{
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
+}
+
 
 #if defined(cl_khr_fp64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3080,15 +3080,6 @@ double2 convert_double2(ushort2 x)
   return (double2)(
     (double)x.s0,
     (double)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double3 convert_double3(ushort3 x)
-{
-  return (double3)(
-    (double)x.s0,
-    (double)x.s1,
-    (double)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3137,6 +3128,15 @@ double16 convert_double16(ushort16 x)
     (double)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double3 convert_double3(ushort3 x)
+{
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3151,15 +3151,6 @@ char2 convert_char2(int2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3(int3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3208,6 +3199,15 @@ char16 convert_char16(int16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3(int3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar(int x)
@@ -3221,15 +3221,6 @@ uchar2 convert_uchar2(int2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3(int3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3278,6 +3269,15 @@ uchar16 convert_uchar16(int16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3(int3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short(int x)
@@ -3291,15 +3291,6 @@ short2 convert_short2(int2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3(int3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3348,6 +3339,15 @@ short16 convert_short16(int16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3(int3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort(int x)
@@ -3361,15 +3361,6 @@ ushort2 convert_ushort2(int2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3(int3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3418,6 +3409,15 @@ ushort16 convert_ushort16(int16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3(int3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int(int x)
@@ -3431,15 +3431,6 @@ int2 convert_int2(int2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3(int3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3488,6 +3479,15 @@ int16 convert_int16(int16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3(int3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint(int x)
@@ -3501,15 +3501,6 @@ uint2 convert_uint2(int2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3(int3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3558,6 +3549,15 @@ uint16 convert_uint16(int16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3(int3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3572,15 +3572,6 @@ long2 convert_long2(int2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3(int3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3629,6 +3620,15 @@ long16 convert_long16(int16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3(int3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -3644,15 +3644,6 @@ ulong2 convert_ulong2(int2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3(int3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3701,6 +3692,15 @@ ulong16 convert_ulong16(int16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3(int3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -3716,15 +3716,6 @@ half2 convert_half2(int2 x)
   return (half2)(
     (half)x.s0,
     (half)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half3 convert_half3(int3 x)
-{
-  return (half3)(
-    (half)x.s0,
-    (half)x.s1,
-    (half)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3773,6 +3764,15 @@ half16 convert_half16(int16 x)
     (half)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3(int3 x)
+{
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3787,15 +3787,6 @@ float2 convert_float2(int2 x)
   return (float2)(
     (float)x.s0,
     (float)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float3 convert_float3(int3 x)
-{
-  return (float3)(
-    (float)x.s0,
-    (float)x.s1,
-    (float)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3844,6 +3835,15 @@ float16 convert_float16(int16 x)
     (float)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float3 convert_float3(int3 x)
+{
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
+}
+
 
 #if defined(cl_khr_fp64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3858,15 +3858,6 @@ double2 convert_double2(int2 x)
   return (double2)(
     (double)x.s0,
     (double)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double3 convert_double3(int3 x)
-{
-  return (double3)(
-    (double)x.s0,
-    (double)x.s1,
-    (double)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3915,6 +3906,15 @@ double16 convert_double16(int16 x)
     (double)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double3 convert_double3(int3 x)
+{
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3929,15 +3929,6 @@ char2 convert_char2(uint2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3(uint3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3986,6 +3977,15 @@ char16 convert_char16(uint16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3(uint3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar(uint x)
@@ -3999,15 +3999,6 @@ uchar2 convert_uchar2(uint2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3(uint3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4056,6 +4047,15 @@ uchar16 convert_uchar16(uint16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3(uint3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short(uint x)
@@ -4069,15 +4069,6 @@ short2 convert_short2(uint2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3(uint3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4126,6 +4117,15 @@ short16 convert_short16(uint16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3(uint3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort(uint x)
@@ -4139,15 +4139,6 @@ ushort2 convert_ushort2(uint2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3(uint3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4196,6 +4187,15 @@ ushort16 convert_ushort16(uint16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3(uint3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int(uint x)
@@ -4209,15 +4209,6 @@ int2 convert_int2(uint2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3(uint3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4266,6 +4257,15 @@ int16 convert_int16(uint16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3(uint3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint(uint x)
@@ -4279,15 +4279,6 @@ uint2 convert_uint2(uint2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3(uint3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4336,6 +4327,15 @@ uint16 convert_uint16(uint16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3(uint3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4350,15 +4350,6 @@ long2 convert_long2(uint2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3(uint3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4407,6 +4398,15 @@ long16 convert_long16(uint16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3(uint3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -4422,15 +4422,6 @@ ulong2 convert_ulong2(uint2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3(uint3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4479,6 +4470,15 @@ ulong16 convert_ulong16(uint16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3(uint3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -4494,15 +4494,6 @@ half2 convert_half2(uint2 x)
   return (half2)(
     (half)x.s0,
     (half)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half3 convert_half3(uint3 x)
-{
-  return (half3)(
-    (half)x.s0,
-    (half)x.s1,
-    (half)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4551,6 +4542,15 @@ half16 convert_half16(uint16 x)
     (half)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3(uint3 x)
+{
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4565,15 +4565,6 @@ float2 convert_float2(uint2 x)
   return (float2)(
     (float)x.s0,
     (float)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float3 convert_float3(uint3 x)
-{
-  return (float3)(
-    (float)x.s0,
-    (float)x.s1,
-    (float)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4622,6 +4613,15 @@ float16 convert_float16(uint16 x)
     (float)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float3 convert_float3(uint3 x)
+{
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
+}
+
 
 #if defined(cl_khr_fp64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4636,15 +4636,6 @@ double2 convert_double2(uint2 x)
   return (double2)(
     (double)x.s0,
     (double)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double3 convert_double3(uint3 x)
-{
-  return (double3)(
-    (double)x.s0,
-    (double)x.s1,
-    (double)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4693,6 +4684,15 @@ double16 convert_double16(uint16 x)
     (double)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double3 convert_double3(uint3 x)
+{
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -4708,15 +4708,6 @@ char2 convert_char2(long2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3(long3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4765,6 +4756,15 @@ char16 convert_char16(long16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3(long3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -4780,15 +4780,6 @@ uchar2 convert_uchar2(long2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3(long3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4837,6 +4828,15 @@ uchar16 convert_uchar16(long16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3(long3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -4852,15 +4852,6 @@ short2 convert_short2(long2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3(long3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4909,6 +4900,15 @@ short16 convert_short16(long16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3(long3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -4924,15 +4924,6 @@ ushort2 convert_ushort2(long2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3(long3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4981,6 +4972,15 @@ ushort16 convert_ushort16(long16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3(long3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -4996,15 +4996,6 @@ int2 convert_int2(long2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3(long3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5053,6 +5044,15 @@ int16 convert_int16(long16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3(long3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5068,15 +5068,6 @@ uint2 convert_uint2(long2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3(long3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5125,6 +5116,15 @@ uint16 convert_uint16(long16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3(long3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5140,15 +5140,6 @@ long2 convert_long2(long2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3(long3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5197,6 +5188,15 @@ long16 convert_long16(long16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3(long3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5212,15 +5212,6 @@ ulong2 convert_ulong2(long2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3(long3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5269,6 +5260,15 @@ ulong16 convert_ulong16(long16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3(long3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp16)
@@ -5284,15 +5284,6 @@ half2 convert_half2(long2 x)
   return (half2)(
     (half)x.s0,
     (half)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half3 convert_half3(long3 x)
-{
-  return (half3)(
-    (half)x.s0,
-    (half)x.s1,
-    (half)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5341,6 +5332,15 @@ half16 convert_half16(long16 x)
     (half)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3(long3 x)
+{
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5356,15 +5356,6 @@ float2 convert_float2(long2 x)
   return (float2)(
     (float)x.s0,
     (float)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float3 convert_float3(long3 x)
-{
-  return (float3)(
-    (float)x.s0,
-    (float)x.s1,
-    (float)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5413,6 +5404,15 @@ float16 convert_float16(long16 x)
     (float)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float3 convert_float3(long3 x)
+{
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp64)
@@ -5428,15 +5428,6 @@ double2 convert_double2(long2 x)
   return (double2)(
     (double)x.s0,
     (double)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double3 convert_double3(long3 x)
-{
-  return (double3)(
-    (double)x.s0,
-    (double)x.s1,
-    (double)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5485,6 +5476,15 @@ double16 convert_double16(long16 x)
     (double)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double3 convert_double3(long3 x)
+{
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5500,15 +5500,6 @@ char2 convert_char2(ulong2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3(ulong3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5557,6 +5548,15 @@ char16 convert_char16(ulong16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3(ulong3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5572,15 +5572,6 @@ uchar2 convert_uchar2(ulong2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3(ulong3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5629,6 +5620,15 @@ uchar16 convert_uchar16(ulong16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3(ulong3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5644,15 +5644,6 @@ short2 convert_short2(ulong2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3(ulong3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5701,6 +5692,15 @@ short16 convert_short16(ulong16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3(ulong3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5716,15 +5716,6 @@ ushort2 convert_ushort2(ulong2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3(ulong3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5773,6 +5764,15 @@ ushort16 convert_ushort16(ulong16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3(ulong3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5788,15 +5788,6 @@ int2 convert_int2(ulong2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3(ulong3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5845,6 +5836,15 @@ int16 convert_int16(ulong16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3(ulong3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5860,15 +5860,6 @@ uint2 convert_uint2(ulong2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3(ulong3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5917,6 +5908,15 @@ uint16 convert_uint16(ulong16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3(ulong3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5932,15 +5932,6 @@ long2 convert_long2(ulong2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3(ulong3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5989,6 +5980,15 @@ long16 convert_long16(ulong16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3(ulong3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -6004,15 +6004,6 @@ ulong2 convert_ulong2(ulong2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3(ulong3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6061,6 +6052,15 @@ ulong16 convert_ulong16(ulong16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3(ulong3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp16)
@@ -6076,15 +6076,6 @@ half2 convert_half2(ulong2 x)
   return (half2)(
     (half)x.s0,
     (half)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half3 convert_half3(ulong3 x)
-{
-  return (half3)(
-    (half)x.s0,
-    (half)x.s1,
-    (half)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6133,6 +6124,15 @@ half16 convert_half16(ulong16 x)
     (half)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3(ulong3 x)
+{
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -6148,15 +6148,6 @@ float2 convert_float2(ulong2 x)
   return (float2)(
     (float)x.s0,
     (float)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float3 convert_float3(ulong3 x)
-{
-  return (float3)(
-    (float)x.s0,
-    (float)x.s1,
-    (float)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6205,6 +6196,15 @@ float16 convert_float16(ulong16 x)
     (float)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float3 convert_float3(ulong3 x)
+{
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp64)
@@ -6220,15 +6220,6 @@ double2 convert_double2(ulong2 x)
   return (double2)(
     (double)x.s0,
     (double)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double3 convert_double3(ulong3 x)
-{
-  return (double3)(
-    (double)x.s0,
-    (double)x.s1,
-    (double)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6277,6 +6268,15 @@ double16 convert_double16(ulong16 x)
     (double)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double3 convert_double3(ulong3 x)
+{
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -6292,15 +6292,6 @@ char2 convert_char2(half2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3(half3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6349,6 +6340,15 @@ char16 convert_char16(half16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3(half3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -6364,15 +6364,6 @@ uchar2 convert_uchar2(half2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3(half3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6421,6 +6412,15 @@ uchar16 convert_uchar16(half16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3(half3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -6436,15 +6436,6 @@ short2 convert_short2(half2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3(half3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6493,6 +6484,15 @@ short16 convert_short16(half16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3(half3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -6508,15 +6508,6 @@ ushort2 convert_ushort2(half2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3(half3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6565,6 +6556,15 @@ ushort16 convert_ushort16(half16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3(half3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -6580,15 +6580,6 @@ int2 convert_int2(half2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3(half3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6637,6 +6628,15 @@ int16 convert_int16(half16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3(half3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -6652,15 +6652,6 @@ uint2 convert_uint2(half2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3(half3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6709,6 +6700,15 @@ uint16 convert_uint16(half16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3(half3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp16)
@@ -6724,15 +6724,6 @@ long2 convert_long2(half2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3(half3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6781,6 +6772,15 @@ long16 convert_long16(half16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3(half3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp16)
@@ -6796,15 +6796,6 @@ ulong2 convert_ulong2(half2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3(half3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6853,6 +6844,15 @@ ulong16 convert_ulong16(half16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3(half3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -6868,15 +6868,6 @@ half2 convert_half2(half2 x)
   return (half2)(
     (half)x.s0,
     (half)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half3 convert_half3(half3 x)
-{
-  return (half3)(
-    (half)x.s0,
-    (half)x.s1,
-    (half)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6925,6 +6916,15 @@ half16 convert_half16(half16 x)
     (half)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3(half3 x)
+{
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -6940,15 +6940,6 @@ float2 convert_float2(half2 x)
   return (float2)(
     (float)x.s0,
     (float)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float3 convert_float3(half3 x)
-{
-  return (float3)(
-    (float)x.s0,
-    (float)x.s1,
-    (float)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6997,6 +6988,15 @@ float16 convert_float16(half16 x)
     (float)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float3 convert_float3(half3 x)
+{
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp64) && defined(cl_khr_fp16)
@@ -7012,15 +7012,6 @@ double2 convert_double2(half2 x)
   return (double2)(
     (double)x.s0,
     (double)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double3 convert_double3(half3 x)
-{
-  return (double3)(
-    (double)x.s0,
-    (double)x.s1,
-    (double)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7069,6 +7060,15 @@ double16 convert_double16(half16 x)
     (double)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double3 convert_double3(half3 x)
+{
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7083,15 +7083,6 @@ char2 convert_char2(float2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3(float3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7140,6 +7131,15 @@ char16 convert_char16(float16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3(float3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar(float x)
@@ -7153,15 +7153,6 @@ uchar2 convert_uchar2(float2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3(float3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7210,6 +7201,15 @@ uchar16 convert_uchar16(float16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3(float3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short(float x)
@@ -7223,15 +7223,6 @@ short2 convert_short2(float2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3(float3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7280,6 +7271,15 @@ short16 convert_short16(float16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3(float3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort(float x)
@@ -7293,15 +7293,6 @@ ushort2 convert_ushort2(float2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3(float3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7350,6 +7341,15 @@ ushort16 convert_ushort16(float16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3(float3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int(float x)
@@ -7363,15 +7363,6 @@ int2 convert_int2(float2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3(float3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7420,6 +7411,15 @@ int16 convert_int16(float16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3(float3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint(float x)
@@ -7433,15 +7433,6 @@ uint2 convert_uint2(float2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3(float3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7490,6 +7481,15 @@ uint16 convert_uint16(float16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3(float3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7504,15 +7504,6 @@ long2 convert_long2(float2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3(float3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7561,6 +7552,15 @@ long16 convert_long16(float16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3(float3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -7576,15 +7576,6 @@ ulong2 convert_ulong2(float2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3(float3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7633,6 +7624,15 @@ ulong16 convert_ulong16(float16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3(float3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -7648,15 +7648,6 @@ half2 convert_half2(float2 x)
   return (half2)(
     (half)x.s0,
     (half)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half3 convert_half3(float3 x)
-{
-  return (half3)(
-    (half)x.s0,
-    (half)x.s1,
-    (half)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7705,6 +7696,15 @@ half16 convert_half16(float16 x)
     (half)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3(float3 x)
+{
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7719,15 +7719,6 @@ float2 convert_float2(float2 x)
   return (float2)(
     (float)x.s0,
     (float)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float3 convert_float3(float3 x)
-{
-  return (float3)(
-    (float)x.s0,
-    (float)x.s1,
-    (float)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7776,6 +7767,15 @@ float16 convert_float16(float16 x)
     (float)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float3 convert_float3(float3 x)
+{
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
+}
+
 
 #if defined(cl_khr_fp64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7790,15 +7790,6 @@ double2 convert_double2(float2 x)
   return (double2)(
     (double)x.s0,
     (double)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double3 convert_double3(float3 x)
-{
-  return (double3)(
-    (double)x.s0,
-    (double)x.s1,
-    (double)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7847,6 +7838,15 @@ double16 convert_double16(float16 x)
     (double)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double3 convert_double3(float3 x)
+{
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -7862,15 +7862,6 @@ char2 convert_char2(double2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3(double3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7919,6 +7910,15 @@ char16 convert_char16(double16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3(double3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -7934,15 +7934,6 @@ uchar2 convert_uchar2(double2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3(double3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7991,6 +7982,15 @@ uchar16 convert_uchar16(double16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3(double3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -8006,15 +8006,6 @@ short2 convert_short2(double2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3(double3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8063,6 +8054,15 @@ short16 convert_short16(double16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3(double3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -8078,15 +8078,6 @@ ushort2 convert_ushort2(double2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3(double3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8135,6 +8126,15 @@ ushort16 convert_ushort16(double16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3(double3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -8150,15 +8150,6 @@ int2 convert_int2(double2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3(double3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8207,6 +8198,15 @@ int16 convert_int16(double16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3(double3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -8222,15 +8222,6 @@ uint2 convert_uint2(double2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3(double3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8279,6 +8270,15 @@ uint16 convert_uint16(double16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3(double3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp64)
@@ -8294,15 +8294,6 @@ long2 convert_long2(double2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3(double3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8351,6 +8342,15 @@ long16 convert_long16(double16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3(double3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp64)
@@ -8366,15 +8366,6 @@ ulong2 convert_ulong2(double2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3(double3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8423,6 +8414,15 @@ ulong16 convert_ulong16(double16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3(double3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp64) && defined(cl_khr_fp16)
@@ -8438,15 +8438,6 @@ half2 convert_half2(double2 x)
   return (half2)(
     (half)x.s0,
     (half)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half3 convert_half3(double3 x)
-{
-  return (half3)(
-    (half)x.s0,
-    (half)x.s1,
-    (half)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8495,6 +8486,15 @@ half16 convert_half16(double16 x)
     (half)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3(double3 x)
+{
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -8510,15 +8510,6 @@ float2 convert_float2(double2 x)
   return (float2)(
     (float)x.s0,
     (float)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float3 convert_float3(double3 x)
-{
-  return (float3)(
-    (float)x.s0,
-    (float)x.s1,
-    (float)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8567,6 +8558,15 @@ float16 convert_float16(double16 x)
     (float)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float3 convert_float3(double3 x)
+{
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -8582,15 +8582,6 @@ double2 convert_double2(double2 x)
   return (double2)(
     (double)x.s0,
     (double)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double3 convert_double3(double3 x)
-{
-  return (double3)(
-    (double)x.s0,
-    (double)x.s1,
-    (double)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8639,6 +8630,15 @@ double16 convert_double16(double16 x)
     (double)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double3 convert_double3(double3 x)
+{
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8653,15 +8653,6 @@ char2 convert_char2_rtz(char2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtz(char3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8710,6 +8701,15 @@ char16 convert_char16_rtz(char16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtz(char3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rte(char x)
@@ -8723,15 +8723,6 @@ char2 convert_char2_rte(char2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rte(char3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8780,6 +8771,15 @@ char16 convert_char16_rte(char16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rte(char3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtp(char x)
@@ -8793,15 +8793,6 @@ char2 convert_char2_rtp(char2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtp(char3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8850,6 +8841,15 @@ char16 convert_char16_rtp(char16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtp(char3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtn(char x)
@@ -8863,15 +8863,6 @@ char2 convert_char2_rtn(char2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtn(char3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8920,6 +8911,15 @@ char16 convert_char16_rtn(char16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtn(char3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtz(char x)
@@ -8933,15 +8933,6 @@ uchar2 convert_uchar2_rtz(char2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtz(char3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8990,6 +8981,15 @@ uchar16 convert_uchar16_rtz(char16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtz(char3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rte(char x)
@@ -9003,15 +9003,6 @@ uchar2 convert_uchar2_rte(char2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rte(char3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9060,6 +9051,15 @@ uchar16 convert_uchar16_rte(char16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rte(char3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtp(char x)
@@ -9073,15 +9073,6 @@ uchar2 convert_uchar2_rtp(char2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtp(char3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9130,6 +9121,15 @@ uchar16 convert_uchar16_rtp(char16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtp(char3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtn(char x)
@@ -9143,15 +9143,6 @@ uchar2 convert_uchar2_rtn(char2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtn(char3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9200,6 +9191,15 @@ uchar16 convert_uchar16_rtn(char16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtn(char3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtz(char x)
@@ -9213,15 +9213,6 @@ short2 convert_short2_rtz(char2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtz(char3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9270,6 +9261,15 @@ short16 convert_short16_rtz(char16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtz(char3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rte(char x)
@@ -9283,15 +9283,6 @@ short2 convert_short2_rte(char2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rte(char3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9340,6 +9331,15 @@ short16 convert_short16_rte(char16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rte(char3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtp(char x)
@@ -9353,15 +9353,6 @@ short2 convert_short2_rtp(char2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtp(char3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9410,6 +9401,15 @@ short16 convert_short16_rtp(char16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtp(char3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtn(char x)
@@ -9423,15 +9423,6 @@ short2 convert_short2_rtn(char2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtn(char3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9480,6 +9471,15 @@ short16 convert_short16_rtn(char16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtn(char3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtz(char x)
@@ -9493,15 +9493,6 @@ ushort2 convert_ushort2_rtz(char2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtz(char3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9550,6 +9541,15 @@ ushort16 convert_ushort16_rtz(char16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtz(char3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rte(char x)
@@ -9563,15 +9563,6 @@ ushort2 convert_ushort2_rte(char2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rte(char3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9620,6 +9611,15 @@ ushort16 convert_ushort16_rte(char16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rte(char3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtp(char x)
@@ -9633,15 +9633,6 @@ ushort2 convert_ushort2_rtp(char2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtp(char3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9690,6 +9681,15 @@ ushort16 convert_ushort16_rtp(char16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtp(char3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtn(char x)
@@ -9703,15 +9703,6 @@ ushort2 convert_ushort2_rtn(char2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtn(char3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9760,6 +9751,15 @@ ushort16 convert_ushort16_rtn(char16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtn(char3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtz(char x)
@@ -9773,15 +9773,6 @@ int2 convert_int2_rtz(char2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtz(char3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9830,6 +9821,15 @@ int16 convert_int16_rtz(char16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtz(char3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rte(char x)
@@ -9843,15 +9843,6 @@ int2 convert_int2_rte(char2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rte(char3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9900,6 +9891,15 @@ int16 convert_int16_rte(char16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rte(char3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtp(char x)
@@ -9913,15 +9913,6 @@ int2 convert_int2_rtp(char2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtp(char3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9970,6 +9961,15 @@ int16 convert_int16_rtp(char16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtp(char3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtn(char x)
@@ -9983,15 +9983,6 @@ int2 convert_int2_rtn(char2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtn(char3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10040,6 +10031,15 @@ int16 convert_int16_rtn(char16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtn(char3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtz(char x)
@@ -10053,15 +10053,6 @@ uint2 convert_uint2_rtz(char2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtz(char3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10110,6 +10101,15 @@ uint16 convert_uint16_rtz(char16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtz(char3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rte(char x)
@@ -10123,15 +10123,6 @@ uint2 convert_uint2_rte(char2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rte(char3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10180,6 +10171,15 @@ uint16 convert_uint16_rte(char16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rte(char3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtp(char x)
@@ -10193,15 +10193,6 @@ uint2 convert_uint2_rtp(char2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtp(char3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10250,6 +10241,15 @@ uint16 convert_uint16_rtp(char16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtp(char3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtn(char x)
@@ -10263,15 +10263,6 @@ uint2 convert_uint2_rtn(char2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtn(char3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10320,6 +10311,15 @@ uint16 convert_uint16_rtn(char16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtn(char3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10334,15 +10334,6 @@ long2 convert_long2_rtz(char2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtz(char3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10391,6 +10382,15 @@ long16 convert_long16_rtz(char16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtz(char3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -10406,15 +10406,6 @@ long2 convert_long2_rte(char2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rte(char3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10463,6 +10454,15 @@ long16 convert_long16_rte(char16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rte(char3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -10478,15 +10478,6 @@ long2 convert_long2_rtp(char2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtp(char3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10535,6 +10526,15 @@ long16 convert_long16_rtp(char16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtp(char3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -10550,15 +10550,6 @@ long2 convert_long2_rtn(char2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtn(char3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10607,6 +10598,15 @@ long16 convert_long16_rtn(char16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtn(char3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -10622,15 +10622,6 @@ ulong2 convert_ulong2_rtz(char2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtz(char3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10679,6 +10670,15 @@ ulong16 convert_ulong16_rtz(char16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtz(char3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -10694,15 +10694,6 @@ ulong2 convert_ulong2_rte(char2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rte(char3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10751,6 +10742,15 @@ ulong16 convert_ulong16_rte(char16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rte(char3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -10766,15 +10766,6 @@ ulong2 convert_ulong2_rtp(char2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtp(char3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10823,6 +10814,15 @@ ulong16 convert_ulong16_rtp(char16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtp(char3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -10838,15 +10838,6 @@ ulong2 convert_ulong2_rtn(char2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtn(char3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10895,6 +10886,15 @@ ulong16 convert_ulong16_rtn(char16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtn(char3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10909,15 +10909,6 @@ char2 convert_char2_rtz(uchar2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtz(uchar3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10966,6 +10957,15 @@ char16 convert_char16_rtz(uchar16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtz(uchar3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rte(uchar x)
@@ -10979,15 +10979,6 @@ char2 convert_char2_rte(uchar2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rte(uchar3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11036,6 +11027,15 @@ char16 convert_char16_rte(uchar16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rte(uchar3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtp(uchar x)
@@ -11049,15 +11049,6 @@ char2 convert_char2_rtp(uchar2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtp(uchar3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11106,6 +11097,15 @@ char16 convert_char16_rtp(uchar16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtp(uchar3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtn(uchar x)
@@ -11119,15 +11119,6 @@ char2 convert_char2_rtn(uchar2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtn(uchar3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11176,6 +11167,15 @@ char16 convert_char16_rtn(uchar16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtn(uchar3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtz(uchar x)
@@ -11189,15 +11189,6 @@ uchar2 convert_uchar2_rtz(uchar2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtz(uchar3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11246,6 +11237,15 @@ uchar16 convert_uchar16_rtz(uchar16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtz(uchar3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rte(uchar x)
@@ -11259,15 +11259,6 @@ uchar2 convert_uchar2_rte(uchar2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rte(uchar3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11316,6 +11307,15 @@ uchar16 convert_uchar16_rte(uchar16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rte(uchar3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtp(uchar x)
@@ -11329,15 +11329,6 @@ uchar2 convert_uchar2_rtp(uchar2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtp(uchar3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11386,6 +11377,15 @@ uchar16 convert_uchar16_rtp(uchar16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtp(uchar3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtn(uchar x)
@@ -11399,15 +11399,6 @@ uchar2 convert_uchar2_rtn(uchar2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtn(uchar3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11456,6 +11447,15 @@ uchar16 convert_uchar16_rtn(uchar16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtn(uchar3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtz(uchar x)
@@ -11469,15 +11469,6 @@ short2 convert_short2_rtz(uchar2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtz(uchar3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11526,6 +11517,15 @@ short16 convert_short16_rtz(uchar16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtz(uchar3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rte(uchar x)
@@ -11539,15 +11539,6 @@ short2 convert_short2_rte(uchar2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rte(uchar3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11596,6 +11587,15 @@ short16 convert_short16_rte(uchar16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rte(uchar3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtp(uchar x)
@@ -11609,15 +11609,6 @@ short2 convert_short2_rtp(uchar2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtp(uchar3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11666,6 +11657,15 @@ short16 convert_short16_rtp(uchar16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtp(uchar3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtn(uchar x)
@@ -11679,15 +11679,6 @@ short2 convert_short2_rtn(uchar2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtn(uchar3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11736,6 +11727,15 @@ short16 convert_short16_rtn(uchar16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtn(uchar3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtz(uchar x)
@@ -11749,15 +11749,6 @@ ushort2 convert_ushort2_rtz(uchar2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtz(uchar3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11806,6 +11797,15 @@ ushort16 convert_ushort16_rtz(uchar16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtz(uchar3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rte(uchar x)
@@ -11819,15 +11819,6 @@ ushort2 convert_ushort2_rte(uchar2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rte(uchar3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11876,6 +11867,15 @@ ushort16 convert_ushort16_rte(uchar16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rte(uchar3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtp(uchar x)
@@ -11889,15 +11889,6 @@ ushort2 convert_ushort2_rtp(uchar2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtp(uchar3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11946,6 +11937,15 @@ ushort16 convert_ushort16_rtp(uchar16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtp(uchar3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtn(uchar x)
@@ -11959,15 +11959,6 @@ ushort2 convert_ushort2_rtn(uchar2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtn(uchar3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12016,6 +12007,15 @@ ushort16 convert_ushort16_rtn(uchar16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtn(uchar3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtz(uchar x)
@@ -12029,15 +12029,6 @@ int2 convert_int2_rtz(uchar2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtz(uchar3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12086,6 +12077,15 @@ int16 convert_int16_rtz(uchar16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtz(uchar3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rte(uchar x)
@@ -12099,15 +12099,6 @@ int2 convert_int2_rte(uchar2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rte(uchar3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12156,6 +12147,15 @@ int16 convert_int16_rte(uchar16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rte(uchar3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtp(uchar x)
@@ -12169,15 +12169,6 @@ int2 convert_int2_rtp(uchar2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtp(uchar3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12226,6 +12217,15 @@ int16 convert_int16_rtp(uchar16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtp(uchar3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtn(uchar x)
@@ -12239,15 +12239,6 @@ int2 convert_int2_rtn(uchar2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtn(uchar3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12296,6 +12287,15 @@ int16 convert_int16_rtn(uchar16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtn(uchar3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtz(uchar x)
@@ -12309,15 +12309,6 @@ uint2 convert_uint2_rtz(uchar2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtz(uchar3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12366,6 +12357,15 @@ uint16 convert_uint16_rtz(uchar16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtz(uchar3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rte(uchar x)
@@ -12379,15 +12379,6 @@ uint2 convert_uint2_rte(uchar2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rte(uchar3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12436,6 +12427,15 @@ uint16 convert_uint16_rte(uchar16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rte(uchar3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtp(uchar x)
@@ -12449,15 +12449,6 @@ uint2 convert_uint2_rtp(uchar2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtp(uchar3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12506,6 +12497,15 @@ uint16 convert_uint16_rtp(uchar16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtp(uchar3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtn(uchar x)
@@ -12519,15 +12519,6 @@ uint2 convert_uint2_rtn(uchar2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtn(uchar3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12576,6 +12567,15 @@ uint16 convert_uint16_rtn(uchar16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtn(uchar3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12590,15 +12590,6 @@ long2 convert_long2_rtz(uchar2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtz(uchar3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12647,6 +12638,15 @@ long16 convert_long16_rtz(uchar16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtz(uchar3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12662,15 +12662,6 @@ long2 convert_long2_rte(uchar2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rte(uchar3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12719,6 +12710,15 @@ long16 convert_long16_rte(uchar16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rte(uchar3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12734,15 +12734,6 @@ long2 convert_long2_rtp(uchar2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtp(uchar3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12791,6 +12782,15 @@ long16 convert_long16_rtp(uchar16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtp(uchar3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12806,15 +12806,6 @@ long2 convert_long2_rtn(uchar2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtn(uchar3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12863,6 +12854,15 @@ long16 convert_long16_rtn(uchar16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtn(uchar3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12878,15 +12878,6 @@ ulong2 convert_ulong2_rtz(uchar2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtz(uchar3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -12935,6 +12926,15 @@ ulong16 convert_ulong16_rtz(uchar16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtz(uchar3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12950,15 +12950,6 @@ ulong2 convert_ulong2_rte(uchar2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rte(uchar3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13007,6 +12998,15 @@ ulong16 convert_ulong16_rte(uchar16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rte(uchar3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13022,15 +13022,6 @@ ulong2 convert_ulong2_rtp(uchar2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtp(uchar3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13079,6 +13070,15 @@ ulong16 convert_ulong16_rtp(uchar16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtp(uchar3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13094,15 +13094,6 @@ ulong2 convert_ulong2_rtn(uchar2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtn(uchar3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13151,6 +13142,15 @@ ulong16 convert_ulong16_rtn(uchar16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtn(uchar3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13165,15 +13165,6 @@ char2 convert_char2_rtz(short2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtz(short3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13222,6 +13213,15 @@ char16 convert_char16_rtz(short16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtz(short3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rte(short x)
@@ -13235,15 +13235,6 @@ char2 convert_char2_rte(short2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rte(short3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13292,6 +13283,15 @@ char16 convert_char16_rte(short16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rte(short3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtp(short x)
@@ -13305,15 +13305,6 @@ char2 convert_char2_rtp(short2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtp(short3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13362,6 +13353,15 @@ char16 convert_char16_rtp(short16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtp(short3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtn(short x)
@@ -13375,15 +13375,6 @@ char2 convert_char2_rtn(short2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtn(short3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13432,6 +13423,15 @@ char16 convert_char16_rtn(short16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtn(short3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtz(short x)
@@ -13445,15 +13445,6 @@ uchar2 convert_uchar2_rtz(short2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtz(short3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13502,6 +13493,15 @@ uchar16 convert_uchar16_rtz(short16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtz(short3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rte(short x)
@@ -13515,15 +13515,6 @@ uchar2 convert_uchar2_rte(short2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rte(short3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13572,6 +13563,15 @@ uchar16 convert_uchar16_rte(short16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rte(short3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtp(short x)
@@ -13585,15 +13585,6 @@ uchar2 convert_uchar2_rtp(short2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtp(short3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13642,6 +13633,15 @@ uchar16 convert_uchar16_rtp(short16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtp(short3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtn(short x)
@@ -13655,15 +13655,6 @@ uchar2 convert_uchar2_rtn(short2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtn(short3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13712,6 +13703,15 @@ uchar16 convert_uchar16_rtn(short16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtn(short3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtz(short x)
@@ -13725,15 +13725,6 @@ short2 convert_short2_rtz(short2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtz(short3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13782,6 +13773,15 @@ short16 convert_short16_rtz(short16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtz(short3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rte(short x)
@@ -13795,15 +13795,6 @@ short2 convert_short2_rte(short2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rte(short3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13852,6 +13843,15 @@ short16 convert_short16_rte(short16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rte(short3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtp(short x)
@@ -13865,15 +13865,6 @@ short2 convert_short2_rtp(short2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtp(short3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13922,6 +13913,15 @@ short16 convert_short16_rtp(short16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtp(short3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtn(short x)
@@ -13935,15 +13935,6 @@ short2 convert_short2_rtn(short2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtn(short3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -13992,6 +13983,15 @@ short16 convert_short16_rtn(short16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtn(short3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtz(short x)
@@ -14005,15 +14005,6 @@ ushort2 convert_ushort2_rtz(short2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtz(short3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14062,6 +14053,15 @@ ushort16 convert_ushort16_rtz(short16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtz(short3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rte(short x)
@@ -14075,15 +14075,6 @@ ushort2 convert_ushort2_rte(short2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rte(short3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14132,6 +14123,15 @@ ushort16 convert_ushort16_rte(short16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rte(short3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtp(short x)
@@ -14145,15 +14145,6 @@ ushort2 convert_ushort2_rtp(short2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtp(short3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14202,6 +14193,15 @@ ushort16 convert_ushort16_rtp(short16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtp(short3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtn(short x)
@@ -14215,15 +14215,6 @@ ushort2 convert_ushort2_rtn(short2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtn(short3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14272,6 +14263,15 @@ ushort16 convert_ushort16_rtn(short16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtn(short3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtz(short x)
@@ -14285,15 +14285,6 @@ int2 convert_int2_rtz(short2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtz(short3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14342,6 +14333,15 @@ int16 convert_int16_rtz(short16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtz(short3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rte(short x)
@@ -14355,15 +14355,6 @@ int2 convert_int2_rte(short2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rte(short3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14412,6 +14403,15 @@ int16 convert_int16_rte(short16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rte(short3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtp(short x)
@@ -14425,15 +14425,6 @@ int2 convert_int2_rtp(short2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtp(short3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14482,6 +14473,15 @@ int16 convert_int16_rtp(short16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtp(short3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtn(short x)
@@ -14495,15 +14495,6 @@ int2 convert_int2_rtn(short2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtn(short3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14552,6 +14543,15 @@ int16 convert_int16_rtn(short16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtn(short3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtz(short x)
@@ -14565,15 +14565,6 @@ uint2 convert_uint2_rtz(short2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtz(short3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14622,6 +14613,15 @@ uint16 convert_uint16_rtz(short16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtz(short3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rte(short x)
@@ -14635,15 +14635,6 @@ uint2 convert_uint2_rte(short2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rte(short3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14692,6 +14683,15 @@ uint16 convert_uint16_rte(short16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rte(short3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtp(short x)
@@ -14705,15 +14705,6 @@ uint2 convert_uint2_rtp(short2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtp(short3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14762,6 +14753,15 @@ uint16 convert_uint16_rtp(short16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtp(short3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtn(short x)
@@ -14775,15 +14775,6 @@ uint2 convert_uint2_rtn(short2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtn(short3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14832,6 +14823,15 @@ uint16 convert_uint16_rtn(short16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtn(short3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14846,15 +14846,6 @@ long2 convert_long2_rtz(short2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtz(short3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14903,6 +14894,15 @@ long16 convert_long16_rtz(short16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtz(short3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -14918,15 +14918,6 @@ long2 convert_long2_rte(short2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rte(short3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -14975,6 +14966,15 @@ long16 convert_long16_rte(short16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rte(short3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -14990,15 +14990,6 @@ long2 convert_long2_rtp(short2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtp(short3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15047,6 +15038,15 @@ long16 convert_long16_rtp(short16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtp(short3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -15062,15 +15062,6 @@ long2 convert_long2_rtn(short2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtn(short3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15119,6 +15110,15 @@ long16 convert_long16_rtn(short16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtn(short3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -15134,15 +15134,6 @@ ulong2 convert_ulong2_rtz(short2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtz(short3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15191,6 +15182,15 @@ ulong16 convert_ulong16_rtz(short16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtz(short3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -15206,15 +15206,6 @@ ulong2 convert_ulong2_rte(short2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rte(short3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15263,6 +15254,15 @@ ulong16 convert_ulong16_rte(short16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rte(short3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -15278,15 +15278,6 @@ ulong2 convert_ulong2_rtp(short2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtp(short3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15335,6 +15326,15 @@ ulong16 convert_ulong16_rtp(short16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtp(short3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -15350,15 +15350,6 @@ ulong2 convert_ulong2_rtn(short2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtn(short3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15407,6 +15398,15 @@ ulong16 convert_ulong16_rtn(short16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtn(short3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15421,15 +15421,6 @@ char2 convert_char2_rtz(ushort2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtz(ushort3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15478,6 +15469,15 @@ char16 convert_char16_rtz(ushort16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtz(ushort3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rte(ushort x)
@@ -15491,15 +15491,6 @@ char2 convert_char2_rte(ushort2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rte(ushort3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15548,6 +15539,15 @@ char16 convert_char16_rte(ushort16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rte(ushort3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtp(ushort x)
@@ -15561,15 +15561,6 @@ char2 convert_char2_rtp(ushort2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtp(ushort3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15618,6 +15609,15 @@ char16 convert_char16_rtp(ushort16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtp(ushort3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtn(ushort x)
@@ -15631,15 +15631,6 @@ char2 convert_char2_rtn(ushort2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtn(ushort3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15688,6 +15679,15 @@ char16 convert_char16_rtn(ushort16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtn(ushort3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtz(ushort x)
@@ -15701,15 +15701,6 @@ uchar2 convert_uchar2_rtz(ushort2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtz(ushort3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15758,6 +15749,15 @@ uchar16 convert_uchar16_rtz(ushort16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtz(ushort3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rte(ushort x)
@@ -15771,15 +15771,6 @@ uchar2 convert_uchar2_rte(ushort2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rte(ushort3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15828,6 +15819,15 @@ uchar16 convert_uchar16_rte(ushort16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rte(ushort3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtp(ushort x)
@@ -15841,15 +15841,6 @@ uchar2 convert_uchar2_rtp(ushort2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtp(ushort3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15898,6 +15889,15 @@ uchar16 convert_uchar16_rtp(ushort16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtp(ushort3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtn(ushort x)
@@ -15911,15 +15911,6 @@ uchar2 convert_uchar2_rtn(ushort2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtn(ushort3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -15968,6 +15959,15 @@ uchar16 convert_uchar16_rtn(ushort16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtn(ushort3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtz(ushort x)
@@ -15981,15 +15981,6 @@ short2 convert_short2_rtz(ushort2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtz(ushort3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -16038,6 +16029,15 @@ short16 convert_short16_rtz(ushort16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtz(ushort3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rte(ushort x)
@@ -16051,15 +16051,6 @@ short2 convert_short2_rte(ushort2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rte(ushort3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -16108,6 +16099,15 @@ short16 convert_short16_rte(ushort16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rte(ushort3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtp(ushort x)
@@ -16121,15 +16121,6 @@ short2 convert_short2_rtp(ushort2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtp(ushort3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -16178,6 +16169,15 @@ short16 convert_short16_rtp(ushort16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtp(ushort3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtn(ushort x)
@@ -16191,15 +16191,6 @@ short2 convert_short2_rtn(ushort2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtn(ushort3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -16248,6 +16239,15 @@ short16 convert_short16_rtn(ushort16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtn(ushort3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtz(ushort x)
@@ -16261,15 +16261,6 @@ ushort2 convert_ushort2_rtz(ushort2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtz(ushort3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -16318,6 +16309,15 @@ ushort16 convert_ushort16_rtz(ushort16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtz(ushort3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rte(ushort x)
@@ -16331,15 +16331,6 @@ ushort2 convert_ushort2_rte(ushort2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rte(ushort3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -16388,6 +16379,15 @@ ushort16 convert_ushort16_rte(ushort16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rte(ushort3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtp(ushort x)
@@ -16401,15 +16401,6 @@ ushort2 convert_ushort2_rtp(ushort2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtp(ushort3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -16458,6 +16449,15 @@ ushort16 convert_ushort16_rtp(ushort16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtp(ushort3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtn(ushort x)
@@ -16471,15 +16471,6 @@ ushort2 convert_ushort2_rtn(ushort2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtn(ushort3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -16528,6 +16519,15 @@ ushort16 convert_ushort16_rtn(ushort16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtn(ushort3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtz(ushort x)
@@ -16541,15 +16541,6 @@ int2 convert_int2_rtz(ushort2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtz(ushort3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -16598,6 +16589,15 @@ int16 convert_int16_rtz(ushort16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtz(ushort3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rte(ushort x)
@@ -16611,15 +16611,6 @@ int2 convert_int2_rte(ushort2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rte(ushort3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -16668,6 +16659,15 @@ int16 convert_int16_rte(ushort16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rte(ushort3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtp(ushort x)
@@ -16681,15 +16681,6 @@ int2 convert_int2_rtp(ushort2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtp(ushort3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -16738,6 +16729,15 @@ int16 convert_int16_rtp(ushort16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtp(ushort3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtn(ushort x)
@@ -16751,15 +16751,6 @@ int2 convert_int2_rtn(ushort2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtn(ushort3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -16808,6 +16799,15 @@ int16 convert_int16_rtn(ushort16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtn(ushort3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtz(ushort x)
@@ -16821,15 +16821,6 @@ uint2 convert_uint2_rtz(ushort2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtz(ushort3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -16878,6 +16869,15 @@ uint16 convert_uint16_rtz(ushort16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtz(ushort3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rte(ushort x)
@@ -16891,15 +16891,6 @@ uint2 convert_uint2_rte(ushort2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rte(ushort3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -16948,6 +16939,15 @@ uint16 convert_uint16_rte(ushort16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rte(ushort3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtp(ushort x)
@@ -16961,15 +16961,6 @@ uint2 convert_uint2_rtp(ushort2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtp(ushort3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17018,6 +17009,15 @@ uint16 convert_uint16_rtp(ushort16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtp(ushort3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtn(ushort x)
@@ -17031,15 +17031,6 @@ uint2 convert_uint2_rtn(ushort2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtn(ushort3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17088,6 +17079,15 @@ uint16 convert_uint16_rtn(ushort16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtn(ushort3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17102,15 +17102,6 @@ long2 convert_long2_rtz(ushort2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtz(ushort3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17159,6 +17150,15 @@ long16 convert_long16_rtz(ushort16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtz(ushort3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -17174,15 +17174,6 @@ long2 convert_long2_rte(ushort2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rte(ushort3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17231,6 +17222,15 @@ long16 convert_long16_rte(ushort16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rte(ushort3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -17246,15 +17246,6 @@ long2 convert_long2_rtp(ushort2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtp(ushort3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17303,6 +17294,15 @@ long16 convert_long16_rtp(ushort16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtp(ushort3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -17318,15 +17318,6 @@ long2 convert_long2_rtn(ushort2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtn(ushort3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17375,6 +17366,15 @@ long16 convert_long16_rtn(ushort16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtn(ushort3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -17390,15 +17390,6 @@ ulong2 convert_ulong2_rtz(ushort2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtz(ushort3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17447,6 +17438,15 @@ ulong16 convert_ulong16_rtz(ushort16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtz(ushort3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -17462,15 +17462,6 @@ ulong2 convert_ulong2_rte(ushort2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rte(ushort3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17519,6 +17510,15 @@ ulong16 convert_ulong16_rte(ushort16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rte(ushort3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -17534,15 +17534,6 @@ ulong2 convert_ulong2_rtp(ushort2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtp(ushort3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17591,6 +17582,15 @@ ulong16 convert_ulong16_rtp(ushort16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtp(ushort3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -17606,15 +17606,6 @@ ulong2 convert_ulong2_rtn(ushort2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtn(ushort3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17663,6 +17654,15 @@ ulong16 convert_ulong16_rtn(ushort16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtn(ushort3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17677,15 +17677,6 @@ char2 convert_char2_rtz(int2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtz(int3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17734,6 +17725,15 @@ char16 convert_char16_rtz(int16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtz(int3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rte(int x)
@@ -17747,15 +17747,6 @@ char2 convert_char2_rte(int2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rte(int3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17804,6 +17795,15 @@ char16 convert_char16_rte(int16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rte(int3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtp(int x)
@@ -17817,15 +17817,6 @@ char2 convert_char2_rtp(int2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtp(int3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17874,6 +17865,15 @@ char16 convert_char16_rtp(int16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtp(int3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtn(int x)
@@ -17887,15 +17887,6 @@ char2 convert_char2_rtn(int2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtn(int3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -17944,6 +17935,15 @@ char16 convert_char16_rtn(int16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtn(int3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtz(int x)
@@ -17957,15 +17957,6 @@ uchar2 convert_uchar2_rtz(int2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtz(int3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18014,6 +18005,15 @@ uchar16 convert_uchar16_rtz(int16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtz(int3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rte(int x)
@@ -18027,15 +18027,6 @@ uchar2 convert_uchar2_rte(int2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rte(int3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18084,6 +18075,15 @@ uchar16 convert_uchar16_rte(int16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rte(int3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtp(int x)
@@ -18097,15 +18097,6 @@ uchar2 convert_uchar2_rtp(int2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtp(int3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18154,6 +18145,15 @@ uchar16 convert_uchar16_rtp(int16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtp(int3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtn(int x)
@@ -18167,15 +18167,6 @@ uchar2 convert_uchar2_rtn(int2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtn(int3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18224,6 +18215,15 @@ uchar16 convert_uchar16_rtn(int16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtn(int3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtz(int x)
@@ -18237,15 +18237,6 @@ short2 convert_short2_rtz(int2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtz(int3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18294,6 +18285,15 @@ short16 convert_short16_rtz(int16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtz(int3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rte(int x)
@@ -18307,15 +18307,6 @@ short2 convert_short2_rte(int2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rte(int3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18364,6 +18355,15 @@ short16 convert_short16_rte(int16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rte(int3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtp(int x)
@@ -18377,15 +18377,6 @@ short2 convert_short2_rtp(int2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtp(int3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18434,6 +18425,15 @@ short16 convert_short16_rtp(int16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtp(int3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtn(int x)
@@ -18447,15 +18447,6 @@ short2 convert_short2_rtn(int2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtn(int3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18504,6 +18495,15 @@ short16 convert_short16_rtn(int16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtn(int3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtz(int x)
@@ -18517,15 +18517,6 @@ ushort2 convert_ushort2_rtz(int2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtz(int3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18574,6 +18565,15 @@ ushort16 convert_ushort16_rtz(int16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtz(int3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rte(int x)
@@ -18587,15 +18587,6 @@ ushort2 convert_ushort2_rte(int2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rte(int3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18644,6 +18635,15 @@ ushort16 convert_ushort16_rte(int16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rte(int3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtp(int x)
@@ -18657,15 +18657,6 @@ ushort2 convert_ushort2_rtp(int2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtp(int3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18714,6 +18705,15 @@ ushort16 convert_ushort16_rtp(int16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtp(int3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtn(int x)
@@ -18727,15 +18727,6 @@ ushort2 convert_ushort2_rtn(int2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtn(int3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18784,6 +18775,15 @@ ushort16 convert_ushort16_rtn(int16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtn(int3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtz(int x)
@@ -18797,15 +18797,6 @@ int2 convert_int2_rtz(int2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtz(int3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18854,6 +18845,15 @@ int16 convert_int16_rtz(int16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtz(int3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rte(int x)
@@ -18867,15 +18867,6 @@ int2 convert_int2_rte(int2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rte(int3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18924,6 +18915,15 @@ int16 convert_int16_rte(int16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rte(int3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtp(int x)
@@ -18937,15 +18937,6 @@ int2 convert_int2_rtp(int2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtp(int3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -18994,6 +18985,15 @@ int16 convert_int16_rtp(int16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtp(int3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtn(int x)
@@ -19007,15 +19007,6 @@ int2 convert_int2_rtn(int2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtn(int3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19064,6 +19055,15 @@ int16 convert_int16_rtn(int16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtn(int3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtz(int x)
@@ -19077,15 +19077,6 @@ uint2 convert_uint2_rtz(int2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtz(int3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19134,6 +19125,15 @@ uint16 convert_uint16_rtz(int16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtz(int3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rte(int x)
@@ -19147,15 +19147,6 @@ uint2 convert_uint2_rte(int2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rte(int3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19204,6 +19195,15 @@ uint16 convert_uint16_rte(int16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rte(int3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtp(int x)
@@ -19217,15 +19217,6 @@ uint2 convert_uint2_rtp(int2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtp(int3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19274,6 +19265,15 @@ uint16 convert_uint16_rtp(int16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtp(int3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtn(int x)
@@ -19287,15 +19287,6 @@ uint2 convert_uint2_rtn(int2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtn(int3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19344,6 +19335,15 @@ uint16 convert_uint16_rtn(int16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtn(int3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19358,15 +19358,6 @@ long2 convert_long2_rtz(int2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtz(int3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19415,6 +19406,15 @@ long16 convert_long16_rtz(int16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtz(int3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -19430,15 +19430,6 @@ long2 convert_long2_rte(int2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rte(int3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19487,6 +19478,15 @@ long16 convert_long16_rte(int16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rte(int3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -19502,15 +19502,6 @@ long2 convert_long2_rtp(int2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtp(int3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19559,6 +19550,15 @@ long16 convert_long16_rtp(int16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtp(int3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -19574,15 +19574,6 @@ long2 convert_long2_rtn(int2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtn(int3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19631,6 +19622,15 @@ long16 convert_long16_rtn(int16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtn(int3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -19646,15 +19646,6 @@ ulong2 convert_ulong2_rtz(int2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtz(int3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19703,6 +19694,15 @@ ulong16 convert_ulong16_rtz(int16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtz(int3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -19718,15 +19718,6 @@ ulong2 convert_ulong2_rte(int2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rte(int3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19775,6 +19766,15 @@ ulong16 convert_ulong16_rte(int16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rte(int3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -19790,15 +19790,6 @@ ulong2 convert_ulong2_rtp(int2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtp(int3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19847,6 +19838,15 @@ ulong16 convert_ulong16_rtp(int16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtp(int3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -19862,15 +19862,6 @@ ulong2 convert_ulong2_rtn(int2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtn(int3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19919,6 +19910,15 @@ ulong16 convert_ulong16_rtn(int16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtn(int3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19933,15 +19933,6 @@ char2 convert_char2_rtz(uint2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtz(uint3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -19990,6 +19981,15 @@ char16 convert_char16_rtz(uint16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtz(uint3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rte(uint x)
@@ -20003,15 +20003,6 @@ char2 convert_char2_rte(uint2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rte(uint3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -20060,6 +20051,15 @@ char16 convert_char16_rte(uint16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rte(uint3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtp(uint x)
@@ -20073,15 +20073,6 @@ char2 convert_char2_rtp(uint2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtp(uint3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -20130,6 +20121,15 @@ char16 convert_char16_rtp(uint16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtp(uint3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtn(uint x)
@@ -20143,15 +20143,6 @@ char2 convert_char2_rtn(uint2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtn(uint3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -20200,6 +20191,15 @@ char16 convert_char16_rtn(uint16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtn(uint3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtz(uint x)
@@ -20213,15 +20213,6 @@ uchar2 convert_uchar2_rtz(uint2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtz(uint3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -20270,6 +20261,15 @@ uchar16 convert_uchar16_rtz(uint16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtz(uint3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rte(uint x)
@@ -20283,15 +20283,6 @@ uchar2 convert_uchar2_rte(uint2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rte(uint3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -20340,6 +20331,15 @@ uchar16 convert_uchar16_rte(uint16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rte(uint3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtp(uint x)
@@ -20353,15 +20353,6 @@ uchar2 convert_uchar2_rtp(uint2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtp(uint3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -20410,6 +20401,15 @@ uchar16 convert_uchar16_rtp(uint16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtp(uint3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtn(uint x)
@@ -20423,15 +20423,6 @@ uchar2 convert_uchar2_rtn(uint2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtn(uint3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -20480,6 +20471,15 @@ uchar16 convert_uchar16_rtn(uint16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtn(uint3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtz(uint x)
@@ -20493,15 +20493,6 @@ short2 convert_short2_rtz(uint2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtz(uint3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -20550,6 +20541,15 @@ short16 convert_short16_rtz(uint16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtz(uint3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rte(uint x)
@@ -20563,15 +20563,6 @@ short2 convert_short2_rte(uint2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rte(uint3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -20620,6 +20611,15 @@ short16 convert_short16_rte(uint16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rte(uint3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtp(uint x)
@@ -20633,15 +20633,6 @@ short2 convert_short2_rtp(uint2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtp(uint3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -20690,6 +20681,15 @@ short16 convert_short16_rtp(uint16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtp(uint3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtn(uint x)
@@ -20703,15 +20703,6 @@ short2 convert_short2_rtn(uint2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtn(uint3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -20760,6 +20751,15 @@ short16 convert_short16_rtn(uint16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtn(uint3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtz(uint x)
@@ -20773,15 +20773,6 @@ ushort2 convert_ushort2_rtz(uint2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtz(uint3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -20830,6 +20821,15 @@ ushort16 convert_ushort16_rtz(uint16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtz(uint3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rte(uint x)
@@ -20843,15 +20843,6 @@ ushort2 convert_ushort2_rte(uint2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rte(uint3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -20900,6 +20891,15 @@ ushort16 convert_ushort16_rte(uint16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rte(uint3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtp(uint x)
@@ -20913,15 +20913,6 @@ ushort2 convert_ushort2_rtp(uint2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtp(uint3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -20970,6 +20961,15 @@ ushort16 convert_ushort16_rtp(uint16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtp(uint3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtn(uint x)
@@ -20983,15 +20983,6 @@ ushort2 convert_ushort2_rtn(uint2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtn(uint3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21040,6 +21031,15 @@ ushort16 convert_ushort16_rtn(uint16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtn(uint3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtz(uint x)
@@ -21053,15 +21053,6 @@ int2 convert_int2_rtz(uint2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtz(uint3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21110,6 +21101,15 @@ int16 convert_int16_rtz(uint16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtz(uint3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rte(uint x)
@@ -21123,15 +21123,6 @@ int2 convert_int2_rte(uint2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rte(uint3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21180,6 +21171,15 @@ int16 convert_int16_rte(uint16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rte(uint3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtp(uint x)
@@ -21193,15 +21193,6 @@ int2 convert_int2_rtp(uint2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtp(uint3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21250,6 +21241,15 @@ int16 convert_int16_rtp(uint16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtp(uint3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtn(uint x)
@@ -21263,15 +21263,6 @@ int2 convert_int2_rtn(uint2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtn(uint3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21320,6 +21311,15 @@ int16 convert_int16_rtn(uint16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtn(uint3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtz(uint x)
@@ -21333,15 +21333,6 @@ uint2 convert_uint2_rtz(uint2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtz(uint3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21390,6 +21381,15 @@ uint16 convert_uint16_rtz(uint16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtz(uint3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rte(uint x)
@@ -21403,15 +21403,6 @@ uint2 convert_uint2_rte(uint2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rte(uint3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21460,6 +21451,15 @@ uint16 convert_uint16_rte(uint16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rte(uint3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtp(uint x)
@@ -21473,15 +21473,6 @@ uint2 convert_uint2_rtp(uint2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtp(uint3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21530,6 +21521,15 @@ uint16 convert_uint16_rtp(uint16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtp(uint3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtn(uint x)
@@ -21543,15 +21543,6 @@ uint2 convert_uint2_rtn(uint2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtn(uint3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21600,6 +21591,15 @@ uint16 convert_uint16_rtn(uint16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtn(uint3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21614,15 +21614,6 @@ long2 convert_long2_rtz(uint2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtz(uint3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21671,6 +21662,15 @@ long16 convert_long16_rtz(uint16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtz(uint3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -21686,15 +21686,6 @@ long2 convert_long2_rte(uint2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rte(uint3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21743,6 +21734,15 @@ long16 convert_long16_rte(uint16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rte(uint3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -21758,15 +21758,6 @@ long2 convert_long2_rtp(uint2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtp(uint3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21815,6 +21806,15 @@ long16 convert_long16_rtp(uint16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtp(uint3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -21830,15 +21830,6 @@ long2 convert_long2_rtn(uint2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtn(uint3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21887,6 +21878,15 @@ long16 convert_long16_rtn(uint16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtn(uint3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -21902,15 +21902,6 @@ ulong2 convert_ulong2_rtz(uint2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtz(uint3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -21959,6 +21950,15 @@ ulong16 convert_ulong16_rtz(uint16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtz(uint3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -21974,15 +21974,6 @@ ulong2 convert_ulong2_rte(uint2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rte(uint3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -22031,6 +22022,15 @@ ulong16 convert_ulong16_rte(uint16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rte(uint3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -22046,15 +22046,6 @@ ulong2 convert_ulong2_rtp(uint2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtp(uint3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -22103,6 +22094,15 @@ ulong16 convert_ulong16_rtp(uint16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtp(uint3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -22118,15 +22118,6 @@ ulong2 convert_ulong2_rtn(uint2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtn(uint3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -22175,6 +22166,15 @@ ulong16 convert_ulong16_rtn(uint16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtn(uint3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -22190,15 +22190,6 @@ char2 convert_char2_rtz(long2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtz(long3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -22247,6 +22238,15 @@ char16 convert_char16_rtz(long16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtz(long3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -22262,15 +22262,6 @@ char2 convert_char2_rte(long2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rte(long3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -22319,6 +22310,15 @@ char16 convert_char16_rte(long16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rte(long3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -22334,15 +22334,6 @@ char2 convert_char2_rtp(long2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtp(long3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -22391,6 +22382,15 @@ char16 convert_char16_rtp(long16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtp(long3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -22406,15 +22406,6 @@ char2 convert_char2_rtn(long2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtn(long3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -22463,6 +22454,15 @@ char16 convert_char16_rtn(long16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtn(long3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -22478,15 +22478,6 @@ uchar2 convert_uchar2_rtz(long2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtz(long3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -22535,6 +22526,15 @@ uchar16 convert_uchar16_rtz(long16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtz(long3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -22550,15 +22550,6 @@ uchar2 convert_uchar2_rte(long2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rte(long3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -22607,6 +22598,15 @@ uchar16 convert_uchar16_rte(long16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rte(long3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -22622,15 +22622,6 @@ uchar2 convert_uchar2_rtp(long2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtp(long3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -22679,6 +22670,15 @@ uchar16 convert_uchar16_rtp(long16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtp(long3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -22694,15 +22694,6 @@ uchar2 convert_uchar2_rtn(long2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtn(long3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -22751,6 +22742,15 @@ uchar16 convert_uchar16_rtn(long16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtn(long3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -22766,15 +22766,6 @@ short2 convert_short2_rtz(long2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtz(long3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -22823,6 +22814,15 @@ short16 convert_short16_rtz(long16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtz(long3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -22838,15 +22838,6 @@ short2 convert_short2_rte(long2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rte(long3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -22895,6 +22886,15 @@ short16 convert_short16_rte(long16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rte(long3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -22910,15 +22910,6 @@ short2 convert_short2_rtp(long2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtp(long3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -22967,6 +22958,15 @@ short16 convert_short16_rtp(long16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtp(long3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -22982,15 +22982,6 @@ short2 convert_short2_rtn(long2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtn(long3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -23039,6 +23030,15 @@ short16 convert_short16_rtn(long16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtn(long3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -23054,15 +23054,6 @@ ushort2 convert_ushort2_rtz(long2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtz(long3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -23111,6 +23102,15 @@ ushort16 convert_ushort16_rtz(long16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtz(long3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -23126,15 +23126,6 @@ ushort2 convert_ushort2_rte(long2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rte(long3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -23183,6 +23174,15 @@ ushort16 convert_ushort16_rte(long16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rte(long3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -23198,15 +23198,6 @@ ushort2 convert_ushort2_rtp(long2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtp(long3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -23255,6 +23246,15 @@ ushort16 convert_ushort16_rtp(long16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtp(long3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -23270,15 +23270,6 @@ ushort2 convert_ushort2_rtn(long2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtn(long3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -23327,6 +23318,15 @@ ushort16 convert_ushort16_rtn(long16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtn(long3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -23342,15 +23342,6 @@ int2 convert_int2_rtz(long2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtz(long3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -23399,6 +23390,15 @@ int16 convert_int16_rtz(long16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtz(long3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -23414,15 +23414,6 @@ int2 convert_int2_rte(long2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rte(long3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -23471,6 +23462,15 @@ int16 convert_int16_rte(long16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rte(long3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -23486,15 +23486,6 @@ int2 convert_int2_rtp(long2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtp(long3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -23543,6 +23534,15 @@ int16 convert_int16_rtp(long16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtp(long3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -23558,15 +23558,6 @@ int2 convert_int2_rtn(long2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtn(long3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -23615,6 +23606,15 @@ int16 convert_int16_rtn(long16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtn(long3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -23630,15 +23630,6 @@ uint2 convert_uint2_rtz(long2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtz(long3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -23687,6 +23678,15 @@ uint16 convert_uint16_rtz(long16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtz(long3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -23702,15 +23702,6 @@ uint2 convert_uint2_rte(long2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rte(long3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -23759,6 +23750,15 @@ uint16 convert_uint16_rte(long16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rte(long3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -23774,15 +23774,6 @@ uint2 convert_uint2_rtp(long2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtp(long3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -23831,6 +23822,15 @@ uint16 convert_uint16_rtp(long16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtp(long3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -23846,15 +23846,6 @@ uint2 convert_uint2_rtn(long2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtn(long3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -23903,6 +23894,15 @@ uint16 convert_uint16_rtn(long16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtn(long3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -23918,15 +23918,6 @@ long2 convert_long2_rtz(long2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtz(long3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -23975,6 +23966,15 @@ long16 convert_long16_rtz(long16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtz(long3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -23990,15 +23990,6 @@ long2 convert_long2_rte(long2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rte(long3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -24047,6 +24038,15 @@ long16 convert_long16_rte(long16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rte(long3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -24062,15 +24062,6 @@ long2 convert_long2_rtp(long2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtp(long3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -24119,6 +24110,15 @@ long16 convert_long16_rtp(long16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtp(long3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -24134,15 +24134,6 @@ long2 convert_long2_rtn(long2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtn(long3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -24191,6 +24182,15 @@ long16 convert_long16_rtn(long16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtn(long3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -24206,15 +24206,6 @@ ulong2 convert_ulong2_rtz(long2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtz(long3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -24263,6 +24254,15 @@ ulong16 convert_ulong16_rtz(long16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtz(long3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -24278,15 +24278,6 @@ ulong2 convert_ulong2_rte(long2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rte(long3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -24335,6 +24326,15 @@ ulong16 convert_ulong16_rte(long16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rte(long3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -24350,15 +24350,6 @@ ulong2 convert_ulong2_rtp(long2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtp(long3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -24407,6 +24398,15 @@ ulong16 convert_ulong16_rtp(long16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtp(long3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -24422,15 +24422,6 @@ ulong2 convert_ulong2_rtn(long2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtn(long3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -24479,6 +24470,15 @@ ulong16 convert_ulong16_rtn(long16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtn(long3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -24494,15 +24494,6 @@ char2 convert_char2_rtz(ulong2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtz(ulong3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -24551,6 +24542,15 @@ char16 convert_char16_rtz(ulong16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtz(ulong3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -24566,15 +24566,6 @@ char2 convert_char2_rte(ulong2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rte(ulong3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -24623,6 +24614,15 @@ char16 convert_char16_rte(ulong16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rte(ulong3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -24638,15 +24638,6 @@ char2 convert_char2_rtp(ulong2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtp(ulong3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -24695,6 +24686,15 @@ char16 convert_char16_rtp(ulong16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtp(ulong3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -24710,15 +24710,6 @@ char2 convert_char2_rtn(ulong2 x)
   return (char2)(
     (char)x.s0,
     (char)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char3 convert_char3_rtn(ulong3 x)
-{
-  return (char3)(
-    (char)x.s0,
-    (char)x.s1,
-    (char)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -24767,6 +24758,15 @@ char16 convert_char16_rtn(ulong16 x)
     (char)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtn(ulong3 x)
+{
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -24782,15 +24782,6 @@ uchar2 convert_uchar2_rtz(ulong2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtz(ulong3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -24839,6 +24830,15 @@ uchar16 convert_uchar16_rtz(ulong16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtz(ulong3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -24854,15 +24854,6 @@ uchar2 convert_uchar2_rte(ulong2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rte(ulong3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -24911,6 +24902,15 @@ uchar16 convert_uchar16_rte(ulong16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rte(ulong3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -24926,15 +24926,6 @@ uchar2 convert_uchar2_rtp(ulong2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtp(ulong3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -24983,6 +24974,15 @@ uchar16 convert_uchar16_rtp(ulong16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtp(ulong3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -24998,15 +24998,6 @@ uchar2 convert_uchar2_rtn(ulong2 x)
   return (uchar2)(
     (uchar)x.s0,
     (uchar)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar3 convert_uchar3_rtn(ulong3 x)
-{
-  return (uchar3)(
-    (uchar)x.s0,
-    (uchar)x.s1,
-    (uchar)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -25055,6 +25046,15 @@ uchar16 convert_uchar16_rtn(ulong16 x)
     (uchar)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtn(ulong3 x)
+{
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -25070,15 +25070,6 @@ short2 convert_short2_rtz(ulong2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtz(ulong3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -25127,6 +25118,15 @@ short16 convert_short16_rtz(ulong16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtz(ulong3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -25142,15 +25142,6 @@ short2 convert_short2_rte(ulong2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rte(ulong3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -25199,6 +25190,15 @@ short16 convert_short16_rte(ulong16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rte(ulong3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -25214,15 +25214,6 @@ short2 convert_short2_rtp(ulong2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtp(ulong3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -25271,6 +25262,15 @@ short16 convert_short16_rtp(ulong16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtp(ulong3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -25286,15 +25286,6 @@ short2 convert_short2_rtn(ulong2 x)
   return (short2)(
     (short)x.s0,
     (short)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short3 convert_short3_rtn(ulong3 x)
-{
-  return (short3)(
-    (short)x.s0,
-    (short)x.s1,
-    (short)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -25343,6 +25334,15 @@ short16 convert_short16_rtn(ulong16 x)
     (short)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtn(ulong3 x)
+{
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -25358,15 +25358,6 @@ ushort2 convert_ushort2_rtz(ulong2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtz(ulong3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -25415,6 +25406,15 @@ ushort16 convert_ushort16_rtz(ulong16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtz(ulong3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -25430,15 +25430,6 @@ ushort2 convert_ushort2_rte(ulong2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rte(ulong3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -25487,6 +25478,15 @@ ushort16 convert_ushort16_rte(ulong16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rte(ulong3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -25502,15 +25502,6 @@ ushort2 convert_ushort2_rtp(ulong2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtp(ulong3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -25559,6 +25550,15 @@ ushort16 convert_ushort16_rtp(ulong16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtp(ulong3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -25574,15 +25574,6 @@ ushort2 convert_ushort2_rtn(ulong2 x)
   return (ushort2)(
     (ushort)x.s0,
     (ushort)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort3 convert_ushort3_rtn(ulong3 x)
-{
-  return (ushort3)(
-    (ushort)x.s0,
-    (ushort)x.s1,
-    (ushort)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -25631,6 +25622,15 @@ ushort16 convert_ushort16_rtn(ulong16 x)
     (ushort)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtn(ulong3 x)
+{
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -25646,15 +25646,6 @@ int2 convert_int2_rtz(ulong2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtz(ulong3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -25703,6 +25694,15 @@ int16 convert_int16_rtz(ulong16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtz(ulong3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -25718,15 +25718,6 @@ int2 convert_int2_rte(ulong2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rte(ulong3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -25775,6 +25766,15 @@ int16 convert_int16_rte(ulong16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rte(ulong3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -25790,15 +25790,6 @@ int2 convert_int2_rtp(ulong2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtp(ulong3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -25847,6 +25838,15 @@ int16 convert_int16_rtp(ulong16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtp(ulong3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -25862,15 +25862,6 @@ int2 convert_int2_rtn(ulong2 x)
   return (int2)(
     (int)x.s0,
     (int)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int3 convert_int3_rtn(ulong3 x)
-{
-  return (int3)(
-    (int)x.s0,
-    (int)x.s1,
-    (int)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -25919,6 +25910,15 @@ int16 convert_int16_rtn(ulong16 x)
     (int)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtn(ulong3 x)
+{
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -25934,15 +25934,6 @@ uint2 convert_uint2_rtz(ulong2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtz(ulong3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -25991,6 +25982,15 @@ uint16 convert_uint16_rtz(ulong16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtz(ulong3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -26006,15 +26006,6 @@ uint2 convert_uint2_rte(ulong2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rte(ulong3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -26063,6 +26054,15 @@ uint16 convert_uint16_rte(ulong16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rte(ulong3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -26078,15 +26078,6 @@ uint2 convert_uint2_rtp(ulong2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtp(ulong3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -26135,6 +26126,15 @@ uint16 convert_uint16_rtp(ulong16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtp(ulong3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -26150,15 +26150,6 @@ uint2 convert_uint2_rtn(ulong2 x)
   return (uint2)(
     (uint)x.s0,
     (uint)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint3 convert_uint3_rtn(ulong3 x)
-{
-  return (uint3)(
-    (uint)x.s0,
-    (uint)x.s1,
-    (uint)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -26207,6 +26198,15 @@ uint16 convert_uint16_rtn(ulong16 x)
     (uint)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtn(ulong3 x)
+{
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -26222,15 +26222,6 @@ long2 convert_long2_rtz(ulong2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtz(ulong3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -26279,6 +26270,15 @@ long16 convert_long16_rtz(ulong16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtz(ulong3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -26294,15 +26294,6 @@ long2 convert_long2_rte(ulong2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rte(ulong3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -26351,6 +26342,15 @@ long16 convert_long16_rte(ulong16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rte(ulong3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -26366,15 +26366,6 @@ long2 convert_long2_rtp(ulong2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtp(ulong3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -26423,6 +26414,15 @@ long16 convert_long16_rtp(ulong16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtp(ulong3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -26438,15 +26438,6 @@ long2 convert_long2_rtn(ulong2 x)
   return (long2)(
     (long)x.s0,
     (long)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long3 convert_long3_rtn(ulong3 x)
-{
-  return (long3)(
-    (long)x.s0,
-    (long)x.s1,
-    (long)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -26495,6 +26486,15 @@ long16 convert_long16_rtn(ulong16 x)
     (long)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtn(ulong3 x)
+{
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -26510,15 +26510,6 @@ ulong2 convert_ulong2_rtz(ulong2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtz(ulong3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -26567,6 +26558,15 @@ ulong16 convert_ulong16_rtz(ulong16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtz(ulong3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -26582,15 +26582,6 @@ ulong2 convert_ulong2_rte(ulong2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rte(ulong3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -26639,6 +26630,15 @@ ulong16 convert_ulong16_rte(ulong16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rte(ulong3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -26654,15 +26654,6 @@ ulong2 convert_ulong2_rtp(ulong2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtp(ulong3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -26711,6 +26702,15 @@ ulong16 convert_ulong16_rtp(ulong16 x)
     (ulong)x.sf);
 }
 
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtp(ulong3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -26726,15 +26726,6 @@ ulong2 convert_ulong2_rtn(ulong2 x)
   return (ulong2)(
     (ulong)x.s0,
     (ulong)x.s1);
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong3 convert_ulong3_rtn(ulong3 x)
-{
-  return (ulong3)(
-    (ulong)x.s0,
-    (ulong)x.s1,
-    (ulong)x.s2);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -26781,6 +26772,15 @@ ulong16 convert_ulong16_rtn(ulong16 x)
     (ulong)x.sd,
     (ulong)x.se,
     (ulong)x.sf);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtn(ulong3 x)
+{
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
 
 #endif

--- a/lib/kernel/convert_type.cl
+++ b/lib/kernel/convert_type.cl
@@ -36,32 +36,66 @@ char convert_char(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2(char2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4(char4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8(char8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16(char16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3(char3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4(char4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8(char8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16(char16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar(char x)
@@ -72,32 +106,66 @@ uchar convert_uchar(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2(char2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4(char4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8(char8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16(char16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3(char3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4(char4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8(char8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16(char16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short(char x)
@@ -108,32 +176,66 @@ short convert_short(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2(char2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4(char4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8(char8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16(char16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3(char3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4(char4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8(char8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16(char16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort(char x)
@@ -144,32 +246,66 @@ ushort convert_ushort(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2(char2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4(char4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8(char8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16(char16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3(char3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4(char4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8(char8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16(char16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int(char x)
@@ -180,32 +316,66 @@ int convert_int(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2(char2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4(char4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8(char8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16(char16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3(char3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4(char4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8(char8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16(char16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint(char x)
@@ -216,32 +386,66 @@ uint convert_uint(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2(char2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4(char4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8(char8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16(char16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3(char3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4(char4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8(char8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16(char16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -253,32 +457,66 @@ long convert_long(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2(char2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4(char4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8(char8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16(char16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3(char3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4(char4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8(char8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16(char16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -291,32 +529,66 @@ ulong convert_ulong(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2(char2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4(char4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8(char8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16(char16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3(char3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4(char4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8(char8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16(char16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -329,32 +601,66 @@ half convert_half(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half2 convert_half2(char2 x)
 {
-  return (half2)(convert_half(x.lo), convert_half(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half4 convert_half4(char4 x)
-{
-  return (half4)(convert_half2(x.lo), convert_half2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half8 convert_half8(char8 x)
-{
-  return (half8)(convert_half4(x.lo), convert_half4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half16 convert_half16(char16 x)
-{
-  return (half16)(convert_half8(x.lo), convert_half8(x.hi));
+  return (half2)(
+    (half)x.s0,
+    (half)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half3 convert_half3(char3 x)
 {
-  return (half3)(convert_half2(x.s01), convert_half(x.s2));
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4(char4 x)
+{
+  return (half4)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8(char8 x)
+{
+  return (half8)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16(char16 x)
+{
+  return (half16)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7,
+    (half)x.s8,
+    (half)x.s9,
+    (half)x.sa,
+    (half)x.sb,
+    (half)x.sc,
+    (half)x.sd,
+    (half)x.se,
+    (half)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -366,32 +672,66 @@ float convert_float(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float2 convert_float2(char2 x)
 {
-  return (float2)(convert_float(x.lo), convert_float(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float4 convert_float4(char4 x)
-{
-  return (float4)(convert_float2(x.lo), convert_float2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float8 convert_float8(char8 x)
-{
-  return (float8)(convert_float4(x.lo), convert_float4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float16 convert_float16(char16 x)
-{
-  return (float16)(convert_float8(x.lo), convert_float8(x.hi));
+  return (float2)(
+    (float)x.s0,
+    (float)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float3 convert_float3(char3 x)
 {
-  return (float3)(convert_float2(x.s01), convert_float(x.s2));
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float4 convert_float4(char4 x)
+{
+  return (float4)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float8 convert_float8(char8 x)
+{
+  return (float8)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float16 convert_float16(char16 x)
+{
+  return (float16)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7,
+    (float)x.s8,
+    (float)x.s9,
+    (float)x.sa,
+    (float)x.sb,
+    (float)x.sc,
+    (float)x.sd,
+    (float)x.se,
+    (float)x.sf);
+}
+
 
 #if defined(cl_khr_fp64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -403,32 +743,66 @@ double convert_double(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double2 convert_double2(char2 x)
 {
-  return (double2)(convert_double(x.lo), convert_double(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double4 convert_double4(char4 x)
-{
-  return (double4)(convert_double2(x.lo), convert_double2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double8 convert_double8(char8 x)
-{
-  return (double8)(convert_double4(x.lo), convert_double4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double16 convert_double16(char16 x)
-{
-  return (double16)(convert_double8(x.lo), convert_double8(x.hi));
+  return (double2)(
+    (double)x.s0,
+    (double)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double3 convert_double3(char3 x)
 {
-  return (double3)(convert_double2(x.s01), convert_double(x.s2));
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double4 convert_double4(char4 x)
+{
+  return (double4)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double8 convert_double8(char8 x)
+{
+  return (double8)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double16 convert_double16(char16 x)
+{
+  return (double16)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7,
+    (double)x.s8,
+    (double)x.s9,
+    (double)x.sa,
+    (double)x.sb,
+    (double)x.sc,
+    (double)x.sd,
+    (double)x.se,
+    (double)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -440,32 +814,66 @@ char convert_char(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2(uchar2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4(uchar4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8(uchar8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16(uchar16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3(uchar3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4(uchar4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8(uchar8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16(uchar16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar(uchar x)
@@ -476,32 +884,66 @@ uchar convert_uchar(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2(uchar2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4(uchar4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8(uchar8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16(uchar16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3(uchar3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4(uchar4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8(uchar8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16(uchar16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short(uchar x)
@@ -512,32 +954,66 @@ short convert_short(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2(uchar2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4(uchar4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8(uchar8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16(uchar16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3(uchar3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4(uchar4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8(uchar8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16(uchar16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort(uchar x)
@@ -548,32 +1024,66 @@ ushort convert_ushort(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2(uchar2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4(uchar4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8(uchar8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16(uchar16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3(uchar3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4(uchar4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8(uchar8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16(uchar16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int(uchar x)
@@ -584,32 +1094,66 @@ int convert_int(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2(uchar2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4(uchar4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8(uchar8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16(uchar16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3(uchar3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4(uchar4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8(uchar8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16(uchar16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint(uchar x)
@@ -620,32 +1164,66 @@ uint convert_uint(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2(uchar2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4(uchar4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8(uchar8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16(uchar16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3(uchar3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4(uchar4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8(uchar8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16(uchar16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -657,32 +1235,66 @@ long convert_long(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2(uchar2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4(uchar4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8(uchar8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16(uchar16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3(uchar3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4(uchar4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8(uchar8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16(uchar16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -695,32 +1307,66 @@ ulong convert_ulong(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2(uchar2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4(uchar4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8(uchar8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16(uchar16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3(uchar3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4(uchar4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8(uchar8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16(uchar16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -733,32 +1379,66 @@ half convert_half(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half2 convert_half2(uchar2 x)
 {
-  return (half2)(convert_half(x.lo), convert_half(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half4 convert_half4(uchar4 x)
-{
-  return (half4)(convert_half2(x.lo), convert_half2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half8 convert_half8(uchar8 x)
-{
-  return (half8)(convert_half4(x.lo), convert_half4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half16 convert_half16(uchar16 x)
-{
-  return (half16)(convert_half8(x.lo), convert_half8(x.hi));
+  return (half2)(
+    (half)x.s0,
+    (half)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half3 convert_half3(uchar3 x)
 {
-  return (half3)(convert_half2(x.s01), convert_half(x.s2));
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4(uchar4 x)
+{
+  return (half4)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8(uchar8 x)
+{
+  return (half8)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16(uchar16 x)
+{
+  return (half16)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7,
+    (half)x.s8,
+    (half)x.s9,
+    (half)x.sa,
+    (half)x.sb,
+    (half)x.sc,
+    (half)x.sd,
+    (half)x.se,
+    (half)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -770,32 +1450,66 @@ float convert_float(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float2 convert_float2(uchar2 x)
 {
-  return (float2)(convert_float(x.lo), convert_float(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float4 convert_float4(uchar4 x)
-{
-  return (float4)(convert_float2(x.lo), convert_float2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float8 convert_float8(uchar8 x)
-{
-  return (float8)(convert_float4(x.lo), convert_float4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float16 convert_float16(uchar16 x)
-{
-  return (float16)(convert_float8(x.lo), convert_float8(x.hi));
+  return (float2)(
+    (float)x.s0,
+    (float)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float3 convert_float3(uchar3 x)
 {
-  return (float3)(convert_float2(x.s01), convert_float(x.s2));
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float4 convert_float4(uchar4 x)
+{
+  return (float4)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float8 convert_float8(uchar8 x)
+{
+  return (float8)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float16 convert_float16(uchar16 x)
+{
+  return (float16)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7,
+    (float)x.s8,
+    (float)x.s9,
+    (float)x.sa,
+    (float)x.sb,
+    (float)x.sc,
+    (float)x.sd,
+    (float)x.se,
+    (float)x.sf);
+}
+
 
 #if defined(cl_khr_fp64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -807,32 +1521,66 @@ double convert_double(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double2 convert_double2(uchar2 x)
 {
-  return (double2)(convert_double(x.lo), convert_double(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double4 convert_double4(uchar4 x)
-{
-  return (double4)(convert_double2(x.lo), convert_double2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double8 convert_double8(uchar8 x)
-{
-  return (double8)(convert_double4(x.lo), convert_double4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double16 convert_double16(uchar16 x)
-{
-  return (double16)(convert_double8(x.lo), convert_double8(x.hi));
+  return (double2)(
+    (double)x.s0,
+    (double)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double3 convert_double3(uchar3 x)
 {
-  return (double3)(convert_double2(x.s01), convert_double(x.s2));
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double4 convert_double4(uchar4 x)
+{
+  return (double4)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double8 convert_double8(uchar8 x)
+{
+  return (double8)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double16 convert_double16(uchar16 x)
+{
+  return (double16)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7,
+    (double)x.s8,
+    (double)x.s9,
+    (double)x.sa,
+    (double)x.sb,
+    (double)x.sc,
+    (double)x.sd,
+    (double)x.se,
+    (double)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -844,32 +1592,66 @@ char convert_char(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2(short2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4(short4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8(short8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16(short16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3(short3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4(short4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8(short8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16(short16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar(short x)
@@ -880,32 +1662,66 @@ uchar convert_uchar(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2(short2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4(short4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8(short8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16(short16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3(short3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4(short4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8(short8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16(short16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short(short x)
@@ -916,32 +1732,66 @@ short convert_short(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2(short2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4(short4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8(short8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16(short16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3(short3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4(short4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8(short8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16(short16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort(short x)
@@ -952,32 +1802,66 @@ ushort convert_ushort(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2(short2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4(short4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8(short8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16(short16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3(short3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4(short4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8(short8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16(short16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int(short x)
@@ -988,32 +1872,66 @@ int convert_int(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2(short2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4(short4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8(short8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16(short16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3(short3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4(short4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8(short8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16(short16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint(short x)
@@ -1024,32 +1942,66 @@ uint convert_uint(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2(short2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4(short4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8(short8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16(short16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3(short3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4(short4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8(short8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16(short16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1061,32 +2013,66 @@ long convert_long(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2(short2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4(short4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8(short8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16(short16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3(short3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4(short4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8(short8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16(short16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -1099,32 +2085,66 @@ ulong convert_ulong(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2(short2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4(short4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8(short8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16(short16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3(short3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4(short4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8(short8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16(short16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -1137,32 +2157,66 @@ half convert_half(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half2 convert_half2(short2 x)
 {
-  return (half2)(convert_half(x.lo), convert_half(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half4 convert_half4(short4 x)
-{
-  return (half4)(convert_half2(x.lo), convert_half2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half8 convert_half8(short8 x)
-{
-  return (half8)(convert_half4(x.lo), convert_half4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half16 convert_half16(short16 x)
-{
-  return (half16)(convert_half8(x.lo), convert_half8(x.hi));
+  return (half2)(
+    (half)x.s0,
+    (half)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half3 convert_half3(short3 x)
 {
-  return (half3)(convert_half2(x.s01), convert_half(x.s2));
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4(short4 x)
+{
+  return (half4)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8(short8 x)
+{
+  return (half8)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16(short16 x)
+{
+  return (half16)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7,
+    (half)x.s8,
+    (half)x.s9,
+    (half)x.sa,
+    (half)x.sb,
+    (half)x.sc,
+    (half)x.sd,
+    (half)x.se,
+    (half)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1174,32 +2228,66 @@ float convert_float(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float2 convert_float2(short2 x)
 {
-  return (float2)(convert_float(x.lo), convert_float(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float4 convert_float4(short4 x)
-{
-  return (float4)(convert_float2(x.lo), convert_float2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float8 convert_float8(short8 x)
-{
-  return (float8)(convert_float4(x.lo), convert_float4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float16 convert_float16(short16 x)
-{
-  return (float16)(convert_float8(x.lo), convert_float8(x.hi));
+  return (float2)(
+    (float)x.s0,
+    (float)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float3 convert_float3(short3 x)
 {
-  return (float3)(convert_float2(x.s01), convert_float(x.s2));
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float4 convert_float4(short4 x)
+{
+  return (float4)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float8 convert_float8(short8 x)
+{
+  return (float8)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float16 convert_float16(short16 x)
+{
+  return (float16)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7,
+    (float)x.s8,
+    (float)x.s9,
+    (float)x.sa,
+    (float)x.sb,
+    (float)x.sc,
+    (float)x.sd,
+    (float)x.se,
+    (float)x.sf);
+}
+
 
 #if defined(cl_khr_fp64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1211,32 +2299,66 @@ double convert_double(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double2 convert_double2(short2 x)
 {
-  return (double2)(convert_double(x.lo), convert_double(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double4 convert_double4(short4 x)
-{
-  return (double4)(convert_double2(x.lo), convert_double2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double8 convert_double8(short8 x)
-{
-  return (double8)(convert_double4(x.lo), convert_double4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double16 convert_double16(short16 x)
-{
-  return (double16)(convert_double8(x.lo), convert_double8(x.hi));
+  return (double2)(
+    (double)x.s0,
+    (double)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double3 convert_double3(short3 x)
 {
-  return (double3)(convert_double2(x.s01), convert_double(x.s2));
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double4 convert_double4(short4 x)
+{
+  return (double4)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double8 convert_double8(short8 x)
+{
+  return (double8)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double16 convert_double16(short16 x)
+{
+  return (double16)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7,
+    (double)x.s8,
+    (double)x.s9,
+    (double)x.sa,
+    (double)x.sb,
+    (double)x.sc,
+    (double)x.sd,
+    (double)x.se,
+    (double)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1248,32 +2370,66 @@ char convert_char(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2(ushort2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4(ushort4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8(ushort8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16(ushort16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3(ushort3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4(ushort4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8(ushort8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16(ushort16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar(ushort x)
@@ -1284,32 +2440,66 @@ uchar convert_uchar(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2(ushort2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4(ushort4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8(ushort8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16(ushort16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3(ushort3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4(ushort4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8(ushort8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16(ushort16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short(ushort x)
@@ -1320,32 +2510,66 @@ short convert_short(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2(ushort2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4(ushort4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8(ushort8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16(ushort16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3(ushort3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4(ushort4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8(ushort8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16(ushort16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort(ushort x)
@@ -1356,32 +2580,66 @@ ushort convert_ushort(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2(ushort2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4(ushort4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8(ushort8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16(ushort16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3(ushort3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4(ushort4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8(ushort8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16(ushort16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int(ushort x)
@@ -1392,32 +2650,66 @@ int convert_int(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2(ushort2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4(ushort4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8(ushort8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16(ushort16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3(ushort3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4(ushort4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8(ushort8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16(ushort16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint(ushort x)
@@ -1428,32 +2720,66 @@ uint convert_uint(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2(ushort2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4(ushort4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8(ushort8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16(ushort16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3(ushort3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4(ushort4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8(ushort8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16(ushort16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1465,32 +2791,66 @@ long convert_long(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2(ushort2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4(ushort4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8(ushort8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16(ushort16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3(ushort3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4(ushort4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8(ushort8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16(ushort16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -1503,32 +2863,66 @@ ulong convert_ulong(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2(ushort2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4(ushort4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8(ushort8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16(ushort16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3(ushort3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4(ushort4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8(ushort8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16(ushort16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -1541,32 +2935,66 @@ half convert_half(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half2 convert_half2(ushort2 x)
 {
-  return (half2)(convert_half(x.lo), convert_half(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half4 convert_half4(ushort4 x)
-{
-  return (half4)(convert_half2(x.lo), convert_half2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half8 convert_half8(ushort8 x)
-{
-  return (half8)(convert_half4(x.lo), convert_half4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half16 convert_half16(ushort16 x)
-{
-  return (half16)(convert_half8(x.lo), convert_half8(x.hi));
+  return (half2)(
+    (half)x.s0,
+    (half)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half3 convert_half3(ushort3 x)
 {
-  return (half3)(convert_half2(x.s01), convert_half(x.s2));
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4(ushort4 x)
+{
+  return (half4)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8(ushort8 x)
+{
+  return (half8)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16(ushort16 x)
+{
+  return (half16)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7,
+    (half)x.s8,
+    (half)x.s9,
+    (half)x.sa,
+    (half)x.sb,
+    (half)x.sc,
+    (half)x.sd,
+    (half)x.se,
+    (half)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1578,32 +3006,66 @@ float convert_float(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float2 convert_float2(ushort2 x)
 {
-  return (float2)(convert_float(x.lo), convert_float(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float4 convert_float4(ushort4 x)
-{
-  return (float4)(convert_float2(x.lo), convert_float2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float8 convert_float8(ushort8 x)
-{
-  return (float8)(convert_float4(x.lo), convert_float4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float16 convert_float16(ushort16 x)
-{
-  return (float16)(convert_float8(x.lo), convert_float8(x.hi));
+  return (float2)(
+    (float)x.s0,
+    (float)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float3 convert_float3(ushort3 x)
 {
-  return (float3)(convert_float2(x.s01), convert_float(x.s2));
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float4 convert_float4(ushort4 x)
+{
+  return (float4)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float8 convert_float8(ushort8 x)
+{
+  return (float8)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float16 convert_float16(ushort16 x)
+{
+  return (float16)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7,
+    (float)x.s8,
+    (float)x.s9,
+    (float)x.sa,
+    (float)x.sb,
+    (float)x.sc,
+    (float)x.sd,
+    (float)x.se,
+    (float)x.sf);
+}
+
 
 #if defined(cl_khr_fp64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1615,32 +3077,66 @@ double convert_double(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double2 convert_double2(ushort2 x)
 {
-  return (double2)(convert_double(x.lo), convert_double(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double4 convert_double4(ushort4 x)
-{
-  return (double4)(convert_double2(x.lo), convert_double2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double8 convert_double8(ushort8 x)
-{
-  return (double8)(convert_double4(x.lo), convert_double4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double16 convert_double16(ushort16 x)
-{
-  return (double16)(convert_double8(x.lo), convert_double8(x.hi));
+  return (double2)(
+    (double)x.s0,
+    (double)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double3 convert_double3(ushort3 x)
 {
-  return (double3)(convert_double2(x.s01), convert_double(x.s2));
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double4 convert_double4(ushort4 x)
+{
+  return (double4)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double8 convert_double8(ushort8 x)
+{
+  return (double8)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double16 convert_double16(ushort16 x)
+{
+  return (double16)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7,
+    (double)x.s8,
+    (double)x.s9,
+    (double)x.sa,
+    (double)x.sb,
+    (double)x.sc,
+    (double)x.sd,
+    (double)x.se,
+    (double)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1652,32 +3148,66 @@ char convert_char(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2(int2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4(int4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8(int8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16(int16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3(int3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4(int4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8(int8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16(int16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar(int x)
@@ -1688,32 +3218,66 @@ uchar convert_uchar(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2(int2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4(int4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8(int8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16(int16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3(int3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4(int4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8(int8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16(int16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short(int x)
@@ -1724,32 +3288,66 @@ short convert_short(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2(int2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4(int4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8(int8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16(int16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3(int3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4(int4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8(int8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16(int16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort(int x)
@@ -1760,32 +3358,66 @@ ushort convert_ushort(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2(int2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4(int4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8(int8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16(int16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3(int3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4(int4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8(int8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16(int16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int(int x)
@@ -1796,32 +3428,66 @@ int convert_int(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2(int2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4(int4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8(int8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16(int16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3(int3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4(int4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8(int8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16(int16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint(int x)
@@ -1832,32 +3498,66 @@ uint convert_uint(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2(int2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4(int4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8(int8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16(int16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3(int3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4(int4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8(int8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16(int16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1869,32 +3569,66 @@ long convert_long(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2(int2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4(int4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8(int8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16(int16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3(int3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4(int4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8(int8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16(int16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -1907,32 +3641,66 @@ ulong convert_ulong(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2(int2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4(int4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8(int8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16(int16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3(int3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4(int4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8(int8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16(int16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -1945,32 +3713,66 @@ half convert_half(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half2 convert_half2(int2 x)
 {
-  return (half2)(convert_half(x.lo), convert_half(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half4 convert_half4(int4 x)
-{
-  return (half4)(convert_half2(x.lo), convert_half2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half8 convert_half8(int8 x)
-{
-  return (half8)(convert_half4(x.lo), convert_half4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half16 convert_half16(int16 x)
-{
-  return (half16)(convert_half8(x.lo), convert_half8(x.hi));
+  return (half2)(
+    (half)x.s0,
+    (half)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half3 convert_half3(int3 x)
 {
-  return (half3)(convert_half2(x.s01), convert_half(x.s2));
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4(int4 x)
+{
+  return (half4)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8(int8 x)
+{
+  return (half8)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16(int16 x)
+{
+  return (half16)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7,
+    (half)x.s8,
+    (half)x.s9,
+    (half)x.sa,
+    (half)x.sb,
+    (half)x.sc,
+    (half)x.sd,
+    (half)x.se,
+    (half)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -1982,32 +3784,66 @@ float convert_float(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float2 convert_float2(int2 x)
 {
-  return (float2)(convert_float(x.lo), convert_float(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float4 convert_float4(int4 x)
-{
-  return (float4)(convert_float2(x.lo), convert_float2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float8 convert_float8(int8 x)
-{
-  return (float8)(convert_float4(x.lo), convert_float4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float16 convert_float16(int16 x)
-{
-  return (float16)(convert_float8(x.lo), convert_float8(x.hi));
+  return (float2)(
+    (float)x.s0,
+    (float)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float3 convert_float3(int3 x)
 {
-  return (float3)(convert_float2(x.s01), convert_float(x.s2));
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float4 convert_float4(int4 x)
+{
+  return (float4)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float8 convert_float8(int8 x)
+{
+  return (float8)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float16 convert_float16(int16 x)
+{
+  return (float16)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7,
+    (float)x.s8,
+    (float)x.s9,
+    (float)x.sa,
+    (float)x.sb,
+    (float)x.sc,
+    (float)x.sd,
+    (float)x.se,
+    (float)x.sf);
+}
+
 
 #if defined(cl_khr_fp64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2019,32 +3855,66 @@ double convert_double(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double2 convert_double2(int2 x)
 {
-  return (double2)(convert_double(x.lo), convert_double(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double4 convert_double4(int4 x)
-{
-  return (double4)(convert_double2(x.lo), convert_double2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double8 convert_double8(int8 x)
-{
-  return (double8)(convert_double4(x.lo), convert_double4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double16 convert_double16(int16 x)
-{
-  return (double16)(convert_double8(x.lo), convert_double8(x.hi));
+  return (double2)(
+    (double)x.s0,
+    (double)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double3 convert_double3(int3 x)
 {
-  return (double3)(convert_double2(x.s01), convert_double(x.s2));
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double4 convert_double4(int4 x)
+{
+  return (double4)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double8 convert_double8(int8 x)
+{
+  return (double8)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double16 convert_double16(int16 x)
+{
+  return (double16)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7,
+    (double)x.s8,
+    (double)x.s9,
+    (double)x.sa,
+    (double)x.sb,
+    (double)x.sc,
+    (double)x.sd,
+    (double)x.se,
+    (double)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2056,32 +3926,66 @@ char convert_char(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2(uint2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4(uint4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8(uint8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16(uint16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3(uint3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4(uint4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8(uint8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16(uint16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar(uint x)
@@ -2092,32 +3996,66 @@ uchar convert_uchar(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2(uint2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4(uint4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8(uint8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16(uint16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3(uint3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4(uint4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8(uint8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16(uint16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short(uint x)
@@ -2128,32 +4066,66 @@ short convert_short(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2(uint2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4(uint4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8(uint8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16(uint16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3(uint3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4(uint4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8(uint8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16(uint16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort(uint x)
@@ -2164,32 +4136,66 @@ ushort convert_ushort(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2(uint2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4(uint4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8(uint8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16(uint16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3(uint3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4(uint4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8(uint8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16(uint16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int(uint x)
@@ -2200,32 +4206,66 @@ int convert_int(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2(uint2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4(uint4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8(uint8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16(uint16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3(uint3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4(uint4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8(uint8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16(uint16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint(uint x)
@@ -2236,32 +4276,66 @@ uint convert_uint(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2(uint2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4(uint4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8(uint8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16(uint16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3(uint3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4(uint4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8(uint8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16(uint16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2273,32 +4347,66 @@ long convert_long(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2(uint2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4(uint4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8(uint8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16(uint16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3(uint3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4(uint4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8(uint8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16(uint16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2311,32 +4419,66 @@ ulong convert_ulong(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2(uint2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4(uint4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8(uint8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16(uint16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3(uint3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4(uint4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8(uint8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16(uint16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -2349,32 +4491,66 @@ half convert_half(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half2 convert_half2(uint2 x)
 {
-  return (half2)(convert_half(x.lo), convert_half(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half4 convert_half4(uint4 x)
-{
-  return (half4)(convert_half2(x.lo), convert_half2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half8 convert_half8(uint8 x)
-{
-  return (half8)(convert_half4(x.lo), convert_half4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half16 convert_half16(uint16 x)
-{
-  return (half16)(convert_half8(x.lo), convert_half8(x.hi));
+  return (half2)(
+    (half)x.s0,
+    (half)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half3 convert_half3(uint3 x)
 {
-  return (half3)(convert_half2(x.s01), convert_half(x.s2));
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4(uint4 x)
+{
+  return (half4)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8(uint8 x)
+{
+  return (half8)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16(uint16 x)
+{
+  return (half16)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7,
+    (half)x.s8,
+    (half)x.s9,
+    (half)x.sa,
+    (half)x.sb,
+    (half)x.sc,
+    (half)x.sd,
+    (half)x.se,
+    (half)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2386,32 +4562,66 @@ float convert_float(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float2 convert_float2(uint2 x)
 {
-  return (float2)(convert_float(x.lo), convert_float(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float4 convert_float4(uint4 x)
-{
-  return (float4)(convert_float2(x.lo), convert_float2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float8 convert_float8(uint8 x)
-{
-  return (float8)(convert_float4(x.lo), convert_float4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float16 convert_float16(uint16 x)
-{
-  return (float16)(convert_float8(x.lo), convert_float8(x.hi));
+  return (float2)(
+    (float)x.s0,
+    (float)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float3 convert_float3(uint3 x)
 {
-  return (float3)(convert_float2(x.s01), convert_float(x.s2));
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float4 convert_float4(uint4 x)
+{
+  return (float4)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float8 convert_float8(uint8 x)
+{
+  return (float8)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float16 convert_float16(uint16 x)
+{
+  return (float16)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7,
+    (float)x.s8,
+    (float)x.s9,
+    (float)x.sa,
+    (float)x.sb,
+    (float)x.sc,
+    (float)x.sd,
+    (float)x.se,
+    (float)x.sf);
+}
+
 
 #if defined(cl_khr_fp64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -2423,32 +4633,66 @@ double convert_double(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double2 convert_double2(uint2 x)
 {
-  return (double2)(convert_double(x.lo), convert_double(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double4 convert_double4(uint4 x)
-{
-  return (double4)(convert_double2(x.lo), convert_double2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double8 convert_double8(uint8 x)
-{
-  return (double8)(convert_double4(x.lo), convert_double4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double16 convert_double16(uint16 x)
-{
-  return (double16)(convert_double8(x.lo), convert_double8(x.hi));
+  return (double2)(
+    (double)x.s0,
+    (double)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double3 convert_double3(uint3 x)
 {
-  return (double3)(convert_double2(x.s01), convert_double(x.s2));
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double4 convert_double4(uint4 x)
+{
+  return (double4)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double8 convert_double8(uint8 x)
+{
+  return (double8)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double16 convert_double16(uint16 x)
+{
+  return (double16)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7,
+    (double)x.s8,
+    (double)x.s9,
+    (double)x.sa,
+    (double)x.sb,
+    (double)x.sc,
+    (double)x.sd,
+    (double)x.se,
+    (double)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2461,32 +4705,66 @@ char convert_char(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2(long2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4(long4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8(long8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16(long16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3(long3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4(long4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8(long8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16(long16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2499,32 +4777,66 @@ uchar convert_uchar(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2(long2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4(long4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8(long8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16(long16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3(long3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4(long4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8(long8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16(long16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2537,32 +4849,66 @@ short convert_short(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2(long2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4(long4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8(long8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16(long16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3(long3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4(long4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8(long8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16(long16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2575,32 +4921,66 @@ ushort convert_ushort(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2(long2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4(long4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8(long8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16(long16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3(long3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4(long4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8(long8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16(long16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2613,32 +4993,66 @@ int convert_int(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2(long2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4(long4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8(long8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16(long16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3(long3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4(long4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8(long8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16(long16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2651,32 +5065,66 @@ uint convert_uint(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2(long2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4(long4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8(long8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16(long16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3(long3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4(long4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8(long8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16(long16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2689,32 +5137,66 @@ long convert_long(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2(long2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4(long4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8(long8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16(long16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3(long3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4(long4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8(long8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16(long16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2727,32 +5209,66 @@ ulong convert_ulong(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2(long2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4(long4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8(long8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16(long16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3(long3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4(long4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8(long8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16(long16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp16)
@@ -2765,32 +5281,66 @@ half convert_half(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half2 convert_half2(long2 x)
 {
-  return (half2)(convert_half(x.lo), convert_half(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half4 convert_half4(long4 x)
-{
-  return (half4)(convert_half2(x.lo), convert_half2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half8 convert_half8(long8 x)
-{
-  return (half8)(convert_half4(x.lo), convert_half4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half16 convert_half16(long16 x)
-{
-  return (half16)(convert_half8(x.lo), convert_half8(x.hi));
+  return (half2)(
+    (half)x.s0,
+    (half)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half3 convert_half3(long3 x)
 {
-  return (half3)(convert_half2(x.s01), convert_half(x.s2));
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4(long4 x)
+{
+  return (half4)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8(long8 x)
+{
+  return (half8)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16(long16 x)
+{
+  return (half16)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7,
+    (half)x.s8,
+    (half)x.s9,
+    (half)x.sa,
+    (half)x.sb,
+    (half)x.sc,
+    (half)x.sd,
+    (half)x.se,
+    (half)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2803,32 +5353,66 @@ float convert_float(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float2 convert_float2(long2 x)
 {
-  return (float2)(convert_float(x.lo), convert_float(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float4 convert_float4(long4 x)
-{
-  return (float4)(convert_float2(x.lo), convert_float2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float8 convert_float8(long8 x)
-{
-  return (float8)(convert_float4(x.lo), convert_float4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float16 convert_float16(long16 x)
-{
-  return (float16)(convert_float8(x.lo), convert_float8(x.hi));
+  return (float2)(
+    (float)x.s0,
+    (float)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float3 convert_float3(long3 x)
 {
-  return (float3)(convert_float2(x.s01), convert_float(x.s2));
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float4 convert_float4(long4 x)
+{
+  return (float4)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float8 convert_float8(long8 x)
+{
+  return (float8)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float16 convert_float16(long16 x)
+{
+  return (float16)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7,
+    (float)x.s8,
+    (float)x.s9,
+    (float)x.sa,
+    (float)x.sb,
+    (float)x.sc,
+    (float)x.sd,
+    (float)x.se,
+    (float)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp64)
@@ -2841,32 +5425,66 @@ double convert_double(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double2 convert_double2(long2 x)
 {
-  return (double2)(convert_double(x.lo), convert_double(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double4 convert_double4(long4 x)
-{
-  return (double4)(convert_double2(x.lo), convert_double2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double8 convert_double8(long8 x)
-{
-  return (double8)(convert_double4(x.lo), convert_double4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double16 convert_double16(long16 x)
-{
-  return (double16)(convert_double8(x.lo), convert_double8(x.hi));
+  return (double2)(
+    (double)x.s0,
+    (double)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double3 convert_double3(long3 x)
 {
-  return (double3)(convert_double2(x.s01), convert_double(x.s2));
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double4 convert_double4(long4 x)
+{
+  return (double4)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double8 convert_double8(long8 x)
+{
+  return (double8)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double16 convert_double16(long16 x)
+{
+  return (double16)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7,
+    (double)x.s8,
+    (double)x.s9,
+    (double)x.sa,
+    (double)x.sb,
+    (double)x.sc,
+    (double)x.sd,
+    (double)x.se,
+    (double)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2879,32 +5497,66 @@ char convert_char(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2(ulong2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4(ulong4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8(ulong8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16(ulong16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3(ulong3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4(ulong4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8(ulong8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16(ulong16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2917,32 +5569,66 @@ uchar convert_uchar(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2(ulong2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4(ulong4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8(ulong8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16(ulong16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3(ulong3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4(ulong4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8(ulong8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16(ulong16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2955,32 +5641,66 @@ short convert_short(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2(ulong2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4(ulong4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8(ulong8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16(ulong16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3(ulong3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4(ulong4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8(ulong8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16(ulong16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -2993,32 +5713,66 @@ ushort convert_ushort(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2(ulong2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4(ulong4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8(ulong8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16(ulong16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3(ulong3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4(ulong4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8(ulong8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16(ulong16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -3031,32 +5785,66 @@ int convert_int(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2(ulong2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4(ulong4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8(ulong8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16(ulong16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3(ulong3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4(ulong4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8(ulong8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16(ulong16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -3069,32 +5857,66 @@ uint convert_uint(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2(ulong2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4(ulong4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8(ulong8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16(ulong16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3(ulong3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4(ulong4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8(ulong8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16(ulong16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -3107,32 +5929,66 @@ long convert_long(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2(ulong2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4(ulong4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8(ulong8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16(ulong16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3(ulong3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4(ulong4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8(ulong8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16(ulong16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -3145,32 +6001,66 @@ ulong convert_ulong(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2(ulong2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4(ulong4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8(ulong8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16(ulong16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3(ulong3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4(ulong4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8(ulong8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16(ulong16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp16)
@@ -3183,32 +6073,66 @@ half convert_half(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half2 convert_half2(ulong2 x)
 {
-  return (half2)(convert_half(x.lo), convert_half(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half4 convert_half4(ulong4 x)
-{
-  return (half4)(convert_half2(x.lo), convert_half2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half8 convert_half8(ulong8 x)
-{
-  return (half8)(convert_half4(x.lo), convert_half4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half16 convert_half16(ulong16 x)
-{
-  return (half16)(convert_half8(x.lo), convert_half8(x.hi));
+  return (half2)(
+    (half)x.s0,
+    (half)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half3 convert_half3(ulong3 x)
 {
-  return (half3)(convert_half2(x.s01), convert_half(x.s2));
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4(ulong4 x)
+{
+  return (half4)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8(ulong8 x)
+{
+  return (half8)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16(ulong16 x)
+{
+  return (half16)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7,
+    (half)x.s8,
+    (half)x.s9,
+    (half)x.sa,
+    (half)x.sb,
+    (half)x.sc,
+    (half)x.sd,
+    (half)x.se,
+    (half)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -3221,32 +6145,66 @@ float convert_float(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float2 convert_float2(ulong2 x)
 {
-  return (float2)(convert_float(x.lo), convert_float(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float4 convert_float4(ulong4 x)
-{
-  return (float4)(convert_float2(x.lo), convert_float2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float8 convert_float8(ulong8 x)
-{
-  return (float8)(convert_float4(x.lo), convert_float4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float16 convert_float16(ulong16 x)
-{
-  return (float16)(convert_float8(x.lo), convert_float8(x.hi));
+  return (float2)(
+    (float)x.s0,
+    (float)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float3 convert_float3(ulong3 x)
 {
-  return (float3)(convert_float2(x.s01), convert_float(x.s2));
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float4 convert_float4(ulong4 x)
+{
+  return (float4)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float8 convert_float8(ulong8 x)
+{
+  return (float8)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float16 convert_float16(ulong16 x)
+{
+  return (float16)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7,
+    (float)x.s8,
+    (float)x.s9,
+    (float)x.sa,
+    (float)x.sb,
+    (float)x.sc,
+    (float)x.sd,
+    (float)x.se,
+    (float)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp64)
@@ -3259,32 +6217,66 @@ double convert_double(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double2 convert_double2(ulong2 x)
 {
-  return (double2)(convert_double(x.lo), convert_double(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double4 convert_double4(ulong4 x)
-{
-  return (double4)(convert_double2(x.lo), convert_double2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double8 convert_double8(ulong8 x)
-{
-  return (double8)(convert_double4(x.lo), convert_double4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double16 convert_double16(ulong16 x)
-{
-  return (double16)(convert_double8(x.lo), convert_double8(x.hi));
+  return (double2)(
+    (double)x.s0,
+    (double)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double3 convert_double3(ulong3 x)
 {
-  return (double3)(convert_double2(x.s01), convert_double(x.s2));
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double4 convert_double4(ulong4 x)
+{
+  return (double4)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double8 convert_double8(ulong8 x)
+{
+  return (double8)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double16 convert_double16(ulong16 x)
+{
+  return (double16)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7,
+    (double)x.s8,
+    (double)x.s9,
+    (double)x.sa,
+    (double)x.sb,
+    (double)x.sc,
+    (double)x.sd,
+    (double)x.se,
+    (double)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -3297,32 +6289,66 @@ char convert_char(half x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2(half2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4(half4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8(half8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16(half16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3(half3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4(half4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8(half8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16(half16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -3335,32 +6361,66 @@ uchar convert_uchar(half x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2(half2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4(half4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8(half8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16(half16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3(half3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4(half4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8(half8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16(half16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -3373,32 +6433,66 @@ short convert_short(half x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2(half2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4(half4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8(half8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16(half16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3(half3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4(half4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8(half8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16(half16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -3411,32 +6505,66 @@ ushort convert_ushort(half x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2(half2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4(half4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8(half8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16(half16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3(half3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4(half4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8(half8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16(half16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -3449,32 +6577,66 @@ int convert_int(half x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2(half2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4(half4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8(half8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16(half16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3(half3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4(half4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8(half8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16(half16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -3487,32 +6649,66 @@ uint convert_uint(half x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2(half2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4(half4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8(half8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16(half16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3(half3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4(half4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8(half8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16(half16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp16)
@@ -3525,32 +6721,66 @@ long convert_long(half x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2(half2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4(half4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8(half8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16(half16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3(half3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4(half4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8(half8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16(half16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp16)
@@ -3563,32 +6793,66 @@ ulong convert_ulong(half x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2(half2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4(half4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8(half8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16(half16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3(half3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4(half4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8(half8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16(half16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -3601,32 +6865,66 @@ half convert_half(half x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half2 convert_half2(half2 x)
 {
-  return (half2)(convert_half(x.lo), convert_half(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half4 convert_half4(half4 x)
-{
-  return (half4)(convert_half2(x.lo), convert_half2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half8 convert_half8(half8 x)
-{
-  return (half8)(convert_half4(x.lo), convert_half4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half16 convert_half16(half16 x)
-{
-  return (half16)(convert_half8(x.lo), convert_half8(x.hi));
+  return (half2)(
+    (half)x.s0,
+    (half)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half3 convert_half3(half3 x)
 {
-  return (half3)(convert_half2(x.s01), convert_half(x.s2));
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4(half4 x)
+{
+  return (half4)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8(half8 x)
+{
+  return (half8)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16(half16 x)
+{
+  return (half16)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7,
+    (half)x.s8,
+    (half)x.s9,
+    (half)x.sa,
+    (half)x.sb,
+    (half)x.sc,
+    (half)x.sd,
+    (half)x.se,
+    (half)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -3639,32 +6937,66 @@ float convert_float(half x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float2 convert_float2(half2 x)
 {
-  return (float2)(convert_float(x.lo), convert_float(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float4 convert_float4(half4 x)
-{
-  return (float4)(convert_float2(x.lo), convert_float2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float8 convert_float8(half8 x)
-{
-  return (float8)(convert_float4(x.lo), convert_float4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float16 convert_float16(half16 x)
-{
-  return (float16)(convert_float8(x.lo), convert_float8(x.hi));
+  return (float2)(
+    (float)x.s0,
+    (float)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float3 convert_float3(half3 x)
 {
-  return (float3)(convert_float2(x.s01), convert_float(x.s2));
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float4 convert_float4(half4 x)
+{
+  return (float4)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float8 convert_float8(half8 x)
+{
+  return (float8)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float16 convert_float16(half16 x)
+{
+  return (float16)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7,
+    (float)x.s8,
+    (float)x.s9,
+    (float)x.sa,
+    (float)x.sb,
+    (float)x.sc,
+    (float)x.sd,
+    (float)x.se,
+    (float)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp64) && defined(cl_khr_fp16)
@@ -3677,32 +7009,66 @@ double convert_double(half x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double2 convert_double2(half2 x)
 {
-  return (double2)(convert_double(x.lo), convert_double(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double4 convert_double4(half4 x)
-{
-  return (double4)(convert_double2(x.lo), convert_double2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double8 convert_double8(half8 x)
-{
-  return (double8)(convert_double4(x.lo), convert_double4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double16 convert_double16(half16 x)
-{
-  return (double16)(convert_double8(x.lo), convert_double8(x.hi));
+  return (double2)(
+    (double)x.s0,
+    (double)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double3 convert_double3(half3 x)
 {
-  return (double3)(convert_double2(x.s01), convert_double(x.s2));
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double4 convert_double4(half4 x)
+{
+  return (double4)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double8 convert_double8(half8 x)
+{
+  return (double8)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double16 convert_double16(half16 x)
+{
+  return (double16)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7,
+    (double)x.s8,
+    (double)x.s9,
+    (double)x.sa,
+    (double)x.sb,
+    (double)x.sc,
+    (double)x.sd,
+    (double)x.se,
+    (double)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3714,32 +7080,66 @@ char convert_char(float x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2(float2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4(float4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8(float8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16(float16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3(float3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4(float4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8(float8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16(float16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar(float x)
@@ -3750,32 +7150,66 @@ uchar convert_uchar(float x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2(float2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4(float4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8(float8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16(float16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3(float3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4(float4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8(float8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16(float16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short(float x)
@@ -3786,32 +7220,66 @@ short convert_short(float x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2(float2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4(float4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8(float8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16(float16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3(float3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4(float4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8(float8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16(float16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort(float x)
@@ -3822,32 +7290,66 @@ ushort convert_ushort(float x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2(float2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4(float4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8(float8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16(float16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3(float3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4(float4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8(float8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16(float16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int(float x)
@@ -3858,32 +7360,66 @@ int convert_int(float x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2(float2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4(float4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8(float8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16(float16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3(float3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4(float4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8(float8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16(float16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint(float x)
@@ -3894,32 +7430,66 @@ uint convert_uint(float x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2(float2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4(float4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8(float8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16(float16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3(float3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4(float4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8(float8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16(float16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -3931,32 +7501,66 @@ long convert_long(float x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2(float2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4(float4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8(float8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16(float16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3(float3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4(float4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8(float8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16(float16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -3969,32 +7573,66 @@ ulong convert_ulong(float x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2(float2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4(float4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8(float8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16(float16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3(float3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4(float4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8(float8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16(float16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp16)
@@ -4007,32 +7645,66 @@ half convert_half(float x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half2 convert_half2(float2 x)
 {
-  return (half2)(convert_half(x.lo), convert_half(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half4 convert_half4(float4 x)
-{
-  return (half4)(convert_half2(x.lo), convert_half2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half8 convert_half8(float8 x)
-{
-  return (half8)(convert_half4(x.lo), convert_half4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half16 convert_half16(float16 x)
-{
-  return (half16)(convert_half8(x.lo), convert_half8(x.hi));
+  return (half2)(
+    (half)x.s0,
+    (half)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half3 convert_half3(float3 x)
 {
-  return (half3)(convert_half2(x.s01), convert_half(x.s2));
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4(float4 x)
+{
+  return (half4)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8(float8 x)
+{
+  return (half8)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16(float16 x)
+{
+  return (half16)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7,
+    (half)x.s8,
+    (half)x.s9,
+    (half)x.sa,
+    (half)x.sb,
+    (half)x.sc,
+    (half)x.sd,
+    (half)x.se,
+    (half)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4044,32 +7716,66 @@ float convert_float(float x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float2 convert_float2(float2 x)
 {
-  return (float2)(convert_float(x.lo), convert_float(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float4 convert_float4(float4 x)
-{
-  return (float4)(convert_float2(x.lo), convert_float2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float8 convert_float8(float8 x)
-{
-  return (float8)(convert_float4(x.lo), convert_float4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float16 convert_float16(float16 x)
-{
-  return (float16)(convert_float8(x.lo), convert_float8(x.hi));
+  return (float2)(
+    (float)x.s0,
+    (float)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float3 convert_float3(float3 x)
 {
-  return (float3)(convert_float2(x.s01), convert_float(x.s2));
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float4 convert_float4(float4 x)
+{
+  return (float4)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float8 convert_float8(float8 x)
+{
+  return (float8)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float16 convert_float16(float16 x)
+{
+  return (float16)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7,
+    (float)x.s8,
+    (float)x.s9,
+    (float)x.sa,
+    (float)x.sb,
+    (float)x.sc,
+    (float)x.sd,
+    (float)x.se,
+    (float)x.sf);
+}
+
 
 #if defined(cl_khr_fp64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4081,32 +7787,66 @@ double convert_double(float x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double2 convert_double2(float2 x)
 {
-  return (double2)(convert_double(x.lo), convert_double(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double4 convert_double4(float4 x)
-{
-  return (double4)(convert_double2(x.lo), convert_double2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double8 convert_double8(float8 x)
-{
-  return (double8)(convert_double4(x.lo), convert_double4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double16 convert_double16(float16 x)
-{
-  return (double16)(convert_double8(x.lo), convert_double8(x.hi));
+  return (double2)(
+    (double)x.s0,
+    (double)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double3 convert_double3(float3 x)
 {
-  return (double3)(convert_double2(x.s01), convert_double(x.s2));
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double4 convert_double4(float4 x)
+{
+  return (double4)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double8 convert_double8(float8 x)
+{
+  return (double8)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double16 convert_double16(float16 x)
+{
+  return (double16)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7,
+    (double)x.s8,
+    (double)x.s9,
+    (double)x.sa,
+    (double)x.sb,
+    (double)x.sc,
+    (double)x.sd,
+    (double)x.se,
+    (double)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -4119,32 +7859,66 @@ char convert_char(double x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2(double2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4(double4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8(double8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16(double16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3(double3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4(double4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8(double8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16(double16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -4157,32 +7931,66 @@ uchar convert_uchar(double x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2(double2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4(double4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8(double8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16(double16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3(double3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4(double4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8(double8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16(double16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -4195,32 +8003,66 @@ short convert_short(double x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2(double2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4(double4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8(double8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16(double16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3(double3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4(double4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8(double8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16(double16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -4233,32 +8075,66 @@ ushort convert_ushort(double x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2(double2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4(double4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8(double8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16(double16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3(double3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4(double4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8(double8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16(double16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -4271,32 +8147,66 @@ int convert_int(double x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2(double2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4(double4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8(double8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16(double16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3(double3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4(double4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8(double8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16(double16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -4309,32 +8219,66 @@ uint convert_uint(double x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2(double2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4(double4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8(double8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16(double16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3(double3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4(double4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8(double8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16(double16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp64)
@@ -4347,32 +8291,66 @@ long convert_long(double x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2(double2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4(double4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8(double8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16(double16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3(double3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4(double4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8(double8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16(double16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64) && defined(cl_khr_fp64)
@@ -4385,32 +8363,66 @@ ulong convert_ulong(double x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2(double2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4(double4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8(double8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16(double16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3(double3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4(double4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8(double8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16(double16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp64) && defined(cl_khr_fp16)
@@ -4423,32 +8435,66 @@ half convert_half(double x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half2 convert_half2(double2 x)
 {
-  return (half2)(convert_half(x.lo), convert_half(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half4 convert_half4(double4 x)
-{
-  return (half4)(convert_half2(x.lo), convert_half2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half8 convert_half8(double8 x)
-{
-  return (half8)(convert_half4(x.lo), convert_half4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-half16 convert_half16(double16 x)
-{
-  return (half16)(convert_half8(x.lo), convert_half8(x.hi));
+  return (half2)(
+    (half)x.s0,
+    (half)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 half3 convert_half3(double3 x)
 {
-  return (half3)(convert_half2(x.s01), convert_half(x.s2));
+  return (half3)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4(double4 x)
+{
+  return (half4)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8(double8 x)
+{
+  return (half8)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16(double16 x)
+{
+  return (half16)(
+    (half)x.s0,
+    (half)x.s1,
+    (half)x.s2,
+    (half)x.s3,
+    (half)x.s4,
+    (half)x.s5,
+    (half)x.s6,
+    (half)x.s7,
+    (half)x.s8,
+    (half)x.s9,
+    (half)x.sa,
+    (half)x.sb,
+    (half)x.sc,
+    (half)x.sd,
+    (half)x.se,
+    (half)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -4461,32 +8507,66 @@ float convert_float(double x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float2 convert_float2(double2 x)
 {
-  return (float2)(convert_float(x.lo), convert_float(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float4 convert_float4(double4 x)
-{
-  return (float4)(convert_float2(x.lo), convert_float2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float8 convert_float8(double8 x)
-{
-  return (float8)(convert_float4(x.lo), convert_float4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-float16 convert_float16(double16 x)
-{
-  return (float16)(convert_float8(x.lo), convert_float8(x.hi));
+  return (float2)(
+    (float)x.s0,
+    (float)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 float3 convert_float3(double3 x)
 {
-  return (float3)(convert_float2(x.s01), convert_float(x.s2));
+  return (float3)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float4 convert_float4(double4 x)
+{
+  return (float4)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float8 convert_float8(double8 x)
+{
+  return (float8)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+float16 convert_float16(double16 x)
+{
+  return (float16)(
+    (float)x.s0,
+    (float)x.s1,
+    (float)x.s2,
+    (float)x.s3,
+    (float)x.s4,
+    (float)x.s5,
+    (float)x.s6,
+    (float)x.s7,
+    (float)x.s8,
+    (float)x.s9,
+    (float)x.sa,
+    (float)x.sb,
+    (float)x.sc,
+    (float)x.sd,
+    (float)x.se,
+    (float)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_fp64)
@@ -4499,32 +8579,66 @@ double convert_double(double x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double2 convert_double2(double2 x)
 {
-  return (double2)(convert_double(x.lo), convert_double(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double4 convert_double4(double4 x)
-{
-  return (double4)(convert_double2(x.lo), convert_double2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double8 convert_double8(double8 x)
-{
-  return (double8)(convert_double4(x.lo), convert_double4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-double16 convert_double16(double16 x)
-{
-  return (double16)(convert_double8(x.lo), convert_double8(x.hi));
+  return (double2)(
+    (double)x.s0,
+    (double)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 double3 convert_double3(double3 x)
 {
-  return (double3)(convert_double2(x.s01), convert_double(x.s2));
+  return (double3)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double4 convert_double4(double4 x)
+{
+  return (double4)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double8 convert_double8(double8 x)
+{
+  return (double8)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+double16 convert_double16(double16 x)
+{
+  return (double16)(
+    (double)x.s0,
+    (double)x.s1,
+    (double)x.s2,
+    (double)x.s3,
+    (double)x.s4,
+    (double)x.s5,
+    (double)x.s6,
+    (double)x.s7,
+    (double)x.s8,
+    (double)x.s9,
+    (double)x.sa,
+    (double)x.sb,
+    (double)x.sc,
+    (double)x.sd,
+    (double)x.se,
+    (double)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -4536,32 +8650,66 @@ char convert_char_rtz(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtz(char2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtz(char4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtz(char8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtz(char16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtz(char3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtz(char4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtz(char8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtz(char16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rte(char x)
@@ -4572,32 +8720,66 @@ char convert_char_rte(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rte(char2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rte(char4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rte(char8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rte(char16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rte(char3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rte(char4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rte(char8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rte(char16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtp(char x)
@@ -4608,32 +8790,66 @@ char convert_char_rtp(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtp(char2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtp(char4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtp(char8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtp(char16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtp(char3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtp(char4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtp(char8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtp(char16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtn(char x)
@@ -4644,32 +8860,66 @@ char convert_char_rtn(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtn(char2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtn(char4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtn(char8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtn(char16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtn(char3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtn(char4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtn(char8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtn(char16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtz(char x)
@@ -4680,32 +8930,66 @@ uchar convert_uchar_rtz(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtz(char2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtz(char4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtz(char8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtz(char16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtz(char3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtz(char4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtz(char8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtz(char16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rte(char x)
@@ -4716,32 +9000,66 @@ uchar convert_uchar_rte(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rte(char2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rte(char4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rte(char8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rte(char16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rte(char3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rte(char4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rte(char8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rte(char16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtp(char x)
@@ -4752,32 +9070,66 @@ uchar convert_uchar_rtp(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtp(char2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtp(char4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtp(char8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtp(char16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtp(char3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtp(char4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtp(char8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtp(char16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtn(char x)
@@ -4788,32 +9140,66 @@ uchar convert_uchar_rtn(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtn(char2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtn(char4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtn(char8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtn(char16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtn(char3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtn(char4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtn(char8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtn(char16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtz(char x)
@@ -4824,32 +9210,66 @@ short convert_short_rtz(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtz(char2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtz(char4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtz(char8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtz(char16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtz(char3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtz(char4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtz(char8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtz(char16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rte(char x)
@@ -4860,32 +9280,66 @@ short convert_short_rte(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rte(char2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rte(char4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rte(char8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rte(char16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rte(char3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rte(char4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rte(char8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rte(char16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtp(char x)
@@ -4896,32 +9350,66 @@ short convert_short_rtp(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtp(char2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtp(char4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtp(char8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtp(char16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtp(char3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtp(char4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtp(char8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtp(char16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtn(char x)
@@ -4932,32 +9420,66 @@ short convert_short_rtn(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtn(char2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtn(char4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtn(char8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtn(char16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtn(char3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtn(char4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtn(char8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtn(char16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtz(char x)
@@ -4968,32 +9490,66 @@ ushort convert_ushort_rtz(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtz(char2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtz(char4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtz(char8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtz(char16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtz(char3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtz(char4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtz(char8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtz(char16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rte(char x)
@@ -5004,32 +9560,66 @@ ushort convert_ushort_rte(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rte(char2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rte(char4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rte(char8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rte(char16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rte(char3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rte(char4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rte(char8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rte(char16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtp(char x)
@@ -5040,32 +9630,66 @@ ushort convert_ushort_rtp(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtp(char2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtp(char4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtp(char8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtp(char16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtp(char3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtp(char4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtp(char8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtp(char16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtn(char x)
@@ -5076,32 +9700,66 @@ ushort convert_ushort_rtn(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtn(char2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtn(char4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtn(char8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtn(char16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtn(char3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtn(char4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtn(char8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtn(char16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtz(char x)
@@ -5112,32 +9770,66 @@ int convert_int_rtz(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtz(char2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtz(char4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtz(char8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtz(char16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtz(char3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtz(char4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtz(char8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtz(char16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rte(char x)
@@ -5148,32 +9840,66 @@ int convert_int_rte(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rte(char2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rte(char4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rte(char8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rte(char16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rte(char3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rte(char4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rte(char8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rte(char16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtp(char x)
@@ -5184,32 +9910,66 @@ int convert_int_rtp(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtp(char2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtp(char4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtp(char8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtp(char16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtp(char3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtp(char4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtp(char8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtp(char16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtn(char x)
@@ -5220,32 +9980,66 @@ int convert_int_rtn(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtn(char2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtn(char4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtn(char8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtn(char16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtn(char3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtn(char4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtn(char8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtn(char16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtz(char x)
@@ -5256,32 +10050,66 @@ uint convert_uint_rtz(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtz(char2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtz(char4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtz(char8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtz(char16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtz(char3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtz(char4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtz(char8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtz(char16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rte(char x)
@@ -5292,32 +10120,66 @@ uint convert_uint_rte(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rte(char2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rte(char4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rte(char8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rte(char16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rte(char3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rte(char4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rte(char8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rte(char16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtp(char x)
@@ -5328,32 +10190,66 @@ uint convert_uint_rtp(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtp(char2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtp(char4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtp(char8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtp(char16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtp(char3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtp(char4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtp(char8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtp(char16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtn(char x)
@@ -5364,32 +10260,66 @@ uint convert_uint_rtn(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtn(char2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtn(char4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtn(char8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtn(char16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtn(char3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtn(char4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtn(char8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtn(char16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5401,32 +10331,66 @@ long convert_long_rtz(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtz(char2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtz(char4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtz(char8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtz(char16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtz(char3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtz(char4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtz(char8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtz(char16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5439,32 +10403,66 @@ long convert_long_rte(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rte(char2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rte(char4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rte(char8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rte(char16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rte(char3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rte(char4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rte(char8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rte(char16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5477,32 +10475,66 @@ long convert_long_rtp(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtp(char2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtp(char4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtp(char8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtp(char16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtp(char3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtp(char4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtp(char8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtp(char16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5515,32 +10547,66 @@ long convert_long_rtn(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtn(char2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtn(char4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtn(char8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtn(char16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtn(char3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtn(char4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtn(char8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtn(char16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5553,32 +10619,66 @@ ulong convert_ulong_rtz(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtz(char2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtz(char4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtz(char8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtz(char16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtz(char3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtz(char4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtz(char8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtz(char16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5591,32 +10691,66 @@ ulong convert_ulong_rte(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rte(char2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rte(char4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rte(char8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rte(char16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rte(char3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rte(char4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rte(char8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rte(char16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5629,32 +10763,66 @@ ulong convert_ulong_rtp(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtp(char2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtp(char4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtp(char8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtp(char16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtp(char3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtp(char4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtp(char8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtp(char16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -5667,32 +10835,66 @@ ulong convert_ulong_rtn(char x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtn(char2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtn(char4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtn(char8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtn(char16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtn(char3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtn(char4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtn(char8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtn(char16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -5704,32 +10906,66 @@ char convert_char_rtz(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtz(uchar2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtz(uchar4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtz(uchar8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtz(uchar16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtz(uchar3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtz(uchar4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtz(uchar8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtz(uchar16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rte(uchar x)
@@ -5740,32 +10976,66 @@ char convert_char_rte(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rte(uchar2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rte(uchar4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rte(uchar8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rte(uchar16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rte(uchar3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rte(uchar4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rte(uchar8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rte(uchar16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtp(uchar x)
@@ -5776,32 +11046,66 @@ char convert_char_rtp(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtp(uchar2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtp(uchar4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtp(uchar8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtp(uchar16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtp(uchar3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtp(uchar4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtp(uchar8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtp(uchar16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtn(uchar x)
@@ -5812,32 +11116,66 @@ char convert_char_rtn(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtn(uchar2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtn(uchar4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtn(uchar8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtn(uchar16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtn(uchar3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtn(uchar4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtn(uchar8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtn(uchar16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtz(uchar x)
@@ -5848,32 +11186,66 @@ uchar convert_uchar_rtz(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtz(uchar2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtz(uchar4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtz(uchar8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtz(uchar16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtz(uchar3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtz(uchar4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtz(uchar8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtz(uchar16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rte(uchar x)
@@ -5884,32 +11256,66 @@ uchar convert_uchar_rte(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rte(uchar2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rte(uchar4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rte(uchar8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rte(uchar16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rte(uchar3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rte(uchar4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rte(uchar8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rte(uchar16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtp(uchar x)
@@ -5920,32 +11326,66 @@ uchar convert_uchar_rtp(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtp(uchar2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtp(uchar4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtp(uchar8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtp(uchar16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtp(uchar3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtp(uchar4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtp(uchar8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtp(uchar16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtn(uchar x)
@@ -5956,32 +11396,66 @@ uchar convert_uchar_rtn(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtn(uchar2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtn(uchar4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtn(uchar8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtn(uchar16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtn(uchar3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtn(uchar4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtn(uchar8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtn(uchar16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtz(uchar x)
@@ -5992,32 +11466,66 @@ short convert_short_rtz(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtz(uchar2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtz(uchar4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtz(uchar8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtz(uchar16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtz(uchar3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtz(uchar4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtz(uchar8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtz(uchar16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rte(uchar x)
@@ -6028,32 +11536,66 @@ short convert_short_rte(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rte(uchar2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rte(uchar4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rte(uchar8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rte(uchar16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rte(uchar3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rte(uchar4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rte(uchar8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rte(uchar16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtp(uchar x)
@@ -6064,32 +11606,66 @@ short convert_short_rtp(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtp(uchar2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtp(uchar4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtp(uchar8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtp(uchar16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtp(uchar3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtp(uchar4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtp(uchar8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtp(uchar16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtn(uchar x)
@@ -6100,32 +11676,66 @@ short convert_short_rtn(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtn(uchar2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtn(uchar4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtn(uchar8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtn(uchar16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtn(uchar3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtn(uchar4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtn(uchar8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtn(uchar16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtz(uchar x)
@@ -6136,32 +11746,66 @@ ushort convert_ushort_rtz(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtz(uchar2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtz(uchar4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtz(uchar8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtz(uchar16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtz(uchar3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtz(uchar4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtz(uchar8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtz(uchar16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rte(uchar x)
@@ -6172,32 +11816,66 @@ ushort convert_ushort_rte(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rte(uchar2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rte(uchar4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rte(uchar8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rte(uchar16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rte(uchar3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rte(uchar4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rte(uchar8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rte(uchar16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtp(uchar x)
@@ -6208,32 +11886,66 @@ ushort convert_ushort_rtp(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtp(uchar2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtp(uchar4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtp(uchar8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtp(uchar16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtp(uchar3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtp(uchar4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtp(uchar8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtp(uchar16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtn(uchar x)
@@ -6244,32 +11956,66 @@ ushort convert_ushort_rtn(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtn(uchar2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtn(uchar4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtn(uchar8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtn(uchar16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtn(uchar3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtn(uchar4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtn(uchar8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtn(uchar16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtz(uchar x)
@@ -6280,32 +12026,66 @@ int convert_int_rtz(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtz(uchar2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtz(uchar4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtz(uchar8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtz(uchar16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtz(uchar3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtz(uchar4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtz(uchar8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtz(uchar16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rte(uchar x)
@@ -6316,32 +12096,66 @@ int convert_int_rte(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rte(uchar2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rte(uchar4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rte(uchar8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rte(uchar16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rte(uchar3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rte(uchar4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rte(uchar8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rte(uchar16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtp(uchar x)
@@ -6352,32 +12166,66 @@ int convert_int_rtp(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtp(uchar2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtp(uchar4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtp(uchar8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtp(uchar16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtp(uchar3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtp(uchar4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtp(uchar8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtp(uchar16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtn(uchar x)
@@ -6388,32 +12236,66 @@ int convert_int_rtn(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtn(uchar2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtn(uchar4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtn(uchar8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtn(uchar16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtn(uchar3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtn(uchar4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtn(uchar8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtn(uchar16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtz(uchar x)
@@ -6424,32 +12306,66 @@ uint convert_uint_rtz(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtz(uchar2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtz(uchar4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtz(uchar8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtz(uchar16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtz(uchar3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtz(uchar4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtz(uchar8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtz(uchar16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rte(uchar x)
@@ -6460,32 +12376,66 @@ uint convert_uint_rte(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rte(uchar2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rte(uchar4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rte(uchar8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rte(uchar16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rte(uchar3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rte(uchar4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rte(uchar8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rte(uchar16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtp(uchar x)
@@ -6496,32 +12446,66 @@ uint convert_uint_rtp(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtp(uchar2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtp(uchar4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtp(uchar8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtp(uchar16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtp(uchar3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtp(uchar4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtp(uchar8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtp(uchar16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtn(uchar x)
@@ -6532,32 +12516,66 @@ uint convert_uint_rtn(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtn(uchar2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtn(uchar4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtn(uchar8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtn(uchar16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtn(uchar3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtn(uchar4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtn(uchar8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtn(uchar16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6569,32 +12587,66 @@ long convert_long_rtz(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtz(uchar2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtz(uchar4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtz(uchar8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtz(uchar16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtz(uchar3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtz(uchar4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtz(uchar8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtz(uchar16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -6607,32 +12659,66 @@ long convert_long_rte(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rte(uchar2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rte(uchar4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rte(uchar8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rte(uchar16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rte(uchar3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rte(uchar4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rte(uchar8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rte(uchar16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -6645,32 +12731,66 @@ long convert_long_rtp(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtp(uchar2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtp(uchar4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtp(uchar8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtp(uchar16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtp(uchar3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtp(uchar4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtp(uchar8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtp(uchar16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -6683,32 +12803,66 @@ long convert_long_rtn(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtn(uchar2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtn(uchar4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtn(uchar8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtn(uchar16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtn(uchar3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtn(uchar4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtn(uchar8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtn(uchar16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -6721,32 +12875,66 @@ ulong convert_ulong_rtz(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtz(uchar2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtz(uchar4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtz(uchar8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtz(uchar16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtz(uchar3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtz(uchar4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtz(uchar8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtz(uchar16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -6759,32 +12947,66 @@ ulong convert_ulong_rte(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rte(uchar2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rte(uchar4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rte(uchar8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rte(uchar16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rte(uchar3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rte(uchar4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rte(uchar8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rte(uchar16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -6797,32 +13019,66 @@ ulong convert_ulong_rtp(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtp(uchar2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtp(uchar4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtp(uchar8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtp(uchar16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtp(uchar3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtp(uchar4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtp(uchar8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtp(uchar16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -6835,32 +13091,66 @@ ulong convert_ulong_rtn(uchar x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtn(uchar2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtn(uchar4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtn(uchar8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtn(uchar16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtn(uchar3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtn(uchar4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtn(uchar8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtn(uchar16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -6872,32 +13162,66 @@ char convert_char_rtz(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtz(short2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtz(short4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtz(short8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtz(short16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtz(short3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtz(short4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtz(short8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtz(short16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rte(short x)
@@ -6908,32 +13232,66 @@ char convert_char_rte(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rte(short2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rte(short4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rte(short8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rte(short16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rte(short3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rte(short4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rte(short8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rte(short16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtp(short x)
@@ -6944,32 +13302,66 @@ char convert_char_rtp(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtp(short2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtp(short4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtp(short8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtp(short16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtp(short3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtp(short4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtp(short8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtp(short16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtn(short x)
@@ -6980,32 +13372,66 @@ char convert_char_rtn(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtn(short2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtn(short4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtn(short8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtn(short16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtn(short3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtn(short4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtn(short8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtn(short16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtz(short x)
@@ -7016,32 +13442,66 @@ uchar convert_uchar_rtz(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtz(short2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtz(short4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtz(short8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtz(short16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtz(short3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtz(short4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtz(short8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtz(short16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rte(short x)
@@ -7052,32 +13512,66 @@ uchar convert_uchar_rte(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rte(short2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rte(short4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rte(short8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rte(short16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rte(short3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rte(short4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rte(short8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rte(short16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtp(short x)
@@ -7088,32 +13582,66 @@ uchar convert_uchar_rtp(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtp(short2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtp(short4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtp(short8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtp(short16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtp(short3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtp(short4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtp(short8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtp(short16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtn(short x)
@@ -7124,32 +13652,66 @@ uchar convert_uchar_rtn(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtn(short2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtn(short4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtn(short8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtn(short16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtn(short3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtn(short4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtn(short8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtn(short16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtz(short x)
@@ -7160,32 +13722,66 @@ short convert_short_rtz(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtz(short2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtz(short4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtz(short8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtz(short16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtz(short3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtz(short4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtz(short8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtz(short16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rte(short x)
@@ -7196,32 +13792,66 @@ short convert_short_rte(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rte(short2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rte(short4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rte(short8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rte(short16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rte(short3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rte(short4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rte(short8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rte(short16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtp(short x)
@@ -7232,32 +13862,66 @@ short convert_short_rtp(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtp(short2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtp(short4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtp(short8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtp(short16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtp(short3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtp(short4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtp(short8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtp(short16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtn(short x)
@@ -7268,32 +13932,66 @@ short convert_short_rtn(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtn(short2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtn(short4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtn(short8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtn(short16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtn(short3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtn(short4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtn(short8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtn(short16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtz(short x)
@@ -7304,32 +14002,66 @@ ushort convert_ushort_rtz(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtz(short2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtz(short4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtz(short8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtz(short16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtz(short3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtz(short4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtz(short8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtz(short16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rte(short x)
@@ -7340,32 +14072,66 @@ ushort convert_ushort_rte(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rte(short2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rte(short4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rte(short8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rte(short16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rte(short3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rte(short4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rte(short8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rte(short16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtp(short x)
@@ -7376,32 +14142,66 @@ ushort convert_ushort_rtp(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtp(short2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtp(short4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtp(short8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtp(short16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtp(short3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtp(short4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtp(short8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtp(short16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtn(short x)
@@ -7412,32 +14212,66 @@ ushort convert_ushort_rtn(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtn(short2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtn(short4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtn(short8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtn(short16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtn(short3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtn(short4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtn(short8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtn(short16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtz(short x)
@@ -7448,32 +14282,66 @@ int convert_int_rtz(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtz(short2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtz(short4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtz(short8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtz(short16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtz(short3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtz(short4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtz(short8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtz(short16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rte(short x)
@@ -7484,32 +14352,66 @@ int convert_int_rte(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rte(short2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rte(short4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rte(short8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rte(short16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rte(short3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rte(short4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rte(short8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rte(short16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtp(short x)
@@ -7520,32 +14422,66 @@ int convert_int_rtp(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtp(short2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtp(short4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtp(short8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtp(short16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtp(short3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtp(short4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtp(short8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtp(short16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtn(short x)
@@ -7556,32 +14492,66 @@ int convert_int_rtn(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtn(short2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtn(short4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtn(short8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtn(short16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtn(short3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtn(short4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtn(short8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtn(short16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtz(short x)
@@ -7592,32 +14562,66 @@ uint convert_uint_rtz(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtz(short2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtz(short4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtz(short8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtz(short16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtz(short3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtz(short4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtz(short8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtz(short16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rte(short x)
@@ -7628,32 +14632,66 @@ uint convert_uint_rte(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rte(short2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rte(short4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rte(short8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rte(short16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rte(short3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rte(short4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rte(short8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rte(short16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtp(short x)
@@ -7664,32 +14702,66 @@ uint convert_uint_rtp(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtp(short2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtp(short4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtp(short8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtp(short16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtp(short3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtp(short4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtp(short8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtp(short16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtn(short x)
@@ -7700,32 +14772,66 @@ uint convert_uint_rtn(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtn(short2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtn(short4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtn(short8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtn(short16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtn(short3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtn(short4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtn(short8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtn(short16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -7737,32 +14843,66 @@ long convert_long_rtz(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtz(short2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtz(short4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtz(short8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtz(short16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtz(short3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtz(short4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtz(short8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtz(short16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -7775,32 +14915,66 @@ long convert_long_rte(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rte(short2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rte(short4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rte(short8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rte(short16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rte(short3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rte(short4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rte(short8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rte(short16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -7813,32 +14987,66 @@ long convert_long_rtp(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtp(short2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtp(short4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtp(short8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtp(short16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtp(short3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtp(short4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtp(short8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtp(short16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -7851,32 +15059,66 @@ long convert_long_rtn(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtn(short2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtn(short4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtn(short8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtn(short16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtn(short3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtn(short4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtn(short8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtn(short16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -7889,32 +15131,66 @@ ulong convert_ulong_rtz(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtz(short2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtz(short4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtz(short8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtz(short16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtz(short3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtz(short4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtz(short8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtz(short16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -7927,32 +15203,66 @@ ulong convert_ulong_rte(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rte(short2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rte(short4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rte(short8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rte(short16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rte(short3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rte(short4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rte(short8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rte(short16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -7965,32 +15275,66 @@ ulong convert_ulong_rtp(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtp(short2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtp(short4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtp(short8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtp(short16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtp(short3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtp(short4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtp(short8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtp(short16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -8003,32 +15347,66 @@ ulong convert_ulong_rtn(short x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtn(short2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtn(short4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtn(short8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtn(short16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtn(short3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtn(short4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtn(short8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtn(short16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8040,32 +15418,66 @@ char convert_char_rtz(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtz(ushort2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtz(ushort4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtz(ushort8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtz(ushort16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtz(ushort3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtz(ushort4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtz(ushort8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtz(ushort16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rte(ushort x)
@@ -8076,32 +15488,66 @@ char convert_char_rte(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rte(ushort2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rte(ushort4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rte(ushort8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rte(ushort16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rte(ushort3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rte(ushort4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rte(ushort8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rte(ushort16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtp(ushort x)
@@ -8112,32 +15558,66 @@ char convert_char_rtp(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtp(ushort2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtp(ushort4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtp(ushort8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtp(ushort16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtp(ushort3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtp(ushort4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtp(ushort8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtp(ushort16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtn(ushort x)
@@ -8148,32 +15628,66 @@ char convert_char_rtn(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtn(ushort2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtn(ushort4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtn(ushort8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtn(ushort16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtn(ushort3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtn(ushort4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtn(ushort8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtn(ushort16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtz(ushort x)
@@ -8184,32 +15698,66 @@ uchar convert_uchar_rtz(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtz(ushort2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtz(ushort4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtz(ushort8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtz(ushort16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtz(ushort3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtz(ushort4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtz(ushort8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtz(ushort16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rte(ushort x)
@@ -8220,32 +15768,66 @@ uchar convert_uchar_rte(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rte(ushort2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rte(ushort4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rte(ushort8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rte(ushort16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rte(ushort3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rte(ushort4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rte(ushort8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rte(ushort16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtp(ushort x)
@@ -8256,32 +15838,66 @@ uchar convert_uchar_rtp(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtp(ushort2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtp(ushort4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtp(ushort8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtp(ushort16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtp(ushort3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtp(ushort4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtp(ushort8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtp(ushort16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtn(ushort x)
@@ -8292,32 +15908,66 @@ uchar convert_uchar_rtn(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtn(ushort2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtn(ushort4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtn(ushort8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtn(ushort16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtn(ushort3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtn(ushort4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtn(ushort8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtn(ushort16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtz(ushort x)
@@ -8328,32 +15978,66 @@ short convert_short_rtz(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtz(ushort2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtz(ushort4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtz(ushort8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtz(ushort16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtz(ushort3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtz(ushort4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtz(ushort8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtz(ushort16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rte(ushort x)
@@ -8364,32 +16048,66 @@ short convert_short_rte(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rte(ushort2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rte(ushort4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rte(ushort8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rte(ushort16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rte(ushort3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rte(ushort4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rte(ushort8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rte(ushort16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtp(ushort x)
@@ -8400,32 +16118,66 @@ short convert_short_rtp(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtp(ushort2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtp(ushort4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtp(ushort8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtp(ushort16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtp(ushort3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtp(ushort4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtp(ushort8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtp(ushort16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtn(ushort x)
@@ -8436,32 +16188,66 @@ short convert_short_rtn(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtn(ushort2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtn(ushort4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtn(ushort8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtn(ushort16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtn(ushort3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtn(ushort4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtn(ushort8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtn(ushort16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtz(ushort x)
@@ -8472,32 +16258,66 @@ ushort convert_ushort_rtz(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtz(ushort2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtz(ushort4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtz(ushort8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtz(ushort16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtz(ushort3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtz(ushort4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtz(ushort8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtz(ushort16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rte(ushort x)
@@ -8508,32 +16328,66 @@ ushort convert_ushort_rte(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rte(ushort2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rte(ushort4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rte(ushort8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rte(ushort16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rte(ushort3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rte(ushort4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rte(ushort8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rte(ushort16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtp(ushort x)
@@ -8544,32 +16398,66 @@ ushort convert_ushort_rtp(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtp(ushort2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtp(ushort4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtp(ushort8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtp(ushort16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtp(ushort3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtp(ushort4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtp(ushort8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtp(ushort16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtn(ushort x)
@@ -8580,32 +16468,66 @@ ushort convert_ushort_rtn(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtn(ushort2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtn(ushort4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtn(ushort8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtn(ushort16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtn(ushort3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtn(ushort4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtn(ushort8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtn(ushort16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtz(ushort x)
@@ -8616,32 +16538,66 @@ int convert_int_rtz(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtz(ushort2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtz(ushort4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtz(ushort8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtz(ushort16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtz(ushort3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtz(ushort4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtz(ushort8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtz(ushort16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rte(ushort x)
@@ -8652,32 +16608,66 @@ int convert_int_rte(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rte(ushort2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rte(ushort4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rte(ushort8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rte(ushort16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rte(ushort3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rte(ushort4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rte(ushort8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rte(ushort16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtp(ushort x)
@@ -8688,32 +16678,66 @@ int convert_int_rtp(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtp(ushort2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtp(ushort4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtp(ushort8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtp(ushort16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtp(ushort3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtp(ushort4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtp(ushort8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtp(ushort16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtn(ushort x)
@@ -8724,32 +16748,66 @@ int convert_int_rtn(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtn(ushort2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtn(ushort4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtn(ushort8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtn(ushort16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtn(ushort3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtn(ushort4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtn(ushort8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtn(ushort16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtz(ushort x)
@@ -8760,32 +16818,66 @@ uint convert_uint_rtz(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtz(ushort2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtz(ushort4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtz(ushort8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtz(ushort16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtz(ushort3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtz(ushort4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtz(ushort8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtz(ushort16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rte(ushort x)
@@ -8796,32 +16888,66 @@ uint convert_uint_rte(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rte(ushort2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rte(ushort4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rte(ushort8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rte(ushort16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rte(ushort3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rte(ushort4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rte(ushort8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rte(ushort16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtp(ushort x)
@@ -8832,32 +16958,66 @@ uint convert_uint_rtp(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtp(ushort2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtp(ushort4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtp(ushort8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtp(ushort16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtp(ushort3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtp(ushort4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtp(ushort8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtp(ushort16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtn(ushort x)
@@ -8868,32 +17028,66 @@ uint convert_uint_rtn(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtn(ushort2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtn(ushort4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtn(ushort8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtn(ushort16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtn(ushort3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtn(ushort4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtn(ushort8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtn(ushort16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -8905,32 +17099,66 @@ long convert_long_rtz(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtz(ushort2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtz(ushort4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtz(ushort8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtz(ushort16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtz(ushort3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtz(ushort4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtz(ushort8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtz(ushort16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -8943,32 +17171,66 @@ long convert_long_rte(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rte(ushort2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rte(ushort4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rte(ushort8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rte(ushort16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rte(ushort3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rte(ushort4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rte(ushort8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rte(ushort16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -8981,32 +17243,66 @@ long convert_long_rtp(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtp(ushort2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtp(ushort4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtp(ushort8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtp(ushort16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtp(ushort3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtp(ushort4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtp(ushort8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtp(ushort16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -9019,32 +17315,66 @@ long convert_long_rtn(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtn(ushort2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtn(ushort4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtn(ushort8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtn(ushort16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtn(ushort3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtn(ushort4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtn(ushort8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtn(ushort16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -9057,32 +17387,66 @@ ulong convert_ulong_rtz(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtz(ushort2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtz(ushort4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtz(ushort8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtz(ushort16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtz(ushort3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtz(ushort4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtz(ushort8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtz(ushort16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -9095,32 +17459,66 @@ ulong convert_ulong_rte(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rte(ushort2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rte(ushort4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rte(ushort8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rte(ushort16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rte(ushort3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rte(ushort4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rte(ushort8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rte(ushort16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -9133,32 +17531,66 @@ ulong convert_ulong_rtp(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtp(ushort2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtp(ushort4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtp(ushort8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtp(ushort16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtp(ushort3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtp(ushort4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtp(ushort8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtp(ushort16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -9171,32 +17603,66 @@ ulong convert_ulong_rtn(ushort x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtn(ushort2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtn(ushort4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtn(ushort8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtn(ushort16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtn(ushort3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtn(ushort4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtn(ushort8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtn(ushort16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -9208,32 +17674,66 @@ char convert_char_rtz(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtz(int2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtz(int4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtz(int8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtz(int16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtz(int3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtz(int4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtz(int8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtz(int16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rte(int x)
@@ -9244,32 +17744,66 @@ char convert_char_rte(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rte(int2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rte(int4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rte(int8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rte(int16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rte(int3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rte(int4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rte(int8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rte(int16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtp(int x)
@@ -9280,32 +17814,66 @@ char convert_char_rtp(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtp(int2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtp(int4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtp(int8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtp(int16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtp(int3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtp(int4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtp(int8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtp(int16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtn(int x)
@@ -9316,32 +17884,66 @@ char convert_char_rtn(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtn(int2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtn(int4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtn(int8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtn(int16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtn(int3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtn(int4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtn(int8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtn(int16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtz(int x)
@@ -9352,32 +17954,66 @@ uchar convert_uchar_rtz(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtz(int2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtz(int4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtz(int8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtz(int16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtz(int3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtz(int4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtz(int8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtz(int16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rte(int x)
@@ -9388,32 +18024,66 @@ uchar convert_uchar_rte(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rte(int2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rte(int4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rte(int8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rte(int16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rte(int3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rte(int4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rte(int8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rte(int16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtp(int x)
@@ -9424,32 +18094,66 @@ uchar convert_uchar_rtp(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtp(int2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtp(int4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtp(int8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtp(int16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtp(int3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtp(int4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtp(int8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtp(int16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtn(int x)
@@ -9460,32 +18164,66 @@ uchar convert_uchar_rtn(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtn(int2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtn(int4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtn(int8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtn(int16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtn(int3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtn(int4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtn(int8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtn(int16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtz(int x)
@@ -9496,32 +18234,66 @@ short convert_short_rtz(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtz(int2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtz(int4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtz(int8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtz(int16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtz(int3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtz(int4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtz(int8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtz(int16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rte(int x)
@@ -9532,32 +18304,66 @@ short convert_short_rte(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rte(int2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rte(int4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rte(int8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rte(int16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rte(int3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rte(int4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rte(int8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rte(int16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtp(int x)
@@ -9568,32 +18374,66 @@ short convert_short_rtp(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtp(int2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtp(int4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtp(int8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtp(int16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtp(int3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtp(int4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtp(int8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtp(int16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtn(int x)
@@ -9604,32 +18444,66 @@ short convert_short_rtn(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtn(int2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtn(int4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtn(int8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtn(int16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtn(int3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtn(int4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtn(int8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtn(int16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtz(int x)
@@ -9640,32 +18514,66 @@ ushort convert_ushort_rtz(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtz(int2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtz(int4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtz(int8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtz(int16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtz(int3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtz(int4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtz(int8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtz(int16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rte(int x)
@@ -9676,32 +18584,66 @@ ushort convert_ushort_rte(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rte(int2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rte(int4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rte(int8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rte(int16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rte(int3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rte(int4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rte(int8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rte(int16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtp(int x)
@@ -9712,32 +18654,66 @@ ushort convert_ushort_rtp(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtp(int2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtp(int4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtp(int8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtp(int16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtp(int3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtp(int4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtp(int8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtp(int16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtn(int x)
@@ -9748,32 +18724,66 @@ ushort convert_ushort_rtn(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtn(int2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtn(int4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtn(int8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtn(int16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtn(int3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtn(int4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtn(int8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtn(int16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtz(int x)
@@ -9784,32 +18794,66 @@ int convert_int_rtz(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtz(int2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtz(int4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtz(int8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtz(int16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtz(int3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtz(int4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtz(int8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtz(int16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rte(int x)
@@ -9820,32 +18864,66 @@ int convert_int_rte(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rte(int2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rte(int4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rte(int8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rte(int16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rte(int3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rte(int4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rte(int8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rte(int16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtp(int x)
@@ -9856,32 +18934,66 @@ int convert_int_rtp(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtp(int2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtp(int4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtp(int8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtp(int16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtp(int3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtp(int4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtp(int8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtp(int16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtn(int x)
@@ -9892,32 +19004,66 @@ int convert_int_rtn(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtn(int2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtn(int4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtn(int8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtn(int16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtn(int3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtn(int4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtn(int8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtn(int16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtz(int x)
@@ -9928,32 +19074,66 @@ uint convert_uint_rtz(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtz(int2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtz(int4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtz(int8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtz(int16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtz(int3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtz(int4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtz(int8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtz(int16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rte(int x)
@@ -9964,32 +19144,66 @@ uint convert_uint_rte(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rte(int2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rte(int4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rte(int8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rte(int16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rte(int3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rte(int4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rte(int8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rte(int16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtp(int x)
@@ -10000,32 +19214,66 @@ uint convert_uint_rtp(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtp(int2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtp(int4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtp(int8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtp(int16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtp(int3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtp(int4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtp(int8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtp(int16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtn(int x)
@@ -10036,32 +19284,66 @@ uint convert_uint_rtn(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtn(int2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtn(int4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtn(int8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtn(int16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtn(int3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtn(int4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtn(int8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtn(int16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10073,32 +19355,66 @@ long convert_long_rtz(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtz(int2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtz(int4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtz(int8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtz(int16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtz(int3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtz(int4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtz(int8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtz(int16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -10111,32 +19427,66 @@ long convert_long_rte(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rte(int2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rte(int4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rte(int8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rte(int16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rte(int3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rte(int4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rte(int8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rte(int16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -10149,32 +19499,66 @@ long convert_long_rtp(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtp(int2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtp(int4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtp(int8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtp(int16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtp(int3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtp(int4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtp(int8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtp(int16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -10187,32 +19571,66 @@ long convert_long_rtn(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtn(int2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtn(int4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtn(int8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtn(int16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtn(int3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtn(int4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtn(int8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtn(int16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -10225,32 +19643,66 @@ ulong convert_ulong_rtz(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtz(int2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtz(int4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtz(int8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtz(int16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtz(int3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtz(int4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtz(int8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtz(int16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -10263,32 +19715,66 @@ ulong convert_ulong_rte(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rte(int2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rte(int4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rte(int8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rte(int16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rte(int3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rte(int4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rte(int8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rte(int16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -10301,32 +19787,66 @@ ulong convert_ulong_rtp(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtp(int2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtp(int4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtp(int8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtp(int16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtp(int3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtp(int4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtp(int8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtp(int16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -10339,32 +19859,66 @@ ulong convert_ulong_rtn(int x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtn(int2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtn(int4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtn(int8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtn(int16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtn(int3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtn(int4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtn(int8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtn(int16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -10376,32 +19930,66 @@ char convert_char_rtz(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtz(uint2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtz(uint4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtz(uint8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtz(uint16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtz(uint3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtz(uint4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtz(uint8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtz(uint16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rte(uint x)
@@ -10412,32 +20000,66 @@ char convert_char_rte(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rte(uint2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rte(uint4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rte(uint8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rte(uint16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rte(uint3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rte(uint4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rte(uint8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rte(uint16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtp(uint x)
@@ -10448,32 +20070,66 @@ char convert_char_rtp(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtp(uint2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtp(uint4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtp(uint8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtp(uint16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtp(uint3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtp(uint4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtp(uint8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtp(uint16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char convert_char_rtn(uint x)
@@ -10484,32 +20140,66 @@ char convert_char_rtn(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtn(uint2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtn(uint4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtn(uint8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtn(uint16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtn(uint3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtn(uint4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtn(uint8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtn(uint16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtz(uint x)
@@ -10520,32 +20210,66 @@ uchar convert_uchar_rtz(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtz(uint2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtz(uint4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtz(uint8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtz(uint16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtz(uint3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtz(uint4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtz(uint8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtz(uint16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rte(uint x)
@@ -10556,32 +20280,66 @@ uchar convert_uchar_rte(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rte(uint2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rte(uint4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rte(uint8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rte(uint16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rte(uint3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rte(uint4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rte(uint8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rte(uint16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtp(uint x)
@@ -10592,32 +20350,66 @@ uchar convert_uchar_rtp(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtp(uint2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtp(uint4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtp(uint8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtp(uint16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtp(uint3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtp(uint4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtp(uint8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtp(uint16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar convert_uchar_rtn(uint x)
@@ -10628,32 +20420,66 @@ uchar convert_uchar_rtn(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtn(uint2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtn(uint4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtn(uint8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtn(uint16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtn(uint3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtn(uint4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtn(uint8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtn(uint16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtz(uint x)
@@ -10664,32 +20490,66 @@ short convert_short_rtz(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtz(uint2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtz(uint4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtz(uint8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtz(uint16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtz(uint3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtz(uint4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtz(uint8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtz(uint16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rte(uint x)
@@ -10700,32 +20560,66 @@ short convert_short_rte(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rte(uint2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rte(uint4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rte(uint8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rte(uint16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rte(uint3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rte(uint4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rte(uint8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rte(uint16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtp(uint x)
@@ -10736,32 +20630,66 @@ short convert_short_rtp(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtp(uint2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtp(uint4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtp(uint8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtp(uint16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtp(uint3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtp(uint4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtp(uint8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtp(uint16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short convert_short_rtn(uint x)
@@ -10772,32 +20700,66 @@ short convert_short_rtn(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtn(uint2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtn(uint4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtn(uint8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtn(uint16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtn(uint3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtn(uint4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtn(uint8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtn(uint16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtz(uint x)
@@ -10808,32 +20770,66 @@ ushort convert_ushort_rtz(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtz(uint2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtz(uint4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtz(uint8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtz(uint16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtz(uint3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtz(uint4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtz(uint8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtz(uint16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rte(uint x)
@@ -10844,32 +20840,66 @@ ushort convert_ushort_rte(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rte(uint2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rte(uint4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rte(uint8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rte(uint16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rte(uint3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rte(uint4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rte(uint8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rte(uint16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtp(uint x)
@@ -10880,32 +20910,66 @@ ushort convert_ushort_rtp(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtp(uint2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtp(uint4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtp(uint8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtp(uint16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtp(uint3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtp(uint4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtp(uint8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtp(uint16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort convert_ushort_rtn(uint x)
@@ -10916,32 +20980,66 @@ ushort convert_ushort_rtn(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtn(uint2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtn(uint4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtn(uint8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtn(uint16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtn(uint3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtn(uint4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtn(uint8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtn(uint16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtz(uint x)
@@ -10952,32 +21050,66 @@ int convert_int_rtz(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtz(uint2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtz(uint4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtz(uint8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtz(uint16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtz(uint3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtz(uint4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtz(uint8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtz(uint16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rte(uint x)
@@ -10988,32 +21120,66 @@ int convert_int_rte(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rte(uint2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rte(uint4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rte(uint8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rte(uint16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rte(uint3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rte(uint4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rte(uint8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rte(uint16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtp(uint x)
@@ -11024,32 +21190,66 @@ int convert_int_rtp(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtp(uint2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtp(uint4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtp(uint8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtp(uint16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtp(uint3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtp(uint4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtp(uint8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtp(uint16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int convert_int_rtn(uint x)
@@ -11060,32 +21260,66 @@ int convert_int_rtn(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtn(uint2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtn(uint4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtn(uint8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtn(uint16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtn(uint3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtn(uint4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtn(uint8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtn(uint16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtz(uint x)
@@ -11096,32 +21330,66 @@ uint convert_uint_rtz(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtz(uint2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtz(uint4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtz(uint8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtz(uint16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtz(uint3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtz(uint4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtz(uint8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtz(uint16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rte(uint x)
@@ -11132,32 +21400,66 @@ uint convert_uint_rte(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rte(uint2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rte(uint4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rte(uint8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rte(uint16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rte(uint3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rte(uint4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rte(uint8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rte(uint16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtp(uint x)
@@ -11168,32 +21470,66 @@ uint convert_uint_rtp(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtp(uint2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtp(uint4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtp(uint8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtp(uint16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtp(uint3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtp(uint4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtp(uint8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtp(uint16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint convert_uint_rtn(uint x)
@@ -11204,32 +21540,66 @@ uint convert_uint_rtn(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtn(uint2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtn(uint4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtn(uint8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtn(uint16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtn(uint3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtn(uint4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtn(uint8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtn(uint16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 
 #if defined(cl_khr_int64)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
@@ -11241,32 +21611,66 @@ long convert_long_rtz(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtz(uint2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtz(uint4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtz(uint8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtz(uint16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtz(uint3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtz(uint4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtz(uint8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtz(uint16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11279,32 +21683,66 @@ long convert_long_rte(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rte(uint2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rte(uint4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rte(uint8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rte(uint16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rte(uint3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rte(uint4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rte(uint8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rte(uint16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11317,32 +21755,66 @@ long convert_long_rtp(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtp(uint2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtp(uint4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtp(uint8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtp(uint16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtp(uint3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtp(uint4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtp(uint8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtp(uint16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11355,32 +21827,66 @@ long convert_long_rtn(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtn(uint2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtn(uint4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtn(uint8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtn(uint16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtn(uint3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtn(uint4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtn(uint8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtn(uint16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11393,32 +21899,66 @@ ulong convert_ulong_rtz(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtz(uint2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtz(uint4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtz(uint8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtz(uint16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtz(uint3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtz(uint4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtz(uint8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtz(uint16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11431,32 +21971,66 @@ ulong convert_ulong_rte(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rte(uint2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rte(uint4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rte(uint8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rte(uint16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rte(uint3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rte(uint4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rte(uint8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rte(uint16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11469,32 +22043,66 @@ ulong convert_ulong_rtp(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtp(uint2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtp(uint4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtp(uint8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtp(uint16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtp(uint3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtp(uint4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtp(uint8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtp(uint16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11507,32 +22115,66 @@ ulong convert_ulong_rtn(uint x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtn(uint2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtn(uint4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtn(uint8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtn(uint16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtn(uint3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtn(uint4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtn(uint8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtn(uint16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11545,32 +22187,66 @@ char convert_char_rtz(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtz(long2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtz(long4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtz(long8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtz(long16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtz(long3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtz(long4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtz(long8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtz(long16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11583,32 +22259,66 @@ char convert_char_rte(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rte(long2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rte(long4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rte(long8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rte(long16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rte(long3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rte(long4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rte(long8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rte(long16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11621,32 +22331,66 @@ char convert_char_rtp(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtp(long2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtp(long4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtp(long8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtp(long16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtp(long3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtp(long4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtp(long8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtp(long16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11659,32 +22403,66 @@ char convert_char_rtn(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtn(long2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtn(long4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtn(long8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtn(long16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtn(long3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtn(long4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtn(long8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtn(long16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11697,32 +22475,66 @@ uchar convert_uchar_rtz(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtz(long2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtz(long4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtz(long8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtz(long16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtz(long3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtz(long4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtz(long8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtz(long16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11735,32 +22547,66 @@ uchar convert_uchar_rte(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rte(long2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rte(long4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rte(long8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rte(long16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rte(long3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rte(long4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rte(long8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rte(long16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11773,32 +22619,66 @@ uchar convert_uchar_rtp(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtp(long2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtp(long4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtp(long8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtp(long16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtp(long3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtp(long4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtp(long8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtp(long16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11811,32 +22691,66 @@ uchar convert_uchar_rtn(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtn(long2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtn(long4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtn(long8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtn(long16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtn(long3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtn(long4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtn(long8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtn(long16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11849,32 +22763,66 @@ short convert_short_rtz(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtz(long2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtz(long4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtz(long8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtz(long16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtz(long3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtz(long4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtz(long8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtz(long16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11887,32 +22835,66 @@ short convert_short_rte(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rte(long2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rte(long4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rte(long8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rte(long16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rte(long3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rte(long4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rte(long8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rte(long16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11925,32 +22907,66 @@ short convert_short_rtp(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtp(long2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtp(long4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtp(long8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtp(long16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtp(long3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtp(long4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtp(long8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtp(long16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -11963,32 +22979,66 @@ short convert_short_rtn(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtn(long2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtn(long4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtn(long8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtn(long16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtn(long3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtn(long4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtn(long8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtn(long16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12001,32 +23051,66 @@ ushort convert_ushort_rtz(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtz(long2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtz(long4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtz(long8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtz(long16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtz(long3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtz(long4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtz(long8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtz(long16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12039,32 +23123,66 @@ ushort convert_ushort_rte(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rte(long2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rte(long4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rte(long8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rte(long16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rte(long3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rte(long4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rte(long8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rte(long16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12077,32 +23195,66 @@ ushort convert_ushort_rtp(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtp(long2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtp(long4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtp(long8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtp(long16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtp(long3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtp(long4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtp(long8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtp(long16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12115,32 +23267,66 @@ ushort convert_ushort_rtn(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtn(long2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtn(long4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtn(long8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtn(long16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtn(long3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtn(long4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtn(long8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtn(long16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12153,32 +23339,66 @@ int convert_int_rtz(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtz(long2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtz(long4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtz(long8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtz(long16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtz(long3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtz(long4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtz(long8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtz(long16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12191,32 +23411,66 @@ int convert_int_rte(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rte(long2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rte(long4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rte(long8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rte(long16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rte(long3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rte(long4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rte(long8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rte(long16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12229,32 +23483,66 @@ int convert_int_rtp(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtp(long2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtp(long4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtp(long8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtp(long16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtp(long3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtp(long4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtp(long8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtp(long16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12267,32 +23555,66 @@ int convert_int_rtn(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtn(long2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtn(long4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtn(long8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtn(long16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtn(long3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtn(long4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtn(long8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtn(long16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12305,32 +23627,66 @@ uint convert_uint_rtz(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtz(long2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtz(long4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtz(long8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtz(long16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtz(long3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtz(long4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtz(long8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtz(long16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12343,32 +23699,66 @@ uint convert_uint_rte(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rte(long2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rte(long4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rte(long8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rte(long16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rte(long3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rte(long4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rte(long8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rte(long16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12381,32 +23771,66 @@ uint convert_uint_rtp(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtp(long2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtp(long4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtp(long8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtp(long16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtp(long3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtp(long4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtp(long8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtp(long16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12419,32 +23843,66 @@ uint convert_uint_rtn(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtn(long2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtn(long4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtn(long8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtn(long16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtn(long3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtn(long4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtn(long8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtn(long16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12457,32 +23915,66 @@ long convert_long_rtz(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtz(long2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtz(long4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtz(long8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtz(long16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtz(long3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtz(long4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtz(long8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtz(long16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12495,32 +23987,66 @@ long convert_long_rte(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rte(long2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rte(long4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rte(long8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rte(long16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rte(long3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rte(long4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rte(long8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rte(long16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12533,32 +24059,66 @@ long convert_long_rtp(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtp(long2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtp(long4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtp(long8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtp(long16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtp(long3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtp(long4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtp(long8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtp(long16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12571,32 +24131,66 @@ long convert_long_rtn(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtn(long2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtn(long4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtn(long8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtn(long16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtn(long3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtn(long4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtn(long8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtn(long16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12609,32 +24203,66 @@ ulong convert_ulong_rtz(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtz(long2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtz(long4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtz(long8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtz(long16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtz(long3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtz(long4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtz(long8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtz(long16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12647,32 +24275,66 @@ ulong convert_ulong_rte(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rte(long2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rte(long4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rte(long8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rte(long16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rte(long3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rte(long4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rte(long8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rte(long16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12685,32 +24347,66 @@ ulong convert_ulong_rtp(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtp(long2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtp(long4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtp(long8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtp(long16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtp(long3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtp(long4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtp(long8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtp(long16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12723,32 +24419,66 @@ ulong convert_ulong_rtn(long x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtn(long2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtn(long4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtn(long8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtn(long16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtn(long3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtn(long4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtn(long8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtn(long16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12761,32 +24491,66 @@ char convert_char_rtz(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtz(ulong2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtz(ulong4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtz(ulong8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtz(ulong16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtz(ulong3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtz(ulong4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtz(ulong8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtz(ulong16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12799,32 +24563,66 @@ char convert_char_rte(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rte(ulong2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rte(ulong4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rte(ulong8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rte(ulong16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rte(ulong3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rte(ulong4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rte(ulong8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rte(ulong16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12837,32 +24635,66 @@ char convert_char_rtp(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtp(ulong2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtp(ulong4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtp(ulong8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtp(ulong16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtp(ulong3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtp(ulong4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtp(ulong8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtp(ulong16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12875,32 +24707,66 @@ char convert_char_rtn(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char2 convert_char2_rtn(ulong2 x)
 {
-  return (char2)(convert_char(x.lo), convert_char(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char4 convert_char4_rtn(ulong4 x)
-{
-  return (char4)(convert_char2(x.lo), convert_char2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char8 convert_char8_rtn(ulong8 x)
-{
-  return (char8)(convert_char4(x.lo), convert_char4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-char16 convert_char16_rtn(ulong16 x)
-{
-  return (char16)(convert_char8(x.lo), convert_char8(x.hi));
+  return (char2)(
+    (char)x.s0,
+    (char)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 char3 convert_char3_rtn(ulong3 x)
 {
-  return (char3)(convert_char2(x.s01), convert_char(x.s2));
+  return (char3)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtn(ulong4 x)
+{
+  return (char4)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtn(ulong8 x)
+{
+  return (char8)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtn(ulong16 x)
+{
+  return (char16)(
+    (char)x.s0,
+    (char)x.s1,
+    (char)x.s2,
+    (char)x.s3,
+    (char)x.s4,
+    (char)x.s5,
+    (char)x.s6,
+    (char)x.s7,
+    (char)x.s8,
+    (char)x.s9,
+    (char)x.sa,
+    (char)x.sb,
+    (char)x.sc,
+    (char)x.sd,
+    (char)x.se,
+    (char)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12913,32 +24779,66 @@ uchar convert_uchar_rtz(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtz(ulong2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtz(ulong4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtz(ulong8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtz(ulong16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtz(ulong3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtz(ulong4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtz(ulong8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtz(ulong16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12951,32 +24851,66 @@ uchar convert_uchar_rte(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rte(ulong2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rte(ulong4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rte(ulong8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rte(ulong16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rte(ulong3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rte(ulong4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rte(ulong8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rte(ulong16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -12989,32 +24923,66 @@ uchar convert_uchar_rtp(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtp(ulong2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtp(ulong4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtp(ulong8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtp(ulong16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtp(ulong3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtp(ulong4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtp(ulong8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtp(ulong16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13027,32 +24995,66 @@ uchar convert_uchar_rtn(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar2 convert_uchar2_rtn(ulong2 x)
 {
-  return (uchar2)(convert_uchar(x.lo), convert_uchar(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar4 convert_uchar4_rtn(ulong4 x)
-{
-  return (uchar4)(convert_uchar2(x.lo), convert_uchar2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar8 convert_uchar8_rtn(ulong8 x)
-{
-  return (uchar8)(convert_uchar4(x.lo), convert_uchar4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uchar16 convert_uchar16_rtn(ulong16 x)
-{
-  return (uchar16)(convert_uchar8(x.lo), convert_uchar8(x.hi));
+  return (uchar2)(
+    (uchar)x.s0,
+    (uchar)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uchar3 convert_uchar3_rtn(ulong3 x)
 {
-  return (uchar3)(convert_uchar2(x.s01), convert_uchar(x.s2));
+  return (uchar3)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtn(ulong4 x)
+{
+  return (uchar4)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtn(ulong8 x)
+{
+  return (uchar8)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtn(ulong16 x)
+{
+  return (uchar16)(
+    (uchar)x.s0,
+    (uchar)x.s1,
+    (uchar)x.s2,
+    (uchar)x.s3,
+    (uchar)x.s4,
+    (uchar)x.s5,
+    (uchar)x.s6,
+    (uchar)x.s7,
+    (uchar)x.s8,
+    (uchar)x.s9,
+    (uchar)x.sa,
+    (uchar)x.sb,
+    (uchar)x.sc,
+    (uchar)x.sd,
+    (uchar)x.se,
+    (uchar)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13065,32 +25067,66 @@ short convert_short_rtz(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtz(ulong2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtz(ulong4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtz(ulong8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtz(ulong16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtz(ulong3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtz(ulong4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtz(ulong8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtz(ulong16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13103,32 +25139,66 @@ short convert_short_rte(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rte(ulong2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rte(ulong4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rte(ulong8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rte(ulong16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rte(ulong3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rte(ulong4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rte(ulong8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rte(ulong16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13141,32 +25211,66 @@ short convert_short_rtp(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtp(ulong2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtp(ulong4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtp(ulong8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtp(ulong16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtp(ulong3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtp(ulong4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtp(ulong8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtp(ulong16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13179,32 +25283,66 @@ short convert_short_rtn(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short2 convert_short2_rtn(ulong2 x)
 {
-  return (short2)(convert_short(x.lo), convert_short(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short4 convert_short4_rtn(ulong4 x)
-{
-  return (short4)(convert_short2(x.lo), convert_short2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short8 convert_short8_rtn(ulong8 x)
-{
-  return (short8)(convert_short4(x.lo), convert_short4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-short16 convert_short16_rtn(ulong16 x)
-{
-  return (short16)(convert_short8(x.lo), convert_short8(x.hi));
+  return (short2)(
+    (short)x.s0,
+    (short)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 short3 convert_short3_rtn(ulong3 x)
 {
-  return (short3)(convert_short2(x.s01), convert_short(x.s2));
+  return (short3)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtn(ulong4 x)
+{
+  return (short4)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtn(ulong8 x)
+{
+  return (short8)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtn(ulong16 x)
+{
+  return (short16)(
+    (short)x.s0,
+    (short)x.s1,
+    (short)x.s2,
+    (short)x.s3,
+    (short)x.s4,
+    (short)x.s5,
+    (short)x.s6,
+    (short)x.s7,
+    (short)x.s8,
+    (short)x.s9,
+    (short)x.sa,
+    (short)x.sb,
+    (short)x.sc,
+    (short)x.sd,
+    (short)x.se,
+    (short)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13217,32 +25355,66 @@ ushort convert_ushort_rtz(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtz(ulong2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtz(ulong4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtz(ulong8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtz(ulong16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtz(ulong3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtz(ulong4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtz(ulong8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtz(ulong16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13255,32 +25427,66 @@ ushort convert_ushort_rte(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rte(ulong2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rte(ulong4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rte(ulong8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rte(ulong16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rte(ulong3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rte(ulong4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rte(ulong8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rte(ulong16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13293,32 +25499,66 @@ ushort convert_ushort_rtp(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtp(ulong2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtp(ulong4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtp(ulong8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtp(ulong16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtp(ulong3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtp(ulong4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtp(ulong8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtp(ulong16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13331,32 +25571,66 @@ ushort convert_ushort_rtn(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort2 convert_ushort2_rtn(ulong2 x)
 {
-  return (ushort2)(convert_ushort(x.lo), convert_ushort(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort4 convert_ushort4_rtn(ulong4 x)
-{
-  return (ushort4)(convert_ushort2(x.lo), convert_ushort2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort8 convert_ushort8_rtn(ulong8 x)
-{
-  return (ushort8)(convert_ushort4(x.lo), convert_ushort4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ushort16 convert_ushort16_rtn(ulong16 x)
-{
-  return (ushort16)(convert_ushort8(x.lo), convert_ushort8(x.hi));
+  return (ushort2)(
+    (ushort)x.s0,
+    (ushort)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ushort3 convert_ushort3_rtn(ulong3 x)
 {
-  return (ushort3)(convert_ushort2(x.s01), convert_ushort(x.s2));
+  return (ushort3)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtn(ulong4 x)
+{
+  return (ushort4)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtn(ulong8 x)
+{
+  return (ushort8)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtn(ulong16 x)
+{
+  return (ushort16)(
+    (ushort)x.s0,
+    (ushort)x.s1,
+    (ushort)x.s2,
+    (ushort)x.s3,
+    (ushort)x.s4,
+    (ushort)x.s5,
+    (ushort)x.s6,
+    (ushort)x.s7,
+    (ushort)x.s8,
+    (ushort)x.s9,
+    (ushort)x.sa,
+    (ushort)x.sb,
+    (ushort)x.sc,
+    (ushort)x.sd,
+    (ushort)x.se,
+    (ushort)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13369,32 +25643,66 @@ int convert_int_rtz(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtz(ulong2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtz(ulong4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtz(ulong8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtz(ulong16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtz(ulong3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtz(ulong4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtz(ulong8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtz(ulong16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13407,32 +25715,66 @@ int convert_int_rte(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rte(ulong2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rte(ulong4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rte(ulong8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rte(ulong16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rte(ulong3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rte(ulong4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rte(ulong8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rte(ulong16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13445,32 +25787,66 @@ int convert_int_rtp(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtp(ulong2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtp(ulong4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtp(ulong8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtp(ulong16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtp(ulong3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtp(ulong4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtp(ulong8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtp(ulong16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13483,32 +25859,66 @@ int convert_int_rtn(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int2 convert_int2_rtn(ulong2 x)
 {
-  return (int2)(convert_int(x.lo), convert_int(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int4 convert_int4_rtn(ulong4 x)
-{
-  return (int4)(convert_int2(x.lo), convert_int2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int8 convert_int8_rtn(ulong8 x)
-{
-  return (int8)(convert_int4(x.lo), convert_int4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-int16 convert_int16_rtn(ulong16 x)
-{
-  return (int16)(convert_int8(x.lo), convert_int8(x.hi));
+  return (int2)(
+    (int)x.s0,
+    (int)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 int3 convert_int3_rtn(ulong3 x)
 {
-  return (int3)(convert_int2(x.s01), convert_int(x.s2));
+  return (int3)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtn(ulong4 x)
+{
+  return (int4)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtn(ulong8 x)
+{
+  return (int8)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtn(ulong16 x)
+{
+  return (int16)(
+    (int)x.s0,
+    (int)x.s1,
+    (int)x.s2,
+    (int)x.s3,
+    (int)x.s4,
+    (int)x.s5,
+    (int)x.s6,
+    (int)x.s7,
+    (int)x.s8,
+    (int)x.s9,
+    (int)x.sa,
+    (int)x.sb,
+    (int)x.sc,
+    (int)x.sd,
+    (int)x.se,
+    (int)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13521,32 +25931,66 @@ uint convert_uint_rtz(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtz(ulong2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtz(ulong4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtz(ulong8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtz(ulong16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtz(ulong3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtz(ulong4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtz(ulong8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtz(ulong16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13559,32 +26003,66 @@ uint convert_uint_rte(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rte(ulong2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rte(ulong4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rte(ulong8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rte(ulong16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rte(ulong3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rte(ulong4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rte(ulong8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rte(ulong16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13597,32 +26075,66 @@ uint convert_uint_rtp(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtp(ulong2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtp(ulong4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtp(ulong8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtp(ulong16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtp(ulong3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtp(ulong4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtp(ulong8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtp(ulong16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13635,32 +26147,66 @@ uint convert_uint_rtn(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint2 convert_uint2_rtn(ulong2 x)
 {
-  return (uint2)(convert_uint(x.lo), convert_uint(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint4 convert_uint4_rtn(ulong4 x)
-{
-  return (uint4)(convert_uint2(x.lo), convert_uint2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint8 convert_uint8_rtn(ulong8 x)
-{
-  return (uint8)(convert_uint4(x.lo), convert_uint4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-uint16 convert_uint16_rtn(ulong16 x)
-{
-  return (uint16)(convert_uint8(x.lo), convert_uint8(x.hi));
+  return (uint2)(
+    (uint)x.s0,
+    (uint)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 uint3 convert_uint3_rtn(ulong3 x)
 {
-  return (uint3)(convert_uint2(x.s01), convert_uint(x.s2));
+  return (uint3)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtn(ulong4 x)
+{
+  return (uint4)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtn(ulong8 x)
+{
+  return (uint8)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtn(ulong16 x)
+{
+  return (uint16)(
+    (uint)x.s0,
+    (uint)x.s1,
+    (uint)x.s2,
+    (uint)x.s3,
+    (uint)x.s4,
+    (uint)x.s5,
+    (uint)x.s6,
+    (uint)x.s7,
+    (uint)x.s8,
+    (uint)x.s9,
+    (uint)x.sa,
+    (uint)x.sb,
+    (uint)x.sc,
+    (uint)x.sd,
+    (uint)x.se,
+    (uint)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13673,32 +26219,66 @@ long convert_long_rtz(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtz(ulong2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtz(ulong4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtz(ulong8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtz(ulong16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtz(ulong3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtz(ulong4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtz(ulong8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtz(ulong16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13711,32 +26291,66 @@ long convert_long_rte(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rte(ulong2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rte(ulong4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rte(ulong8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rte(ulong16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rte(ulong3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rte(ulong4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rte(ulong8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rte(ulong16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13749,32 +26363,66 @@ long convert_long_rtp(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtp(ulong2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtp(ulong4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtp(ulong8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtp(ulong16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtp(ulong3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtp(ulong4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtp(ulong8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtp(ulong16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13787,32 +26435,66 @@ long convert_long_rtn(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long2 convert_long2_rtn(ulong2 x)
 {
-  return (long2)(convert_long(x.lo), convert_long(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long4 convert_long4_rtn(ulong4 x)
-{
-  return (long4)(convert_long2(x.lo), convert_long2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long8 convert_long8_rtn(ulong8 x)
-{
-  return (long8)(convert_long4(x.lo), convert_long4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-long16 convert_long16_rtn(ulong16 x)
-{
-  return (long16)(convert_long8(x.lo), convert_long8(x.hi));
+  return (long2)(
+    (long)x.s0,
+    (long)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 long3 convert_long3_rtn(ulong3 x)
 {
-  return (long3)(convert_long2(x.s01), convert_long(x.s2));
+  return (long3)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtn(ulong4 x)
+{
+  return (long4)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtn(ulong8 x)
+{
+  return (long8)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtn(ulong16 x)
+{
+  return (long16)(
+    (long)x.s0,
+    (long)x.s1,
+    (long)x.s2,
+    (long)x.s3,
+    (long)x.s4,
+    (long)x.s5,
+    (long)x.s6,
+    (long)x.s7,
+    (long)x.s8,
+    (long)x.s9,
+    (long)x.sa,
+    (long)x.sb,
+    (long)x.sc,
+    (long)x.sd,
+    (long)x.se,
+    (long)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13825,32 +26507,66 @@ ulong convert_ulong_rtz(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtz(ulong2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtz(ulong4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtz(ulong8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtz(ulong16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtz(ulong3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtz(ulong4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtz(ulong8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtz(ulong16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13863,32 +26579,66 @@ ulong convert_ulong_rte(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rte(ulong2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rte(ulong4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rte(ulong8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rte(ulong16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rte(ulong3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rte(ulong4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rte(ulong8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rte(ulong16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13901,32 +26651,66 @@ ulong convert_ulong_rtp(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtp(ulong2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtp(ulong4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtp(ulong8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtp(ulong16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtp(ulong3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtp(ulong4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtp(ulong8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtp(ulong16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 #if defined(cl_khr_int64)
@@ -13939,32 +26723,66 @@ ulong convert_ulong_rtn(ulong x)
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong2 convert_ulong2_rtn(ulong2 x)
 {
-  return (ulong2)(convert_ulong(x.lo), convert_ulong(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong4 convert_ulong4_rtn(ulong4 x)
-{
-  return (ulong4)(convert_ulong2(x.lo), convert_ulong2(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong8 convert_ulong8_rtn(ulong8 x)
-{
-  return (ulong8)(convert_ulong4(x.lo), convert_ulong4(x.hi));
-}
-
-_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-ulong16 convert_ulong16_rtn(ulong16 x)
-{
-  return (ulong16)(convert_ulong8(x.lo), convert_ulong8(x.hi));
+  return (ulong2)(
+    (ulong)x.s0,
+    (ulong)x.s1);
 }
 
 _CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 ulong3 convert_ulong3_rtn(ulong3 x)
 {
-  return (ulong3)(convert_ulong2(x.s01), convert_ulong(x.s2));
+  return (ulong3)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2);
 }
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtn(ulong4 x)
+{
+  return (ulong4)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtn(ulong8 x)
+{
+  return (ulong8)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7);
+}
+
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtn(ulong16 x)
+{
+  return (ulong16)(
+    (ulong)x.s0,
+    (ulong)x.s1,
+    (ulong)x.s2,
+    (ulong)x.s3,
+    (ulong)x.s4,
+    (ulong)x.s5,
+    (ulong)x.s6,
+    (ulong)x.s7,
+    (ulong)x.s8,
+    (ulong)x.s9,
+    (ulong)x.sa,
+    (ulong)x.sb,
+    (ulong)x.sc,
+    (ulong)x.sd,
+    (ulong)x.se,
+    (ulong)x.sf);
+}
+
 #endif
 
 

--- a/lib/kernel/convert_type.py
+++ b/lib/kernel/convert_type.py
@@ -37,7 +37,8 @@ int64_types = ['long', 'ulong']
 float16_types = ['half']
 float64_types = ['double']
 vector_sizes = ['', '2', '3', '4', '8', '16']
-half_sizes = [('2',''), ('4','2'), ('8','4'), ('16','8')]
+numvec_sizes = [2, 3, 4, 8, 16]
+vector_lanes = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f']
 
 saturation = ['','_sat']
 rounding_modes = ['_rtz','_rte','_rtp','_rtn']
@@ -229,20 +230,16 @@ def generate_default_conversion(src, dst, mode):
 """.format(SRC=src, DST=dst, M=mode))
 
   # vector conversions, done through decomposition to components
-  for size, half_size in half_sizes:
+  for size in numvec_sizes:
     print("""_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
 {DST}{N} convert_{DST}{N}{M}({SRC}{N} x)
 {{
-  return ({DST}{N})(convert_{DST}{H}(x.lo), convert_{DST}{H}(x.hi));
+  return ({DST}{N})(""".format(SRC=src, DST=dst, N=size, M=mode))
+    for i in range (0, size - 1):
+      print("""    ({DST})x.s{LANE},""".format(DST=dst, LANE=vector_lanes[i]))
+    print("""    ({DST})x.s{LANE});
 }}
-""".format(SRC=src, DST=dst, N=size, H=half_size, M=mode))
-
-  # 3-component vector conversions
-  print("""_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
-{DST}3 convert_{DST}3{M}({SRC}3 x)
-{{
-  return ({DST}3)(convert_{DST}2(x.s01), convert_{DST}(x.s2));
-}}""".format(SRC=src, DST=dst, M=mode))
+""".format(DST=dst, LANE=vector_lanes[size - 1]))
 
   if close_conditional:
     print("#endif")

--- a/lib/kernel/convert_type.py
+++ b/lib/kernel/convert_type.py
@@ -37,7 +37,7 @@ int64_types = ['long', 'ulong']
 float16_types = ['half']
 float64_types = ['double']
 vector_sizes = ['', '2', '3', '4', '8', '16']
-numvec_sizes = [2, 3, 4, 8, 16]
+numvec_sizes = [2, 4, 8, 16, 3]
 vector_lanes = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f']
 
 saturation = ['','_sat']


### PR DESCRIPTION
Change replaces the original lo/hi decomposition of `convert_typeN(sourceN)` for a decomposition of the kind `(typeN)((type) source.s0, (type) source.s1, ... )`, which emits `sext`/ `zext` llvm IR opcodes (for integral types), which, in their turn, autovectorize nicely on ISAs with corresponding ops. Change addresses issue #796.