### PR TITLE
CMakeLists.txt: Handle 'undefined' values returned by getconf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,6 +446,10 @@ if(NOT HOST_CPU_CACHELINE_SIZE)
         message(WARNING "getconf exited with nonzero status!")
         set(CL_SIZE 0)
       else()
+        # getconf may in rare conditions return "undefined" value
+        if (CL_SIZE STREQUAL "undefined\n")
+          set(CL_SIZE 0)
+        endif()
         # getconf sometimes just returns zero
         if(NOT (CL_SIZE EQUAL 0))
           string(STRIP "${CL_SIZE}" CL_SIZE)


### PR DESCRIPTION
This allows to avoid build failures when using qemu user mode for riscv64 [1]:
the corresponding bug in qemu [2] will get fixed but handling that here allows
to keep pocl buildable by old qemu versions.

[1]: https://bugs.launchpad.net/ubuntu/+source/pocl/+bug/1942895
[2]: https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1942884

Signed-off-by: Alexandre Ghiti <alexandre.ghiti@canonical.com>