### PR TITLE
Cuda: remove unused nvPTXCompiler header

### DIFF
--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -1360,6 +1360,8 @@ pocl_cuda_submit_kernel (CUstream stream, _cl_command_node *cmd,
               {
                 size_t size = arguments[i].size;
                 size_t align = kdata->alignments[i];
+                if (align < 1)
+                    align = 1;
 
                 /* Pad offset to align memory */
                 if (sharedMemBytes % align)
@@ -1448,6 +1450,8 @@ pocl_cuda_submit_kernel (CUstream stream, _cl_command_node *cmd,
         {
           size_t size = meta->local_sizes[i];
           size_t align = kdata->alignments[arg_index];
+          if (align < 1)
+              align = 1;
 
           /* Pad offset to align memory */
           if (sharedMemBytes % align)

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -43,7 +43,6 @@
 
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <nvPTXCompiler.h>
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -1107,9 +1106,6 @@ pocl_cuda_build_cuda_builtins (cl_program program, cl_uint device_i)
   cl_device_id dev = program->devices[device_i];
   pocl_cuda_device_data_t *ddata = (pocl_cuda_device_data_t *)dev->data;
   int have_tensors = (ddata->sm_maj >= 7);
-
-  nvPTXCompilerHandle compiler = NULL;
-  nvPTXCompileResult result;
 
   uint64_t builtins_file_len = 0;
   char *builtins_file = NULL;


### PR DESCRIPTION
The header is not needed, and since it's inclusion causes issues with older Cuda versions, remove it for now.