### PR TITLE
Fix build on MinGW

### DIFF
--- a/examples/example2/example2.c
+++ b/examples/example2/example2.c
@@ -27,7 +27,7 @@
 #include <CL/opencl.h>
 #include "poclu.h"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #  include "vccompat.hpp"
 #endif
 

--- a/examples/example2a/example2a.c
+++ b/examples/example2a/example2a.c
@@ -28,7 +28,7 @@
 #include <CL/opencl.h>
 #include "poclu.h"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #  include "vccompat.hpp"
 #endif
 

--- a/examples/matrix1/matrix1.c
+++ b/examples/matrix1/matrix1.c
@@ -35,7 +35,13 @@
 #include <string.h>
 #include <time.h>
 
+#ifdef _WIN32
+#  include "vccompat.hpp"
+#endif
+
+#ifndef min
 #define min(X, Y) X < Y ? X : Y
+#endif
 
 int
 exec_matrix_kernel (cl_context context, cl_device_id device,

--- a/include/poclu.h
+++ b/include/poclu.h
@@ -26,7 +26,7 @@
 
 #include <CL/opencl.h>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #define POCLU_CALL __cdecl
 #define POCLU_API __declspec(dllexport)
 #else

--- a/include/vccompat.hpp
+++ b/include/vccompat.hpp
@@ -28,7 +28,7 @@
 #ifndef VCCOMPAT_HPP
 #define VCCOMPAT_HPP
 
-#include <Windows.h>
+#include <windows.h>
 #define __restrict__ __restrict
 #define restrict __restrict
 
@@ -50,17 +50,24 @@ static inline int snprintf(char *str, size_t size, const char *format, ...) {
 }
 */
 
+#ifdef _MSC_VER
 static inline char* strtok_r(char *str, const char *delim, char **saveptr) {
   return strtok_s(str, delim, saveptr);
 }
+#endif
 
 #define _USE_MATH_DEFINES
 
 #define srand48(x) srand(x)
-#define drand48() (double(rand()) / RAND_MAX)
+#define drand48() (((double)rand()) / RAND_MAX)
+
+#define random rand
+#define srandom(x) srand(x)
 
 #include <sys/utime.h>
 #define utime _utime;
+
+#ifdef _MSC_VER
 
 #define RTLD_NOW 1
 #define RTLD_LOCAL 1
@@ -80,6 +87,7 @@ static inline int dlerror(void) {
 static inline void *dlsym(void* handle, const char *symbol) {
   return GetProcAddress((HMODULE)handle, symbol);
 }
+#endif
 
 /**
  * Filesystem stuff
@@ -93,7 +101,7 @@ static inline void *dlsym(void* handle, const char *symbol) {
 #include <direct.h>
 #include <process.h>
 
-#define mkdir(a,b) mkdir(a)
+#define mkdir(a,b) _mkdir(a)
 
 /**
  * TODO: test these implementations...
@@ -131,6 +139,8 @@ static int posix_memalign(void **p, size_t align, size_t size) {
    return 0;
 }
 
+#ifdef _MSC_VER
 #define alloca _alloca
+#endif
 
 #endif

--- a/lib/CL/clCreateContextFromType.c
+++ b/lib/CL/clCreateContextFromType.c
@@ -40,7 +40,7 @@ int context_set_properties(cl_context                    ctx,
 CL_API_ENTRY cl_context CL_API_CALL
 POname(clCreateContextFromType)(const cl_context_properties *properties,
                         cl_device_type device_type,
-                        void (*pfn_notify)(const char *, const void *, size_t, void *),
+                        void (CL_CALLBACK *pfn_notify)(const char *, const void *, size_t, void *),
                         void *user_data,
                         cl_int *errcode_ret) CL_API_SUFFIX__VERSION_1_0
 {

--- a/lib/CL/clCreateKernel.c
+++ b/lib/CL/clCreateKernel.c
@@ -24,7 +24,7 @@
 
 #include <string.h>
 #include <sys/stat.h>
-#ifndef _MSC_VER
+#ifndef _WIN32
 #  include <unistd.h>
 #else
 #  include "vccompat.hpp"

--- a/lib/CL/clEnqueueNDRangeKernel.c
+++ b/lib/CL/clEnqueueNDRangeKernel.c
@@ -33,7 +33,7 @@
 #include "pocl_util.h"
 #include "utlist.h"
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 #  include <unistd.h>
 #else
 #  include "vccompat.hpp"

--- a/lib/CL/clGetPlatformInfo.c
+++ b/lib/CL/clGetPlatformInfo.c
@@ -26,8 +26,8 @@
 static const char *pocl_version
     = "OpenCL " POCL_CL_VERSION " pocl " PACKAGE_VERSION
 
-#if defined(_WIN32) || defined(__MINGW32__)
-   #if defined(_WIN64) || defined(__MINGW64__)
+#if defined(_WIN32)
+   #if defined(_WIN64)
       "  Windows x86-64"
    #else
       "  Windows x86"

--- a/lib/CL/clReleaseProgram.c
+++ b/lib/CL/clReleaseProgram.c
@@ -24,7 +24,7 @@
 
 #include <string.h>
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 #  include <unistd.h>
 #else
 #  include "vccompat.hpp"

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -36,7 +36,7 @@
 #include <unistd.h>
 #include <utlist.h>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include "vccompat.hpp"
 #endif
 

--- a/lib/CL/devices/cpuinfo.c
+++ b/lib/CL/devices/cpuinfo.c
@@ -25,7 +25,7 @@
 #include <pocl_cl.h>
 #include <string.h>
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 #  include <unistd.h>
 #else
 #  include "vccompat.hpp"

--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -36,7 +36,7 @@
 #include <ucontext.h>
 #endif
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 #  include <unistd.h>
 #else
 #  include "vccompat.hpp"
@@ -161,7 +161,7 @@ static pocl_lock_t pocl_init_lock = POCL_LOCK_INITIALIZER;
 
 static void *pocl_device_handles[POCL_NUM_DEVICE_TYPES];
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 #define POCL_PATH_SEPARATOR "/"
 #else
 #define POCL_PATH_SEPARATOR "\\"

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include <errno.h>
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 #  include <unistd.h>
 #else
 #  include "vccompat.hpp"

--- a/lib/CL/pocl_build.c
+++ b/lib/CL/pocl_build.c
@@ -31,7 +31,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 #  include <unistd.h>
 #else
 #  include "vccompat.hpp"

--- a/lib/CL/pocl_cache.c
+++ b/lib/CL/pocl_cache.c
@@ -445,7 +445,7 @@ pocl_cache_init_topdir ()
 #ifdef __ANDROID__
         POCL_ABORT ("Please set the POCL_CACHE_DIR env var to your app's cache directory (Context.getCacheDir())\n");
 
-#elif defined(_MSC_VER) || defined(__MINGW32__)
+#elif defined(_WIN32)
         tmp_path = getenv("LOCALAPPDATA");
         if (!tmp_path)
             tmp_path = getenv("TEMP");

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -34,7 +34,7 @@
 #include <valgrind/helgrind.h>
 #endif
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #  include "vccompat.hpp"
 #endif
 /* To get adaptive mutex type */
@@ -287,7 +287,7 @@ extern uint64_t last_object_id;
 #  define POsym(name)
 #  define POsymAlways(name)
 
-#elif defined(_MSC_VER)
+#elif defined(_WIN32)
 /* Visual Studio does not support this magic either */
 #  define POname(name) name
 #  define POdeclsym(name)
@@ -1424,6 +1424,25 @@ struct _cl_sampler {
   #define le64toh(x) OSSwapLittleToHostInt64(x)
 #elif defined(__FreeBSD__)
   #include <sys/endian.h>
+#elif defined (_WIN32)
+    #ifndef htole64
+      #define htole64(x) (x)
+    #endif
+    #ifndef htole32
+      #define htole32(x) (x)
+    #endif
+    #ifndef htole16
+      #define htole16(x) (x)
+    #endif
+    #ifndef le64toh
+      #define le64toh(x) (x)
+    #endif
+    #ifndef le32toh
+      #define le32toh(x) (x)
+    #endif
+    #ifndef le16toh
+      #define le16toh(x) (x)
+    #endif
 #else
   #include <endian.h>
   #if defined(__GLIBC__) && __GLIBC__ == 2 && \

--- a/lib/CL/pocl_timing.c
+++ b/lib/CL/pocl_timing.c
@@ -23,7 +23,7 @@
 
 #include "config.h"
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 #  define _DEFAULT_SOURCE
 #  define __POSIX_VISIBLE 200112L
 #  ifndef _POSIX_C_SOURCE

--- a/tests/kernel/kernel.c
+++ b/tests/kernel/kernel.c
@@ -5,7 +5,7 @@
 
 #include "poclu.h"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #  include "vccompat.hpp"
 #endif
 

--- a/tests/regression/test_flatten_barrier_subs.cpp
+++ b/tests/regression/test_flatten_barrier_subs.cpp
@@ -28,6 +28,10 @@
 #include <numeric>
 #include <CL/cl2.hpp>
 
+#ifdef _WIN32
+#  include "vccompat.hpp"
+#endif
+
 std::string read_text_file(const std::string& path)
 {
     FILE* f = fopen(path.c_str(), "rb");

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -23,10 +23,11 @@
 #
 #=============================================================================
 
-
-# do not link test_dlopen with -lOpenCL
-add_executable("test_dlopen" "test_dlopen.c")
-target_link_libraries("test_dlopen" ${DL_LIB})
+if (UNIX)
+  # do not link test_dlopen with -lOpenCL
+  add_executable("test_dlopen" "test_dlopen.c")
+  target_link_libraries("test_dlopen" ${DL_LIB})
+endif ()
 
 set(PROGRAMS_TO_BUILD test_clFinish test_clGetDeviceInfo test_clGetEventInfo
   test_clCreateProgramWithBinary test_clGetSupportedImageFormats

--- a/tests/runtime/test_event_cycle.c
+++ b/tests/runtime/test_event_cycle.c
@@ -47,7 +47,7 @@ main(void)
   cl_device_id devices[MAX_DEVICES];
   cl_uint ndevices;
   cl_uint i, j;
-
+#ifndef _WIN32
   /* set up a signal handler for ALRM that will kill
    * the program with EXIT_FAILURE on timeout
    */
@@ -139,6 +139,6 @@ main(void)
   }
 
   CHECK_CL_ERROR (clUnloadCompiler ());
-
+#endif
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
With this I succeeded in building libpocl.dll and the tests.
Now vccompat.hpp is used also for mingw because many things are shared with the msvc path.
It should help to build on MSVC as some common paths were fixed.
Yet to figure out why the loader fails.