### PR TITLE
Disable jump threading pass from crashing pocl with LLVM 11 and 12

### DIFF
--- a/lib/CL/pocl_llvm_utils.cc
+++ b/lib/CL/pocl_llvm_utils.cc
@@ -323,6 +323,21 @@ void InitializeLLVM() {
     O->addOccurrence(1, StringRef("vectorizer-min-trip-count"), StringRef("2"),
                      false);
 
+    // Disable jump threading optimization with following two options from
+    // duplicating blocks. Using jump threading will mess up parallel region
+    // construction especially when kernel contains barriers.
+    // TODO: If enabled then parallel region construction code needs
+    // improvements and make sure it doesn't disallow other optimizations like
+    // vectorization.
+    O = opts["jump-threading-threshold"];
+    assert(O && "could not find LLVM option 'jump-threading-threshold'");
+    O->addOccurrence(1, StringRef("jump-threading-threshold"), StringRef("0"),
+                     false);
+    O = opts["jump-threading-implication-search-threshold"];
+    assert(O && "could not find LLVM option 'jump-threading-implication-search-threshold'");
+    O->addOccurrence(1, StringRef("jump-threading-implication-search-threshold"), StringRef("0"),
+                     false);
+
     if (pocl_get_bool_option("POCL_VECTORIZER_REMARKS", 0) == 1) {
       // Enable diagnostics from the loop vectorizer.
       O = opts["pass-remarks-missed"];

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -44,8 +44,10 @@ set(PROGRAMS_TO_BUILD test_barrier_between_for_loops test_early_return
   test_undominated_variable test_setargs test_null_arg
   test_fors_with_var_iteration_counts test_issue_231 test_issue_445
   test_autolocals_in_constexprs test_issue_553 test_issue_577 test_issue_757
-  test_flatten_barrier_subs
-  test_alignment_with_dynamic_wg test_alignment_with_dynamic_wg2 test_alignment_with_dynamic_wg3)
+  test_flatten_barrier_subs test_alignment_with_dynamic_wg
+  test_alignment_with_dynamic_wg2 test_alignment_with_dynamic_wg3
+  test_issue_893
+)
 
 if (MSVC)
   add_compile_options(${OPENCL_CFLAGS})
@@ -73,6 +75,8 @@ add_test_pocl(NAME "regression/test_issue_553" COMMAND "test_issue_553")
 add_test_pocl(NAME "regression/test_issue_577" COMMAND "test_issue_577")
 
 add_test_pocl(NAME "regression/test_issue_757" COMMAND "test_issue_757")
+
+add_test_pocl(NAME "regression/test_issue_893" COMMAND "test_issue_893")
 
 add_test_pocl(NAME "regression/test_flatten_barrier_subs" COMMAND "test_flatten_barrier_subs" EXPECTED_OUTPUT "test_flatten_barrier_subs.output")
 
@@ -266,6 +270,7 @@ set_tests_properties("regression/setting_a_buffer_argument_to_NULL_causes_a_segf
   "regression/autolocals_in_constexprs" "regression/test_issue_231"
   "regression/test_issue_445" "regression/test_issue_553"
   "regression/test_issue_577" "regression/test_issue_757"
+  "regression/test_issue_893"
   "regression/test_flatten_barrier_subs"
   ${TCE_TESTS}
   PROPERTIES

--- a/tests/regression/test_issue_893.cpp
+++ b/tests/regression/test_issue_893.cpp
@@ -1,0 +1,63 @@
+/* See https://github.com/pocl/pocl/issues/893.
+ *
+ * This test will test that PoCL will not crash on LLVM 11 onward. The reason
+ * was a jump threading optimizations which will duplicate basic blocks and
+ * cause PoCL to form illegal parallel regions which does not follow
+ * single-entry single-exit rule. This test doesn't care about the kernel result
+ * or the arguments given to it. Point is to see that the kernel compiles
+ * without any problems.
+ *
+ * More specifically the issue was the jump threading will cause kernel for loop
+ * latch block to be duplicated when OpenCL is compiled to IR. Then later when
+ * standard -O3 is ran as part of the PoCL passes the loop backedge is
+ * duplicated, causing the loop duplication. When PoCL tries to form parallel
+ * regions from explicit barrier to loop latch barrier the parallel region is
+ * not form correctly. It contains incoming edges from outside of the parallel
+ * region which will cause assert to fail. Those incoming edges are coming from
+ * duplicated latch blocks.
+ */
+
+#define CL_HPP_MINIMUM_OPENCL_VERSION 120
+#define CL_HPP_TARGET_OPENCL_VERSION 120
+#include <CL/cl2.hpp>
+
+const char *SOURCE = R"RAW(
+#define lid(N) ((int) get_local_id(N))
+#define gid(N) ((int) get_group_id(N))
+
+__kernel void loopy_kernel(__global float *__restrict__ out, int const im_h, int const im_w)
+{
+  float acc_f_x_f_y_icolor;
+
+  if (-1 + -1 * /* im_y_inner */ lid(1) + -16 * /* im_y_outer */ gid(1) + im_h >= 0 && -1 + -1 * /* im_x_inner */ lid(0) + -16 * /* im_x_outer */ gid(0) + im_w >= 0)
+    acc_f_x_f_y_icolor = 0.0f;
+  for (int icolor = 0; icolor <= 2; ++icolor)
+  {
+    barrier(CLK_LOCAL_MEM_FENCE) /* for img_fetch (insn_f_x_f_y_icolor_update depends on img_fetch_rule) */;
+    if (-1 + -1 * /* im_y_inner */ lid(1) + -16 * /* im_y_outer */ gid(1) + im_h >= 0 && -1 + -1 * /* im_x_inner */ lid(0) + -16 * /* im_x_outer */ gid(0) + im_w >= 0)
+      for (int f_x = -3; f_x <= 3; ++f_x)
+        acc_f_x_f_y_icolor = acc_f_x_f_y_icolor + 10 * 3;
+  }
+  if (-1 + -1 * /* im_y_inner */ lid(1) + -16 * /* im_y_outer */ gid(1) + im_h >= 0 && -1 + -1 * /* im_x_inner */ lid(0) + -16 * /* im_x_outer */ gid(0) + im_w >= 0)
+    out[im_h * im_w * /* ifeat */ gid(2) + im_h * (16 * /* im_x_outer */ gid(0) + /* im_x_inner */ lid(0)) + 16 * /* im_y_outer */ gid(1) + /* im_y_inner */ lid(1)] = acc_f_x_f_y_icolor;
+}
+)RAW";
+
+int main() {
+  int n = 8;
+  cl::Device device = cl::Device::getDefault();
+  cl::CommandQueue queue = cl::CommandQueue::getDefault();
+  cl::Program program(SOURCE, true);
+  cl::Buffer buffer(CL_MEM_WRITE_ONLY, sizeof(float) * 256);
+  cl::Kernel kernel(program, "loopy_kernel");
+  kernel.setArg(0, buffer);
+  kernel.setArg(1, n);
+  kernel.setArg(2, n);
+  queue.enqueueNDRangeKernel(
+    kernel,
+    cl::NullRange,
+    cl::NDRange(n),
+    cl::NDRange(n));
+  queue.finish();
+  return EXIT_SUCCESS;
+}

--- a/tests/regression/test_issue_893.cpp
+++ b/tests/regression/test_issue_893.cpp
@@ -1,3 +1,23 @@
+// Copyright (c) 2021 PoCL developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 /* See https://github.com/pocl/pocl/issues/893.
  *
  * This test will test that PoCL will not crash on LLVM 11 onward. The reason
@@ -16,7 +36,6 @@
  * region which will cause assert to fail. Those incoming edges are coming from
  * duplicated latch blocks.
  */
-
 #define CL_HPP_MINIMUM_OPENCL_VERSION 120
 #define CL_HPP_TARGET_OPENCL_VERSION 120
 #include <CL/cl2.hpp>


### PR DESCRIPTION
This PR will fix issue #893. The crash was caused by PoCL construction invalid parallel regions which don't follow single-entry single-exit policy. This happens because LLVM 11 onward jump threading pass is enabled by default in the front end when OpenCL kernel is compiled to IR before other PoCL passes run. IR contains duplicate blocks which will mess up parallel regions especially when kernel contain barriers.

To fix this for now I disabled jump threading pass with options it provides. There wasn't option to explicitly turn it off. I also left comment if this is enabled later then parallel region construction code might need some improvements and also to make sure using this pass doesn't disable other optimizations like vectorization. Maybe also running this pass later after PoCL passes would be better option than running it before PoCL does anything with the kernel.