### PR TITLE
Pthread fixes

### DIFF
--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -2035,7 +2035,7 @@ void
 pocl_hsa_notify_event_finished (cl_event event)
 {
   pocl_hsa_event_data_t *e_d = (pocl_hsa_event_data_t *)event->data;
-  pthread_cond_broadcast (&e_d->event_cond);
+  PTHREAD_CHECK (pthread_cond_broadcast (&e_d->event_cond));
 }
 
 void
@@ -2048,7 +2048,7 @@ pocl_hsa_update_event (cl_device_id device, cl_event event)
       pocl_hsa_event_data_t *e_d
           = (pocl_hsa_event_data_t *)malloc (sizeof (pocl_hsa_event_data_t));
       assert (e_d);
-      pthread_cond_init (&e_d->event_cond, NULL);
+      PTHREAD_CHECK (pthread_cond_init (&e_d->event_cond, NULL));
       event->data = (void *)e_d;
     }
   else

--- a/lib/CL/devices/proxy/pocl_proxy.c
+++ b/lib/CL/devices/proxy/pocl_proxy.c
@@ -1515,8 +1515,7 @@ pocl_proxy_notify_cmdq_finished (cl_command_queue cq)
    * this must be a broadcast since there could be multiple
    * user threads waiting on the same command queue */
   proxy_queue_data_t *dd = (proxy_queue_data_t *)cq->data;
-  int r = POCL_BROADCAST_COND (dd->wait_cond);
-  assert (r == 0);
+  POCL_BROADCAST_COND (dd->wait_cond);
 }
 
 void
@@ -1534,8 +1533,7 @@ pocl_proxy_join (cl_device_id device, cl_command_queue cq)
         }
       else
         {
-          int r = POCL_WAIT_COND (dd->wait_cond, cq->pocl_lock);
-          assert (r == 0);
+          POCL_WAIT_COND (dd->wait_cond, cq->pocl_lock);
         }
     }
 }

--- a/lib/CL/devices/pthread/pocl-pthread_scheduler.h
+++ b/lib/CL/devices/pthread/pocl-pthread_scheduler.h
@@ -36,7 +36,7 @@
 typedef struct pool_thread_data thread_data;
 
 /* Initializes scheduler. Must be called before any kernel enqueue */
-void pthread_scheduler_init (cl_device_id device);
+cl_int pthread_scheduler_init (cl_device_id device);
 
 void pthread_scheduler_uninit ();
 

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -294,8 +294,7 @@ pocl_pthread_join(cl_device_id device, cl_command_queue cq)
         }
       else
         {
-          int r = pthread_cond_wait (cq_cond, &cq->pocl_lock);
-          assert (r == 0);
+          PTHREAD_CHECK (pthread_cond_wait (cq_cond, &cq->pocl_lock));
         }
     }
   return;
@@ -335,15 +334,14 @@ pocl_pthread_notify_cmdq_finished (cl_command_queue cq)
    * user threads waiting on the same command queue
    * in pthread_scheduler_wait_cq(). */
   pthread_cond_t *cq_cond = (pthread_cond_t *)cq->data;
-  int r = pthread_cond_broadcast (cq_cond);
-  assert (r == 0);
+  PTHREAD_CHECK (pthread_cond_broadcast (cq_cond));
 }
 
 void
 pocl_pthread_notify_event_finished (cl_event event)
 {
   struct event_data *e_d = event->data;
-  pthread_cond_broadcast (&e_d->event_cond);
+  PTHREAD_CHECK (pthread_cond_broadcast (&e_d->event_cond));
 }
 
 void
@@ -355,7 +353,7 @@ pocl_pthread_update_event (cl_device_id device, cl_event event)
       e_d = malloc(sizeof(struct event_data));
       assert(e_d);
 
-      pthread_cond_init(&e_d->event_cond, NULL);
+      PTHREAD_CHECK (pthread_cond_init (&e_d->event_cond, NULL));
       event->data = (void *) e_d;
     }
 }
@@ -367,7 +365,7 @@ void pocl_pthread_wait_event (cl_device_id device, cl_event event)
   POCL_LOCK_OBJ (event);
   while (event->status > CL_COMPLETE)
     {
-      pthread_cond_wait(&e_d->event_cond, &event->pocl_lock);
+      PTHREAD_CHECK (pthread_cond_wait (&e_d->event_cond, &event->pocl_lock));
     }
   POCL_UNLOCK_OBJ (event);
 }
