### PR TITLE
[cmake] use ninja's compile and link pools

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,10 @@ Notable Bug Fixes
     This is done by adding ${POCL_LIBRARY_NAME} to target_link_libraries() in CMake.
   - Fixed POCL_FAST_INIT macro; POCL_INIT_LOCK must be invoked with only one argument.
 
+Other
+-----
+- Add cmake options PARALLEL_COMPILE_JOBS, PARALLEL_LINK_JOBS to
+  use ninja's seperate compile and link job pools.
 
 1.7 May 2021
 ============

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,30 @@ if(VISIBILITY_HIDDEN)
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fvisibility-inlines-hidden>)
 endif()
 
+
+# Ninja Job Pool support
+set(PARALLEL_COMPILE_JOBS "" CACHE STRING
+  "Define the maximum number of concurrent compilation jobs (Ninja only).")
+if(PARALLEL_COMPILE_JOBS)
+  if(CMAKE_GENERATOR STREQUAL "Ninja")
+    set_property(GLOBAL APPEND PROPERTY JOB_POOLS compile_job_pool=${PARALLEL_COMPILE_JOBS})
+    set(CMAKE_JOB_POOL_COMPILE compile_job_pool)
+  endif()
+endif()
+
+set(PARALLEL_LINK_JOBS "" CACHE STRING
+  "Define the maximum number of concurrent link jobs (Ninja only).")
+if(CMAKE_GENERATOR STREQUAL "Ninja")
+  if(PARALLEL_LINK_JOBS)
+    set_property(GLOBAL APPEND PROPERTY JOB_POOLS link_job_pool=${PARALLEL_LINK_JOBS})
+    set(CMAKE_JOB_POOL_LINK link_job_pool)
+  endif()
+endif()
+
+if(NOT CMAKE_GENERATOR STREQUAL "Ninja" AND (PARALLEL_COMPILE_JOBS OR PARALLEL_LINK_JOBS))
+  message(WARNING "Job pooling is only available with Ninja generators.")
+endif()
+
 #### these are mostly useful for pocl developers
 
 option(DEVELOPER_MODE "This will SIGNIFICANTLY slow down pocl (but speed up its compilation). Only turn on if you know what you're doing." OFF)
@@ -1709,6 +1733,12 @@ MESSAGE(STATUS "INSTALL_OPENCL_HEADERS (Install our headers): ${INSTALL_OPENCL_H
 MESSAGE(STATUS "OCL_DRIVERS (Drivers built): ${OCL_DRIVERS}")
 MESSAGE(STATUS "OCL_TARGETS (Targets built): ${OCL_TARGETS}")
 MESSAGE(STATUS "ENABLE_LLVM: ${ENABLE_LLVM}")
+if(PARALLEL_COMPILE_JOBS AND CMAKE_GENERATOR STREQUAL "Ninja")
+  MESSAGE(STATUS "PARALLEL_COMPILE_JOBS: ${PARALLEL_COMPILE_JOBS}")
+endif()
+if(PARALLEL_LINK_JOBS AND CMAKE_GENERATOR STREQUAL "Ninja")
+  MESSAGE(STATUS "PARALLEL_LINK_JOBS: ${PARALLEL_LINK_JOBS}")
+endif()
 MESSAGE(STATUS "POCL_ICD_ABSOLUTE_PATH: ${POCL_ICD_ABSOLUTE_PATH}")
 MESSAGE(STATUS "POCL_ASSERTS_BUILD: ${POCL_ASSERTS_BUILD}")
 MESSAGE(STATUS "TESTS_USE_ICD: ${TESTS_USE_ICD}")

--- a/CREDITS
+++ b/CREDITS
@@ -80,3 +80,5 @@ Roman Rusyaev <rusyaev.rm@gmail.com>
 Väinö Liukko <vaino.liukko@gmail.com>
 Nia Alarie <nia@NetBSD.org>
 fn ⌃ ⌥ (FnControlOption)
+Tom Rix <trix@redhat.com>
+


### PR DESCRIPTION
When CMAKE_BUILD_TYPE=DEBUG, the linking memory usage is so
high the build fails without setting -j <low_num> on the command
line.

The llvm project has a similar problem which is solved on the
ninja buildsystem by splitting the compile and link jobs.
see llvm-project/llvm/cmake/modules/HandleLLVMOptions.cmake
and these variables
LLVM_PARALLEL_COMPILE_JOBS and LLVM_PARALLEL_LINK_JOBS

The new POCL equivelent variables are
PARALLEL_COMPILE_JOBS and PARALLEL_LINK_JOBS

ex/ used in the cmake configure step
  cmake -G Ninja
   -DPARALLEL_COMPILE_JOBS=16
   -DPARALLEL_LINK_JOBS=8

And reported if used as status
...
-- OCS_AVAILABLE: ON
-- PARALLEL_COMPILE_JOBS: 16
-- PARALLEL_LINK_JOBS: 8
-- POCL_ICD_ABSOLUTE_PATH: ON
...

Signed-off-by: Tom Rix <trix@redhat.com>