### PR TITLE
Debug: add IDs to debug messages

### DIFF
--- a/lib/CL/clCreateBuffer.c
+++ b/lib/CL/clCreateBuffer.c
@@ -253,7 +253,7 @@ CL_API_ENTRY cl_mem CL_API_CALL POname (clCreateBuffer) (
 
   POname(clRetainContext)(context);
 
-  POCL_MSG_PRINT_MEMORY ("Created Buffer ID %" PRIu64 " / %p, MEM_HOST_PTR: %p, "
+  POCL_MSG_PRINT_MEMORY ("Created Buffer %" PRIu64 " (%p), MEM_HOST_PTR: %p, "
                          "device_ptrs[0]: %p, SIZE %zu, FLAGS %" PRIu64 " \n",
                          mem->id, mem, mem->mem_host_ptr,
                          mem->device_ptrs[0].mem_ptr, size, flags);

--- a/lib/CL/clCreateCommandQueue.c
+++ b/lib/CL/clCreateCommandQueue.c
@@ -42,9 +42,7 @@ POname(clCreateCommandQueue)(cl_context context,
   POCL_GOTO_ERROR_COND ((!IS_CL_OBJECT_VALID (device)), CL_INVALID_DEVICE);
 
   POCL_GOTO_ERROR_ON ((device->available != CL_TRUE), CL_INVALID_DEVICE,
-                        "device is not available\n");
-
-  POCL_MSG_PRINT_INFO("Create Command queue on device %d\n", device->dev_id);
+                      "Device %d is not available\n", device->dev_id);
 
   /* validate flags */
   cl_command_queue_properties all_properties
@@ -63,8 +61,10 @@ POname(clCreateCommandQueue)(cl_context context,
         found = CL_TRUE;
     }
 
-  POCL_GOTO_ERROR_ON((found == CL_FALSE), CL_INVALID_DEVICE,
-                                "Could not find device in the context\n");
+  POCL_GOTO_ERROR_ON (
+      (found == CL_FALSE), CL_INVALID_DEVICE,
+      "Could not find real device of device %d in the context\n",
+      device->dev_id);
 
   cl_command_queue command_queue
       = (cl_command_queue)calloc (1, sizeof (struct _cl_command_queue));
@@ -94,6 +94,9 @@ POname(clCreateCommandQueue)(cl_context context,
 
   if (errcode_ret != NULL)
     *errcode_ret = errcode;
+
+  POCL_MSG_PRINT_INFO ("Created Command Queue %" PRId64 " (%p) on device %d\n",
+                       command_queue->id, command_queue, device->dev_id);
 
   return command_queue;
 

--- a/lib/CL/clCreateContext.c
+++ b/lib/CL/clCreateContext.c
@@ -224,6 +224,8 @@ POname(clCreateContext)(const cl_context_properties * properties,
   cl_context_count += 1;
   POCL_UNLOCK (pocl_context_handling_lock);
 
+  POCL_MSG_PRINT_GENERAL ("Created Context %" PRId64 " (%p)\n", context->id,
+                          context);
   return context;
   
 ERROR:

--- a/lib/CL/clCreateImage.c
+++ b/lib/CL/clCreateImage.c
@@ -210,8 +210,9 @@ pocl_create_image_internal (cl_context context, cl_mem_flags flags,
         /* Retain the buffer we're referencing */
         POname (clRetainMemObject) (b);
 
-        POCL_MSG_PRINT_MEMORY ("CREATED IMAGE: %p REF BUFFER: %p \n\n", mem,
-                               b);
+        POCL_MSG_PRINT_MEMORY ("Created Image:  %" PRId64
+                               " (%p), Refbuffer: %" PRId64 " (%p) \n\n",
+                               mem->id, mem, b->id, b);
       }
     else
       {
@@ -266,8 +267,9 @@ pocl_create_image_internal (cl_context context, cl_mem_flags flags,
     POCL_RETAIN_OBJECT (context);
 
     POCL_MSG_PRINT_MEMORY (
-        "Created Image %p, HOST_PTR: %p, SIZE %zu RP %zu SP %zu FLAGS %u \n",
-        mem, mem->mem_host_ptr, size, mem->image_row_pitch,
+        "Created Image %" PRId64
+        " (%p), HOST_PTR: %p, SIZE %zu RP %zu SP %zu FLAGS %u \n",
+        mem->id, mem, mem->mem_host_ptr, size, mem->image_row_pitch,
         mem->image_slice_pitch, (unsigned)flags);
 
     POCL_ATOMIC_INC (image_c);

--- a/lib/CL/clCreateKernel.c
+++ b/lib/CL/clCreateKernel.c
@@ -135,6 +135,7 @@ ERROR:
   kernel = NULL;
 
 SUCCESS:
+  POCL_MSG_PRINT_GENERAL ("Created Kernel %s (%p)\n", kernel->name, kernel);
   if(errcode_ret != NULL)
   {
     *errcode_ret = errcode;

--- a/lib/CL/clReleaseCommandQueue.c
+++ b/lib/CL/clReleaseCommandQueue.c
@@ -38,7 +38,9 @@ POname(clReleaseCommandQueue)(cl_command_queue command_queue) CL_API_SUFFIX__VER
 
   POname(clFlush)(command_queue);
   POCL_RELEASE_OBJECT(command_queue, new_refcount);
-  POCL_MSG_PRINT_REFCOUNTS ("Release Command Queue %p  %d\n", command_queue, new_refcount);
+  POCL_MSG_PRINT_REFCOUNTS ("Release Command Queue %" PRId64
+                            " (%p), Refcount: %d\n",
+                            command_queue->id, command_queue, new_refcount);
 
   if (new_refcount == 0)
     {
@@ -53,7 +55,8 @@ POname(clReleaseCommandQueue)(cl_command_queue command_queue) CL_API_SUFFIX__VER
         POname (clReleaseContext) (context);
 
       assert (command_queue->command_count == 0);
-      POCL_MSG_PRINT_REFCOUNTS ("Free Command Queue %p\n", command_queue);
+      POCL_MSG_PRINT_REFCOUNTS ("Free Command Queue %" PRId64 " (%p)\n",
+                                command_queue->id, command_queue);
       if (command_queue->device->ops->free_queue)
         command_queue->device->ops->free_queue (device, command_queue);
       POCL_DESTROY_OBJECT (command_queue);

--- a/lib/CL/clReleaseContext.c
+++ b/lib/CL/clReleaseContext.c
@@ -44,15 +44,18 @@ POname(clReleaseContext)(cl_context context) CL_API_SUFFIX__VERSION_1_0
   int new_refcount;
   POCL_LOCK (pocl_context_handling_lock);
 
-  POCL_MSG_PRINT_REFCOUNTS ("Release Context \n");
   POCL_RELEASE_OBJECT(context, new_refcount);
+  POCL_MSG_PRINT_REFCOUNTS ("Release Context %" PRId64 " (%p), Refcount: %d\n",
+                            context->id, context, new_refcount);
+
   if (new_refcount == 0)
     {
       VG_REFC_ZERO (context);
 
       POCL_ATOMIC_DEC (context_c);
 
-      POCL_MSG_PRINT_REFCOUNTS ("Free Context %p\n", context);
+      POCL_MSG_PRINT_REFCOUNTS ("Free Context %" PRId64 " (%p)\n", context->id,
+                                context);
 
       /* The context holds references to all its devices,
          memory objects, command-queues etc. Release the

--- a/lib/CL/clReleaseDevice.c
+++ b/lib/CL/clReleaseDevice.c
@@ -39,12 +39,13 @@ POname(clReleaseDevice)(cl_device_id device) CL_API_SUFFIX__VERSION_1_2
       POCL_DESTROY_OBJECT (device);
       POCL_MEM_FREE (device->partition_type);
       POCL_MEM_FREE (device->builtin_kernel_list);
-      POCL_MSG_PRINT_REFCOUNTS ("Free Device %p\n", device);
+      POCL_MSG_PRINT_REFCOUNTS ("Free Device %d (%p)\n", device->dev_id,
+                                device);
       POCL_MEM_FREE (device);
     }
   else
-    POCL_MSG_PRINT_REFCOUNTS ("Release Device %p : %u\n", device,
-                              device->pocl_refcount);
+    POCL_MSG_PRINT_REFCOUNTS ("Release Device %d (%p), Refcount: %d\n",
+                              device->dev_id, device, device->pocl_refcount);
 
   return CL_SUCCESS;
 }

--- a/lib/CL/clReleaseEvent.c
+++ b/lib/CL/clReleaseEvent.c
@@ -35,7 +35,9 @@ POname(clReleaseEvent)(cl_event event) CL_API_SUFFIX__VERSION_1_0
   POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (event)), CL_INVALID_EVENT);
 
   POCL_RELEASE_OBJECT (event, new_refcount);
-  
+  POCL_MSG_PRINT_REFCOUNTS ("Release Event %" PRIu64 " (%p), Refcount: %d\n",
+                            event->id, event, new_refcount);
+
   if (new_refcount == 0)
     {
       VG_REFC_ZERO (event);
@@ -57,8 +59,8 @@ POname(clReleaseEvent)(cl_event event) CL_API_SUFFIX__VERSION_1_0
       else
         POCL_ATOMIC_DEC (event_c);
 
-      POCL_MSG_PRINT_REFCOUNTS ("Free event %" PRIu64 " | %p\n",
-                                event->id, event);
+      POCL_MSG_PRINT_REFCOUNTS ("Free Event %" PRIu64 " (%p)\n", event->id,
+                                event);
       if (event->command_type != CL_COMMAND_USER &&
           event->queue->device->ops->free_event_data)
         event->queue->device->ops->free_event_data(event);

--- a/lib/CL/clReleaseKernel.c
+++ b/lib/CL/clReleaseKernel.c
@@ -35,7 +35,8 @@ POname(clReleaseKernel)(cl_kernel kernel) CL_API_SUFFIX__VERSION_1_0
   POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (kernel)), CL_INVALID_KERNEL);
 
   POCL_RELEASE_OBJECT (kernel, new_refcount);
-  POCL_MSG_PRINT_REFCOUNTS ("Release kernel %p  %d\n", kernel, new_refcount);
+  POCL_MSG_PRINT_REFCOUNTS ("Release Kernel %s (%p), Refcount: %d\n",
+                            kernel->name, kernel, new_refcount);
 
   if (new_refcount == 0)
     {
@@ -45,7 +46,7 @@ POname(clReleaseKernel)(cl_kernel kernel) CL_API_SUFFIX__VERSION_1_0
 
       TP_FREE_KERNEL (kernel->context->id, kernel->id, kernel->name);
 
-      POCL_MSG_PRINT_REFCOUNTS ("Free kernel %p\n", kernel);
+      POCL_MSG_PRINT_REFCOUNTS ("Free Kernel %s (%p)\n", kernel->name, kernel);
       cl_program program = kernel->program;
       assert (program != NULL);
 

--- a/lib/CL/clReleaseMemObject.c
+++ b/lib/CL/clReleaseMemObject.c
@@ -45,7 +45,9 @@ POname(clReleaseMemObject)(cl_mem memobj) CL_API_SUFFIX__VERSION_1_0
 
   POCL_RELEASE_OBJECT(memobj, new_refcount);
 
-  POCL_MSG_PRINT_REFCOUNTS ("Release mem obj %p  %d\n", memobj, new_refcount);
+  POCL_MSG_PRINT_REFCOUNTS ("Release Memory Object %" PRId64
+                            " (%p), Refcount: %d\n",
+                            memobj->id, memobj, new_refcount);
 
   /* OpenCL 1.2 Page 118:
 
@@ -85,8 +87,9 @@ POname(clReleaseMemObject)(cl_mem memobj) CL_API_SUFFIX__VERSION_1_0
           assert (memobj->mappings == NULL);
           assert (memobj->map_count == 0);
 
-          POCL_MSG_PRINT_REFCOUNTS ("Free mem obj %p FLAGS %" PRIu64 "\n",
-                                    memobj, memobj->flags);
+          POCL_MSG_PRINT_REFCOUNTS ("Free Memory Object %" PRId64
+                                    " (%p), Flags: %" PRIu64 "\n",
+                                    memobj->id, memobj, memobj->flags);
 
           for (i = 0; i < context->num_devices; ++i)
             {

--- a/lib/CL/clReleaseProgram.c
+++ b/lib/CL/clReleaseProgram.c
@@ -47,7 +47,9 @@ POname(clReleaseProgram)(cl_program program) CL_API_SUFFIX__VERSION_1_0
   POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (program)), CL_INVALID_PROGRAM);
 
   POCL_RELEASE_OBJECT (program, new_refcount);
-  POCL_MSG_PRINT_REFCOUNTS ("Release program %p, new refcount: %d, kernel #: %zu \n", program, new_refcount, program->num_kernels);
+  POCL_MSG_PRINT_REFCOUNTS (
+      "Release Program %" PRId64 " (%p), Refcount: %d, Kernel #: %zu \n",
+      program->id, program, new_refcount, program->num_kernels);
 
   if (new_refcount == 0)
     {
@@ -56,7 +58,8 @@ POname(clReleaseProgram)(cl_program program) CL_API_SUFFIX__VERSION_1_0
       POCL_ATOMIC_DEC (program_c);
 
       cl_context context = program->context;
-      POCL_MSG_PRINT_REFCOUNTS ("Free program %p\n", program);
+      POCL_MSG_PRINT_REFCOUNTS ("Free Program %" PRId64 " (%p)\n", program->id,
+                                program);
       TP_FREE_PROGRAM (context->id, program->id);
 
       /* there should be no kernels left when we're releasing the program */

--- a/lib/CL/clReleaseSampler.c
+++ b/lib/CL/clReleaseSampler.c
@@ -34,13 +34,16 @@ CL_API_SUFFIX__VERSION_1_0
 
   int new_refcount;
   POCL_RELEASE_OBJECT (sampler, new_refcount);
-  POCL_MSG_PRINT_REFCOUNTS ("RELEASE Sampler %p, REFCNT: %d\n", sampler,
-                            new_refcount);
+  POCL_MSG_PRINT_REFCOUNTS ("Release Sampler %" PRId64 " (%p), Refcount: %d\n",
+                            sampler->id, sampler, new_refcount);
 
   if (new_refcount == 0)
     {
       VG_REFC_ZERO (sampler);
       POCL_ATOMIC_DEC (sampler_c);
+
+      POCL_MSG_PRINT_REFCOUNTS ("Free Sampler %" PRId64 " (%p)\n", sampler->id,
+                                sampler);
 
       cl_context context = sampler->context;
       TP_FREE_SAMPLER (context->id, sampler->id);

--- a/lib/CL/clRetainCommandQueue.c
+++ b/lib/CL/clRetainCommandQueue.c
@@ -30,8 +30,9 @@ POname(clRetainCommandQueue)(cl_command_queue command_queue) CL_API_SUFFIX__VERS
                           CL_INVALID_COMMAND_QUEUE);
   int refc;
   POCL_RETAIN_OBJECT_REFCOUNT (command_queue, refc);
-  POCL_MSG_PRINT_REFCOUNTS ("Retain Command Queue %p  : %d\n",
-                            command_queue, refc);
+  POCL_MSG_PRINT_REFCOUNTS ("Retain Command Queue %" PRId64
+                            " (%p), Refcount: %d\n",
+                            command_queue->id, command_queue, refc);
   return CL_SUCCESS;
 }
 POsym(clRetainCommandQueue)

--- a/lib/CL/clRetainContext.c
+++ b/lib/CL/clRetainContext.c
@@ -29,7 +29,8 @@ POname(clRetainContext)(cl_context context) CL_API_SUFFIX__VERSION_1_0
   POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (context)), CL_INVALID_CONTEXT);
   int refc;
   POCL_RETAIN_OBJECT_REFCOUNT (context, refc);
-  POCL_MSG_PRINT_REFCOUNTS ("Retain Context %p  : %d\n", context, refc);
+  POCL_MSG_PRINT_REFCOUNTS ("Retain Context %" PRId64 " (%p), Refcount: %d\n",
+                            context->id, context, refc);
   return CL_SUCCESS;
 }
 POsym(clRetainContext)

--- a/lib/CL/clRetainDevice.c
+++ b/lib/CL/clRetainDevice.c
@@ -32,7 +32,8 @@ POname(clRetainDevice)(cl_device_id device) CL_API_SUFFIX__VERSION_1_2
 
   int refc;
   POCL_RETAIN_OBJECT_REFCOUNT (device, refc);
-  POCL_MSG_PRINT_REFCOUNTS ("Retain Device %p  : %d\n", device, refc);
+  POCL_MSG_PRINT_REFCOUNTS ("Retain Device %d (%p), Refcount: %d\n",
+                            device->dev_id, device, refc);
   return CL_SUCCESS;
 }
 POsym(clRetainDevice)

--- a/lib/CL/clRetainEvent.c
+++ b/lib/CL/clRetainEvent.c
@@ -30,7 +30,8 @@ POname(clRetainEvent)(cl_event  event ) CL_API_SUFFIX__VERSION_1_0
 
   int refc;
   POCL_RETAIN_OBJECT_REFCOUNT (event, refc);
-  POCL_MSG_PRINT_REFCOUNTS ("Retain Event %p  : %d\n", event, refc);
+  POCL_MSG_PRINT_REFCOUNTS ("Retain Event %" PRIu64 " (%p), Refcount: %d\n",
+                            event->id, event, refc);
 
   return CL_SUCCESS;
 }

--- a/lib/CL/clRetainKernel.c
+++ b/lib/CL/clRetainKernel.c
@@ -30,7 +30,8 @@ POname(clRetainKernel)(cl_kernel kernel) CL_API_SUFFIX__VERSION_1_0
 
   int refc;
   POCL_RETAIN_OBJECT_REFCOUNT (kernel, refc);
-  POCL_MSG_PRINT_REFCOUNTS ("Retain Kernel %p  : %d\n", kernel, refc);
+  POCL_MSG_PRINT_REFCOUNTS ("Retain Kernel %s (%p), Refcount: %d\n",
+                            kernel->name, kernel, refc);
   return CL_SUCCESS;
 }
 POsym(clRetainKernel)

--- a/lib/CL/clRetainMemObject.c
+++ b/lib/CL/clRetainMemObject.c
@@ -29,7 +29,9 @@ POname(clRetainMemObject)(cl_mem memobj) CL_API_SUFFIX__VERSION_1_0
   POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (memobj)),
                           CL_INVALID_MEM_OBJECT);
   POCL_RETAIN_OBJECT(memobj);
