### PR TITLE
ttasim: Initialize CL_DEVICE_MAX_PARAMETER_SIZE

### DIFF
--- a/lib/CL/devices/tce/ttasim/ttasim.cc
+++ b/lib/CL/devices/tce/ttasim/ttasim.cc
@@ -718,6 +718,8 @@ pocl_ttasim_init (unsigned j, cl_device_id dev, const char* parameters)
   dev->mem_base_addr_align = 128;
   dev->min_data_type_align_size = 128;
 
+  dev->max_parameter_size = 1024;
+
   return CL_SUCCESS;
 }
 


### PR DESCRIPTION
This was left to 0, which is non-compliant. 
After this, the basic PyOpenCL code seems to run.