### PR TITLE
Remove redundant `const` qualifier on parameter declarations

### DIFF
--- a/lib/CL/devices/common_driver.c
+++ b/lib/CL/devices/common_driver.c
@@ -708,7 +708,7 @@ pocl_driver_setup_metadata (cl_device_id device, cl_program program,
 }
 
 int
-pocl_driver_supports_binary (cl_device_id device, const size_t length,
+pocl_driver_supports_binary (cl_device_id device, size_t length,
                              const char *binary)
 {
 #ifdef ENABLE_LLVM

--- a/lib/CL/devices/common_driver.h
+++ b/lib/CL/devices/common_driver.h
@@ -107,7 +107,7 @@ POCL_EXPORT
   int pocl_driver_setup_metadata (cl_device_id device, cl_program program,
                                   unsigned program_device_i);
 POCL_EXPORT
-  int pocl_driver_supports_binary (cl_device_id device, const size_t length,
+  int pocl_driver_supports_binary (cl_device_id device, size_t length,
                                    const char *binary);
 POCL_EXPORT
   int pocl_driver_build_poclbinary (cl_program program, cl_uint device_i);

--- a/lib/CL/devices/prototypes.inc
+++ b/lib/CL/devices/prototypes.inc
@@ -116,7 +116,7 @@
   int pocl_##__DRV__##_setup_metadata (                                       \
       cl_device_id device, cl_program program, unsigned program_device_i);    \
   int pocl_##__DRV__##_supports_binary (                                      \
-      cl_device_id device, const size_t length, const char *binary);          \
+      cl_device_id device, size_t length, const char *binary);                \
   void pocl_##__DRV__##_memfill (void *data, pocl_mem_identifier *dst_mem_id, \
                                  cl_mem dst_buf, size_t size, size_t offset,  \
                                  const void *__restrict__ pattern,            \

--- a/lib/CL/devices/vulkan/pocl-vulkan.c
+++ b/lib/CL/devices/vulkan/pocl-vulkan.c
@@ -1422,7 +1422,7 @@ ERROR:
 }
 
 int
-pocl_vulkan_supports_binary (cl_device_id device, const size_t length,
+pocl_vulkan_supports_binary (cl_device_id device, size_t length,
                              const char *binary)
 {
 /* TODO remove ifdef once the build callbacks


### PR DESCRIPTION
Remove `const` qualifier on the declaration of the `length` parameter of `pocl_*_supports_binary` functions.
This silences `clang-tidy` and makes the code more consistent.