### PR TITLE
Improve generic vload vstore functions

### DIFF
--- a/lib/kernel/vload.cl
+++ b/lib/kernel/vload.cl
@@ -31,7 +31,8 @@
   TYPE##2 _CL_OVERLOADABLE                                              \
   vload2(size_t offset, const MOD TYPE *p)                              \
   {                                                                     \
-    return (TYPE##2)(p[offset*2], p[offset*2+1]);                       \
+    const MOD TYPE##2 *pp = (const MOD TYPE##2 *)(p + offset*2);        \
+    return pp[0];                                                       \
   }                                                                     \
                                                                         \
   TYPE##3 _CL_OVERLOADABLE                                              \
@@ -43,19 +44,22 @@
   TYPE##4 _CL_OVERLOADABLE                                              \
   vload4(size_t offset, const MOD TYPE *p)                              \
   {                                                                     \
-    return (TYPE##4)(vload2(0, &p[offset*4]), vload2(0, &p[offset*4+2])); \
+    const MOD TYPE##4 *pp = (const MOD TYPE##4 *)(p + offset*4);        \
+    return pp[0];                                                       \
   }                                                                     \
                                                                         \
   TYPE##8 _CL_OVERLOADABLE                                              \
   vload8(size_t offset, const MOD TYPE *p)                              \
   {                                                                     \
-    return (TYPE##8)(vload4(0, &p[offset*8]), vload4(0, &p[offset*8+4])); \
+    const MOD TYPE##8 *pp = (const MOD TYPE##8 *)(p + offset*8);        \
+    return pp[0];                                                       \
   }                                                                     \
                                                                         \
   TYPE##16 _CL_OVERLOADABLE                                             \
   vload16(size_t offset, const MOD TYPE *p)                             \
   {                                                                     \
-    return (TYPE##16)(vload8(0, &p[offset*16]), vload8(0, &p[offset*16+8])); \
+    const MOD TYPE##16 *pp = (const MOD TYPE##16 *)(p + offset*16);     \
+    return pp[0];                                                       \
   }
 
 

--- a/lib/kernel/vstore.cl
+++ b/lib/kernel/vstore.cl
@@ -31,8 +31,8 @@
   void _CL_OVERLOADABLE                                 \
   vstore2(TYPE##2 data, size_t offset, MOD TYPE *p)     \
   {                                                     \
-    p[offset*2] = data.lo;                              \
-    p[offset*2+1] = data.hi;                            \
+    MOD TYPE##2 *pp = (MOD TYPE##2 *)(p + offset*2);    \
+    pp[0] = data;                                       \
   }                                                     \
                                                         \
   void _CL_OVERLOADABLE                                 \
@@ -45,22 +45,22 @@
   void _CL_OVERLOADABLE                                 \
   vstore4(TYPE##4 data, size_t offset, MOD TYPE *p)     \
   {                                                     \
-    vstore2(data.lo, 0, &p[offset*4]);                  \
-    vstore2(data.hi, 0, &p[offset*4+2]);                \
+    MOD TYPE##4 *pp = (MOD TYPE##4 *)(p + offset*4);    \
+    pp[0] = data;                                       \
   }                                                     \
                                                         \
   void _CL_OVERLOADABLE                                 \
   vstore8(TYPE##8 data, size_t offset, MOD TYPE *p)     \
   {                                                     \
-    vstore4(data.lo, 0, &p[offset*8]);                  \
-    vstore4(data.hi, 0, &p[offset*8+4]);                \
+    MOD TYPE##8 *pp = (MOD TYPE##8 *)(p + offset*8);    \
+    pp[0] = data;                                       \
   }                                                     \
                                                         \
   void _CL_OVERLOADABLE                                 \
   vstore16(TYPE##16 data, size_t offset, MOD TYPE *p)   \
   {                                                     \
-    vstore8(data.lo, 0, &p[offset*16]);                 \
-    vstore8(data.hi, 0, &p[offset*16+8]);               \
+    MOD TYPE##16 *pp = (MOD TYPE##16 *)(p + offset*16); \
+    pp[0] = data;                                       \
   }
 
 


### PR DESCRIPTION
- Current implementation splits a vload4 into two vload2 for example,
preventing compiler from performing load/store packing.
- This commit improve it by doing load/store packing explicitly
(vload3/vstore3 are not concerned).