### PR TITLE
Fix a crash when a null kernel object is passed to clEnqueueNDRangeKernel

### DIFF
--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -108,14 +108,15 @@ POname(clEnqueueNDRangeKernel)(cl_command_queue command_queue,
   int errcode = 0;
   cl_device_id realdev = NULL;
   _cl_command_node *command_node;
-  /* alloc from stack to avoid malloc. num_args is the absolute max needed */
-  cl_mem mem_list[kernel->meta->num_args + 1];
-  /* reserve space for potential buffer migrate events */
-  cl_event new_event_wait_list[num_events_in_wait_list + kernel->meta->num_args + 1];
 
   POCL_RETURN_ERROR_COND((command_queue == NULL), CL_INVALID_COMMAND_QUEUE);
 
   POCL_RETURN_ERROR_COND((kernel == NULL), CL_INVALID_KERNEL);
+
+  /* alloc from stack to avoid malloc. num_args is the absolute max needed */
+  cl_mem mem_list[kernel->meta->num_args + 1];
+  /* reserve space for potential buffer migrate events */
+  cl_event new_event_wait_list[num_events_in_wait_list + kernel->meta->num_args + 1];
 
   POCL_RETURN_ERROR_ON((command_queue->context != kernel->context),
     CL_INVALID_CONTEXT,


### PR DESCRIPTION
It looks like the 'kernel' parameter is used before is checked for nullness.
If you pass NULL as kernel argument to clEnqueueNDRangeKernel, the POCL library crashes.
This PR simply moves the nullness check before 'kernel' is actually used.

p.s.
I am not an OpenCL expert and new to this project, so maybe there is a reason I cannot see for this.