### PR TITLE
Turn off automatic conversion of locals to args in CUDA

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,8 +8,8 @@ Notable User Facing Changes
   previous release. Users need to delete their pocl cache.
 
 
-Notable Bug Fixes
------------------
+Optimizations
+-------------
 
 - Improved the PTX code generation for __local blocks. Previously constant
   __local blocks and __local arguments were using one dynamic shared CUDA
@@ -19,28 +19,17 @@ Notable Bug Fixes
   time constants. This improves the performance due to better SASS code
   generation because it avoids what appears to be a pointer aliasing issue.
 
-  Running shoc benchmark GEMM with size class 4 on a NVIDIA Titan X gives
-  the following.
+  Running SHOC benchmark GEMM with size class 4 on a NVIDIA Titan X gives
+  the following performance improvements.
 
-    result for sgemm_n:                        376.0500 GFLOPS
-    result for sgemm_t:                        814.1860 GFLOPS
-    result for sgemm_n_pcie:                   351.6180 GFLOPS
-    result for sgemm_t_pcie:                   708.6310 GFLOPS
-    result for dgemm_n:                        172.8970 GFLOPS
-    result for dgemm_t:                        173.9350 GFLOPS
-    result for dgemm_n_pcie:                   153.0720 GFLOPS
-    result for dgemm_t_pcie:                   154.3020 GFLOPS
-
-  Benchmarking 1.5 gives the following.
-
-    result for sgemm_n:                        288.9410 GFLOPS
-    result for sgemm_t:                        663.3480 GFLOPS
-    result for sgemm_n_pcie:                   269.8090 GFLOPS
-    result for sgemm_t_pcie:                   570.5630 GFLOPS
-    result for dgemm_n:                         84.0000 GFLOPS
-    result for dgemm_t:                        169.0820 GFLOPS
-    result for dgemm_n_pcie:                    74.0927 GFLOPS
-    result for dgemm_t_pcie:                   143.6500 GFLOPS
+    sgemm_n:        23.2%
+    sgemm_t:        18.5%
+    sgemm_n_pcie:   23.3%
+    sgemm_t_pcie:   19.5%
+    dgemm_n:        51.4%
+    dgemm_t:         2.8%
+    dgemm_n_pcie:   51.6%
+    dgemm_t_pcie:    6.9%
 
 
 1.5 April 2020

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,47 @@
 1.6 unreleased
 ==============
 
+Notable User Facing Changes
+---------------------------
+
+- CUDA kernels using constant __local blocks are now ABI incompatible with
+  previous release. Users need to delete their pocl cache.
+
+
+Notable Bug Fixes
+-----------------
+
+- Improved the PTX code generation for __local blocks. Previously constant
+  __local blocks and __local arguments were using one dynamic shared CUDA
+  memory block with offsets computed at runtime. Now if there is no __local
+  arguments, separate static shared CUDA memory is used. If there are
+  __local arguments, the constant __local blocks are indexed with compile
+  time constants. This improves the performance due to better SASS code
+  generation because it avoids what appears to be a pointer aliasing issue.
+
+  Running shoc benchmark GEMM with size class 4 on a NVIDIA Titan X gives
+  the following.
+
+    result for sgemm_n:                        376.0500 GFLOPS
+    result for sgemm_t:                        814.1860 GFLOPS
+    result for sgemm_n_pcie:                   351.6180 GFLOPS
+    result for sgemm_t_pcie:                   708.6310 GFLOPS
+    result for dgemm_n:                        172.8970 GFLOPS
+    result for dgemm_t:                        173.9350 GFLOPS
+    result for dgemm_n_pcie:                   153.0720 GFLOPS
+    result for dgemm_t_pcie:                   154.3020 GFLOPS
+
+  Benchmarking 1.5 gives the following.
+
+    result for sgemm_n:                        288.9410 GFLOPS
+    result for sgemm_t:                        663.3480 GFLOPS
+    result for sgemm_n_pcie:                   269.8090 GFLOPS
+    result for sgemm_t_pcie:                   570.5630 GFLOPS
+    result for dgemm_n:                         84.0000 GFLOPS
+    result for dgemm_t:                        169.0820 GFLOPS
+    result for dgemm_n_pcie:                    74.0927 GFLOPS
+    result for dgemm_t_pcie:                   143.6500 GFLOPS
+
 
 1.5 April 2020
 ==============

--- a/lib/CL/devices/cuda/pocl-cuda-types.h
+++ b/lib/CL/devices/cuda/pocl-cuda-types.h
@@ -77,4 +77,3 @@ typedef struct pocl_cuda_event_data_s
   cl_int *ext_event_flag;
   volatile unsigned num_ext_events;
 } pocl_cuda_event_data_t;
-

