### PR TITLE
Mark _constant_memory_region_ as external linkage with no initializer

### DIFF
--- a/lib/CL/devices/cuda/pocl-ptx-gen.cc
+++ b/lib/CL/devices/cuda/pocl-ptx-gen.cc
@@ -762,8 +762,8 @@ void fixConstantMemArgs(llvm::Module *Module, const char *KernelName) {
       llvm::ArrayType::get(llvm::Type::getInt8Ty(Module->getContext()),
                            65536 - TotalAutoConstantSize);
   llvm::GlobalVariable *ConstantMemBase = new llvm::GlobalVariable(
-      *Module, ByteArrayType, false, llvm::GlobalValue::InternalLinkage,
-      llvm::Constant::getNullValue(ByteArrayType), "_constant_memory_region_",
+      *Module, ByteArrayType, false, llvm::GlobalValue::ExternalLinkage,
+      NULL, "_constant_memory_region_",
       NULL, llvm::GlobalValue::NotThreadLocal, 4, false);
 
   convertPtrArgsToOffsets(Module, KernelName, 4, ConstantMemBase);


### PR DESCRIPTION
In OpenCL, `__kernel` functions can have `__constant` pointers and CUDA
doesn't allow that. So POCL needs to copy those from `__global`
to `__constant` memory region before calling the CUDA kernel.
These are copied to `_constant_memory_region_`. Since this buffer
is set externally to the CUDA module, need to mark it as external
linkage.

Fixes https://github.com/pocl/pocl/issues/1047