### PR TITLE
Use a higher unroll threshold for non workgroup_pass devices like CUDA

### DIFF
--- a/lib/CL/pocl_llvm_wg.cc
+++ b/lib/CL/pocl_llvm_wg.cc
@@ -53,6 +53,7 @@ IGNORE_COMPILER_WARNING("-Wunused-parameter")
 
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #include <llvm/Transforms/Utils/Cloning.h>
+#include <llvm/Transforms/Scalar.h>
 
 #include <llvm/PassRegistry.h>
 #include <llvm/PassInfo.h>
@@ -321,6 +322,10 @@ kernel_compiler_passes(cl_device_id device, llvm::Module *input,
       }
       Builder.VerifyInput = true;
       Builder.VerifyOutput = true;
+      if (not device->workgroup_pass) {
+        // Threshold of 300 is the default for O3
+        Passes->add(createLoopUnrollPass(3, false, false, 300));
+      }
       Builder.populateModulePassManager(*Passes);
       continue;
     }


### PR DESCRIPTION
Since POCL sets the unroll threshold at https://github.com/pocl/pocl/blob/e64cc2a08eeca19a259258c8c8ae4850d9cdb1d7/lib/CL/pocl_llvm_utils.cc#L347-L349 to 1, there are some optimizations missed.

What's the reason for changing the default of the loop unroll threshold? I assumed it has something to do with CPU devices and therefore changed it only for devices like CUDA.

SHOC GEMM benchmark improvements on an NVIDIA Titan X
```
sgemm_n:        443.20%
sgemm_t:        151.69%
sgemm_n_pcie:   323.49%
sgemm_t_pcie:   110.75%
dgemm_n:        4.66%
dgemm_t:        0.07%
dgemm_n_pcie:   4.18%
dgemm_t_pcie:   0.12%
```

Fixes https://github.com/pocl/pocl/issues/825

Thanks to @mattwala for debugging this.

cc @inducer, @nchristensen