--- a/lib/CL/devices/cuda/pocl-cuda-types.h
+++ b/lib/CL/devices/cuda/pocl-cuda-types.h
@@ -1,0 +1,80 @@
+/* pocl-cuda.c - driver for CUDA devices
+
+   Copyright (c) 2016-2017 James Price / University of Bristol
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+#include "config.h"
+
+#include "common.h"
+#include "pocl.h"
+#include "pocl_util.h"
+
+#include <cuda.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+typedef struct pocl_cuda_device_data_s
+{
+  CUdevice device;
+  CUcontext context;
+  CUevent epoch_event;
+  cl_ulong epoch;
+  char libdevice[PATH_MAX];
+  pocl_lock_t compile_lock;
+} pocl_cuda_device_data_t;
+
+typedef struct pocl_cuda_queue_data_s
+{
+  CUstream stream;
+  int use_threads;
+  pthread_t submit_thread;
+  pthread_t finalize_thread;
+  pthread_mutex_t lock;
+  pthread_cond_t pending_cond;
+  pthread_cond_t running_cond;
+  _cl_command_node *volatile pending_queue;
+  _cl_command_node *volatile running_queue;
+  cl_command_queue queue;
+} pocl_cuda_queue_data_t;
+
+typedef struct pocl_cuda_kernel_data_s
+{
+  CUmodule module;
+  CUmodule module_offsets;
+  CUfunction kernel;
+  CUfunction kernel_offsets;
+  size_t *alignments;
+  size_t auto_local_offset;
+} pocl_cuda_kernel_data_t;
+
+typedef struct pocl_cuda_event_data_s
+{
+  CUevent start;
+  CUevent end;
+  volatile int events_ready;
+  cl_int *ext_event_flag;
+  volatile unsigned num_ext_events;
+} pocl_cuda_event_data_t;
+

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -191,6 +191,8 @@ pocl_cuda_init (unsigned j, cl_device_id dev, const char *parameters)
   /* TODO: Get images working */
   dev->image_support = CL_FALSE;
 
+  dev->autolocals_to_args = CL_FALSE;
+
   dev->has_64bit_long = 1;
 
   pocl_cuda_device_data_t *data = calloc (1, sizeof (pocl_cuda_device_data_t));

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -785,8 +785,7 @@ load_or_generate_kernel (cl_kernel kernel, cl_device_id device,
   /* Get pointer aligment */
   if (!kdata->alignments)
     {
-      kdata->alignments
-          = calloc (meta->num_args + 4, sizeof (size_t));
+      kdata->alignments = calloc (meta->num_args + 4, sizeof (size_t));
       pocl_cuda_get_ptr_arg_alignment (bc_filename, kernel->name,
                                        kdata->alignments);
     }

--- a/lib/CL/devices/cuda/pocl-ptx-gen.h
+++ b/lib/CL/devices/cuda/pocl-ptx-gen.h
@@ -25,6 +25,7 @@
 #define POCL_PTX_GEN_H
 
 #include "config.h"
+#include "pocl-cuda-types.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -43,6 +44,7 @@ int findLibDevice(char LibDevicePath[PATH_MAX], const char *Arch);
 /* Returns zero on success, non-zero on failure. */
 int pocl_ptx_gen(const char *BitcodeFilename,
                  const char *PTXFilename,
+		 pocl_cuda_kernel_data_t *KernelData,
                  const char *KernelName,
                  const char *Arch,
                  const char *LibDevicePath,

--- a/lib/CL/devices/cuda/pocl-ptx-gen.h
+++ b/lib/CL/devices/cuda/pocl-ptx-gen.h
@@ -42,13 +42,9 @@ int findLibDevice(char LibDevicePath[PATH_MAX], const char *Arch);
 
 /* Generate a PTX file from an LLVM bitcode file. */
 /* Returns zero on success, non-zero on failure. */
-int pocl_ptx_gen(const char *BitcodeFilename,
-                 const char *PTXFilename,
-		 pocl_cuda_kernel_data_t *KernelData,
-                 const char *KernelName,
-                 const char *Arch,
-                 const char *LibDevicePath,
-                 int HasOffsets);
+int pocl_ptx_gen (const char *BitcodeFilename, const char *PTXFilename,
+                  pocl_cuda_kernel_data_t *KernelData, const char *KernelName,
+                  const char *Arch, const char *LibDevicePath, int HasOffsets);
 
 /* Populate the Alignments array with the required pointer alignments for */
 /* each kernel argument. */

--- a/lib/CL/pocl_debug.h
+++ b/lib/CL/pocl_debug.h
@@ -63,7 +63,6 @@ extern "C" {
 #define POCL_FILTER_TYPE_WARN 2
 #define POCL_FILTER_TYPE_ERR 3
 
-
 #ifdef __GNUC__
 #pragma GCC visibility push(hidden)
 #endif

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -36,7 +36,6 @@
 #error aligned malloc unavailable
 #endif
 
-
 #ifdef __GNUC__
 #pragma GCC visibility push(hidden)
 #endif


### PR DESCRIPTION
Turning it on prevents optimization opportunities.

Fixes #823