### PR TITLE
pocl_gettimemono_ns: use ULL suffix for int64_t

### DIFF
--- a/lib/CL/pocl_timing.c
+++ b/lib/CL/pocl_timing.c
@@ -95,7 +95,7 @@ uint64_t pocl_gettimemono_ns() {
   res |= ft.dwHighDateTime;
   res <<= 32;
   res |= ft.dwLowDateTime;
-  res -= 11644473600000000Ui64;
+  res -= 11644473600000000ULL;
   res /= 10;
   return res;
 


### PR DESCRIPTION
allows to build with mingw