@@ -386,8 +384,7 @@ pocl_pthread_init_queue (cl_device_id device, cl_command_queue queue)
   queue->data
       = pocl_aligned_malloc (HOST_CPU_CACHELINE_SIZE, sizeof (pthread_cond_t));
   pthread_cond_t *cond = (pthread_cond_t *)queue->data;
-  int r = pthread_cond_init (cond, NULL);
-  assert (r == 0);
+  PTHREAD_CHECK (pthread_cond_init (cond, NULL));
   return CL_SUCCESS;
 }
 
@@ -395,8 +392,7 @@ int
 pocl_pthread_free_queue (cl_device_id device, cl_command_queue queue)
 {
   pthread_cond_t *cond = (pthread_cond_t *)queue->data;
-  int r = pthread_cond_destroy (cond);
-  assert (r == 0);
+  PTHREAD_CHECK (pthread_cond_destroy (cond));
   POCL_MEM_FREE (queue->data);
   return CL_SUCCESS;
 }

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -208,14 +208,19 @@ pocl_pthread_init (unsigned j, cl_device_id device, const char* parameters)
   device->num_partition_types = 0;
   device->partition_type = NULL;
 
+  cl_int ret = CL_SUCCESS;
   if (!scheduler_initialized)
     {
-      scheduler_initialized = 1;
       pocl_init_dlhandle_cache();
       pocl_init_kernel_run_command_manager();
-      pthread_scheduler_init (device);
+      ret = pthread_scheduler_init (device);
+      if (ret == CL_SUCCESS)
+        {
+          scheduler_initialized = 1;
+        }
     }
-  return CL_SUCCESS;
+
+  return ret;
 }
 
 cl_int
@@ -246,13 +251,17 @@ pocl_pthread_reinit (unsigned j, cl_device_id device)
   d->current_kernel = NULL;
   device->data = d;
 
+  cl_int ret = CL_SUCCESS;
   if (!scheduler_initialized)
     {
-      pthread_scheduler_init (device);
-      scheduler_initialized = 1;
+      ret = pthread_scheduler_init (device);
+      if (ret == CL_SUCCESS)
+        {
+          scheduler_initialized = 1;
+        }
     }
 
-  return CL_SUCCESS;
+  return ret;
 }
 
 void

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -81,7 +81,7 @@ typedef struct scheduler_data_
 
 static scheduler_data scheduler;
 
-void
+cl_int
 pthread_scheduler_init (cl_device_id device)
 {
   unsigned i;
@@ -114,6 +114,7 @@ pthread_scheduler_init (cl_device_id device)
                                      (void *)&scheduler.thread_pool[i]));
     }
 
+  return CL_SUCCESS;
 }
 
 void

--- a/lib/CL/devices/pthread/pthread_utils.c
+++ b/lib/CL/devices/pthread/pthread_utils.c
@@ -62,21 +62,21 @@ kernel_run_command* new_kernel_run_command ()
     {
       LL_DELETE (kernel_pool, k);
       memset (k, 0, sizeof(kernel_run_command));
-      pthread_mutex_init(&k->lock, NULL);
+      PTHREAD_CHECK (pthread_mutex_init (&k->lock, NULL));
       POCL_UNLOCK (kernel_pool_lock);
       return k;
     }
 
   POCL_UNLOCK (kernel_pool_lock);
   k = (kernel_run_command*)calloc (1, sizeof (kernel_run_command));
-  pthread_mutex_init (&k->lock, NULL);
+  PTHREAD_CHECK (pthread_mutex_init (&k->lock, NULL));
   return k;
 }
 
 void free_kernel_run_command (kernel_run_command *k)
 {
   POCL_LOCK (kernel_pool_lock);
-  pthread_mutex_destroy (&k->lock);
+  PTHREAD_CHECK (pthread_mutex_destroy (&k->lock));
   LL_PREPEND (kernel_pool, k);
   POCL_UNLOCK (kernel_pool_lock);
 }

--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -1023,8 +1023,7 @@ int pocl_tce_init_queue(cl_device_id device, cl_command_queue queue) {
     goto ERROR;
   queue->data = dd;
 
-  if (POCL_INIT_COND(dd->cq_cond))
-    goto ERROR;
+  POCL_INIT_COND(dd->cq_cond);
 
   return CL_SUCCESS;
 
@@ -1085,8 +1084,7 @@ void pocl_tce_notify_cmdq_finished(cl_command_queue cq) {
    * this must be a broadcast since there could be multiple
    * user threads waiting on the same command queue */
   tce_queue_data_t *dd = (tce_queue_data_t *)cq->data;
-  int r = POCL_BROADCAST_COND(dd->cq_cond);
-  assert(r == 0);
+  POCL_BROADCAST_COND(dd->cq_cond);
 }
 
 void pocl_tce_join(cl_device_id device, cl_command_queue cq) {
@@ -1098,8 +1096,7 @@ void pocl_tce_join(cl_device_id device, cl_command_queue cq) {
       POCL_UNLOCK_OBJ(cq);
       return;
     } else {
-      int r = POCL_WAIT_COND(dd->cq_cond, cq->pocl_lock);
-      assert(r == 0);
+      POCL_WAIT_COND(dd->cq_cond, cq->pocl_lock);
     }
   }
 }

