### PR TITLE
prefix exported symbols with pocl_

### DIFF
--- a/lib/CL/devices/accel/accel.cc
+++ b/lib/CL/devices/accel/accel.cc
@@ -170,17 +170,18 @@ BIKD::BIKD(BuiltinKernelId KernelIdentifier, const char *KernelName,
 #define PTR_ARG POCL_ARG_TYPE_POINTER
 #define GLOBAL_AS CL_KERNEL_ARG_ADDRESS_GLOBAL
 
-BIKD BIDescriptors[] = {BIKD(POCL_CDBI_COPY, "pocl.copy",
-                             {BIArg("char*", "input", PTR_ARG, GLOBAL_AS),
-                              BIArg("char*", "output", PTR_ARG, GLOBAL_AS)}),
-                        BIKD(POCL_CDBI_ADD32, "pocl.add32",
-                             {BIArg("int*", "input", PTR_ARG, GLOBAL_AS),
-                              BIArg("int*", "input", PTR_ARG, GLOBAL_AS),
-                              BIArg("int*", "output", PTR_ARG, GLOBAL_AS)}),
-                        BIKD(POCL_CDBI_MUL32, "pocl.mul32",
-                             {BIArg("int*", "input", PTR_ARG, GLOBAL_AS),
-                              BIArg("int*", "input", PTR_ARG, GLOBAL_AS),
-                              BIArg("int*", "output", PTR_ARG, GLOBAL_AS)})};
+BIKD pocl_BIDescriptors[] = {
+    BIKD(POCL_CDBI_COPY, "pocl.copy",
+         {BIArg("char*", "input", PTR_ARG, GLOBAL_AS),
+          BIArg("char*", "output", PTR_ARG, GLOBAL_AS)}),
+    BIKD(POCL_CDBI_ADD32, "pocl.add32",
+         {BIArg("int*", "input", PTR_ARG, GLOBAL_AS),
+          BIArg("int*", "input", PTR_ARG, GLOBAL_AS),
+          BIArg("int*", "output", PTR_ARG, GLOBAL_AS)}),
+    BIKD(POCL_CDBI_MUL32, "pocl.mul32",
+         {BIArg("int*", "input", PTR_ARG, GLOBAL_AS),
+          BIArg("int*", "input", PTR_ARG, GLOBAL_AS),
+          BIArg("int*", "output", PTR_ARG, GLOBAL_AS)})};
 
 class MMAPRegion {
 public:
@@ -470,15 +471,15 @@ cl_int pocl_accel_init(unsigned j, cl_device_id dev, const char *parameters) {
   while (paramToken = strtok_r(NULL, ",", &savePtr)) {
     auto token = strtoul(paramToken, NULL, 0);
     BuiltinKernelId kernelId = static_cast<BuiltinKernelId>(token);
-    size_t numBIKDs = sizeof(BIDescriptors) / sizeof(*BIDescriptors);
+    size_t numBIKDs = sizeof(pocl_BIDescriptors) / sizeof(*pocl_BIDescriptors);
 
     bool found = false;
     for (size_t i = 0; i < numBIKDs; ++i) {
-      if (BIDescriptors[i].KernelId == kernelId) {
+      if (pocl_BIDescriptors[i].KernelId == kernelId) {
         if (supportedList.size() > 0)
           supportedList += ";";
-        supportedList += BIDescriptors[i].name;
-        D->SupportedKernels.insert(&BIDescriptors[i]);
+        supportedList += pocl_BIDescriptors[i].name;
+        D->SupportedKernels.insert(&pocl_BIDescriptors[i]);
         found = true;
         break;
       }
@@ -577,9 +578,9 @@ pocl_accel_get_builtin_kernel_metadata(void *data, const char *kernel_name,
                                        pocl_kernel_metadata_t *target) {
   AccelData *D = (AccelData *)data;
   BIKD *Desc = nullptr;
-  for (size_t i = 0; i < sizeof(BIDescriptors) / sizeof(BIDescriptors[0]);
-       ++i) {
-    Desc = &BIDescriptors[i];
+  for (size_t i = 0;
+       i < sizeof(pocl_BIDescriptors) / sizeof(pocl_BIDescriptors[0]); ++i) {
+    Desc = &pocl_BIDescriptors[i];
     if (std::string(Desc->name) == kernel_name) {
       memcpy(target, (pocl_kernel_metadata_t *)Desc,
              sizeof(pocl_kernel_metadata_t));

--- a/lib/CL/devices/builtin_kernels.cc
+++ b/lib/CL/devices/builtin_kernels.cc
@@ -182,7 +182,7 @@ int pocl_sanitize_builtin_kernel_name(cl_kernel kernel, char **saved_name) {
   return 0;
 }
 
-int restore_builtin_kernel_name(cl_kernel kernel, char *saved_name) {
+int pocl_restore_builtin_kernel_name(cl_kernel kernel, char *saved_name) {
   if (kernel->program->num_builtin_kernels) {
     std::free((void *)kernel->name);
     kernel->meta->name = saved_name;

--- a/lib/CL/devices/builtin_kernels.cc
+++ b/lib/CL/devices/builtin_kernels.cc
@@ -165,7 +165,7 @@ int pocl_setup_builtin_metadata(cl_device_id device, cl_program program,
   return 1;
 }
 
-int sanitize_builtin_kernel_name(cl_kernel kernel, char **saved_name) {
+int pocl_sanitize_builtin_kernel_name(cl_kernel kernel, char **saved_name) {
   *saved_name = nullptr;
   if (kernel->program->num_builtin_kernels) {
     *saved_name = kernel->meta->name;

--- a/lib/CL/devices/builtin_kernels.cc
+++ b/lib/CL/devices/builtin_kernels.cc
@@ -19,7 +19,7 @@
       CL_KERNEL_ARG_ACCESS_NONE, CL_KERNEL_ARG_TYPE_NONE
 #define POD_ARG_32b POD_ARG, 4
 
-BIKD BIDescriptors[BIKERNELS] = {
+BIKD pocl_BIDescriptors[BIKERNELS] = {
     BIKD(POCL_CDBI_COPY_I8, "pocl.copy.i8",
          {BIArg("char*", "input", READ_BUF),
           BIArg("char*", "output", WRITE_BUF)}),
@@ -116,7 +116,7 @@ static cl_int pocl_get_builtin_kernel_metadata(cl_device_id dev,
 
   BIKD *Desc = nullptr;
   for (size_t i = 0; i < BIKERNELS; ++i) {
-    Desc = &BIDescriptors[i];
+    Desc = &pocl_BIDescriptors[i];
     if (std::string(Desc->name) == kernel_name) {
       memcpy(target, (pocl_kernel_metadata_t *)Desc,
              sizeof(pocl_kernel_metadata_t));
@@ -170,7 +170,7 @@ int sanitize_builtin_kernel_name(cl_kernel kernel, char **saved_name) {
   if (kernel->program->num_builtin_kernels) {
     *saved_name = kernel->meta->name;
     std::string name(kernel->name);
-    for (BIKD &BI : BIDescriptors) {
+    for (BIKD &BI : pocl_BIDescriptors) {
       if (name.compare(BI.name) == 0) {
         std::replace(name.begin(), name.end(), '.', '_');
         kernel->meta->name = strdup(name.c_str());

--- a/lib/CL/devices/builtin_kernels.hh
+++ b/lib/CL/devices/builtin_kernels.hh
@@ -6,7 +6,7 @@
 
   1) add it to the end of BuiltinKernelId enum in this file
 
-  2) open builtin_kernels.cc and edit BIDescriptors, add a new struct
+  2) open builtin_kernels.cc and edit pocl_BIDescriptors, add a new struct
      for the new kernel, with argument metadata
 
   3) make sure that devices where you want to support this builtin kernel,
@@ -94,7 +94,7 @@ struct BIKD : public pocl_kernel_metadata_t {
 };
 
 #define BIKERNELS POCL_CDBI_LAST
-POCL_EXPORT extern BIKD BIDescriptors[BIKERNELS];
+POCL_EXPORT extern BIKD pocl_BIDescriptors[BIKERNELS];
 
 #endif // #ifdef __cplusplus
 

--- a/lib/CL/devices/builtin_kernels.hh
+++ b/lib/CL/devices/builtin_kernels.hh
@@ -110,7 +110,7 @@ POCL_EXPORT
 int pocl_sanitize_builtin_kernel_name(cl_kernel kernel, char **saved_name);
 
 POCL_EXPORT
-int restore_builtin_kernel_name(cl_kernel kernel, char *saved_name);
+int pocl_restore_builtin_kernel_name(cl_kernel kernel, char *saved_name);
 
 #ifdef __cplusplus
 }

--- a/lib/CL/devices/builtin_kernels.hh
+++ b/lib/CL/devices/builtin_kernels.hh
@@ -107,7 +107,7 @@ int pocl_setup_builtin_metadata(cl_device_id device, cl_program program,
                                 unsigned program_device_i);
 
 POCL_EXPORT
-int sanitize_builtin_kernel_name(cl_kernel kernel, char **saved_name);
+int pocl_sanitize_builtin_kernel_name(cl_kernel kernel, char **saved_name);
 
 POCL_EXPORT
 int restore_builtin_kernel_name(cl_kernel kernel, char *saved_name);

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1834,5 +1834,5 @@ pocl_setup_features_with_version (cl_device_id dev)
 void
 pocl_setup_builtin_kernels_with_version (cl_device_id dev)
 {
-  /* implementation should use BIDescriptors */
+  /* implementation should use pocl_BIDescriptors */
 }

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -1316,7 +1316,7 @@ pocl_cuda_submit_kernel (CUstream stream, _cl_command_node *cmd,
                   module = has_offsets ? kdata->module_offsets : kdata->module;
                   function
                       = has_offsets ? kdata->kernel_offsets : kdata->kernel;
-                  restore_builtin_kernel_name (kernel, saved_name);
+                  pocl_restore_builtin_kernel_name (kernel, saved_name);
                 }
             }
         }

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -1307,7 +1307,7 @@ pocl_cuda_submit_kernel (CUstream stream, _cl_command_node *cmd,
                   meta->data[cmd->program_device_i]
                       = &OpenclBuiltinKernelsData[i];
                   char *saved_name = NULL;
-                  sanitize_builtin_kernel_name (kernel, &saved_name);
+                  pocl_sanitize_builtin_kernel_name (kernel, &saved_name);
                   kdata = load_or_generate_kernel (kernel, device, has_offsets,
                                                    cmd->program_device_i, cmd,
                                                    1);

--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -461,7 +461,7 @@ void pocl_tce_compile_kernel(_cl_command_node *Command, cl_kernel Kernel,
     Device = Command->device;
 
   char *Save;
-  sanitize_builtin_kernel_name(Kernel, &Save);
+  pocl_sanitize_builtin_kernel_name(Kernel, &Save);
 
   POCL_LOCK(Dev->tce_compile_lock);
   int Error = pocl_llvm_generate_workgroup_function(

--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -514,7 +514,7 @@ void pocl_tce_compile_kernel(_cl_command_node *Command, cl_kernel Kernel,
     }
   }
 
-  restore_builtin_kernel_name(Kernel, Save);
+  pocl_restore_builtin_kernel_name(Kernel, Save);
 
   POCL_UNLOCK(Dev->tce_compile_lock);
 }


### PR DESCRIPTION
some newly exported symbols didn't have the `pocl_` prefix