### PR TITLE
Fix value of CL_DEVICE_PCI_DOMAIN_ID_NV

### DIFF
--- a/include/CL/cl_ext.h
+++ b/include/CL/cl_ext.h
@@ -230,7 +230,7 @@ typedef CL_API_ENTRY cl_command_queue
 #define CL_DEVICE_PCI_SLOT_ID_NV                    0x4009
 
 /* extension to cl_nv_device_attribute_query */
-#define CL_DEVICE_PCI_DOMAIN_ID_NV                  0x4010
+#define CL_DEVICE_PCI_DOMAIN_ID_NV                  0x400A
 
 /*********************************
 * cl_amd_device_attribute_query *


### PR DESCRIPTION
This value was initially fixed by #917 but got reverted by #931 (specifically https://github.com/pocl/pocl/commit/5f806ca03228f6c4ab4a3a3042dd4475913125a5).

cc: @Vinsteri 