### PR TITLE
WI loops: ensure loads in parallel loops are safe to execute unconditionally

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,8 @@ Optimizations
 Notable Bug Fixes
 -----------------
 - Fix LLVM loop vectorizing remarks printing (POCL_VECTORIZER_REMARKS=1).
+- Fix an issue in which the loop vectorizer produced code with invalid
+  memory reads (issue #757).
 
 1.5 April 2020
 ==============

--- a/lib/llvmopencl/ParallelRegion.cc
+++ b/lib/llvmopencl/ParallelRegion.cc
@@ -473,6 +473,7 @@ ParallelRegion::Verify()
  * is safe. Given an instruction reading from memory,
  * IsLoadUnconditionallySafe should return whether it is safe under
  * (unconditional, unpredicated) speculative execution.
+ * See https://bugs.llvm.org/show_bug.cgi?id=46666
  */
 void
 ParallelRegion::AddParallelLoopMetadata(

--- a/lib/llvmopencl/ParallelRegion.h
+++ b/lib/llvmopencl/ParallelRegion.h
@@ -24,6 +24,7 @@
 #ifndef _POCL_PARALLEL_REGION_H
 #define _POCL_PARALLEL_REGION_H
 
+#include <functional>
 #include <vector>
 #include <sstream>
 
@@ -79,7 +80,9 @@ class Kernel;
                        std::size_t y = 0, 
                        std::size_t z = 0);
 
-    void AddParallelLoopMetadata(llvm::MDNode *Identifier);
+    void AddParallelLoopMetadata
+        (llvm::MDNode *Identifier,
+         std::function<bool(llvm::Instruction *)> IsLoadUnconditionallySafe);
 
     bool HasBlock(llvm::BasicBlock *bb);
 

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -43,7 +43,7 @@ set(PROGRAMS_TO_BUILD test_barrier_between_for_loops test_early_return
   test_barrier_before_return test_infinite_loop test_constant_array
   test_undominated_variable test_setargs test_null_arg
   test_fors_with_var_iteration_counts test_issue_231 test_issue_445
-  test_autolocals_in_constexprs test_issue_553 test_issue_577
+  test_autolocals_in_constexprs test_issue_553 test_issue_577 test_issue_757
   test_flatten_barrier_subs
   test_alignment_with_dynamic_wg test_alignment_with_dynamic_wg2 test_alignment_with_dynamic_wg3)
 
@@ -71,6 +71,8 @@ add_test_pocl(NAME "regression/test_issue_445" COMMAND "test_issue_445")
 add_test_pocl(NAME "regression/test_issue_553" COMMAND "test_issue_553")
 
 add_test_pocl(NAME "regression/test_issue_577" COMMAND "test_issue_577")
+
+add_test_pocl(NAME "regression/test_issue_757" COMMAND "test_issue_757")
 
 add_test_pocl(NAME "regression/test_flatten_barrier_subs" COMMAND "test_flatten_barrier_subs" EXPECTED_OUTPUT "test_flatten_barrier_subs.output")
 
@@ -263,7 +265,8 @@ set_tests_properties("regression/setting_a_buffer_argument_to_NULL_causes_a_segf
   "regression/struct_kernel_arguments" "regression/vector_kernel_arguments"
   "regression/autolocals_in_constexprs" "regression/test_issue_231"
   "regression/test_issue_445" "regression/test_issue_553"
-  "regression/test_issue_577" "regression/test_flatten_barrier_subs"
+  "regression/test_issue_577" "regression/test_issue_757"
+  "regression/test_flatten_barrier_subs"
   ${TCE_TESTS}
   PROPERTIES
     COST 1.5

--- a/tests/regression/test_issue_757.cpp
+++ b/tests/regression/test_issue_757.cpp
@@ -1,0 +1,75 @@
+// See https://github.com/pocl/pocl/issues/757
+// Caused an out of bounds read.
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <vector>
+
+#define CL_HPP_MINIMUM_OPENCL_VERSION 120
+#define CL_HPP_TARGET_OPENCL_VERSION 120
+#include <CL/cl2.hpp>
+
+const char *SOURCE = R"RAW(
+#define lid(N) ((int) get_local_id(N))
+#define gid(N) ((int) get_group_id(N))
+
+__kernel void __attribute__ ((reqd_work_group_size(128, 1, 1))) grudge_assign_0(
+  int const grdg_n,
+  __global double *__restrict__ expr_8,
+  int const expr_8_offset,
+  __global double const *__restrict__ grdg_sub_discr_dx0_dr0,
+  int const grdg_sub_discr_dx0_dr0_offset)
+{
+  if (-1 + -128 * gid(0) + -1 * lid(0) + grdg_n >= 0)
+    expr_8[expr_8_offset + 128 * gid(0) + lid(0)] = grdg_sub_discr_dx0_dr0[grdg_sub_discr_dx0_dr0_offset + 128 * gid(0) + lid(0)];
+}
+)RAW";
+
+int main(int argc, char *argv[]) {
+  int n = 8;
+
+  cl::Device device = cl::Device::getDefault();
+  cl::CommandQueue queue = cl::CommandQueue::getDefault();
+  cl::Program program(SOURCE, true);
+
+  // Create buffers on the device.
+  cl::Buffer buffer_A(CL_MEM_READ_WRITE, sizeof(double) * n);
+  cl::Buffer buffer_B(CL_MEM_READ_WRITE, sizeof(double) * n);
+
+  std::vector<double> A(n);
+  std::vector<double> B(n);
+  std::fill(B.begin(), B.end(), 1);
+
+  // Write arrays to the device.
+  queue.enqueueWriteBuffer(buffer_A, CL_TRUE, 0, sizeof(double) * n, A.data());
+  queue.enqueueWriteBuffer(buffer_B, CL_TRUE, 0, sizeof(double) * n, B.data());
+
+  // Run the kernel.
+  cl::Kernel knl(program, "grudge_assign_0");
+  int sz = 1;
+  knl.setArg(0, sz);
+  knl.setArg(1, buffer_A);
+  knl.setArg(2, 0);
+  knl.setArg(3, buffer_B);
+  knl.setArg(4, 0);
+  queue.enqueueNDRangeKernel(
+    knl,
+    cl::NullRange,
+    cl::NDRange(((sz+127)/128)*128),
+    cl::NDRange(128));
+  queue.finish();
+
+  // Read result A from the device.
+  queue.enqueueReadBuffer(buffer_A, CL_TRUE, 0, sizeof(double) * n, A.data());
+
+  for (int i = 0; i < n; ++i) {
+    if (i < sz) {
+      assert(A[i] == 1);
+    } else {
+      assert(A[i] == 0);
+    }
+  }
+  
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This change checks that loads in parallel loops are safe to execute
unconditionally before adding parallel loop metadata to the
instruction. LLVM makes this assumption. Without this change,
it's possible code can be generated that reads out of bounds
by the loop vectorizer.

See issue #757