### PR TITLE
Syncronization to previous events only in case of out-of-order queue

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,12 @@ Optimizations
     dgemm_t:         2.8%
     dgemm_n_pcie:   51.6%
     dgemm_t_pcie:    6.9%
+- Improved pocl's inner even handling related to consuming commands from
+  in-order and out-of-order queues. Measured with PolyBench OpenCL Gramschmidt
+  kernel, execution time went down from 44 seconds to around 0.5 seconds. Better
+  event handling also removed a little bit of overhead and improved pocl
+  execution time in general. Measured with PolyBench OpenCL fdtd2-2d kernel,
+  execution time came down from 4.13 seconds to 3.99 seconds.
 
 Notable Bug Fixes
 -----------------

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -510,18 +510,6 @@ cl_int pocl_create_command (_cl_command_node **cmd,
   (*cmd)->device = command_queue->device;
   (*cmd)->event->command = (*cmd);
 
-  /* in case of in-order queue, synchronize to previously enqueued command
-     if available */
-  if (!(command_queue->properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE))
-    {
-      POCL_LOCK_OBJ (command_queue);
-      if (command_queue->last_event.event)
-        {
-          pocl_create_event_sync ((*cmd)->event,
-                                  command_queue->last_event.event);
-        }
-      POCL_UNLOCK_OBJ (command_queue);
-    }
   /* Form event synchronizations based on the given wait list */
   for (i = 0; i < num_events; ++i)
     {
@@ -546,8 +534,22 @@ void pocl_command_enqueue (cl_command_queue command_queue,
 
   POCL_LOCK_OBJ (command_queue);
   ++command_queue->command_count;
-  if ((node->type == CL_COMMAND_BARRIER || node->type == CL_COMMAND_MARKER) &&
-      node->command.barrier.has_wait_list == 0)
+  /* in case of in-order queue, synchronize to previously enqueued command
+     if available */
+  if (!(command_queue->properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE))
+    {
+      if (command_queue->last_event.event)
+        {
+          pocl_create_event_sync (node->event,
+                                  command_queue->last_event.event);
+        }
+    }
+  /* Command queue is out-of-order queue. If command type is a barrier, then
+     synchronize to all previously enqueued commands to make sure they are
+     executed before the barrier. */
+  else if ((node->type == CL_COMMAND_BARRIER
+            || node->type == CL_COMMAND_MARKER)
+           && node->command.barrier.has_wait_list == 0)
     {
       DL_FOREACH (command_queue->events, event)
         {


### PR DESCRIPTION
Using pocl with [PolyBench gramschmidt](https://github.com/cavazos-lab/PolyBench-ACC/blob/master/OpenCL/linear-algebra/solvers/gramschmidt/gramschmidt.cl) kernel. Execution time is very high compared to normal CPU execution. Pocl execution takes around 44 seconds compared to CPU which only takes less than a second. Reason is use of barriers in the command queue which are synchronized to all previous commands in the queue. This change only does the synchronization if the command queue is out-of-order queue. Otherwise it defaults to binding to the last event when queue is in-order queue.

I moved last event binding to `pocl_command_enqueue()` function because I thought that where it should be with other event synchronizations.