### PR TITLE
Fix uneven distribution of work groups to threads

### DIFF
--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -189,6 +189,7 @@ get_wg_index_range (kernel_run_command *k, unsigned *start_index,
   const unsigned scaled_max_wgs = POCL_PTHREAD_MAX_WGS * num_threads;
   const unsigned scaled_min_wgs = POCL_PTHREAD_MIN_WGS * num_threads;
 
+  unsigned limit;
   unsigned max_wgs;
   POCL_FAST_LOCK (k->lock);
   if (k->remaining_wgs == 0)
@@ -205,10 +206,13 @@ get_wg_index_range (kernel_run_command *k, unsigned *start_index,
    * num_threads, otherwise fallback to smaller workgroups.
    */
   if (k->remaining_wgs <= (scaled_max_wgs * num_threads))
-    max_wgs = min (scaled_min_wgs, (1 + k->remaining_wgs / num_threads));
+    limit = scaled_min_wgs;
   else
-    max_wgs = min (scaled_max_wgs, (1 + k->remaining_wgs / num_threads));
+    limit = scaled_max_wgs;
 
+  // divide two integers rounding up, i.e. ceil(k->remaining_wgs/num_threads)
+  const unsigned wgs_per_thread = (1 + (k->remaining_wgs - 1) / num_threads);
+  max_wgs = min (limit, wgs_per_thread);
   max_wgs = min (max_wgs, k->remaining_wgs);
   assert (max_wgs > 0);
 


### PR DESCRIPTION
### Problem ([L208](https://github.com/pocl/pocl/blob/master/lib/CL/devices/pthread/pthread_scheduler.c#L208) and [L210](https://github.com/pocl/pocl/blob/master/lib/CL/devices/pthread/pthread_scheduler.c#L210))
Integer division discards fractional part. To avoid result `0`, `1` is added (poor man's `ceil()`). If `num_threads` divides `k->remaining_wgs` evenly, `1` is added anyway and the result is to high. This results in an uneven distribution of work groups to threads. An example: There are 4 work groups and 4 threads. For the first thread, `num_threads` divides `k->remaining_wgs` evenly (`4/4=1`), giving 2 work groups to the first thread. Thread 2 and 3 get 1 work group each. There is nothing left to do for the 4th thread which idles, while the first thread has double work.
```
if (k->remaining_wgs <= (scaled_max_wgs * num_threads))
  max_wgs = min (scaled_min_wgs, (1 + k->remaining_wgs / num_threads));
else
  max_wgs = min (scaled_max_wgs, (1 + k->remaining_wgs / num_threads));
```
### Solution
The problem is solved by subtracting `1` from `k->remaining_wgs` (as [suggested](https://github.com/pocl/pocl/pull/806#discussion_r395375041) by @noma). I also refactored the if-statement to make the code more readable.
```
const unsigned wgs_per_thread = (1 + (k->remaining_wgs - 1) / num_threads);
```
### Question
Why are `POCL_PTHREAD_MAX_WGS`/`POCL_PTHREAD_MIN_WGS` multiplied by `num_threads` in [L189](https://github.com/pocl/pocl/blob/master/lib/CL/devices/pthread/pthread_scheduler.c#L189)/[L190](https://github.com/pocl/pocl/blob/master/lib/CL/devices/pthread/pthread_scheduler.c#L190)? They appear to be a local (i.e. per thread) limit according to [L208](https://github.com/pocl/pocl/blob/master/lib/CL/devices/pthread/pthread_scheduler.c#L208)/[L210](https://github.com/pocl/pocl/blob/master/lib/CL/devices/pthread/pthread_scheduler.c#L210). `scaled_max_wgs` is again multiplied by `num_threads` in [L207](https://github.com/pocl/pocl/blob/master/lib/CL/devices/pthread/pthread_scheduler.c#L207), which makes sense because `k->remaining_wgs` is a global value, which is now compared against a value that contains `num_threads` squared. Maybe [the commits author](https://github.com/pocl/pocl/commit/15e0142127d3888f348a5281bb8161c92e4db070) @franz can help?