### PR TITLE
matrix1: add missing #define

### DIFF
--- a/examples/matrix1/matrix1.c
+++ b/examples/matrix1/matrix1.c
@@ -23,6 +23,7 @@
 
 /* For srandom. */
 #define _DEFAULT_SOURCE
+#define _BSD_SOURCE
 
 #include <CL/opencl.h>
 #include <assert.h>


### PR DESCRIPTION
Required for RHEL 7.6 Power9/clang 9.0.