--- a/lib/CL/devices/tce/ttasim/ttasim.cc
+++ b/lib/CL/devices/tce/ttasim/ttasim.cc
@@ -223,8 +223,10 @@ public:
 
     POCL_INIT_LOCK(lock);
     POCL_INIT_COND(simulation_start_cond);
-    pthread_create (&ttasim_thread, NULL, pocl_ttasim_thread, this);
-    pthread_create(&driver_thread, NULL, pocl_tce_driver_thread, this);
+    PTHREAD_CHECK(
+        pthread_create(&ttasim_thread, NULL, pocl_ttasim_thread, this));
+    PTHREAD_CHECK(
+        pthread_create(&driver_thread, NULL, pocl_tce_driver_thread, this));
   }
 
   ~TTASimDevice() {
@@ -541,7 +543,7 @@ pocl_ttasim_thread (void *p)
     if (d->shutdownRequested)
       goto EXIT;
     POCL_LOCK(d->lock);
-    pthread_cond_wait (&d->simulation_start_cond, &d->lock);
+    PTHREAD_CHECK(pthread_cond_wait(&d->simulation_start_cond, &d->lock));
     POCL_UNLOCK(d->lock);
     if (d->shutdownRequested)
       goto EXIT;

--- a/lib/CL/devices/vulkan/pocl-vulkan.c
+++ b/lib/CL/devices/vulkan/pocl-vulkan.c
@@ -1242,8 +1242,8 @@ pocl_vulkan_init (unsigned j, cl_device_id dev, const char *parameters)
 
   d->work_queue = NULL;
 
-  pthread_create (&d->driver_pthread_id, NULL, pocl_vulkan_driver_pthread,
-                  dev);
+  PTHREAD_CHECK (pthread_create (&d->driver_pthread_id, NULL,
+                                 pocl_vulkan_driver_pthread, dev));
 
   return CL_SUCCESS;
 }
@@ -1827,8 +1827,7 @@ pocl_vulkan_init_queue (cl_device_id dev, cl_command_queue queue)
   queue->data
       = pocl_aligned_malloc (HOST_CPU_CACHELINE_SIZE, sizeof (pthread_cond_t));
   pthread_cond_t *cond = (pthread_cond_t *)queue->data;
-  int r = pthread_cond_init (cond, NULL);
-  assert (r == 0);
+  PTHREAD_CHECK (pthread_cond_init (cond, NULL));
   return CL_SUCCESS;
 }
 
@@ -1836,8 +1835,7 @@ int
 pocl_vulkan_free_queue (cl_device_id dev, cl_command_queue queue)
 {
   pthread_cond_t *cond = (pthread_cond_t *)queue->data;
-  int r = pthread_cond_destroy (cond);
-  assert (r == 0);
+  PTHREAD_CHECK (pthread_cond_destroy (cond));
   POCL_MEM_FREE (queue->data);
   return CL_SUCCESS;
 }
@@ -1850,8 +1848,7 @@ pocl_vulkan_notify_cmdq_finished (cl_command_queue cq)
    * user threads waiting on the same command queue
    * in pthread_scheduler_wait_cq(). */
   pthread_cond_t *cq_cond = (pthread_cond_t *)cq->data;
-  int r = pthread_cond_broadcast (cq_cond);
-  assert (r == 0);
+  PTHREAD_CHECK (pthread_cond_broadcast (cq_cond));
 }
 
 void
@@ -1884,8 +1881,7 @@ pocl_vulkan_join (cl_device_id device, cl_command_queue cq)
         }
       else
         {
-          int r = pthread_cond_wait (cq_cond, &cq->pocl_lock);
-          assert (r == 0);
+          PTHREAD_CHECK (pthread_cond_wait (cq_cond, &cq->pocl_lock));
         }
     }
   return;
