### PR TITLE
fix(lib/CL/clReleaseCommandBufferKHR)

### DIFF
--- a/lib/CL/clReleaseCommandBufferKHR.c
+++ b/lib/CL/clReleaseCommandBufferKHR.c
@@ -129,4 +129,4 @@ POname (clReleaseCommandBufferKHR) (cl_command_buffer_khr command_buffer)
 
   return errcode_ret;
 }
-POsym (clRetainCommandBufferKHR)
+POsym (clReleaseCommandBufferKHR)


### PR DESCRIPTION
A spelling mistake at the end of this file causes a compile error.