### PR TITLE
Remove flatten-inline-all pass for device without autolocals_to_args

### DIFF
--- a/lib/CL/pocl_llvm_wg.cc
+++ b/lib/CL/pocl_llvm_wg.cc
@@ -229,7 +229,9 @@ kernel_compiler_passes(cl_device_id device, llvm::Module *input,
     passes.push_back("automatic-locals");
 
   if (SPMDDevice) {
-    passes.push_back("flatten-inline-all");
+    if (device->autolocals_to_args) {
+      passes.push_back("flatten-inline-all");
+    }
     passes.push_back("always-inline");
   } else {
     passes.push_back("flatten-globals");


### PR DESCRIPTION
In CUDA, we don't convert autolocals to args and use a constant offset
for autolocals. To identify these, they shouldn't be marked as always
inline. This is a hack, but in order to properly fix this, we'll have
to identify the autolocals some other way.

Fixes https://github.com/pocl/pocl/issues/832