### PR TITLE
TCE driver fixes

### DIFF
--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -235,6 +235,8 @@
 
 #define TCE_DEVICE_EXTENSIONS "@TCE_DEVICE_EXTENSIONS@"
 
+#define OACC_EXECUTABLE "@TCECC@"
+
 /* Defined on big endian systems */
 #define WORDS_BIGENDIAN @WORDS_BIGENDIAN@
 

--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -267,12 +267,12 @@ TCEString TCEDevice::tceccCommandLine(_cl_command_run *run_cmd,
   /* Compile in steps to save the program.bc for automated exploration 
      use case when producing the kernel capture scripts. */
   TCEString cmdLine;
-  cmdLine << "tcecc -llwpr " + poclIncludePathSwitch + " " + deviceMainSrc +
+  cmdLine << OACC_EXECUTABLE << " -llwpr " + poclIncludePathSwitch + " " + deviceMainSrc +
                  " " + " " + kernelObjSrc + " " + inputSrc + " -k " +
                  kernelMdSymbolName + " -g -O2 --emit-llvm -o " +
                  programBcFile + " " + extraFlags + ";";
 
-  cmdLine << "tcecc -a " << machine_file << " " << programBcFile << " -O1 -o "
+  cmdLine << OACC_EXECUTABLE << " -a " << machine_file << " " << programBcFile << " -O1 -o "
           << outputTpef << +" " + extraFlags + "\n";
   return cmdLine;
 }


### PR DESCRIPTION
Two commits:
1. Fix the tce-driver to not call "bare" tcecc, but instead propagate the binary name from CMake.
2. Add old timestamping code to update_event callback. This is an old feature that seems to have not been propagated to here yet.