### PR TITLE
Removed deprecated option from PyOpenCL testsuite configurations

### DIFF
--- a/examples/PyOpenCL/configure.sh
+++ b/examples/PyOpenCL/configure.sh
@@ -6,4 +6,4 @@ TS_SRCDIR="$3"
 VIRTUALENV="$4"
 PYTH="$5"
 
-cd "${TS_BASEDIR}/src" && "${VIRTUALENV}" --no-site-packages "--python=$PYTH" "PyOpenCL-build" && cd "${TS_SRCDIR}" && ${TS_BUILDDIR}/bin/pip3 install mako pybind11 pytest && ${TS_BUILDDIR}/bin/python3 configure.py
+cd "${TS_BASEDIR}/src" && "${VIRTUALENV}" "--python=$PYTH" "PyOpenCL-build" && cd "${TS_SRCDIR}" && ${TS_BUILDDIR}/bin/pip3 install mako pybind11 pytest && ${TS_BUILDDIR}/bin/python3 configure.py


### PR DESCRIPTION
--no-site-packages option has been removed from latest versions of python virtualenv causing PyOpenCL testsuite error out during make prepare_examples. 

Only information about this option I found from python3 virtualenv version 16.7.9 where this command is already deprecated and its functionality is the default behavior. 
[https://virtualenv.pypa.io/en/legacy/reference.html#cmdoption-no-site-packages]