@@ -2817,7 +2813,7 @@ RETRY:
 
   if ((cmd == NULL) && (do_exit == 0))
     {
-      pthread_cond_wait (&d->wakeup_cond, &d->wq_lock_fast);
+      PTHREAD_CHECK (pthread_cond_wait (&d->wakeup_cond, &d->wq_lock_fast));
       /* since cond_wait returns with locked mutex, might as well retry */
       goto RETRY;
     }

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -107,6 +107,20 @@ typedef pthread_t pocl_thread_t;
 #define ALIGN_CACHE(x) x
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+POCL_EXPORT
+void pocl_abort_on_pthread_error (int status, unsigned line, const char *func);
+
+#ifdef __cplusplus
+}
+#endif
+
+#define PTHREAD_CHECK(code)                                                   \
+  pocl_abort_on_pthread_error ((code), __LINE__, __FUNCTION__);
+
 /* Generic functionality for handling different types of 
    OpenCL (host) objects. */
 

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -118,8 +118,20 @@ void pocl_abort_on_pthread_error (int status, unsigned line, const char *func);
 }
 #endif
 
-#define PTHREAD_CHECK(code)                                                   \
-  pocl_abort_on_pthread_error ((code), __LINE__, __FUNCTION__);
+/* Some pthread_*() calls may return '0' or a specific non-zero value on
+ * success.
+ */
+#define PTHREAD_CHECK2(_status_ok, _code)                                     \
+  do                                                                          \
+    {                                                                         \
+      int _pthread_status = (_code);                                          \
+      if (_pthread_status != 0 && _pthread_status != (_status_ok))            \
+        pocl_abort_on_pthread_error (_pthread_status, __LINE__,               \
+                                     __FUNCTION__);                           \
+    }                                                                         \
+  while (0)
+
+#define PTHREAD_CHECK(code) PTHREAD_CHECK2 (0, code)
 
 /* Generic functionality for handling different types of 
    OpenCL (host) objects. */

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -28,6 +28,7 @@
 #include "config.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <stdio.h>
 
 #ifdef HAVE_VALGRIND
@@ -136,37 +137,15 @@ void pocl_abort_on_pthread_error (int status, unsigned line, const char *func);
 /* Generic functionality for handling different types of 
    OpenCL (host) objects. */
 
-#define POCL_LOCK(__LOCK__)                                                   \
-  do                                                                          \
-    {                                                                         \
-      int r = pthread_mutex_lock (&(__LOCK__));                               \
-      assert (r == 0);                                                        \
-    }                                                                         \
-  while (0)
+#define POCL_LOCK(__LOCK__) PTHREAD_CHECK (pthread_mutex_lock (&(__LOCK__)))
 #define POCL_UNLOCK(__LOCK__)                                                 \
-  do                                                                          \
-    {                                                                         \
-      int r = pthread_mutex_unlock (&(__LOCK__));                             \
-      assert (r == 0);                                                        \
-    }                                                                         \
-  while (0)
+  PTHREAD_CHECK (pthread_mutex_unlock (&(__LOCK__)))
 #define POCL_INIT_LOCK(__LOCK__)                                              \
-  do                                                                          \
-    {                                                                         \
-      int r = pthread_mutex_init (&(__LOCK__), NULL);                         \
-      assert (r == 0);                                                        \
-    }                                                                         \
-  while (0)
+  PTHREAD_CHECK (pthread_mutex_init (&(__LOCK__), NULL))
 /* We recycle OpenCL objects by not actually freeing them until the
-   very end. Thus, the lock should not be destoryed at the refcount 0. */
+   very end. Thus, the lock should not be destroyed at the refcount 0. */
 #define POCL_DESTROY_LOCK(__LOCK__)                                           \
-  do                                                                          \
-    {                                                                         \
-      int r = pthread_mutex_destroy (&(__LOCK__));                            \
-      assert (r == 0);                                                        \
-    }                                                                         \
-  while (0)
-
+  PTHREAD_CHECK (pthread_mutex_destroy (&(__LOCK__)))
 
 /* If available, use an Adaptive mutex for locking in the pthread driver,
    otherwise fallback to simple mutexes */
@@ -179,10 +158,10 @@ void pocl_abort_on_pthread_error (int status, unsigned line, const char *func);
     do { \
       pthread_mutexattr_t attrs; \
       pthread_mutexattr_init (&attrs); \
-      int r = pthread_mutexattr_settype (&attrs, PTHREAD_MUTEX_ADAPTIVE_NP); \
-      assert (r == 0); \
-      pthread_mutex_init(&l, &attrs); \
-      pthread_mutexattr_destroy(&attrs);\
+      PTHREAD_CHECK (                                                         \
+          pthread_mutexattr_settype (&attrs, PTHREAD_MUTEX_ADAPTIVE_NP));     \
+      PTHREAD_CHECK (pthread_mutex_init (&l, &attrs));                        \
+      PTHREAD_CHECK (pthread_mutexattr_destroy (&attrs));                     \
     } while (0)
 #else
 #define POCL_FAST_INIT(l) POCL_INIT_LOCK (l)
