### PR TITLE
minor clEnqueueSVMMigrateMem fixes

### DIFF
--- a/lib/CL/clEnqueueSVMMigrateMem.c
+++ b/lib/CL/clEnqueueSVMMigrateMem.c
@@ -44,10 +44,6 @@ POname (clEnqueueSVMMigrateMem) (cl_command_queue command_queue,
       (command_queue->context->svm_allocdev == NULL), CL_INVALID_OPERATION,
       "None of the devices in this context is SVM-capable\n");
 
-  POCL_RETURN_ERROR_ON (
-      (command_queue->context->svm_allocdev == NULL), CL_INVALID_OPERATION,
-      "None of the devices in this context is SVM-capable\n");
-
   POCL_RETURN_ERROR_COND ((svm_pointers == NULL), CL_INVALID_VALUE);
 
   POCL_RETURN_ERROR_COND ((num_svm_pointers == 0), CL_INVALID_VALUE);

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -709,7 +709,7 @@ pocl_exec_command (_cl_command_node *node)
         dev->ops->svm_migrate (dev, cmd->svm_migrate.num_svm_pointers,
                                cmd->svm_migrate.svm_pointers,
                                cmd->svm_migrate.sizes);
-      POCL_UPDATE_EVENT_COMPLETE_MSG (event, "Event SVM MemFill           ");
+      POCL_UPDATE_EVENT_COMPLETE_MSG (event, "Event SVM Migrate_Mem       ");
       break;
 
     default:


### PR DESCRIPTION
Removes a duplicate check and fixes the event tracing string.