### PR TITLE
ocl3 : export some functions calls

### DIFF
--- a/lib/CL/clGetDeviceAndHostTimer.c
+++ b/lib/CL/clGetDeviceAndHostTimer.c
@@ -30,3 +30,4 @@ CL_API_ENTRY cl_int CL_API_ENTRY POname (clGetDeviceAndHostTimer) (
   /* PoCL does not support device and host timer synchronization */
   return CL_INVALID_OPERATION;
 }
+POsym(clGetDeviceAndHostTimer)

--- a/lib/CL/clGetHostTimer.c
+++ b/lib/CL/clGetHostTimer.c
@@ -29,3 +29,4 @@ CL_API_ENTRY cl_int CL_API_ENTRY POname (clGetHostTimer) (
   /* PoCL does not support device and host timer synchronization */
   return CL_INVALID_OPERATION;
 }
+POsym(clGetHostTimer)

--- a/lib/CL/clGetKernelSubGroupInfo.c
+++ b/lib/CL/clGetKernelSubGroupInfo.c
@@ -61,3 +61,4 @@ CL_API_ENTRY cl_int CL_API_ENTRY POname (clGetKernelSubGroupInfo) (
       "subgroup support\n");
   return CL_INVALID_OPERATION;
 }
+POsym(clGetKernelSubGroupInfo)

--- a/lib/CL/clGetPipeInfo.c
+++ b/lib/CL/clGetPipeInfo.c
@@ -30,3 +30,4 @@ CL_API_ENTRY cl_int CL_API_ENTRY POname (clGetPipeInfo) (
 {
   return CL_INVALID_MEM_OBJECT;
 }
+POsym(clGetPipeInfo)

--- a/lib/CL/clSetProgramReleaseCallback.c
+++ b/lib/CL/clSetProgramReleaseCallback.c
@@ -31,3 +31,4 @@ CL_API_ENTRY cl_int CL_API_ENTRY POname (clSetProgramReleaseCallback) (
 {
   return CL_INVALID_OPERATION;
 }
+POsym(clSetProgramReleaseCallback)


### PR DESCRIPTION
Resolve several cts linking errors against the standalone libOpenCL
by exporting some function calls.

Signed-off-by: Tom Rix <trix@redhat.com>