### PR TITLE
Also split if the resulting group size is equal to the minimum group size

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -69,3 +69,4 @@ Maxim Eremenko <moeryomenko@gmail.com>
 Andrew Gozillon <andrew.gozillon@yahoo.com>
 Jan Solanti <jan.solanti@tuni.fi>
 Stefan Brüns <stefan.bruens@rwth-aachen.de>
+Tobias Baumann <t.baumann@agdsn.de>

--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -398,7 +398,7 @@ if (local_##coord > 1) \
       /* Only proceed if splitting wouldn't bring us below the minimum
        * group size */
       while (((splits = ncus / (nwg_x * nwg_y * nwg_z)) > 1) &&
-             (local_x * local_y * local_z > splits * min_group_size))
+             (local_x * local_y * local_z >= splits * min_group_size))
         {
           /* Very simple splitting approach: find a dimension divisible by
            * split, and lacking that divide by something less, if possible.


### PR DESCRIPTION
clEnqueueNDRangeKernel(): When hitting a `global_work_size := global_x * global_y * global_z` that equals `4 * preferred_wg_multiple * max_compute_units`, the program will now run in parallel (new behaviour) rather than not running in parallel (old behaviour).
- If `global_work_size` is smaller, the program will not run in parallel (unchanged).
- If `global_work_size` is bigger, the program will run in parallel (unchanged).
