### PR TITLE
Fix event timing data for CUDA

### DIFF
--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -1454,7 +1454,7 @@ pocl_cuda_update_event (cl_device_id device, cl_event event)
           event_data->start);
       CUDA_CHECK (result, "cuEventElapsedTime");
       event->time_start = (cl_ulong) (epoch + diff * 1e6);
-      event->time_start = max (event->time_start, event->time_submit + 1);
+      event->time_start = max (event->time_start, epoch + 1);
 
       result = cuEventElapsedTime (
           &diff, ((pocl_cuda_device_data_t *)device->data)->epoch_event,


### PR DESCRIPTION
In contrast to `start` and `end`, `time_submit` is not based on a CUDA event
and sometimes represents a time stamp that is *after*`start` and `end`, leading to bogus event timings.

See e.g. https://github.com/illinois-ceesd/mirgecom/issues/71#issuecomment-678298984