### PR TITLE
OpenCL 3.0 API conformance: Program Scope Global Variables

### DIFF
--- a/lib/CL/clGetProgramBuildInfo.c
+++ b/lib/CL/clGetProgramBuildInfo.c
@@ -121,6 +121,10 @@ POname(clGetProgramBuildInfo)(cl_program            program,
     {
       POCL_RETURN_GETINFO(cl_program_binary_type, program->binary_type);
     }
+  case CL_PROGRAM_BUILD_GLOBAL_VARIABLE_TOTAL_SIZE:
+    {
+      POCL_RETURN_GETINFO (size_t, device->global_var_pref_size);
+    }
   }
   
   return CL_INVALID_VALUE;

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1496,6 +1496,8 @@ pocl_init_default_device_infos (cl_device_id dev)
   dev->has_64bit_long = 1;
   dev->autolocals_to_args = POCL_AUTOLOCALS_TO_ARGS_ALWAYS;
   dev->device_alloca_locals = 0;
+  dev->global_var_max_size = 0;
+  dev->global_var_pref_size = 0;
 
 #ifdef ENABLE_LLVM
 


### PR DESCRIPTION
Made program scope global variables API calls OpenCL 3.0 conformant. See, https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_program_scope_global_variables