### PR TITLE
Wrap calls to clRetainKernel and clRetainEvent

### DIFF
--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -362,7 +362,7 @@ POname(clEnqueueNDRangeKernel)(cl_command_queue command_queue,
   if (pocl_cq_profiling_enabled)
     {
       pocl_cq_profiling_register_event (command_node->event);
-      clRetainKernel (kernel);
+      POname(clRetainKernel) (kernel);
       command_node->event->meta_data->kernel = kernel;
     }
 

--- a/lib/CL/pocl_cq_profiling.c
+++ b/lib/CL/pocl_cq_profiling.c
@@ -127,7 +127,7 @@ pocl_cq_profiling_init ()
 void
 pocl_cq_profiling_register_event (cl_event event)
 {
-  clRetainEvent (event);
+  POname(clRetainEvent) (event);
   if (event->meta_data == NULL)
     event->meta_data = (pocl_event_md *)malloc (sizeof (pocl_event_md));
 


### PR DESCRIPTION
These were causing some linking errors (undefined symbols) on my Linux system.