### PR TITLE
clang-14: handle deprecated warnings for opaque ptr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1093,6 +1093,39 @@ else()
   set(HOST_DEVICE_CL_VERSION_MINOR 2)
 endif()
 
+#
+# LLVM_OPAQUE_POINTERS
+#
+# llvm has changed from typed pointers to opaque pointers, their guidance is
+#
+# From https://llvm.org/docs/OpaquePointers.html, version support
+# LLVM 14: Supports all necessary APIs for migrating to opaque pointers and deprecates/removes
+#          incompatible APIs. However, using opaque pointers in the optimization pipeline is not fully
+#          supported. This release can be used to make out-of-tree code compatible with opaque
+#          pointers, but opaque pointers should not be enabled in production.
+#
+# LLVM 15: Opaque pointers are enabled by default. Typed pointers are still available, but only
+#          supported on a best-effort basis and may be untested.
+#
+# LLVM 16: Only opaque pointers will be supported. Typed pointers will not be supported.
+#
+# Pre llvm 14, ENABLE_LLVM_OPAQUE_POINTERS will not be defined and the legacy typed pointers will be used.
+# Post llvm 15, ENABLE_LLVM_OPAQUE_POINTERS will not be defined and opaque pointers will be used.
+# For llvm 14 and 15 this macro will be controlled by the build parameter ENABLE_LLVM_OPAQUE_POINTERS
+# For llvm 14 it will default to OFF
+# For llvm 15 it will default to  ON
+if(LLVM_VERSION VERSION_LESS_EQUAL 13.0)
+  set(ENABLE_LLVM_OPAQUE_POINTERS 0)
+elseif(LLVM_VERSION VERSION_EQUAL 14.0)
+  option(ENABLE_LLVM_OPAQUE_POINTERS "Handle the change to llvm opaque pointers." OFF)
+elseif(LLVM_VERSION VERSION_EQUAL 15.0)
+  option(ENABLE_LLVM_OPAQUE_POINTERS "Handle the change to llvm opaque pointers." ON)
+else()
+  set(ENABLE_LLVM_OPAQUE_POINTERS 1)
+endif()
+if (ENABLE_LLVM_OPAQUE_POINTERS)
+  set(LLVM_OPAQUE_POINTERS 1)
+endif()
 
 # These are mandatory for OpenCL 1.1 (except for 3D writes but those are CPU-independent)
 set(HOST_DEVICE_EXTENSIONS "cl_khr_byte_addressable_store cl_khr_global_int32_base_atomics \

--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -263,3 +263,5 @@
 
 
 #cmakedefine USE_POCL_MEMMANAGER
+
+#cmakedefine LLVM_OPAQUE_POINTERS

--- a/lib/llvmopencl/LLVMUtils.h
+++ b/lib/llvmopencl/LLVMUtils.h
@@ -135,4 +135,9 @@ void CloneFunctionIntoAbs(llvm::Function *NewFunc,
 #endif
 }
 
+#ifndef LLVM_OPAQUE_POINTERS
+// Globals
+#define getValueType getType()->getElementType
+#endif /* LLVM_OPAQUE_POINTERS */
+
 #endif

--- a/lib/llvmopencl/LLVMUtils.h
+++ b/lib/llvmopencl/LLVMUtils.h
@@ -140,4 +140,8 @@ void CloneFunctionIntoAbs(llvm::Function *NewFunc,
 #define getValueType getType()->getElementType
 #endif /* LLVM_OPAQUE_POINTERS */
 
+#ifdef LLVM_OLDER_THAN_14_0
+#define LLVMBuildGEP2(A, B, C, D, E, F) LLVMBuildGEP(A, C, D, E, F)
+#endif
+
 #endif

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -1280,7 +1280,8 @@ LLVMValueRef Workgroup::createArgBufferLoad(LLVMBuilderRef Builder,
   LLVMValueRef Offs =
       LLVMConstInt(LLVMInt32TypeInContext(LLVMContext), ArgPos, 0);
   LLVMValueRef ArgByteOffset =
-      LLVMBuildGEP(Builder, ArgBufferPtr, &Offs, 1, "arg_byte_offset");
+      LLVMBuildGEP2(Builder, LLVMTypeOf(ArgBufferPtr), ArgBufferPtr, &Offs, 1,
+                    "arg_byte_offset");
 
   llvm::Argument &Arg = cast<Argument>(*unwrap(Param));
 
@@ -1416,7 +1417,8 @@ Workgroup::createArgBufferWorkgroupLauncher(Function *Func,
         uint64_t ArgPos = ArgBufferOffsets[i];
         LLVMValueRef Offs = LLVMConstInt(Int32Type, ArgPos, 0);
         LLVMValueRef SizeByteOffset =
-            LLVMBuildGEP(Builder, ArgBuffer, &Offs, 1, "size_byte_offset");
+            LLVMBuildGEP2(Builder, LLVMTypeOf(ArgBuffer), ArgBuffer, &Offs, 1,
+                          "size_byte_offset");
         LLVMTypeRef DestTy = LLVMPointerType(ParamIntType, 0);
         LLVMValueRef SizeOffsetBitcast =
             LLVMBuildPointerCast(Builder, SizeByteOffset, DestTy, "size_ptr");

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -886,7 +886,7 @@ Workgroup::privatizeContext(Function *F)
     LocalIdGlobals[i] = M->getGlobalVariable(TempStr);
     if (LocalIdGlobals[i] != NULL) {
       LocalIdAllocas[i] =
-        Builder.CreateAlloca(LocalIdGlobals[i]->getType()->getElementType(), 0,
+        Builder.CreateAlloca(LocalIdGlobals[i]->getValueType(), 0,
                              TempStr);
       if (LocalIdGlobals[i]->hasInitializer()) {
         Constant *C = LocalIdGlobals[i]->getInitializer();
@@ -911,7 +911,7 @@ Workgroup::privatizeContext(Function *F)
     LocalSizeGlobals[i] = M->getGlobalVariable(TempStr);
     if (LocalSizeGlobals[i] != NULL) {
       LocalSizeAllocas[i] =
-        Builder.CreateAlloca(LocalSizeGlobals[i]->getType()->getElementType(),
+        Builder.CreateAlloca(LocalSizeGlobals[i]->getValueType(),
                              0, TempStr);
       if (LocalSizeGlobals[i]->hasInitializer()) {
         Constant *C = LocalSizeGlobals[i]->getInitializer();
@@ -1055,7 +1055,11 @@ Workgroup::createDefaultWorkgroupLauncher(llvm::Function *F) {
     if (DeviceAllocaLocals && isLocalMemFunctionArg(F, i)) {
       // Generate allocas for the local buffer arguments.
       PointerType *ParamType = dyn_cast<PointerType>(ArgType);
+#ifdef LLVM_OPAQUE_POINTERS
+      Type *ArgElementType = ii->getParamByValType();
+#else
       Type *ArgElementType = ParamType->getElementType();
+#endif
       if (ArgElementType->isArrayTy()) {
         // Known static local size (converted automatic local).
         Arg =

--- a/lib/llvmopencl/WorkitemLoops.cc
+++ b/lib/llvmopencl/WorkitemLoops.cc
@@ -958,7 +958,7 @@ WorkitemLoops::GetContextArray(llvm::Instruction *instruction,
          unique stack space to all the work-items when its wiloop
          iteration is executed. */
       elementType = 
-        dyn_cast<AllocaInst>(instruction)->getType()->getElementType();
+        dyn_cast<AllocaInst>(instruction)->getAllocatedType();
     } 
   else 
     {

--- a/lib/llvmopencl/linker.cpp
+++ b/lib/llvmopencl/linker.cpp
@@ -222,8 +222,7 @@ CopyFunc(const llvm::StringRef Name,
         DB_PRINT("   %s not found in destination module, creating\n",
                  Name.data());
         DstFunc =
-          Function::Create(cast<FunctionType>(
-                             SrcFunc->getType()->getElementType()),
+        Function::Create(cast<FunctionType>(SrcFunc->getValueType()),
                            SrcFunc->getLinkage(),
                            SrcFunc->getName(),
                            To);
@@ -477,7 +476,7 @@ int link(llvm::Module *Program, const llvm::Module *Lib, std::string &log,
   for (gi = Lib->global_begin(), ge = Lib->global_end(); gi != ge; gi++) {
     DB_PRINT(" %s\n", gi->getName().data());
     GlobalVariable *GV = new GlobalVariable(
-      *Program, gi->getType()->getElementType(), gi->isConstant(),
+      *Program, gi->getValueType(), gi->isConstant(),
       gi->getLinkage(), (Constant*)0, gi->getName(), (GlobalVariable*)0,
       gi->getThreadLocalMode(), gi->getType()->getAddressSpace());
     GV->copyAttributesFrom(&*gi);
@@ -536,7 +535,7 @@ int copyKernelFromBitcode(const char* name, llvm::Module *parallel_bc,
   for (gi=program->global_begin(), ge=program->global_end(); gi != ge; gi++) {
     DB_PRINT(" %s\n", gi->getName().data());
     GlobalVariable *GV = new GlobalVariable(
-      *parallel_bc, gi->getType()->getElementType(), gi->isConstant(),
+      *parallel_bc, gi->getValueType(), gi->isConstant(),
       gi->getLinkage(), (Constant*)0, gi->getName(), (GlobalVariable*)0,
       gi->getThreadLocalMode(), gi->getType()->getAddressSpace());
     GV->copyAttributesFrom(&*gi);


### PR DESCRIPTION
clang is moving to typeless, opaque pointers
clang-14 warns about some deprecations.  These are a subset of
what must be done for clang-15. So clean them up in 14.

see
https://llvm.org/docs/OpaquePointers.html

Signed-off-by: Tom Rix <trix@redhat.com>