### PR TITLE
CL_MEM_ASSOCIATED_MEMOBJECT Fix

### DIFF
--- a/lib/CL/clCreateImage.c
+++ b/lib/CL/clCreateImage.c
@@ -186,6 +186,7 @@ CL_API_SUFFIX__VERSION_1_2
         mem->context = context;
         assert (mem->context == b->context);
 
+        mem->parent = b;
         pocl_cl_mem_inherit_flags (mem, b, flags);
 
         /* Retain the buffer we're referencing */


### PR DESCRIPTION
[This](https://github.com/pocl/OpenCL-CTS/blob/4a6af23ff362cd95477abada53d85a948d394069/test_conformance/images/samplerlessReads/test_read_1D_buffer.cpp#L88) test case fails as `memobj->parent`, is not set if image type is `CL_MEM_OBJECT_IMAGE1D_BUFFER`