-  POCL_MSG_PRINT_REFCOUNTS ("Retain MemObj %p  : %d\n", memobj, memobj->pocl_refcount);
+  POCL_MSG_PRINT_REFCOUNTS ("Retain Memory Object %" PRId64
+                            " (%p), Refcount: %d\n",
+                            memobj->id, memobj, memobj->pocl_refcount);
   return CL_SUCCESS;
 }
 POsym(clRetainMemObject)

--- a/lib/CL/clRetainProgram.c
+++ b/lib/CL/clRetainProgram.c
@@ -28,7 +28,8 @@ POname(clRetainProgram)(cl_program program) CL_API_SUFFIX__VERSION_1_0
 {
   POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (program)), CL_INVALID_PROGRAM);
   POCL_RETAIN_OBJECT(program);
-  POCL_MSG_PRINT_REFCOUNTS ("Retain Program %p  : %d\n", program, program->pocl_refcount);
+  POCL_MSG_PRINT_REFCOUNTS ("Retain Program %" PRId64 " (%p), Refcount: %d\n",
+                            program->id, program, program->pocl_refcount);
   return CL_SUCCESS;
 }
 POsym(clRetainProgram)

--- a/lib/CL/clRetainSampler.c
+++ b/lib/CL/clRetainSampler.c
@@ -29,8 +29,8 @@ CL_API_ENTRY cl_int CL_API_CALL POname (clRetainSampler) (cl_sampler sampler)
   POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (sampler)), CL_INVALID_SAMPLER);
 
   POCL_RETAIN_OBJECT (sampler);
