### PR TITLE
Fix uneven distribution of work groups to threads

### DIFF
--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -190,6 +190,7 @@ get_wg_index_range (kernel_run_command *k, unsigned *start_index,
   const unsigned scaled_max_wgs = POCL_PTHREAD_MAX_WGS * num_threads;
   const unsigned scaled_min_wgs = POCL_PTHREAD_MIN_WGS * num_threads;
 
+  unsigned limit;
   unsigned max_wgs;
   POCL_FAST_LOCK (k->lock);
   if (k->remaining_wgs == 0)
@@ -205,12 +206,13 @@ get_wg_index_range (kernel_run_command *k, unsigned *start_index,
    * If we have enough workgroups, scale up the requests linearly by
    * num_threads, otherwise fallback to smaller workgroups.
    */
-  const unsigned my_wgs = ceil ((float) k->remaining_wgs / (float) num_threads);
   if (k->remaining_wgs <= (scaled_max_wgs * num_threads))
-    max_wgs = min (scaled_min_wgs, my_wgs);
+    limit = scaled_min_wgs;
   else
-    max_wgs = min (scaled_max_wgs, my_wgs);
+    limit = scaled_max_wgs;
 
+  const unsigned wgs_per_thread = ceil ((float) k->remaining_wgs / (float) num_threads);
+  max_wgs = min (limit, wgs_per_thread);
   max_wgs = min (max_wgs, k->remaining_wgs);
   assert (max_wgs > 0);
 

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -27,6 +27,7 @@
 #include <sched.h>
 #endif
 
+#include <math.h>
 #include <pthread.h>
 #include <string.h>
 #include <time.h>
@@ -204,10 +205,11 @@ get_wg_index_range (kernel_run_command *k, unsigned *start_index,
    * If we have enough workgroups, scale up the requests linearly by
    * num_threads, otherwise fallback to smaller workgroups.
    */
+  const unsigned my_wgs = ceil ((float) k->remaining_wgs / (float) num_threads);
   if (k->remaining_wgs <= (scaled_max_wgs * num_threads))
-    max_wgs = min (scaled_min_wgs, (1 + k->remaining_wgs / num_threads));
+    max_wgs = min (scaled_min_wgs, my_wgs);
   else
-    max_wgs = min (scaled_max_wgs, (1 + k->remaining_wgs / num_threads));
+    max_wgs = min (scaled_max_wgs, my_wgs);
 
   max_wgs = min (max_wgs, k->remaining_wgs);
   assert (max_wgs > 0);

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -27,7 +27,6 @@
 #include <sched.h>
 #endif
 
-#include <math.h>
 #include <pthread.h>
 #include <string.h>
 #include <time.h>
@@ -211,7 +210,8 @@ get_wg_index_range (kernel_run_command *k, unsigned *start_index,
   else
     limit = scaled_max_wgs;
 
-  const unsigned wgs_per_thread = ceil ((float) k->remaining_wgs / (float) num_threads);
+  // divide two integers rounding up, i.e. ceil(k->remaining_wgs/num_threads)
+  const unsigned wgs_per_thread = (1 + (k->remaining_wgs - 1) / num_threads);
   max_wgs = min (limit, wgs_per_thread);
   max_wgs = min (max_wgs, k->remaining_wgs);
   assert (max_wgs > 0);


### PR DESCRIPTION
### Problem ([L208](https://github.com/pocl/pocl/blob/master/lib/CL/devices/pthread/pthread_scheduler.c#L208) and [L210](https://github.com/pocl/pocl/blob/master/lib/CL/devices/pthread/pthread_scheduler.c#L210))
Integer division discards fractional part. To avoid result `0`, `1` is added (poor man's `ceil()`). If `num_threads` divides `k->remaining_wgs` evenly, `1` is added anyway and the result is to high. This results in an uneven distribution of work groups to threads. An example: There are 4 work groups and 4 threads. For the first thread, `num_threads` divides `k->remaining_wgs` evenly (`4/4=1`), giving 2 work groups to the first thread. Thread 2 and 3 get 1 work group each. There is nothing left to do for the 4th thread which idles, while the first thread has double work.
```
if (k->remaining_wgs <= (scaled_max_wgs * num_threads))
  max_wgs = min (scaled_min_wgs, (1 + k->remaining_wgs / num_threads));
else
  max_wgs = min (scaled_max_wgs, (1 + k->remaining_wgs / num_threads));
```
### Solution
Floating point division and `ceil()`:
```
int my_wgs = ceil ((float) k->remaining_wgs / (float) num_threads);
if (k->remaining_wgs <= (scaled_max_wgs * num_threads))
  max_wgs = min (scaled_min_wgs, my_wgs);
else
  max_wgs = min (scaled_max_wgs, my_wgs);
```
See [before.png](https://www2.informatik.hu-berlin.de/~baumanty/before.png) and [after.png](https://www2.informatik.hu-berlin.de/~baumanty/after.png).