### PR TITLE
Avoid division by 0 in profiling output if total_commands is 0

### DIFF
--- a/lib/CL/pocl_cq_profiling.c
+++ b/lib/CL/pocl_cq_profiling.c
@@ -103,8 +103,9 @@ pocl_atexit ()
   printf ("     %-30s %10s %15s %3s %10s\n", "",
           "==========", "==========", "====", "==========");
 
+  /* Add !total_commands to avoid a division by 0 if total_commands is 0 */
   printf ("     %-30s %10lu %15lu %4s %10lu\n", "", total_commands, total_time,
-          "100%", total_time / total_commands);
+          "100%", total_time / (total_commands + !total_commands) );
 
   /* TODO: Critical path information of the task graph. */
 }


### PR DESCRIPTION
This is achieved by adding !total_commands to the divisor, which is a
quick way to divide by 1 if total_commands is 0, and by total_commands
itself if total_command is non-zero.

This should fix #909 