### PR TITLE
`clEnqueueSVMMemFree`: copy pointers

### DIFF
--- a/lib/CL/clEnqueueSVMFree.c
+++ b/lib/CL/clEnqueueSVMFree.c
@@ -60,11 +60,11 @@ POname(clEnqueueSVMFree) (cl_command_queue command_queue,
   if (errcode != CL_SUCCESS)
     return errcode;
 
-  const size_t svm_pointers_nbytes = sizeof(void *) * num_svm_pointers;
-  void *svm_pointers_copy = malloc(svm_pointers_nbytes);
+  const size_t svm_pointers_nbytes = sizeof (void *) * num_svm_pointers;
+  void *svm_pointers_copy = malloc (svm_pointers_nbytes);
   if (svm_pointers_copy == NULL)
     return CL_OUT_OF_HOST_MEMORY;
-  memcpy(svm_pointers_copy, svm_pointers, svm_pointers_nbytes);
+  memcpy (svm_pointers_copy, svm_pointers, svm_pointers_nbytes);
 
   _cl_command_node *cmd = NULL;
 
@@ -75,7 +75,7 @@ POname(clEnqueueSVMFree) (cl_command_queue command_queue,
   if (errcode != CL_SUCCESS)
     {
       POCL_MEM_FREE(cmd);
-      POCL_MEM_FREE(svm_pointers_copy);
+      POCL_MEM_FREE (svm_pointers_copy);
       return errcode;
     }
 

--- a/lib/CL/clEnqueueSVMFree.c
+++ b/lib/CL/clEnqueueSVMFree.c
@@ -60,6 +60,12 @@ POname(clEnqueueSVMFree) (cl_command_queue command_queue,
   if (errcode != CL_SUCCESS)
     return errcode;
 
+  const size_t svm_pointers_nbytes = sizeof(void *) * num_svm_pointers;
+  void *svm_pointers_copy = malloc(svm_pointers_nbytes);
+  if (svm_pointers_copy == NULL)
+    return CL_OUT_OF_HOST_MEMORY;
+  memcpy(svm_pointers_copy, svm_pointers, svm_pointers_nbytes);
+
   _cl_command_node *cmd = NULL;
 
   errcode = pocl_create_command (&cmd, command_queue, CL_COMMAND_SVM_FREE,
@@ -69,11 +75,12 @@ POname(clEnqueueSVMFree) (cl_command_queue command_queue,
   if (errcode != CL_SUCCESS)
     {
       POCL_MEM_FREE(cmd);
+      POCL_MEM_FREE(svm_pointers_copy);
       return errcode;
     }
 
   cmd->command.svm_free.num_svm_pointers = num_svm_pointers;
-  cmd->command.svm_free.svm_pointers = svm_pointers;
+  cmd->command.svm_free.svm_pointers = svm_pointers_copy;
   cmd->command.svm_free.queue = command_queue;
   cmd->command.svm_free.data = user_data;
   cmd->command.svm_free.pfn_free_func = pfn_free_func;

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -655,6 +655,7 @@ pocl_exec_command (_cl_command_node *node)
             POname (clReleaseContext) (event->context);
             dev->ops->svm_free (dev, ptr);
           }
+      POCL_MEM_FREE(cmd->svm_free.svm_pointers);
       POCL_UPDATE_EVENT_COMPLETE_MSG (event, "Event SVM Free              ");
       break;
 

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -655,7 +655,6 @@ pocl_exec_command (_cl_command_node *node)
             POname (clReleaseContext) (event->context);
             dev->ops->svm_free (dev, ptr);
           }
-      POCL_MEM_FREE(cmd->svm_free.svm_pointers);
       POCL_UPDATE_EVENT_COMPLETE_MSG (event, "Event SVM Free              ");
       break;
 

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -2005,7 +2005,7 @@ static void pocl_free_event_node (cl_event event)
       break;
 
     case CL_COMMAND_SVM_FREE:
-      POCL_MEM_FREE(node->command.svm_free.svm_pointers);
+      POCL_MEM_FREE (node->command.svm_free.svm_pointers);
       break;
     }
   pocl_mem_manager_free_command (node);

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -551,7 +551,7 @@ pocl_create_event_sync (cl_event waiting_event, cl_event notifier_event)
   wait_list_item = pocl_mem_manager_new_event_node();
   if (!notify_target || !wait_list_item)
     return CL_OUT_OF_HOST_MEMORY;
-    
+
   notify_target->event = waiting_event;
   wait_list_item->event = notifier_event;
   LL_PREPEND (notifier_event->notify_list, notify_target);
@@ -2002,6 +2002,10 @@ static void pocl_free_event_node (cl_event event)
     case CL_COMMAND_SVM_MIGRATE_MEM:
       POCL_MEM_FREE (node->command.svm_migrate.sizes);
       POCL_MEM_FREE (node->command.svm_migrate.svm_pointers);
+      break;
+
+    case CL_COMMAND_SVM_FREE:
+      POCL_MEM_FREE(node->command.svm_free.svm_pointers);
       break;
     }
   pocl_mem_manager_free_command (node);


### PR DESCRIPTION
The spec for [`clEnqueueSVMMemFree`](https://www.khronos.org/registry/OpenCL/specs/2.2/html/OpenCL_API.html#clEnqueueSVMFree) says:

> The memory associated with `svm_pointers` can be reused or freed after the function returns.

AFAICT, the current code in pocl simply holds onto the memory passed in by the user, which I believe is not conformant behavior. This change makes a copy instead.

cc @matthiasdiener 