-  POCL_MSG_PRINT_REFCOUNTS ("RETAIN Sampler %p  : %d\n", sampler,
-                            sampler->pocl_refcount);
+  POCL_MSG_PRINT_REFCOUNTS ("Retain Sampler %" PRId64 " (%p), Refcount: %d\n",
+                            sampler->id, sampler, sampler->pocl_refcount);
 
   return CL_SUCCESS;
 }

--- a/lib/CL/pocl_llvm_utils.cc
+++ b/lib/CL/pocl_llvm_utils.cc
@@ -28,6 +28,7 @@
 #include "pocl_llvm.h"
 #include "pocl_llvm_api.h"
 #include "pocl_runtime_config.h"
+#include <unistd.h>
 
 #include "CompilerWarnings.h"
 IGNORE_COMPILER_WARNING("-Wunused-parameter")
@@ -376,8 +377,6 @@ static unsigned GlobalLLVMContextRefcount = 0;
 
 void pocl_llvm_create_context(cl_context ctx) {
 
-  POCL_MSG_PRINT_LLVM("creating LLVM context\n");
-
 #ifdef GLOBAL_LLVM_CONTEXT
   if (GlobalLLVMContext != nullptr) {
     ctx->llvm_context_data = GlobalLLVMContext;
@@ -410,6 +409,8 @@ void pocl_llvm_create_context(cl_context ctx) {
   GlobalLLVMContext = data;
   ++GlobalLLVMContextRefcount;
 #endif
+
+  POCL_MSG_PRINT_LLVM("Created context %" PRId64 " (%p)\n", ctx->id, ctx);
 }
 
 void pocl_llvm_release_context(cl_context ctx) {

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -511,8 +511,8 @@ pocl_create_event (cl_event *event, cl_command_queue command_queue,
   else
     POCL_ATOMIC_INC (event_c);
 
-  POCL_MSG_PRINT_EVENTS ("Created event %p / ID %" PRIu64 " / Command %s\n",
-                         (*event), (*event)->id,
+  POCL_MSG_PRINT_EVENTS ("Created event %" PRIu64 " (%p) Command %s\n",
+                         (*event)->id, (*event),
                          pocl_command_to_str (command_type));
 
   return CL_SUCCESS;
@@ -648,8 +648,8 @@ pocl_create_command_struct (_cl_command_node **cmd,
       pocl_create_event_sync ((*event), wle);
     }
   POCL_MSG_PRINT_EVENTS (
-      "Created command struct: CMD %p (event %" PRIu64 " / %p, type: %s)\n", *cmd,
-      (*event)->id, *event, pocl_command_to_str (command_type));
+      "Created command struct: CMD %p (event %" PRIu64 " / %p, type: %s)\n",
+      *cmd, (*event)->id, *event, pocl_command_to_str (command_type));
   return CL_SUCCESS;
 }
 


### PR DESCRIPTION
This makes it easier to follow the life cycles of objects
instead of looking at addresses.
This is very useful when looking at reference counts.

objects changed:
* buffer
* command queue
* context
* device
* image
* kernel
* program
* sampler