### PR TITLE
Avoid loss of precision in CUDA event time calculations

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,6 +26,7 @@ Notable Bug Fixes
 - Fixed the post-event-finish-cleanup process in the drivers,
   this should improve reliability
 - Few more fixes for Android
+- Fixed loss of precision in CUDA event times due to type conversion
 
 Other
 -----

--- a/CREDITS
+++ b/CREDITS
@@ -84,3 +84,4 @@ Tom Rix <trix@redhat.com>
 Joachim Meyer <joachim@joameyer.de>
 Alexandre Ghiti <alexandre.ghiti@canonical.com>
 Michel Migdal
+Nicholas Christensen

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -1540,14 +1540,14 @@ pocl_cuda_update_event (cl_device_id device, cl_event event)
           &diff, ((pocl_cuda_device_data_t *)device->data)->epoch_event,
           event_data->start);
       CUDA_CHECK (result, "cuEventElapsedTime");
-      event->time_start = (cl_ulong) (epoch + diff * 1e6);
+      event->time_start = epoch + (cl_ulong)(diff * 1e6);
       event->time_start = max (event->time_start, epoch + 1);
 
       result = cuEventElapsedTime (
           &diff, ((pocl_cuda_device_data_t *)device->data)->epoch_event,
           event_data->end);
       CUDA_CHECK (result, "cuEventElapsedTime");
-      event->time_end = (cl_ulong) (epoch + diff * 1e6);
+      event->time_end = epoch + (cl_ulong)(diff * 1e6);
       event->time_end = max (event->time_end, event->time_start + 1);
     }
 }


### PR DESCRIPTION
The current code implicitly converts `epoch` to a float before calculating `time_end` and `time_start` and converting back to a `cl_ulong`. A `float` only has seven or so digits of accuracy meaning this conversion throws away the least significant digits of `epoch` if `epoch` is larger than about 1e8. Conversely, the precision of `diff` is around 1e-3 so multiplying by 1e6 makes all of these digits > 1 and converting this number to a `cl_ulong` will not lose any  digits. The gist below illustrates this in Python.

https://gist.github.com/nchristensen/15ab1fd53ba099accaab780ab6dbad90