### PR TITLE
support building with -fvisibility=hidden -fvisibility-inlines-hidden

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,12 @@ option(POCL_ICD_ABSOLUTE_PATH "Use absolute path in pocl.icd" ON)
 
 option(ENABLE_POCL_BUILDING "When OFF, env var POCL_BUILDING has no effect. Defaults to ON" ON)
 
+option(VISIBILITY_HIDDEN "Build with -fvisibility=hidden -fvisibility-inlines-hidden" OFF)
+if(VISIBILITY_HIDDEN)
+  add_compile_options(-fvisibility=hidden)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fvisibility-inlines-hidden>)
+endif()
+
 #### these are mostly useful for pocl developers
 
 option(DEVELOPER_MODE "This will SIGNIFICANTLY slow down pocl (but speed up its compilation). Only turn on if you know what you're doing." OFF)

--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -243,8 +243,8 @@ string(STRIP "${LLVM_SYSLIBS}" LLVM_SYSLIBS)
 ####################################################################
 
 # llvm-config does not include clang libs
-if((9 LESS LLVM_MAJOR) AND (NOT STATIC_LLVM))
-  # For Clang 10+, link against a single shared library instead of multiple component shared
+if((8 LESS LLVM_MAJOR) AND (NOT STATIC_LLVM))
+  # For Clang 9+, link against a single shared library instead of multiple component shared
   # libraries.
   if("${LLVM_LIBNAMES}" MATCHES "LLVMTCE")
     set(CLANG_LIBNAMES clangTCE-cpp)
@@ -261,7 +261,7 @@ endif()
 foreach(LIBNAME ${CLANG_LIBNAMES})
   find_library(C_LIBFILE_${LIBNAME} NAMES "${LIBNAME}" HINTS "${LLVM_LIBDIR}")
   list(APPEND CLANG_LIBFILES "${C_LIBFILE_${LIBNAME}}")
-  if(UNIX AND (NOT APPLE))
+  if(UNIX AND (NOT APPLE) AND (NOT ((8 LESS LLVM_MAJOR) AND (NOT STATIC_LLVM))))
     set(LLVM_LDFLAGS "${LLVM_LDFLAGS} -Wl,--exclude-libs,lib${LIBNAME}")
   endif()
 endforeach()

--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -735,6 +735,7 @@ if(NOT DEFINED CLANG_MARCH_FLAG)
       message(FATAL_ERROR "Could not determine whether to use -march or -mcpu with clang")
     endif()
   endif()
+  message(STATUS "  Using ${CLANG_MARCH_FLAG}")
 
   set(CLANG_MARCH_FLAG ${CLANG_MARCH_FLAG} CACHE INTERNAL "Clang option used to specify the target cpu")
 endif()

--- a/examples/vecadd/CMakeLists.txt
+++ b/examples/vecadd/CMakeLists.txt
@@ -42,7 +42,9 @@ if(NOT ENABLE_ANYSAN)
     PASS_REGULAR_EXPRESSION "OK")
 endif()
 
