### PR TITLE
Don't probe for Vulkan devices if not requested

### DIFF
--- a/lib/CL/devices/vulkan/pocl-vulkan.c
+++ b/lib/CL/devices/vulkan/pocl-vulkan.c
@@ -867,7 +867,7 @@ pocl_vulkan_probe (struct pocl_device_ops *ops)
 
   pocl_vulkan_enable_validation = pocl_is_option_set ("POCL_VULKAN_VALIDATE");
 
-  if (env_count < 0)
+  if (env_count <= 0)
     return 0;
 
   size_t i;
@@ -997,6 +997,9 @@ pocl_vulkan_probe (struct pocl_device_ops *ops)
 
   POCL_MSG_PRINT_VULKAN ("%u Vulkan devices found.\n",
                          pocl_vulkan_device_count);
+
+  /* TODO: clamp pocl_vulkan_device_count to env_count */
+
   return pocl_vulkan_device_count;
 }
 


### PR DESCRIPTION
Due to its experimental nature, the Vulkan driver does not probe for
devices unless included on POCL_DEVICES, but this was done incorrectly:
checking for pocl_device_get_env_count() < 0 only tells if POCL_DEVICES
was set or not, not if VULKAN was actually present in the env string.

Hence, Vulkan was disabled if POCL_DEVICES was unset, but enabled if
POCL_DEVICES was set, regardless of whether it included the string
'VULKAN' in it or not, so e.g. `POCL_DEVICES=basic clinfo -l` would show
all Vulkan devices in addition to the basic device.

Fix this by checking for env_count <= 0 instead. This allows us to avoid
probing for Vulkan devices if no Vulkan devices are requested. If VULKAN
was requested in POCL_DEVICES, we still return all Vulkan devices (not
just the first requested number). This is by choice at the moment since
there's no guarantee on how they will be sorted and we will need
something more sophisticated than just the requested device count to
determine which Vulkan devices to expose.