### PR TITLE
llvm 13: handle deprecated CreateLoad

### DIFF
--- a/lib/llvmopencl/ParallelRegion.cc
+++ b/lib/llvmopencl/ParallelRegion.cc
@@ -622,9 +622,12 @@ ParallelRegion::LocalIDZLoad()
 {
   if (LocalIDZLoadInstr != NULL) return LocalIDZLoadInstr;
   IRBuilder<> builder(&*(entryBB()->getFirstInsertionPt()));
-  return LocalIDZLoadInstr =
-    builder.CreateLoad
-    (entryBB()->getParent()->getParent()->getGlobalVariable(POCL_LOCAL_ID_Z_GLOBAL));
+  Value *Ptr = entryBB()->getParent()->getParent()->getGlobalVariable(POCL_LOCAL_ID_Z_GLOBAL);
+  return LocalIDZLoadInstr = builder.CreateLoad(
+#ifndef LLVM_OLDER_THAN_13_0
+    Ptr->getType()->getPointerElementType(),
+#endif
+    Ptr);
 }
 
 /**
@@ -636,9 +639,12 @@ ParallelRegion::LocalIDYLoad()
 {
   if (LocalIDYLoadInstr != NULL) return LocalIDYLoadInstr;
   IRBuilder<> builder(&*(entryBB()->getFirstInsertionPt()));
-  return LocalIDYLoadInstr = 
-    builder.CreateLoad
-    (entryBB()->getParent()->getParent()->getGlobalVariable(POCL_LOCAL_ID_Y_GLOBAL));
+  Value *Ptr = entryBB()->getParent()->getParent()->getGlobalVariable(POCL_LOCAL_ID_Y_GLOBAL);
+  return LocalIDYLoadInstr = builder.CreateLoad(
+#ifndef LLVM_OLDER_THAN_13_0
+    Ptr->getType()->getPointerElementType(),
+#endif
+    Ptr);
 }
 
 /**
@@ -650,9 +656,12 @@ ParallelRegion::LocalIDXLoad()
 {
   if (LocalIDXLoadInstr != NULL) return LocalIDXLoadInstr;
   IRBuilder<> builder(&*(entryBB()->getFirstInsertionPt()));
-  return LocalIDXLoadInstr = 
-    builder.CreateLoad
-    (entryBB()->getParent()->getParent()->getGlobalVariable(POCL_LOCAL_ID_X_GLOBAL));
+  Value *Ptr = entryBB()->getParent()->getParent()->getGlobalVariable(POCL_LOCAL_ID_X_GLOBAL);
+  return LocalIDXLoadInstr = builder.CreateLoad(
+#ifndef LLVM_OLDER_THAN_13_0
+    Ptr->getType()->getPointerElementType(),
+#endif
+    Ptr);
 }
 
 void

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -405,7 +405,7 @@ llvm::Value *
 Workgroup::createLoadFromContext(
   IRBuilder<> &Builder, int StructFieldIndex, int FieldIndex=-1) {
 
-  Value *GEP;
+  Value *GEP, *Ptr;
   Type *ContextType = ContextArg->getType()->getPointerElementType();
   GEP = Builder.CreateStructGEP(ContextType, ContextArg, StructFieldIndex);
   Type *GEPType = GEP->getType()->getPointerElementType();
@@ -413,29 +413,34 @@ Workgroup::createLoadFromContext(
   llvm::LoadInst *Load = nullptr;
   if (SizeTWidth == 64) {
     if (FieldIndex == -1)
-      Load = Builder.CreateLoad(Builder.CreateConstGEP1_64(
+      Ptr = Builder.CreateConstGEP1_64(
 #ifndef LLVM_OLDER_THAN_13_0
           GEPType,
 #endif
-          GEP, 0));
+          GEP, 0);
     else
-      Load = Builder.CreateLoad(Builder.CreateConstGEP2_64(
+      Ptr = Builder.CreateConstGEP2_64(
 #ifndef LLVM_OLDER_THAN_13_0
           GEPType,
 #endif
-          GEP, 0, FieldIndex));
+          GEP, 0, FieldIndex);
   } else {
     if (FieldIndex == -1)
-      Load = Builder.CreateLoad(Builder.CreateConstGEP1_32(
+      Ptr = Builder.CreateConstGEP1_32(
 #ifndef LLVM_OLDER_THAN_13_0
           GEPType,
 #endif
-          GEP, 0));
+          GEP, 0);
     else
-      Load = Builder.CreateLoad(Builder.CreateConstGEP2_32(
+      Ptr = Builder.CreateConstGEP2_32(
           GEPType,
-          GEP, 0, FieldIndex));
+          GEP, 0, FieldIndex);
   }
+  Load = Builder.CreateLoad(
+#ifndef LLVM_OLDER_THAN_13_0
+	  Ptr->getType()->getPointerElementType(),
+#endif
+	  Ptr);
   addRangeMetadataForPCField(Load, StructFieldIndex, FieldIndex);
   return Load;
 }


### PR DESCRIPTION
As of llvm 13, CreateLoad prefers to have a type arguement as it's
first parameter, deprecating the old api.

For readablity, seperated out the CreateConstGEP* calls which have
a similar deprecation.

Signed-off-by: Tom Rix <trix@redhat.com>