### PR TITLE
build: avoid duplicating prefix in install paths by using full paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,47 +328,31 @@ else()
   set(COMMAND_USES_TERMINAL USES_TERMINAL)
 endif()
 
-if(UNIX)
-  include(GNUInstallDirs)
-else()
-  if (WIN32)
-    set(${CMAKE_INSTALL_LIBDIR} "lib")
-    set(${CMAKE_INSTALL_DATADIR} "share")
-    set(${CMAKE_INSTALL_INCLUDEDIR} "include")
-    set(${CMAKE_INSTALL_BINDIR} "bin")
-    message(STATUS "Setting installation destination on Windows to: ${CMAKE_INSTALL_PREFIX}")
-  else()
-    message(FATAL_ERROR "System not UNIX nor WIN32 - not implemented yet")
-  endif()
-endif()
+include(GNUInstallDirs)
 
 # for libpocl.so
-set(POCL_INSTALL_PUBLIC_LIBDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH "POCL public libdir")
+set(POCL_INSTALL_PUBLIC_LIBDIR "${CMAKE_INSTALL_FULL_LIBDIR}" CACHE PATH "POCL public libdir")
 
 # for libpocl-devices-*.so
-set(POCL_INSTALL_PRIVATE_LIBDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pocl" CACHE PATH "POCL private libdir")
+set(POCL_INSTALL_PRIVATE_LIBDIR "${CMAKE_INSTALL_FULL_LIBDIR}/pocl" CACHE PATH "POCL private libdir")
 
 # for pocl.icd
-if(UNIX AND (NOT CMAKE_CROSSCOMPILING) AND (CMAKE_INSTALL_PREFIX STREQUAL "/usr"))
-  set(POCL_INSTALL_ICD_VENDORDIR "/etc/OpenCL/vendors" CACHE PATH "POCL ICD file destination")
-else()
-  set(POCL_INSTALL_ICD_VENDORDIR "${CMAKE_INSTALL_PREFIX}/etc/OpenCL/vendors" CACHE PATH "POCL ICD file destination")
-endif()
+set(POCL_INSTALL_ICD_VENDORDIR "${CMAKE_INSTALL_FULL_SYSCONFDIR}/OpenCL/vendors" CACHE PATH "POCL ICD file destination")
 
 # for kernel-<target>.bc
-set(POCL_INSTALL_PRIVATE_DATADIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/pocl" CACHE PATH "POCL private datadir")
+set(POCL_INSTALL_PRIVATE_DATADIR "${CMAKE_INSTALL_FULL_DATADIR}/pocl" CACHE PATH "POCL private datadir")
 
 # for poclu.h
-set(POCL_INSTALL_PUBLIC_HEADER_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}" CACHE PATH "POCL public header dir")
+set(POCL_INSTALL_PUBLIC_HEADER_DIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}" CACHE PATH "POCL public header dir")
 
 # for _kernel.h et al
 set(POCL_INSTALL_PRIVATE_HEADER_DIR "${POCL_INSTALL_PRIVATE_DATADIR}/include" CACHE PATH "POCL private header dir")
 
 # for pocl-standalone et al
-set(POCL_INSTALL_PUBLIC_BINDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}" CACHE PATH "POCL public bindir")
+set(POCL_INSTALL_PUBLIC_BINDIR "${CMAKE_INSTALL_FULL_BINDIR}" CACHE PATH "POCL public bindir")
 
 # for PoclConfig.cmake & stuff
-set(POCL_INSTALL_CMAKE_CONFIG_DIR "${POCL_INSTALL_PRIVATE_LIBDIR}" CACHE PATH   "Installation directory for CMake files")
+set(POCL_INSTALL_CMAKE_CONFIG_DIR "${POCL_INSTALL_PRIVATE_LIBDIR}/cmake" CACHE PATH   "Installation directory for CMake files")
 
 # TODO maybe use output of pkg-config --variable=pc_path pkg-config ?
 set(POCL_INSTALL_PKGCONFIG_DIR "${POCL_INSTALL_PUBLIC_LIBDIR}/pkgconfig" CACHE PATH "Destination for pocl.pc")


### PR DESCRIPTION
When explicit full paths are provided for BINDIR, LIBDIR, etc, like is the case in [Nix](https://nixos.org/), they would get the prefix prepended to them regardless, which is wrong:

```
/nix/store/g2lx5mamf4dapv52w91r98c69vcc7glq-pocl-1.8
├── nix
│  └── store
│     └── g2lx5mamf4dapv52w91r98c69vcc7glq-pocl-1.8
│        ├── bin
│        │  └── poclcc
│        ├── include
│        │  └── CL
│        │     ├── cl.h
│        │     ├── cl2.hpp
│        │     ├── cl_d3d10.h
│        │     ├── cl_d3d11.h
│        │     ├── cl_dx9_media_sharing.h
│        │     ├── cl_dx9_media_sharing_intel.h
│        │     ├── cl_egl.h
│        │     ├── cl_ext.h
│        │     ├── cl_ext_intel.h
│        │     ├── cl_ext_pocl.h
│        │     ├── cl_gl.h
│        │     ├── cl_gl_ext.h
│        │     ├── cl_half.h
│        │     ├── cl_icd.h
│        │     ├── cl_platform.h
│        │     ├── cl_va_api_media_sharing_intel.h
│        │     ├── cl_version.h
│        │     └── opencl.h
│        └── lib
│           ├── libOpenCL.so -> libOpenCL.so.2
│           ├── libOpenCL.so.2 -> libOpenCL.so.2.9.0
│           ├── libOpenCL.so.2.9.0
│           ├── pkgconfig
│           │  └── pocl.pc
│           └── pocl
│              ├── libpocl-devices-basic.so
│              └── libpocl-devices-pthread.so
└── share
   └── pocl
      ├── include
      │  ├── _builtin_renames.h
      │  ├── _clang_opencl.h
      │  ├── _enable_all_exts.h
      │  ├── _kernel.h
      │  ├── _kernel_c.h
      │  ├── _kernel_constants.h
      │  ├── _libclang_versions_checks.h
      │  ├── opencl-c-base.h
      │  ├── opencl-c.h
      │  ├── pocl.h
      │  ├── pocl_device.h
      │  ├── pocl_image_types.h
      │  ├── pocl_spir.h
      │  └── pocl_types.h
      └── kernel-x86_64-unknown-linux-gnu-znver3.bc
```

Using the `_FULL_` variants from GNUInstallDirs works correctly and is apparently also the recommended way to go on Windows despite the name (I haven't tried building on Windows with these changes though, so that still needs verifying):

```
/nix/store/iw0ss9qzddzghfw8zqwwdxcfkdvr4hq4-pocl-1.8
├── bin
│  └── poclcc
├── include
│  └── CL
│     ├── cl.h
│     ├── cl2.hpp
│     ├── cl_d3d10.h
│     ├── cl_d3d11.h
│     ├── cl_dx9_media_sharing.h
│     ├── cl_dx9_media_sharing_intel.h
│     ├── cl_egl.h
│     ├── cl_ext.h
│     ├── cl_ext_intel.h
│     ├── cl_ext_pocl.h
│     ├── cl_gl.h
│     ├── cl_gl_ext.h
│     ├── cl_half.h
│     ├── cl_icd.h
│     ├── cl_platform.h
│     ├── cl_va_api_media_sharing_intel.h
│     ├── cl_version.h
│     └── opencl.h
├── lib
│  ├── libOpenCL.so -> libOpenCL.so.2
│  ├── libOpenCL.so.2 -> libOpenCL.so.2.9.0
│  ├── libOpenCL.so.2.9.0
│  ├── pkgconfig
│  │  └── pocl.pc
│  └── pocl
│     ├── libpocl-devices-basic.so
│     └── libpocl-devices-pthread.so
└── share
   └── pocl
      ├── include
      │  ├── _builtin_renames.h
      │  ├── _clang_opencl.h
      │  ├── _enable_all_exts.h
      │  ├── _kernel.h
      │  ├── _kernel_c.h
      │  ├── _kernel_constants.h
      │  ├── _libclang_versions_checks.h
      │  ├── opencl-c-base.h
      │  ├── opencl-c.h
      │  ├── pocl.h
      │  ├── pocl_device.h
      │  ├── pocl_image_types.h
      │  ├── pocl_spir.h
      │  └── pocl_types.h
      └── kernel-x86_64-unknown-linux-gnu-znver3.bc
```

This also gets is part of the way towards more idiomatic CMake packaging as is demonstrated in https://github.com/alexreinking/SharedStaticStarter