### PR TITLE
Avoid assert in get_llvm_cpu_name() when ENABLE_HOST_CPU_DEVICES=0 and llvm fails to recognize the host cpu

### DIFF
--- a/lib/CL/pocl_llvm_utils.cc
+++ b/lib/CL/pocl_llvm_utils.cc
@@ -108,13 +108,15 @@ int getModuleTriple(const char *input_stream, size_t size,
 }
 
 char *
-get_llvm_cpu_name ()
-{
-
+get_llvm_cpu_name () {
   StringRef r = llvm::sys::getHostCPUName();
 
+  // LLVM may return an empty string -- treat as generic
+  if (r.empty())
+    r = "generic";
+
 #ifndef KERNELLIB_HOST_DISTRO_VARIANTS
-  if (r.str() == "generic") {
+  if (r.str() == "generic" && strlen(OCL_KERNEL_TARGET_CPU)) {
     POCL_MSG_WARN("LLVM does not recognize your cpu, trying to use "
                    OCL_KERNEL_TARGET_CPU " for -target-cpu\n");
     r = llvm::StringRef(OCL_KERNEL_TARGET_CPU);


### PR DESCRIPTION
Configuring pocl with ENABLE_HOST_CPU_DEVICES=0 on a platform where llvm fails to recognize the host cpu leads to a situation where `get_llvm_cpu_name()` tries to get the host cpu from OCL_KERNEL_TARGET_CPU, which was never set in the first place. That produces an empty string which subsequently triggers an assert in `get_llvm_cpu_name()`.