### PR TITLE
Fixed LLVM 12 support: clang::CompilerInvocation::setLangDefaults signature was changed

### DIFF
--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -419,7 +419,13 @@ int pocl_llvm_build_program(cl_program program,
 #else
                              clang::InputKind::OpenCL,
 #endif
-                             triple, po, clang::LangStandard::lang_opencl12);
+                             triple,
+#ifndef LLVM_OLDER_THAN_12_0
+                             po.Includes,
+#else
+                             po,
+#endif
+                             clang::LangStandard::lang_opencl12);
 
   // LLVM 3.3 and older do not set that char is signed which is
   // defined by the OpenCL C specs (but not by C specs).


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/c495dfe0268bc2be8737725d657411baa1399e9d