### PR TITLE
Add build infra for clang 16

### DIFF
--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -55,6 +55,7 @@ else()
     NAMES
       "llvmtce-config"
       "llvm-config"
+      "llvm-config-mp-16.0" "llvm-config-16" "llvm-config160"
       "llvm-config-mp-15.0" "llvm-config-15" "llvm-config150"
       "llvm-config-mp-14.0" "llvm-config-14" "llvm-config140"
       "llvm-config-mp-13.0" "llvm-config-13" "llvm-config130"
@@ -229,8 +230,11 @@ elseif(LLVM_VERSION MATCHES "^14[.]")
 elseif(LLVM_VERSION MATCHES "^15[.]")
   set(LLVM_MAJOR 15)
   set(LLVM_15_0 1)
+elseif(LLVM_VERSION MATCHES "^16[.]")
+  set(LLVM_MAJOR 16)
+  set(LLVM_16_0 1)
 else()
-  message(FATAL_ERROR "LLVM version between 6.0 and 15.0 required, found: ${LLVM_VERSION}")
+  message(FATAL_ERROR "LLVM version between 6.0 and 16.0 required, found: ${LLVM_VERSION}")
 endif()
 
 #############################################################

--- a/include/_kernel.h
+++ b/include/_kernel.h
@@ -168,6 +168,11 @@
 #undef LLVM_15_0
 #define LLVM_15_0
 
+#elif (__clang_major__ == 16)
+
+#undef LLVM_16_0
+#define LLVM_16_0
+
 #else
 
 #error Unsupported Clang/LLVM version.

--- a/include/_libclang_versions_checks.h
+++ b/include/_libclang_versions_checks.h
@@ -1,3 +1,7 @@
+#if CLANG_MAJOR < 16
+#define LLVM_OLDER_THAN_16_0 1
+#endif
+
 #if CLANG_MAJOR < 15
 #define LLVM_OLDER_THAN_15_0 1
 #endif


### PR DESCRIPTION
Clang 16 is in development.
In 16, typed pointer support will be removed.
So this infra is needed to work on opaque pointer before the release

Signed-off-by: Tom Rix <trix@redhat.com>