@@ -190,17 +169,18 @@ void pocl_abort_on_pthread_error (int status, unsigned line, const char *func);
 
 #define POCL_FAST_DESTROY(l) POCL_DESTROY_LOCK(l)
 
-#define POCL_INIT_COND(c) pthread_cond_init (&c, NULL)
-#define POCL_DESTROY_COND(c) pthread_cond_destroy (&c)
-#define POCL_SIGNAL_COND(c) pthread_cond_signal (&c)
-#define POCL_BROADCAST_COND(c) pthread_cond_broadcast (&c)
-#define POCL_WAIT_COND(c, m) pthread_cond_wait (&c, &m)
-#define POCL_TIMEDWAIT_COND(c, m, t) pthread_cond_timedwait (&c, &m, &t)
+#define POCL_INIT_COND(c) PTHREAD_CHECK (pthread_cond_init (&c, NULL))
+#define POCL_DESTROY_COND(c) PTHREAD_CHECK (pthread_cond_destroy (&c))
+#define POCL_SIGNAL_COND(c) PTHREAD_CHECK (pthread_cond_signal (&c))
+#define POCL_BROADCAST_COND(c) PTHREAD_CHECK (pthread_cond_broadcast (&c))
+#define POCL_WAIT_COND(c, m) PTHREAD_CHECK (pthread_cond_wait (&c, &m))
+#define POCL_TIMEDWAIT_COND(c, m, t) PTHREAD_CHECK2(ETIMEDOUT, pthread_cond_timedwait (&c, &m, &t))
 
 #define POCL_CREATE_THREAD(thr, func, arg)                                    \
-  pthread_create (&thr, NULL, func, arg)
-#define POCL_JOIN_THREAD(thr) pthread_join (thr, NULL)
-#define POCL_JOIN_THREAD2(thr, res_ptr) pthread_join (thr, res_ptr)
+  PTHREAD_CHECK (pthread_create (&thr, NULL, func, arg))
+#define POCL_JOIN_THREAD(thr) PTHREAD_CHECK (pthread_join (thr, NULL))
+#define POCL_JOIN_THREAD2(thr, res_ptr)                                       \
+  PTHREAD_CHECK (pthread_join (thr, res_ptr))
 #define POCL_EXIT_THREAD(res) pthread_exit (res)
 
 //############################################################################

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -1679,8 +1679,8 @@ pocl_abort_on_pthread_error (int status, unsigned line, const char *func)
 {
   if (status != 0)
     {
-      POCL_MSG_PRINT2 (HSA, func, line, "Error from pthread call:\n");
-      POCL_ABORT ("%s\n", strerror (status));
+      POCL_MSG_PRINT2 (ERROR, func, line, "Error from pthread call:\n");
+      POCL_ABORT ("PTHREAD ERROR in %s():%u: %s (%d)\n", func, line, strerror (status), status);
     }
 }
 

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -184,11 +184,6 @@ int pocl_check_event_wait_list(cl_command_queue     command_queue,
                                cl_uint              num_events_in_wait_list,
                                const cl_event *     event_wait_list);
 
-void pocl_abort_on_pthread_error (int status, unsigned line, const char *func);
-
-#define PTHREAD_CHECK(code)                                                   \
-  pocl_abort_on_pthread_error ((code), __LINE__, __FUNCTION__);
-
 void pocl_update_event_queued (cl_event event);
 
 POCL_EXPORT


### PR DESCRIPTION
some fixes for the pthread device, mainly:
* `pthread_scheduler_init()`: `abort()` if `pthread_create()` fails (also if it fails with `EAGAIN`)
  * recovery would be hard: terminate the partially created thread pool and return an error code
* if any worker thread experienced an allocation failure during initialization, don't assert, but report this back to the scheduler: uninitialize the scheduler (shut down the worker thread pool) in this case and return an error code from  `pthread_scheduler_init()`

this may not totally solve the original issue, but at least in case of only the allocations failing the application would have the possibility to handle the unavailable device

there are more `pthread_create()` and other `pthread_*()` calls missing error handling in the pocl codebase, these are not covered here

fixes: #1009