### PR TITLE
Remove const to make SLEEF compatible with POCL

### DIFF
--- a/lib/kernel/sleef/include/sleef.h
+++ b/lib/kernel/sleef/include/sleef.h
@@ -13,12 +13,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#if (defined(__GNUC__) || defined(__CLANG__)) && !defined(__INTEL_COMPILER)
-#define CONST const
-#else
-#define CONST
-#endif
-
 #if (defined(__GNUC__) || defined(__CLANG__))                                 \
     && (defined(__i386__) || defined(__x86_64__))
 #include <x86intrin.h>


### PR DESCRIPTION
Apparently on PPC64le the compiler is "properly" detected then compilation fails as
signatures are not aligned. 

I suspect on AMD64, the compiler is not properly detected and it work "by accident" (?)

close #876