### PR TITLE
Conditional event free test

### DIFF
--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -1471,7 +1471,8 @@ pocl_cuda_wait_event_recurse (cl_device_id device, cl_event event)
   while (event->wait_list)
     pocl_cuda_wait_event_recurse (device, event->wait_list->event);
 
-  pocl_cuda_finalize_command (device, event);
+  if (event->status > CL_COMPLETE)
+    pocl_cuda_finalize_command (device, event);
 }
 
 void

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -144,6 +144,7 @@ set_property(TEST
   "runtime/clGetSupportedImageFormats"
   "runtime/clCreateKernelsInProgram"
   "runtime/test_event_cycle"
+  "runtime/test_event_free"
   "runtime/test_event_double_wait"
   "runtime/test_user_event"
   "runtime/clSetMemObjectDestructorCallback"

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -30,6 +30,7 @@ set(PROGRAMS_TO_BUILD test_clFinish test_clGetDeviceInfo test_clGetEventInfo
   test_clCreateKernelsInProgram test_clCreateKernel test_clGetKernelArgInfo
   test_version test_kernel_cache_includes test_event_cycle test_link_error
   test_read-copy-write-buffer test_buffer-image-copy test_clCreateSubDevices test_event_free
+  test_event_double_wait
   test_enqueue_kernel_from_binary test_user_event test_fill-buffer
   test_clSetMemObjectDestructorCallback)
 
@@ -90,6 +91,8 @@ add_test_pocl(NAME "runtime/clCreateSubDevices" COMMAND  "test_clCreateSubDevice
 
 add_test_pocl(NAME "runtime/test_event_free" COMMAND  "test_event_free")
 
+add_test_pocl(NAME "runtime/test_event_double_wait" COMMAND  "test_event_double_wait")
+
 add_test_pocl(NAME "runtime/test_enqueue_kernel_from_binary" COMMAND "test_enqueue_kernel_from_binary")
 
 add_test_pocl(NAME "runtime/test_user_event" COMMAND  "test_user_event")
@@ -104,7 +107,7 @@ set_tests_properties( "runtime/clGetDeviceInfo" "runtime/clEnqueueNativeKernel"
   "runtime/test_kernel_cache_includes" "runtime/test_event_cycle"
   "runtime/test_read-copy-write-buffer" "runtime/test_buffer-image-copy"
   "runtime/test_fill-buffer"
-  "runtime/test_event_free" "runtime/clCreateSubDevices"
+  "runtime/test_event_free" "runtime/test_event_double_wait" "runtime/clCreateSubDevices"
   "runtime/test_enqueue_kernel_from_binary" "runtime/test_user_event"
   "runtime/clSetMemObjectDestructorCallback" "runtime/test_link_error"
   PROPERTIES
@@ -141,6 +144,7 @@ set_property(TEST
   "runtime/clGetSupportedImageFormats"
   "runtime/clCreateKernelsInProgram"
   "runtime/test_event_cycle"
+  "runtime/test_event_double_wait"
   "runtime/test_user_event"
   "runtime/clSetMemObjectDestructorCallback"
   APPEND PROPERTY LABELS "cuda")

--- a/tests/runtime/test_event_double_wait.c
+++ b/tests/runtime/test_event_double_wait.c
@@ -1,0 +1,70 @@
+/* Test that waiting for an event twice doesn't lead to double-frees
+
+   Copyright (C) 2020 Giuseppe Bilotta <giuseppe.bilotta@gmail.com>
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <CL/cl.h>
+#include "poclu.h"
+
+int main(int argc, char **argv)
+{
+  cl_int err;
+  const char *krn_src = "kernel void test () { }";
+  cl_program program;
+  cl_context ctx;
+  cl_command_queue queue;
+  cl_device_id did;
+  cl_kernel kernel;
+  cl_event kern_evt;
+  const size_t gws[] = { 1 };
+
+  CHECK_CL_ERROR (poclu_get_any_device (&ctx, &did, &queue));
+  TEST_ASSERT (ctx);
+  TEST_ASSERT (did);
+  TEST_ASSERT (queue);
+
+  program = clCreateProgramWithSource (ctx, 1, &krn_src, NULL, &err);
+  CHECK_OPENCL_ERROR_IN ("clCreateProgramWithSource");
+
+  CHECK_CL_ERROR (clBuildProgram (program, 1, &did, "", NULL, NULL));
+
+  kernel = clCreateKernel (program, "test", &err);
+  CHECK_OPENCL_ERROR_IN ("clCreateKernel");
+
+  CHECK_CL_ERROR (clEnqueueNDRangeKernel (queue, kernel, 1, NULL, gws, NULL, 0, NULL, &kern_evt));
+
+  CHECK_CL_ERROR (clWaitForEvents (1, &kern_evt));
+  CHECK_CL_ERROR (clWaitForEvents (1, &kern_evt));
+  CHECK_CL_ERROR (clFinish (queue));
+
+  CHECK_CL_ERROR (clReleaseCommandQueue (queue));
+  CHECK_CL_ERROR (clReleaseProgram (program));
+  CHECK_CL_ERROR (clReleaseContext (ctx));
+  CHECK_CL_ERROR (clUnloadCompiler ());
+
+  return EXIT_SUCCESS;
+
+}
+
+


### PR DESCRIPTION
This changes test_event_free so that it doesn't run the image-related tests when the device doesn't support it (e.g. CUDA) and consequently labels the test as valid for the CUDA device.

It's built on top of #891 but it doesn't actually depend on it. If necessary I can rebase (which needs to be done manually because the changes in `CMakeList.txt` are right next to each other).