### PR TITLE
Remove LLVM_OLDER_THAN_6_0

### DIFF
--- a/include/_libclang_versions_checks.h
+++ b/include/_libclang_versions_checks.h
@@ -33,7 +33,3 @@
 #if CLANG_MAJOR < 7
 #define LLVM_OLDER_THAN_7_0 1
 #endif
-
-#if CLANG_MAJOR < 6
-#define LLVM_OLDER_THAN_6_0 1
-#endif

--- a/lib/CL/pocl_llvm_wg.cc
+++ b/lib/CL/pocl_llvm_wg.cc
@@ -145,15 +145,9 @@ static TargetMachine *GetTargetMachine(cl_device_id device, Triple &triple) {
     return 0;
   }
 
-#ifdef LLVM_OLDER_THAN_6_0
-  TargetMachine *TM = TheTarget->createTargetMachine(
-      triple.getTriple(), MCPU, StringRef(""), GetTargetOptions(), Reloc::PIC_,
-      CodeModel::Default, CodeGenOpt::Aggressive);
-#else
   TargetMachine *TM = TheTarget->createTargetMachine(
       triple.getTriple(), MCPU, StringRef(""), GetTargetOptions(), Reloc::PIC_,
       CodeModel::Small, CodeGenOpt::Aggressive);
-#endif
 
   assert(TM != NULL && "llvm target has no targetMachine constructor");
   if (device->ops->init_target_machine)

--- a/tests/tce/fp16/CMakeLists.txt
+++ b/tests/tce/fp16/CMakeLists.txt
@@ -53,9 +53,3 @@ set_tests_properties( "tce/fp16/repl"
 #    ENVIRONMENT "POCL_DEVICES=ttasim;POCL_TTASIM0_PARAMETERS=${CMAKE_SOURCE_DIR}/tools/data/test_machine_fp16.adf;POCL_WORK_GROUP_METHOD=loopvec"
 #    DEPENDS "pocl_version_check")
 
-#if(LLVM_OLDER_THAN_6_0)
-# TODO: Produces wrong results also with LLVM 7 now. It seems to be very
-# fragile to IR changes.
-#  set_property(TEST "tce/fp16/loopvec"
-#  APPEND PROPERTY WILL_FAIL 1)
-#endif()


### PR DESCRIPTION
The define LLVM_OLDER_THAN_6_0 means llvm 5 or older.
The toplevel CMakeList.txt prohibits this, so remove the
definition and use of this macro.

Signed-off-by: Tom Rix <trix@redhat.com>