### PR TITLE
Don't call pocl_<device>_init_ops twice

### DIFF
--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -231,7 +231,6 @@ get_pocl_device_lib_path (char *result, char *device_name, int absolute_path)
                 {
                   strcat (result, device_name);
                 }
-              strcat (result, POCL_PATH_SEPARATOR);
             }
           else
 #endif
@@ -554,11 +553,7 @@ pocl_init_devices ()
           strcat (init_device_ops_name, "_init_device_ops");
           pocl_devices_init_ops[i] = (init_device_ops)dlsym (
           pocl_device_handles[i], init_device_ops_name);
-          if (pocl_devices_init_ops[i] != NULL)
-            {
-              pocl_devices_init_ops[i](&pocl_device_ops[i]);
-            }
-          else
+          if (pocl_devices_init_ops[i] == NULL)
             {
               POCL_MSG_ERR ("Loading symbol %s from %s failed: %s\n",
                              init_device_ops_name, device_library,


### PR DESCRIPTION
If a device driver allocates resources in `pocl_<device>_init_ops`,
calling it twice can result in a memory leak.
Also, don't append the path separator twice when building the path
to the device's DSO.