### PR TITLE
cpuinfo: check for fopen() failure when opening sysfs nodes

### DIFF
--- a/lib/CL/devices/cpuinfo.c
+++ b/lib/CL/devices/cpuinfo.c
@@ -416,9 +416,12 @@ pocl_cpuinfo_get_cpu_name_and_vendor(cl_device_id device)
   if (!device->vendor_id)
     {
       f = fopen (pci_bus_root_vendor_file, "r");
-      num_read = fscanf (f, "%x", &device->vendor_id);
-      fclose (f);
-      /* no error checking, if it failed we just won't have the info */
+      if (f)
+        {
+          /* no error checking, if it failed we just won't have the info */
+          num_read = fscanf (f, "%x", &device->vendor_id);
+          fclose (f);
+        }
     }
 }
 


### PR DESCRIPTION
If sysfs is not mounted (or not available, e.g. on BSD), fopen() will return a NULL pointer and this will be passed to fscanf, potentially resulting in NULL dereference. This fixes a segmentation fault running poclcc -l on NetBSD.