### PR TITLE
Print loop vertorizer remarks when using poclcc

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -31,6 +31,10 @@ Optimizations
     dgemm_n_pcie:   51.6%
     dgemm_t_pcie:    6.9%
 
+Notable Bug Fixes
+-----------------
+- Fix poclcc to emit LLVM loop vectorizing remarks when POCL_VECTORIZER_REMARKS
+  environment variable is set.
 
 1.5 April 2020
 ==============

--- a/CREDITS
+++ b/CREDITS
@@ -74,3 +74,4 @@ Alberto Cerato <alberto.cerato@fcagroup.com>
 Simon Branford <s.j.branford@bham.ac.uk>
 Alexandru Fikl <alexfikl@gmail.com>
 Matthias Diener <mdiener@illinois.edu>
+Mauri Mustonen <mauri_mustonen@hotmail.com>

--- a/lib/CL/pocl_llvm_utils.cc
+++ b/lib/CL/pocl_llvm_utils.cc
@@ -235,6 +235,7 @@ static DiagnosticPrinterRawOStream poclDiagPrinter(poclDiagStream);
 
 static void diagHandler(const DiagnosticInfo &DI, void *Context) {
   DI.print(poclDiagPrinter);
+  poclDiagPrinter << "\n";
 }
 
 std::string getDiagString() {

--- a/lib/CL/pocl_llvm_wg.cc
+++ b/lib/CL/pocl_llvm_wg.cc
@@ -441,6 +441,11 @@ int pocl_llvm_generate_workgroup_function_nowrite(
   llvm::reportAndResetTimings();
 #endif
 
+  // Print loop vectorizer remarks if enabled.
+  if (pocl_get_bool_option("POCL_VECTORIZER_REMARKS", 0) == 1) {
+    std::cout << getDiagString();
+  }
+
   assert(Output != NULL);
   *Output = (void *)ParallelBC;
   ++numberOfIRs;


### PR DESCRIPTION
If POCL_VECTORIZER_REMARKS environment variable is set, print vectorizer remarks. Fixes issue #613 