### PR TITLE
cl_ext_relaxed_printf_address_space for CPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1100,7 +1100,7 @@ endif()
 # These are mandatory for OpenCL 1.1 (except for 3D writes but those are CPU-independent)
 set(HOST_DEVICE_EXTENSIONS "cl_khr_byte_addressable_store cl_khr_global_int32_base_atomics \
   cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics \
-  cl_khr_local_int32_extended_atomics cl_khr_3d_image_writes")
+  cl_khr_local_int32_extended_atomics cl_khr_3d_image_writes cl_ext_relaxed_printf_address_space")
 
 set(HOST_DEVICE_FEATURES_30 "__opencl_c_3d_image_writes  __opencl_c_images \
   __opencl_c_atomic_order_acq_rel __opencl_c_atomic_order_seq_cst \

--- a/include/_kernel.h
+++ b/include/_kernel.h
@@ -220,6 +220,18 @@
 
 #include "_clang_opencl.h"
 
+
+#ifdef cl_ext_relaxed_printf_address_space
+
+int _CL_OVERLOADABLE printf(__global const char* restrict format, ...)
+  __attribute__((format(printf, 1, 2)));
+int _CL_OVERLOADABLE printf(__local const char* restrict format, ...)
+  __attribute__((format(printf, 1, 2)));
+int _CL_OVERLOADABLE printf(__private const char* restrict format, ...)
+  __attribute__((format(printf, 1, 2)));
+
+#endif
+
 /****************************************************************************/
 
 /* GNU's libm seems to use INT_MIN here while the Clang's header uses

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1697,7 +1697,8 @@ pocl_setup_opencl_c_with_version (cl_device_id dev, int supports_30)
 }
 
 static const cl_name_version OPENCL_EXTENSIONS[]
-    = { { CL_MAKE_VERSION (1, 0, 0), "cl_khr_byte_addressable_store" },
+    = { { CL_MAKE_VERSION (1, 0, 0), "cl_ext_relaxed_printf_address_space" },
+        { CL_MAKE_VERSION (1, 0, 0), "cl_khr_byte_addressable_store" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_global_int32_base_atomics" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_global_int32_extended_atomics" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_local_int32_base_atomics" },

--- a/lib/kernel/printf_base.h
+++ b/lib/kernel/printf_base.h
@@ -22,6 +22,7 @@
 */
 
 #include "pocl_types.h"
+#include "pocl_spir.h"
 
 /* printing largest double with %f formatter requires about ~1024 digits for
  * integral part, plus precision digits for decimal part, plus some space for
@@ -35,7 +36,7 @@
 /* Produce a SPIR-V compliant bitcode where the format string is
    in the constant address space (2 in SPIR-V). Address space cast
    in Workgroup.cc in case of native compilation. */
-#define PRINTF_FMT_STR_AS __attribute__ ((address_space (2)))
+#define PRINTF_FMT_STR_AS SPIR_ADDRESS_SPACE_CONSTANT
 #else
 /* Use the default address space with the older LLVMs. No SPIR-V
    support. */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,10 +101,12 @@ endif()
 endif()
 #######################################################################
 
+add_subdirectory("ext")
 add_subdirectory("kernel")
 add_subdirectory("regression")
 add_subdirectory("runtime")
 add_subdirectory("workgroup")
+
 if(ENABLE_TCE)
   add_subdirectory("tce")
 endif()

--- a/tests/ext/CMakeLists.txt
+++ b/tests/ext/CMakeLists.txt
@@ -1,0 +1,42 @@
+#=============================================================================
+#   CMake build system files
+#
+#   Copyright (c) 2022 Pekka Jääskeläinen
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#   THE SOFTWARE.
+#
+#=============================================================================
+
+add_definitions("-DSRCDIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"")
+
+add_executable("relaxed_printf_address_space" relaxed_printf_address_space.cc)
+
+target_link_libraries("relaxed_printf_address_space" ${POCLU_LINK_OPTIONS})
+
+add_test_pocl(NAME "ext/relaxed_printf_address_space"
+              EXPECTED_OUTPUT "relaxed_printf_address_space.stdout"
+              COMMAND "relaxed_printf_address_space")
+
+set_tests_properties( "ext/relaxed_printf_address_space"
+  PROPERTIES
+    COST 4.0
+    PROCESSORS 1
+    LABELS "internal;ext"
+    DEPENDS "pocl_version_check")
+

--- a/tests/ext/relaxed_printf_address_space.cc
+++ b/tests/ext/relaxed_printf_address_space.cc
@@ -1,0 +1,168 @@
+/* relaxed_printf_address_space.cc -
+   Test cases for cl_ext_relaxed_printf_address_space
+
+   Copyright (c) 2022 Pekka Jääskeläinen / Parmance
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#include <CL/cl.h>
+
+#include <vector>
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <string.h>
+
+#define CHECK_ERR(X) do {					\
+    if ((X) != CL_SUCCESS) {					\
+      std::cerr << #X "ERROR at " << __LINE__ << std::endl;	\
+      abort();							\
+    } } while (0)
+
+std::vector<std::string> getKernelNames(cl_program Program) {
+  size_t KernelNamesSize;
+  CHECK_ERR(clGetProgramInfo(Program, CL_PROGRAM_KERNEL_NAMES,
+			     0, NULL,
+			     &KernelNamesSize));
+
+
+  char Names[KernelNamesSize + 1];
+  CHECK_ERR(clGetProgramInfo(Program, CL_PROGRAM_KERNEL_NAMES,
+			     KernelNamesSize, &Names[0],
+			     &KernelNamesSize));
+
+  // The specs doesn't ensure a null terminated string.
+  Names[KernelNamesSize] = 0;
+
+  std::vector<std::string> KernelNames;
+  //Construct a stream from the string
+  std::stringstream StreamData(Names);
+  std::string Kern;
+  while (std::getline(StreamData, Kern, ';')) {
+    KernelNames.push_back(Kern);
+  }
+  return KernelNames;
+}
+
+int main(int Argc, char *Argv[]) {
+
+  cl_uint Count;
+  cl_platform_id Platform;
+
+  clGetPlatformIDs (1, &Platform, &Count);
+  if (Count == 0)
+    abort();
+
+  cl_context_properties Properties[] =
+    {CL_CONTEXT_PLATFORM, (cl_context_properties)Platform, 0};
+
+  cl_context Context =
+    clCreateContextFromType (Properties, CL_DEVICE_TYPE_ALL,
+			     NULL, NULL, NULL);
+
+  cl_uint NumDevices;
+  cl_int Err = clGetDeviceIDs(Platform, CL_DEVICE_TYPE_ALL, 0, NULL,
+			      &NumDevices);
+  if (Err != CL_SUCCESS || NumDevices == 0)
+    return EXIT_FAILURE;
+
+  cl_device_id Device;
+  Err = clGetDeviceIDs (Platform, CL_DEVICE_TYPE_ALL, 1, &Device, NULL);
+  if (Err != CL_SUCCESS)
+    return EXIT_FAILURE;
+
+  std::ifstream File(SRCDIR "/relaxed_printf_address_space.cl",
+		     std::ios::binary | std::ios::ate);
+  std::streamsize SrcSize = File.tellg();
+  File.seekg(0, std::ios::beg);
+
+  std::vector<char> Src(SrcSize);
+  if (!File.read(Src.data(), SrcSize))
+    return EXIT_FAILURE;
+
+  const char *SrcCStr = (const char*)Src.data();
+
+  cl_program Program =
+    clCreateProgramWithSource (Context, 1, &SrcCStr,
+			       (const size_t*)&SrcSize, &Err);
+  CHECK_ERR(Err);
+
+  Err = clBuildProgram (Program, 0, NULL, "", NULL, NULL);
+  CHECK_ERR(Err);
+
+  cl_command_queue Queue =
+    clCreateCommandQueueWithProperties(Context, Device, 0, &Err);
+  CHECK_ERR(Err);
+
+  cl_kernel Kernel = clCreateKernel(Program,
+				    "relaxed_printf_address_space_tests",
+				    NULL);
+  int IO = 1;
+  cl_mem IOBuffer =
+    clCreateBuffer (Context,
+		    CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+		    sizeof(int), &IO, &Err);
+  CHECK_ERR(Err);
+  Err = clSetKernelArg (Kernel, 0, sizeof (cl_mem), (void *)&IOBuffer);
+  CHECK_ERR(Err);
+
+  char GlobalFmtStr[] = "%s through a global format str\n\0";
+  cl_mem GlobalFmtStrBuffer =
+    clCreateBuffer (Context,
+		    CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+		    strlen(GlobalFmtStr) + 1, &GlobalFmtStr, &Err);
+  CHECK_ERR(Err);
+  Err = clSetKernelArg (Kernel, 1, sizeof (cl_mem),
+			(void *)&GlobalFmtStrBuffer);
+  CHECK_ERR(Err);
+
+  char GlobalStr[] = "global address space str arg\0";
+  cl_mem GlobalStrBuffer =
+    clCreateBuffer (Context,
+		    CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+		    strlen(GlobalStr) + 1, &GlobalStr, &Err);
+  CHECK_ERR(Err);
+  Err = clSetKernelArg (Kernel, 2, sizeof (cl_mem),
+			(void *)&GlobalStrBuffer);
+  CHECK_ERR(Err);
+
+  Err = clSetKernelArg (Kernel, 3, 1000, NULL);
+  CHECK_ERR(Err);
+
+  Err = clSetKernelArg (Kernel, 4, 1000, NULL);
+  CHECK_ERR(Err);
+
+  const size_t LocalSize[] = {1, 1, 1};
+  const size_t GlobalSize[] = {1, 1, 1};
+
+  Err = clEnqueueNDRangeKernel (Queue, Kernel, 1, NULL, LocalSize,
+				GlobalSize, 0, NULL, NULL);
+  CHECK_ERR(Err);
+
+  Err = clEnqueueReadBuffer (Queue, IOBuffer, CL_TRUE, 0,
+			       sizeof(int), &IO, 0, NULL, NULL);
+  CHECK_ERR(Err);
+
+  clFinish(Queue);
+
+  std::cout << "IO == " << IO << std::endl << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/tests/ext/relaxed_printf_address_space.cl
+++ b/tests/ext/relaxed_printf_address_space.cl
@@ -1,0 +1,94 @@
+/* relaxed_printf_address_space.cl -
+   Test cases for cl_ext_relaxed_printf_address_space
+
+   Copyright (c) 2022 Pekka Jääskeläinen / Parmance
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#ifndef cl_ext_relaxed_printf_address_space
+#error cl_ext_relaxed_printf_address_space not supported by the device!
+#endif
+
+constant const char *constant c_fmt = "%s through a constant format str\n";
+constant const char *constant c_arg = "constant address space str arg";
+
+constant const char *constant l_fmt_init = "%s through a local format str\n";
+constant const char *constant l_arg_init = "local address space str arg";
+
+constant const char *constant p_fmt_init = "%s through a private format str\n";
+constant const char *constant p_arg_init = "private address space str arg";
+
+#define strcpy(dst, src) do {			\
+    char c;					\
+    int i = 0;					\
+    do {					\
+      c = src[i];				\
+      dst[i] = c;				\
+      ++i;					\
+    } while (c != '\0');			\
+  } while (0)
+
+kernel void relaxed_printf_address_space_tests(global int *io,
+					       global char *g_fmt,
+					       global char *g_arg,
+					       local char *l_fmt,
+					       local char *l_arg) {
+  char p_arg[1000];
+  char p_fmt[1000];
+
+  strcpy(l_fmt, l_fmt_init);
+  strcpy(l_arg, l_arg_init);
+
+  strcpy(p_arg, p_arg_init);
+  strcpy(p_fmt, p_fmt_init);
+
+  io[0] = printf(g_fmt, g_arg);
+  io[0] += printf(c_fmt, c_arg);
+  io[0] += printf(l_fmt, l_arg);
+  io[0] += printf(p_fmt, p_arg);
+
+  printf("\n");
+
+  io[0] += printf(g_fmt, p_arg);
+  io[0] += printf(g_fmt, c_arg);
+  io[0] += printf(g_fmt, l_arg);
+  io[0] += printf(g_fmt, g_arg);
+
+  printf("\n");
+
+  io[0] += printf(c_fmt, p_arg);
+  io[0] += printf(c_fmt, g_arg);
+  io[0] += printf(c_fmt, l_arg);
+  io[0] += printf(c_fmt, c_arg);
+
+  printf("\n");
+
+  io[0] += printf(l_fmt, p_arg);
+  io[0] += printf(l_fmt, g_arg);
+  io[0] += printf(l_fmt, c_arg);
+  io[0] += printf(l_fmt, l_arg);
+
+  printf("\n");
+
+  io[0] += printf(p_fmt, l_arg);
+  io[0] += printf(p_fmt, g_arg);
+  io[0] += printf(p_fmt, c_arg);
+  io[0] += printf(p_fmt, p_arg);
+}

--- a/tests/ext/relaxed_printf_address_space.stdout
+++ b/tests/ext/relaxed_printf_address_space.stdout
@@ -1,0 +1,26 @@
+global address space str arg through a global format str
+constant address space str arg through a constant format str
+local address space str arg through a local format str
+private address space str arg through a private format str
+
+private address space str arg through a global format str
+constant address space str arg through a global format str
+local address space str arg through a global format str
+global address space str arg through a global format str
+
+private address space str arg through a constant format str
+global address space str arg through a constant format str
+local address space str arg through a constant format str
+constant address space str arg through a constant format str
+
+private address space str arg through a local format str
+global address space str arg through a local format str
+constant address space str arg through a local format str
+local address space str arg through a local format str
+
+local address space str arg through a private format str
+global address space str arg through a private format str
+constant address space str arg through a private format str
+private address space str arg through a private format str
+IO == 0
+


### PR DESCRIPTION
Implements the relaxed printf AS extension for flat address space targets (read: CPUs).  Supporting disjoint AS targets would require a bit more work.

The extension is [here](https://github.com/parmance/OpenCL-Docs/blob/eprintf/extensions/cl_ext_relaxed_printf_string_address_space.asciidoc).