-set_tests_properties( "examples/vecadd"
+set_tests_properties(
+  "examples/vecadd"
+  "examples/vecadd_large_grid"
   PROPERTIES
     COST 3.0
     ${PROPS}

--- a/include/pocl.h
+++ b/include/pocl.h
@@ -40,6 +40,8 @@
 
 #include "config.h"
 
+#include "pocl_export.h"
+
 #include "pocl_context.h"
 
 /* detects restrict, variadic macros etc */

--- a/include/pocl_export.h
+++ b/include/pocl_export.h
@@ -1,0 +1,33 @@
+/* pocl_export.h: macros for symbol visibility
+
+   Copyright (c) 2021 pocl developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#ifndef POCL_EXPORT_H
+#define POCL_EXPORT_H
+
+#if defined(__GNUC__) && (__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__ >= 1)
+#define POCL_EXPORT __attribute__ ((visibility ("default")))
+#else
+#define POCL_EXPORT
+#endif
+
+#endif

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -377,7 +377,7 @@ pocl_basic_run (void *data, _cl_command_node *cmd)
       else if (meta->arg_info[i].type == POCL_ARG_TYPE_IMAGE)
         {
           dev_image_t di;
-          fill_dev_image_t (&di, al, cmd->device);
+          pocl_fill_dev_image_t (&di, al, cmd->device);
 
           void *devptr = pocl_aligned_malloc (MAX_EXTENDED_ALIGNMENT,
                                               sizeof (dev_image_t));
@@ -388,7 +388,7 @@ pocl_basic_run (void *data, _cl_command_node *cmd)
       else if (meta->arg_info[i].type == POCL_ARG_TYPE_SAMPLER)
         {
           dev_sampler_t ds;
-          fill_dev_sampler_t(&ds, al);
+          pocl_fill_dev_sampler_t (&ds, al);
           arguments[i] = malloc (sizeof (void *));
           *(void **)(arguments[i]) = (void *)ds;
         }

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -261,8 +261,8 @@ FINISH:
  * from given kernel image argument
  */
 void
-fill_dev_image_t (dev_image_t* di, struct pocl_argument* parg,
-                  cl_device_id device)
+pocl_fill_dev_image_t (dev_image_t *di, struct pocl_argument *parg,
+                       cl_device_id device)
 {
   cl_mem mem = *(cl_mem *)parg->value;
   di->_width = mem->image_width;
@@ -791,7 +791,7 @@ pocl_broadcast (cl_event brc_event)
  * from given kernel sampler argument
  */
 void
-fill_dev_sampler_t (dev_sampler_t *ds, struct pocl_argument *parg)
+pocl_fill_dev_sampler_t (dev_sampler_t *ds, struct pocl_argument *parg)
 {
   cl_sampler sampler = *(cl_sampler *)parg->value;
 

--- a/lib/CL/devices/common.h
+++ b/lib/CL/devices/common.h
@@ -64,10 +64,10 @@ int llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
                   cl_device_id device, _cl_command_node *command,
                   int specialize);
 
-void fill_dev_image_t (dev_image_t *di, struct pocl_argument *parg,
-                       cl_device_id device);
+void pocl_fill_dev_image_t (dev_image_t *di, struct pocl_argument *parg,
+                            cl_device_id device);
 
-void fill_dev_sampler_t (dev_sampler_t *ds, struct pocl_argument *parg);
+void pocl_fill_dev_sampler_t (dev_sampler_t *ds, struct pocl_argument *parg);
 
 void pocl_copy_mem_object (cl_device_id dest_dev, cl_mem dest,
                            size_t dest_offset,

--- a/lib/CL/devices/common.h
+++ b/lib/CL/devices/common.h
@@ -64,9 +64,11 @@ int llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
                   cl_device_id device, _cl_command_node *command,
                   int specialize);
 
+POCL_EXPORT
 void pocl_fill_dev_image_t (dev_image_t *di, struct pocl_argument *parg,
                             cl_device_id device);
 
+POCL_EXPORT
 void pocl_fill_dev_sampler_t (dev_sampler_t *ds, struct pocl_argument *parg);
 
 void pocl_copy_mem_object (cl_device_id dest_dev, cl_mem dest,
@@ -79,33 +81,42 @@ void pocl_migrate_mem_objects (_cl_command_node *node);
 void pocl_scheduler (_cl_command_node * volatile * ready_list,
                      pthread_mutex_t *lock_ptr);
 
+POCL_EXPORT
 void pocl_exec_command (_cl_command_node * volatile node);
 
+POCL_EXPORT
 void pocl_ndrange_node_cleanup(_cl_command_node *node);
 void pocl_mem_objs_cleanup (cl_event event);
 
+POCL_EXPORT
 void pocl_broadcast (cl_event event);
 
+POCL_EXPORT
 void pocl_init_dlhandle_cache ();
 
 char *pocl_check_kernel_disk_cache (_cl_command_node *cmd, int specialized);
 
 size_t pocl_cmd_max_grid_dim_width (_cl_command_run *cmd);
 
+POCL_EXPORT
 void pocl_check_kernel_dlhandle_cache (_cl_command_node *command,
                                        unsigned initial_refcount,
                                        int specialize);
 
+POCL_EXPORT
 void pocl_release_dlhandle_cache (_cl_command_node *cmd);
 
 void pocl_setup_device_for_system_memory(cl_device_id device);
 
 void pocl_reinit_system_memory();
 
+POCL_EXPORT
 void pocl_set_buffer_image_limits(cl_device_id device);
 
+POCL_EXPORT
 void* pocl_aligned_malloc_global_mem(cl_device_id device, size_t align, size_t size);
 
+POCL_EXPORT
 void pocl_free_global_mem(cl_device_id device, void *ptr, size_t size);
 
 void pocl_print_system_memory_stats();
@@ -113,6 +124,7 @@ void pocl_print_system_memory_stats();
 void pocl_calculate_kernel_hash (cl_program program, unsigned kernel_i,
                                  unsigned device_i);
 
+POCL_EXPORT
 void pocl_init_default_device_infos (cl_device_id dev);
 
 #ifdef __cplusplus

--- a/lib/CL/devices/cpuinfo.h
+++ b/lib/CL/devices/cpuinfo.h
@@ -32,6 +32,7 @@
 
 #include "pocl_cl.h"
 
+POCL_EXPORT
 void pocl_cpuinfo_detect_device_info(cl_device_id device);
 
 #endif /* POCL_TOPOLOGY_H */

--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -531,7 +531,7 @@ pocl_init_devices ()
 #ifdef POCL_DEBUG_MESSAGES
   const char* debug = pocl_get_string_option ("POCL_DEBUG", "0");
   pocl_debug_messages_setup (debug);
-  stderr_is_a_tty = isatty(fileno(stderr));
+  pocl_stderr_is_a_tty = isatty(fileno(stderr));
 #endif
 
   POCL_GOTO_ERROR_ON ((pocl_cache_init_topdir ()), CL_DEVICE_NOT_FOUND,

--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -595,11 +595,23 @@ pocl_init_devices ()
             {
               pocl_devices_init_ops[i] = (init_device_ops)dlsym (
                   pocl_device_handles[i], init_device_ops_name);
-              pocl_devices_init_ops[i](&pocl_device_ops[i]);
+              if (pocl_devices_init_ops[i] != NULL)
+                {
+                  pocl_devices_init_ops[i](&pocl_device_ops[i]);
+                }
+              else
+                {
+                  POCL_MSG_ERR ("Loading symbol %s from %s failed: %s\n",
+                                init_device_ops_name, device_library,
+                                dlerror ());
+                  device_count[i] = 0;
+                  continue;
+                }
             }
           else
             {
-              POCL_MSG_WARN ("Loading %s failed.\n", device_library);
+              POCL_MSG_WARN ("Loading %s failed: %s\n", device_library,
+                             dlerror ());
               device_count[i] = 0;
               continue;
             }

--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -80,7 +80,6 @@
 /* the enabled devices */
 static struct _cl_device_id* pocl_devices = NULL;
 unsigned int pocl_num_devices = 0;
-unsigned int pocl_num_device_types = 0;
 
 /* Init function prototype */
 typedef void (*init_device_ops)(struct pocl_device_ops*);

--- a/lib/CL/devices/devices.h
+++ b/lib/CL/devices/devices.h
@@ -68,6 +68,7 @@ unsigned int pocl_get_devices(cl_device_type device_type, struct _cl_device_id *
  * \return If the env var was not set, return -1, if the env var is specified, return 0
  * or the number of occurrence of dev_type in the env var
  */
+POCL_EXPORT
 int pocl_device_get_env_count(const char *dev_type);
 
 /**

--- a/lib/CL/devices/devices.h
+++ b/lib/CL/devices/devices.h
@@ -70,7 +70,6 @@ unsigned int pocl_get_devices(cl_device_type device_type, struct _cl_device_id *
  */
 int pocl_device_get_env_count(const char *dev_type);
 
-
 /**
  * \brief Unique global memory id for devices with distinct memory from the system memory
  * \return Unique global mem id, id > 0. Zero is reserved for shared system memory

--- a/lib/CL/devices/pocl_local_size.h
+++ b/lib/CL/devices/pocl_local_size.h
@@ -27,6 +27,7 @@
 #include "pocl_cl.h"
 /* The generic local size optimizer used by default, in case there's no target
  * specific one defined in the device driver. */
+POCL_EXPORT
 void pocl_default_local_size_optimizer (cl_device_id dev, size_t global_x,
                                         size_t global_y, size_t global_z,
                                         size_t *local_x, size_t *local_y,

--- a/lib/CL/devices/prototypes.inc
+++ b/lib/CL/devices/prototypes.inc
@@ -31,6 +31,7 @@
   void pocl_##__DRV__##_wait_event (cl_device_id device, cl_event event);     \
   void pocl_##__DRV__##_update_event (cl_device_id device, cl_event event);   \
   void pocl_##__DRV__##_free_event_data (cl_event event);                     \
+  POCL_EXPORT                                                                 \
   void pocl_##__DRV__##_init_device_ops (struct pocl_device_ops *ops);        \
   cl_int pocl_##__DRV__##_uninit (unsigned j, cl_device_id device);           \
   cl_int pocl_##__DRV__##_reinit (unsigned j, cl_device_id device);           \

--- a/lib/CL/devices/pthread/pthread_utils.c
+++ b/lib/CL/devices/pthread/pthread_utils.c
@@ -146,7 +146,7 @@ setup_kernel_arg_array (kernel_run_command *k)
       else if (meta->arg_info[i].type == POCL_ARG_TYPE_IMAGE)
         {
           dev_image_t di;
-          fill_dev_image_t(&di, al, k->device);
+          pocl_fill_dev_image_t (&di, al, k->device);
           void *devptr = pocl_aligned_malloc (MAX_EXTENDED_ALIGNMENT,
                                               sizeof (dev_image_t));
           arguments[i] = &arguments2[i];
@@ -156,7 +156,7 @@ setup_kernel_arg_array (kernel_run_command *k)
       else if (meta->arg_info[i].type == POCL_ARG_TYPE_SAMPLER)
         {
           dev_sampler_t ds;
-          fill_dev_sampler_t(&ds, al);
+          pocl_fill_dev_sampler_t (&ds, al);
 
           arguments[i] = &arguments2[i];
           arguments2[i] = (void *)ds;

--- a/lib/CL/devices/topology/pocl_topology.h
+++ b/lib/CL/devices/topology/pocl_topology.h
@@ -33,6 +33,7 @@
 
 #include "pocl_cl.h"
 
+POCL_EXPORT
 int pocl_topology_detect_device_info(cl_device_id device);
 
 #endif /* POCL_TOPOLOGY_H */

--- a/lib/CL/pocl_cache.c
+++ b/lib/CL/pocl_cache.c
@@ -517,7 +517,7 @@ pocl_cache_init_topdir ()
             "library. \nThis is not a bug in pocl and there's nothing we "
             "can do to fix it - you need both pocl and your program to be"
             " compiled for your system. This is known to happen with "
-            "Luxmark benchmark binaries dowloaded from website; Luxmark "
+            "Luxmark benchmark binaries downloaded from website; Luxmark "
             "installed from your linux distribution's packages should "
             "work.\n",
             cache_topdir);

--- a/lib/CL/pocl_debug.c
+++ b/lib/CL/pocl_debug.c
@@ -11,7 +11,7 @@
 #ifdef POCL_DEBUG_MESSAGES
 
 uint64_t pocl_debug_messages_filter; /* Bitfield */
-int stderr_is_a_tty;
+int pocl_stderr_is_a_tty;
 
 static pthread_mutex_t console_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -100,15 +100,15 @@ static pthread_mutex_t console_mutex = PTHREAD_MUTEX_INITIALIZER;
         const char *formatstring;
 
         if (filter_type == POCL_FILTER_TYPE_ERR)
-          filter_type_str = (stderr_is_a_tty ? POCL_COLOR_RED : " *** ERROR *** ");
+          filter_type_str = (pocl_stderr_is_a_tty ? POCL_COLOR_RED : " *** ERROR *** ");
         else if (filter_type == POCL_FILTER_TYPE_WARN)
-          filter_type_str = (stderr_is_a_tty ? POCL_COLOR_YELLOW : " *** WARNING *** ");
+          filter_type_str = (pocl_stderr_is_a_tty ? POCL_COLOR_YELLOW : " *** WARNING *** ");
         else if (filter_type == POCL_FILTER_TYPE_INFO)
-          filter_type_str = (stderr_is_a_tty ? POCL_COLOR_GREEN : " *** INFO *** ");
+          filter_type_str = (pocl_stderr_is_a_tty ? POCL_COLOR_GREEN : " *** INFO *** ");
         else
-          filter_type_str = (stderr_is_a_tty ? POCL_COLOR_GREEN : " *** UNKNOWN *** ");
+          filter_type_str = (pocl_stderr_is_a_tty ? POCL_COLOR_GREEN : " *** UNKNOWN *** ");
 
-        if (stderr_is_a_tty)
+        if (pocl_stderr_is_a_tty)
           formatstring = POCL_COLOR_BLUE
               "[%04i-%02i-%02i %02i:%02i:%02i.%09li]"
               POCL_COLOR_RESET "POCL: in fn %s "
@@ -143,7 +143,7 @@ static pthread_mutex_t console_mutex = PTHREAD_MUTEX_INITIALIZER;
       if (!(pocl_debug_messages_filter & POCL_DEBUG_FLAG_TIMING))
         return;
       const char* formatstring;
-      if (stderr_is_a_tty)
+      if (pocl_stderr_is_a_tty)
         formatstring = "      >>>  " POCL_COLOR_MAGENTA "     %3" PRIu64
                        ".%03" PRIu64 " " POCL_COLOR_RESET " %s    %s\n";
       else
@@ -157,7 +157,7 @@ static pthread_mutex_t console_mutex = PTHREAD_MUTEX_INITIALIZER;
       if ((sec == 0) && (nsec < 1000))
         {
           b = nsec % 1000;
-          if (stderr_is_a_tty)
+          if (pocl_stderr_is_a_tty)
             formatstring = "      >>>      " POCL_COLOR_MAGENTA
                     "     %3" PRIu64 " " POCL_COLOR_RESET " ns    %s\n";
           else
@@ -178,7 +178,7 @@ static pthread_mutex_t console_mutex = PTHREAD_MUTEX_INITIALIZER;
         }
       else
         {
-          if (stderr_is_a_tty)
+          if (pocl_stderr_is_a_tty)
             formatstring = "      >>>  " POCL_COLOR_MAGENTA "     %3" PRIu64
                            ".%09" PRIu64 " " POCL_COLOR_RESET " %s    %s\n";
           else

--- a/lib/CL/pocl_debug.h
+++ b/lib/CL/pocl_debug.h
@@ -110,7 +110,7 @@ extern "C" {
 #ifdef POCL_DEBUG_MESSAGES
 
     extern uint64_t pocl_debug_messages_filter;
-    extern int stderr_is_a_tty;
+    extern int pocl_stderr_is_a_tty;
 
     #define POCL_DEBUGGING_ON (pocl_debug_messages_filter)
 
@@ -148,7 +148,7 @@ extern "C" {
           if (pocl_debug_messages_filter & POCL_DEBUG_FLAG_ ## FILTER) {    \
             pocl_debug_output_lock ();                                      \
                 POCL_DEBUG_HEADER(FILTER, POCL_FILTER_TYPE_ ## TYPE)        \
-                if (stderr_is_a_tty)                                        \
+                if (pocl_stderr_is_a_tty)                                   \
                   fprintf (stderr, "%s", POCL_COLOR_BOLDRED                 \
                                     ERRCODE " "  POCL_COLOR_RESET);         \
                 else                                                        \

--- a/lib/CL/pocl_debug.h
+++ b/lib/CL/pocl_debug.h
@@ -17,6 +17,8 @@
 
 #include "config.h"
 
+#include "pocl_export.h"
+
 // size_t print spec
 #ifndef PRIuS
 # define PRIuS "zu"
@@ -105,7 +107,9 @@ extern "C" {
 
 #ifdef POCL_DEBUG_MESSAGES
 
+POCL_EXPORT
     extern uint64_t pocl_debug_messages_filter;
+POCL_EXPORT
     extern int pocl_stderr_is_a_tty;
 
     #define POCL_DEBUGGING_ON (pocl_debug_messages_filter)
@@ -118,9 +122,12 @@ extern "C" {
 
         #define POCL_DEBUG_HEADER(FILTER, FILTER_TYPE) \
             pocl_debug_print_header (__func__, __LINE__, #FILTER, FILTER_TYPE);
+POCL_EXPORT
         extern void pocl_debug_output_lock ();
+POCL_EXPORT
         extern void pocl_debug_output_unlock ();
         extern void pocl_debug_messages_setup (const char *debug);
+POCL_EXPORT
         extern void pocl_debug_print_header (const char * func, unsigned line,
                                              const char* filter, int filter_type);
         extern void pocl_debug_measure_start (uint64_t* start);

--- a/lib/CL/pocl_debug.h
+++ b/lib/CL/pocl_debug.h
@@ -103,10 +103,6 @@ extern "C" {
                               *errcode_ret = CL_SUCCESS;                \
                             } } while (0)
 
-
-
-#include "config.h"
-
 #ifdef POCL_DEBUG_MESSAGES
 
     extern uint64_t pocl_debug_messages_filter;

--- a/lib/CL/pocl_llvm.h
+++ b/lib/CL/pocl_llvm.h
@@ -30,6 +30,7 @@ extern "C" {
 #endif
 
 /* Returns the cpu name as reported by LLVM. */
+POCL_EXPORT
 char *get_llvm_cpu_name ();
 /* Returns if the cpu supports FMA instruction (uses LLVM). */
 int cpu_has_fma();

--- a/lib/CL/pocl_llvm_api.h
+++ b/lib/CL/pocl_llvm_api.h
@@ -65,6 +65,7 @@ public:
 };
 
 
+POCL_EXPORT
 extern cl_device_id currentPoclDevice;
 
 void InitializeLLVM();

--- a/lib/CL/pocl_runtime_config.h
+++ b/lib/CL/pocl_runtime_config.h
@@ -25,12 +25,16 @@
 #ifndef _POCL_RUNTIME_CONFIG_H
 #define _POCL_RUNTIME_CONFIG_H
 
+#include "pocl_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 int pocl_is_option_set(const char *key);
+POCL_EXPORT
 int pocl_get_int_option(const char *key, int default_value);
+POCL_EXPORT
 int pocl_get_bool_option(const char *key, int default_value);
 const char* pocl_get_string_option(const char *key, const char *default_value);
 

--- a/lib/CL/pocl_timing.c
+++ b/lib/CL/pocl_timing.c
@@ -35,7 +35,7 @@
 #  else
 #    include <sys/time.h>
 #  endif
-#  ifdef __MACH__
+#  ifdef __APPLE__
 #    include <mach/clock.h>
 #    include <mach/mach.h>
 #  endif

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -57,17 +57,23 @@ uint32_t byteswap_uint32_t (uint32_t word, char should_swap);
 float byteswap_float (float word, char should_swap);
 
 /* set rounding mode */
+POCL_EXPORT
 void pocl_restore_rm (unsigned rm);
 /* get current rounding mode */
+POCL_EXPORT
 unsigned pocl_save_rm ();
 /* set OpenCL's default (round to nearest) rounding mode */
+POCL_EXPORT
 void pocl_set_default_rm ();
 
 /* sets the flush-denorms-to-zero flag on the CPU, if supported */
+POCL_EXPORT
 void pocl_set_ftz (unsigned ftz);
 
 /* saves / restores cpu flags*/
+POCL_EXPORT
 unsigned pocl_save_ftz ();
+POCL_EXPORT
 void pocl_restore_ftz (unsigned ftz);
 
 /* Finds the next highest power of two of the given value. */
@@ -83,6 +89,7 @@ uint64_t pocl_size_ceil2_64 (uint64_t x);
  * must be a non-zero power of 2.
  */
 
+POCL_EXPORT
 void *pocl_aligned_malloc(size_t alignment, size_t size);
 #define pocl_aligned_free(x) POCL_MEM_FREE(x)
 
@@ -131,6 +138,7 @@ check_copy_overlap(const size_t src_offset[3],
  * Push a command into ready list if all previous events are completed or
  * in pending_list if the command still has pending dependencies
  */
+POCL_EXPORT
 void
 pocl_command_push (_cl_command_node *node, 
                    _cl_command_node * volatile * ready_list, 
@@ -182,12 +190,15 @@ void pocl_abort_on_pthread_error (int status, unsigned line, const char *func);
 
 void pocl_update_event_queued (cl_event event);
 
+POCL_EXPORT
 void pocl_update_event_submitted (cl_event event);
 
 void pocl_update_event_running_unlocked (cl_event event);
 
+POCL_EXPORT
 void pocl_update_event_running (cl_event event);
 
+POCL_EXPORT
 void pocl_update_event_complete_msg (const char *func, unsigned line,
                                      cl_event event, const char *msg);
 
@@ -197,6 +208,7 @@ void pocl_update_event_complete_msg (const char *func, unsigned line,
 #define POCL_UPDATE_EVENT_COMPLETE(__event)                                   \
   pocl_update_event_complete_msg (__func__, __LINE__, (__event), NULL);
 
+POCL_EXPORT
 void pocl_update_event_failed (cl_event event);
 
 const char*

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,41 @@ endif()
 
 #######################################################################
 
+add_test("pocl_test_dlopen_libpocl" "runtime/test_dlopen")
+set_property(TEST "pocl_version_check" APPEND PROPERTY DEPENDS "pocl_test_dlopen_libpocl")
+
+if(BUILD_BASIC)
+  add_test("pocl_test_dlopen_device_basic" "runtime/test_dlopen" "basic")
+  set_property(TEST "pocl_version_check" APPEND PROPERTY DEPENDS "pocl_test_dlopen_device_basic")
+endif()
+
+if(BUILD_PTHREAD)
+  add_test("pocl_test_dlopen_device_pthread" "runtime/test_dlopen" "pthread")
+  set_property(TEST "pocl_version_check" APPEND PROPERTY DEPENDS "pocl_test_dlopen_device_pthread")
+endif()
+
+if(BUILD_ACCEL)
+  add_test("pocl_test_dlopen_device_accel" "runtime/test_dlopen" "accel")
+  set_property(TEST "pocl_version_check" APPEND PROPERTY DEPENDS "pocl_test_dlopen_device_accel")
+endif()
+
+if(ENABLE_TCE)
+  add_test("pocl_test_dlopen_device_tce" "runtime/test_dlopen" "tce")
+  set_property(TEST "pocl_version_check" APPEND PROPERTY DEPENDS "pocl_test_dlopen_device_tce")
+endif()
+
+if(ENABLE_HSA)
+  add_test("pocl_test_dlopen_device_hsa" "runtime/test_dlopen" "hsa")
+  set_property(TEST "pocl_version_check" APPEND PROPERTY DEPENDS "pocl_test_dlopen_device_hsa")
+endif()
+
+if(ENABLE_CUDA)
+  add_test("pocl_test_dlopen_device_cuda" "runtime/test_dlopen" "cuda")
+  set_property(TEST "pocl_version_check" APPEND PROPERTY DEPENDS "pocl_test_dlopen_device_cuda")
+endif()
+
+#######################################################################
+
 add_subdirectory("kernel")
 add_subdirectory("regression")
 add_subdirectory("runtime")

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -24,6 +24,10 @@
 #=============================================================================
 
 
+# do not link test_dlopen with -lOpenCL
+add_executable("test_dlopen" "test_dlopen.c")
+target_link_libraries("test_dlopen" ${DL_LIB})
+
 set(PROGRAMS_TO_BUILD test_clFinish test_clGetDeviceInfo test_clGetEventInfo
   test_clCreateProgramWithBinary test_clGetSupportedImageFormats
   test_clSetEventCallback test_clEnqueueNativeKernel test_clBuildProgram

--- a/tests/runtime/test_dlopen.c
+++ b/tests/runtime/test_dlopen.c
@@ -1,0 +1,63 @@
+/* Test that pocl libraries can be dlopen()ed
+
+   Copyright (c) 2021 pocl developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#include <dlfcn.h>
+#include <stdio.h>
+
+int
+main (int argc, char **argv)
+{
+  int ret = 0;
+  const char *libpocl = "$ORIGIN/../../lib/CL/libpocl.so";
+  char libdevice[4096] = "";
+  if (argc > 1)
+    snprintf (libdevice, sizeof (libdevice),
+              "$ORIGIN/../../lib/CL/devices/%s/libpocl-devices-%s.so", argv[1],
+              argv[1]);
+
+  void *handle_libpocl = dlopen (libpocl, RTLD_NOW | RTLD_GLOBAL);
+  if (!handle_libpocl)
+    {
+      fprintf (stderr, "dlopen(%s, RTLD_NOW | RTLD_GLOBAL) failed: %s\n",
+               libpocl, dlerror ());
+      ret = 1;
+    }
+
+  if (ret == 0 && argc > 1)
+    {
+      void *handle_device = dlopen (libdevice, RTLD_NOW);
+      if (!handle_device)
+        {
+          fprintf (stderr, "dlopen(%s, RTLD_NOW) failed: %s\n", libdevice,
+                   dlerror ());
+          ret = 1;
+        }
+      if (handle_device)
+        dlclose (handle_device);
+    }
+
+  if (handle_libpocl)
+    dlclose (handle_libpocl);
+
+  return ret;
+}

--- a/tests/workgroup/CMakeLists.txt
+++ b/tests/workgroup/CMakeLists.txt
@@ -38,10 +38,6 @@ add_test_pocl(NAME "workgroup/different_implicit_barrier_injection_scenarios"
               EXPECTED_OUTPUT "implicit_barriers_1_2_1_1.stdout"
               COMMAND "run_kernel" "implicit_barriers.cl" 1 2 1 1)
 
-add_test_pocl(NAME "workgroup/unconditional_barriers"
-              EXPECTED_OUTPUT "basic_barriers_2_2_2_2.stdout"
-              COMMAND "run_kernel" "basic_barriers.cl" 2 2 2 2)
-
 add_test_pocl(NAME "workgroup/unbarriered_for_loops"
               EXPECTED_OUTPUT "forloops_2_2_1_1.stdout"
               COMMAND "run_kernel" "forloops.cl" 2 2 1 1)
@@ -54,10 +50,6 @@ add_test_pocl(NAME "workgroup/switch_case"
               EXPECTED_OUTPUT "switch_case_1_4_1_1.stdout"
               COMMAND "run_kernel" "switch_case.cl" 1 4 1 1)
 
-add_test_pocl(NAME "workgroup/conditional_barrier"
-              EXPECTED_OUTPUT "cond_barriers_1_2_1_1.stdout"
-              COMMAND "run_kernel" "conditional_barriers.cl" 1 2 1 1)
-
 add_test_pocl(NAME "workgroup/b_loop_with_none_of_the_WIs_reaching_the_barrier"
               EXPECTED_OUTPUT "tricky_for_1_2_1_1.stdout"
               COMMAND "run_kernel" "tricky_for.cl" 1 2 1 1)
@@ -65,6 +57,30 @@ add_test_pocl(NAME "workgroup/b_loop_with_none_of_the_WIs_reaching_the_barrier"
 add_test_pocl(NAME "workgroup/for_with_divergent_return"
               EXPECTED_OUTPUT "for_with_divergent_return_1_6_1_1.stdout"
               COMMAND "run_kernel" "for_with_divergent_return.cl" 1 6 1 1)
+
+# Cases which are not dependent on the work-group or work-item
+# execution (printout) order or the method (use the default method
+# for the device).
+set_tests_properties(
+  "workgroup/different_implicit_barrier_injection_scenarios"
+  "workgroup/unbarriered_for_loops"
+  "workgroup/barriered_for_loops"
+  "workgroup/switch_case"
+  "workgroup/b_loop_with_none_of_the_WIs_reaching_the_barrier"
+  "workgroup/for_with_divergent_return"
+  PROPERTIES
+    COST 2.0
+    PROCESSORS 1
+    DEPENDS "pocl_version_check"
+    LABELS "internal;workgroup")
+
+add_test_pocl(NAME "workgroup/unconditional_barriers"
+              EXPECTED_OUTPUT "basic_barriers_2_2_2_2.stdout"
+              COMMAND "run_kernel" "basic_barriers.cl" 2 2 2 2)
+
+add_test_pocl(NAME "workgroup/conditional_barrier"
+              EXPECTED_OUTPUT "cond_barriers_1_2_1_1.stdout"
+              COMMAND "run_kernel" "conditional_barriers.cl" 1 2 1 1)
 
 add_test_pocl(NAME "workgroup/forcing_horizontal_parallelization_to_some_outer_loops"
               EXPECTED_OUTPUT "outerlooppar_2_2_1_1.stdout"
@@ -98,7 +114,8 @@ add_test_pocl(NAME "workgroup/range_md_large_grid"
 # These tests are now always ran with the basic device with a predefined
 # work-group execution order. Their printout verification depends
 # on it.
-set_tests_properties( "workgroup/unconditional_barriers"
+set_tests_properties(
+  "workgroup/unconditional_barriers"
   "workgroup/conditional_barrier"
   "workgroup/forcing_horizontal_parallelization_to_some_outer_loops"
   "workgroup/loop_with_two_paths_to_the_latch"
@@ -110,22 +127,7 @@ set_tests_properties( "workgroup/unconditional_barriers"
   PROPERTIES
     COST 2.0
     PROCESSORS 1
-    LABELS "workgroup"
     ENVIRONMENT "POCL_DEVICES=basic;POCL_WORK_GROUP_METHOD=workitemloops"
-    DEPENDS "pocl_version_check"
-    LABELS "internal;workgroup")
-
-# Cases which are not dependent on the work-group or work-item
-# execution (printout) order or the method (use the default method
-# for the device).
-set_tests_properties("workgroup/unbarriered_for_loops"
-  "workgroup/barriered_for_loops"
-  "workgroup/switch_case"
-  "workgroup/b_loop_with_none_of_the_WIs_reaching_the_barrier"
-  PROPERTIES
-    COST 2.0
-    PROCESSORS 1
-    LABELS "workgroup"
     DEPENDS "pocl_version_check"
     LABELS "internal;workgroup")
 


### PR DESCRIPTION
Here I have a patch series to finally allow building with `-fvisibility=hidden -fvisibility-inlines-hidden` to reduce the amount of (mostly c++) symbols exposed by the shared libraries. It starts with some fixes I've long been carrying in the Debian packages and some further cleanup (e.g. pocl symbols should be prefixed with `pocl` and tests should depend on `pocl_version_check`).
Please merge or cherry-pick as much as you like and we can continue working on the remaining parts.

I've only tested it with the CPU devices (`basic` and `pthread`) and only with building an ICD and testing with pocl's internal testsuite. There may be adjustments needed for other build configurations, e.g. more declarations needing a `POCL_EXPORT` decoration. (I've tried to keep the `pocl_*` symbols exposed minimal.)
In order to quickly check for missing symbols I've added some `dlopen` tests.

I've intentionally not reformatted the commit adding the `POCL_EXPORT` decorations. Please advise how you'd like them.

Is there a reason for `dlopen()`ing the device library with `RTLD_LAZY` instead of `RTLD_NOW`? (it would indicate missing symbols immediately.)

What is currently unclear to me, is how `libllvmopencl.so` is to be used. It isn't used by pocl itself or any of the tests unless I missed something. If I simply `dlopen()` it, I get a missing symbol (or more), that is available in `libpocl` and if the symbols from`libpocl` are loaded, `dlopen()` fails with
```
Two passes with the same argument (-allocastoentry) attempted to be registered!
Segmentation fault
```
(That was with llvm-9, I haven't tried other versions.)