### PR TITLE
Fix detection of dlopen()/libdl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -778,7 +778,7 @@ include_directories("include")
 
 ######################################################################################
 
-set(HAVE_LIBDL OFF CACHE BOOL "dlopen" FORCE)
+set(HAVE_DLFCN_H OFF CACHE BOOL "dlopen" FORCE)
 
 if(WIN32)
   message(STATUS "Using LoadLibrary/FreeLibrary in Windows, libltdl not needed.")
@@ -787,9 +787,15 @@ elseif(UNIX)
 
     find_library(DL_LIB "dl")
     find_file(DL_H "dlfcn.h")
+
     if(DL_LIB AND DL_H)
       message(STATUS "libdl found")
+    else()
+      message(STATUS "libdl not found, assuming dlopen() is in libc")
+      set(DL_LIB "")
+    endif()
 
+    if(DL_H)
       get_filename_component(DL_H_INCLUDE_DIR "${DL_H}" DIRECTORY)
       string(FIND "${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}" "${DL_H_INCLUDE_DIR}" LTPOSITION)
       # include the directory of dlfcn.h, if its not in the default system include dirs
@@ -797,9 +803,9 @@ elseif(UNIX)
       if((LTPOSITION LESS "0") AND (NOT CMAKE_CROSSCOMPILING))
         include_directories("${DL_H_INCLUDE_DIR}")
       endif()
-      set(HAVE_LIBDL ON CACHE BOOL "dlopen" FORCE)
+      set(HAVE_DLFCN_H ON CACHE BOOL "dlfcn.h" FORCE)
     else()
-      message(FATAL_ERROR "Could not find DL library!")
+      message(FATAL_ERROR "Could not find dlfcn.h!")
     endif()
 
 else()

--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -35,6 +35,8 @@
 
 #cmakedefine ENABLE_SPIRV
 
+#cmakedefine HAVE_DLFCN_H
+
 #cmakedefine HAVE_FORK
 
 #cmakedefine HAVE_VFORK
@@ -56,8 +58,6 @@
 #cmakedefine HAVE_FUTIMENS
 
 #cmakedefine HAVE_LTTNG_UST
-
-#cmakedefine HAVE_LIBDL
 
 #cmakedefine HAVE_OCL_ICD
 

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -50,10 +50,6 @@
 #include "pocl_llvm.h"
 #endif
 
-#ifndef HAVE_LIBDL
-#error Basic driver requires DL library
-#endif
-
 struct data {
   /* Currently loaded kernel. */
   cl_kernel current_kernel;

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -61,7 +61,7 @@
 #include <unistd.h>
 #endif
 
-#ifdef HAVE_LIBDL
+#ifdef HAVE_DLFCN_H
 #if defined(__APPLE__)
 #define _DARWIN_C_SOURCE
 #endif

--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -70,7 +70,7 @@
 #define PATH_MAX 4096
 #endif
 
-#ifdef HAVE_LIBDL
+#ifdef HAVE_DLFCN_H
 #if defined(__APPLE__)
 #define _DARWIN_C_SOURCE
 #endif

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -73,10 +73,6 @@
 
 #endif
 
-#ifndef HAVE_LIBDL
-#error HSA driver requires DL library
-#endif
-
 #include "pocl-hsa.h"
 #include "common.h"
 #include "devices.h"

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -51,10 +51,6 @@
 #include "pocl_util.h"
 #include "pocl_mem_management.h"
 
-#ifndef HAVE_LIBDL
-#error Pthread driver requires DL library
-#endif
-
 #ifdef OCS_AVAILABLE
 #include "pocl_llvm.h"
 #endif


### PR DESCRIPTION
- Many Unix systems do not need (macOS, Linux with musl?), or do  not have (most BSDs) libdl, and dlopen() is in libc instead.  Therefore, libdl being missing should not be fatal.   Replace checks for libdl.so with checks for dlfcn.h.

- Remove #error checks for libdl from indivial C files. The CMake build system will already refuse to run if dlopen()  is missing, so these checks are redundant.

Helps with building on NetBSD.