### PR TITLE
Add parallel loop metadata on LLVM 13 onward for load instructions inside conditions

### DIFF
--- a/lib/llvmopencl/ParallelRegion.cc
+++ b/lib/llvmopencl/ParallelRegion.cc
@@ -468,12 +468,23 @@ ParallelRegion::Verify()
  *     !1 distinct !{}
  *     !2 distinct !{}
  *
- * Parallel loop metadata on memory reads also implies that
+ * Parallel loop metadata prior to LLVM 13 on memory reads also implies that
  * if-conversion (i.e., speculative execution within a loop iteration)
  * is safe. Given an instruction reading from memory,
  * IsLoadUnconditionallySafe should return whether it is safe under
  * (unconditional, unpredicated) speculative execution.
- * See https://bugs.llvm.org/show_bug.cgi?id=46666
+ * See https://bugs.llvm.org/show_bug.cgi?id=46666.
+ *
+ * From LLVM 13 onward parallel loop metadata does not imply if-conversion
+ * safety anymore. This got fixed by this change:
+ * https://reviews.llvm.org/D103907. In other words this means that before the
+ * fix, the loop vectorizer was not able to vectorize some kernels because they
+ * would required a huge runtime memory check code insertion. Leading to
+ * vectorizer to give up. With above fix, we can add metadata to every load.
+ * This will cause vectorizer to skip runtime memory check code insertion part
+ * because it indicates that iterations do not depend on each other. Which in
+ * turn makes vectorization easier. In this case using of
+ * IsLoadUnconditionallySafe parameter will be skipped.
  */
 void
 ParallelRegion::AddParallelLoopMetadata(
@@ -487,9 +498,13 @@ ParallelRegion::AddParallelLoopMetadata(
         continue;
       }
 
+#ifdef LLVM_OLDER_THAN_13_0
+      // This check will skip insertion of metadata on loads inside conditions
+      // before LLVM 13.
       if (ii->mayReadFromMemory() && !IsLoadUnconditionallySafe(&*ii)) {
         continue;
       }
+#endif
 
       MDNode *NewMD = MDNode::get(bb->getContext(), Identifier);
       MDNode *OldMD = ii->getMetadata(PARALLEL_MD_NAME);


### PR DESCRIPTION
Now that parallel loop metadata if-conversion safety is removed by [this](https://reviews.llvm.org/D103907) change for LLVM 13 branch. This change will enable adding metadata insertion on load instructions unconditionally. Prior to LLVM 13 will still use conditional placement of metadata to avoid miscompilations. This change is a follow-up to #850.

I tested this locally and with the fix using latest LLVM from trunk is not producing illegal code anymore. Also earlier vectorization failures from PolyBench kernels [this](https://github.com/cavazos-lab/PolyBench-ACC/blob/master/OpenCL/stencils/convolution-3d/3DConvolution.cl) and [this](https://github.com/cavazos-lab/PolyBench-ACC/blob/master/OpenCL/stencils/convolution-2d/2DConvolution.cl) are now vectorizing successfully and executing faster.