### PR TITLE
Fix internal tests to work with multiple devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1759,7 +1759,7 @@ if(ENABLE_TESTS)
 
     # make check & make check_tier1
     add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} "--output-on-failure" -j ${CORECOUNT} ${COMMAND_USES_TERMINAL})
-    add_custom_target(check_tier1 COMMAND ${CMAKE_CTEST_COMMAND} "--output-on-failure" -L "'internal|piglit|PyOpenCL|conformance_suite_micro|CLBlast|shoc'" -j ${CORECOUNT} ${COMMAND_USES_TERMINAL})
+    add_custom_target(check_tier1 COMMAND ${CMAKE_CTEST_COMMAND} "--output-on-failure" -L "'internal|piglit|PyOpenCL|conformance_suite_micro|shoc'" -j ${CORECOUNT} ${COMMAND_USES_TERMINAL})
 endif()
 
 if(ENABLE_EXAMPLES)

--- a/doc/sphinx/source/development.rst
+++ b/doc/sphinx/source/development.rst
@@ -220,16 +220,13 @@ before submitting PRs. Thus, regressions on these suites should be detected
 early. The required testsuites can be enabled at buildtime with
 ``-DENABLE_TESTSUITES=tier1`` cmake option.
 
-Currently (2017-03-16) the following are included in the tier-1 test suites:
+Currently (2022-11-07) the following are included in the tier-1 test suites:
 
 * The standard test suite of pocl.
-* AMD SDK 3.0 test suite
 * PyOpenCL test suite
 * piglit test suite
 * conformance_suite_micro test suite
-* CLBlast tests (excluding the longest running ones)
-* HSA test suite (uses the LLVM 3.7 with an HSAIL backend and targets an AMD Kaveri GPU)
-* TCE short smoke test suite (against the latest TCE open source release)
+* OpenASIP short smoke test suite (against the latest OpenASIP open source release)
 
 Please note that not necessarily all the tests currently pass in the suites,
 we just ensure the currently passing ones do not regress with new

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -72,7 +72,7 @@ endif()
 
 if("${ENABLE_TESTSUITES}" MATCHES "tier1")
   list(REMOVE_ITEM ENABLE_TESTSUITES "tier1")
-  list(APPEND ENABLE_TESTSUITES "piglit" "PyOpenCL" "conformance" "CLBlast" "shoc")
+  list(APPEND ENABLE_TESTSUITES "piglit" "PyOpenCL" "conformance" "shoc")
 endif()
 
 include(ExternalProject)

--- a/examples/matrix1/CMakeLists.txt
+++ b/examples/matrix1/CMakeLists.txt
@@ -63,7 +63,7 @@ set_tests_properties( "examples/matrix1" "examples/matrix1_local" ${SPIREX}
     COST 8.0
     PASS_REGULAR_EXPRESSION "OK"
     PROCESSORS 1
-    LABELS "matrix"
+    LABELS "matrix;internal"
     DEPENDS "pocl_version_check")
 
 # devices which don't support SPIR

--- a/poclu/misc.c
+++ b/poclu/misc.c
@@ -393,8 +393,6 @@ poclu_load_program_multidev (cl_context context, cl_device_id *devices,
   int from_source = (!spir && !spirv && !poclbin);
   TEST_ASSERT (num_devices > 0);
   cl_device_id device = devices[0];
-  if (num_devices > 1)
-    TEST_ASSERT (from_source);
 
   *p = NULL;
   final_opts[0] = 0;

--- a/tests/kernel/CMakeLists.txt
+++ b/tests/kernel/CMakeLists.txt
@@ -83,6 +83,7 @@ set_tests_properties( "kernel/test_as_type" "kernel/test_bitselect"
 
 set_tests_properties( "kernel/test_as_type" "kernel/test_bitselect"
   "kernel/test_convert_type_1" "kernel/test_convert_type_2"
+  "kernel/test_hadd_loops" "kernel/test_hadd_loopvec"
   PROPERTIES
     LABELS "internal;kernel")
 
@@ -266,6 +267,7 @@ set_tests_properties("kernel/test_shuffle_char"
   "kernel/test_shuffle_int" "kernel/test_shuffle_uint"
   "kernel/test_shuffle_long" "kernel/test_shuffle_ulong"
   "kernel/test_shuffle_float"
+  "kernel/test_ucharn"
   "kernel/test_printf"
   "kernel/test_sizeof_uint"
   ${EXTRA_TESTS}

--- a/tests/kernel/image_query_funcs.c
+++ b/tests/kernel/image_query_funcs.c
@@ -21,7 +21,6 @@ int main(int argc, char **argv)
   size_t srcdir_length, name_length, filename_size;
   char *filename = NULL;
   char *source = NULL;
-  cl_device_id devices[1];
   cl_context context = NULL;
   cl_command_queue queue = NULL;
   cl_program program = NULL;
@@ -74,8 +73,15 @@ int main(int argc, char **argv)
       context, CL_FALSE, CL_ADDRESS_NONE, CL_FILTER_NEAREST, &err);
   CHECK_OPENCL_ERROR_IN ("clCreateSampler");
 
-  CHECK_CL_ERROR (clGetContextInfo (context, CL_CONTEXT_DEVICES,
-                                    sizeof (cl_device_id), devices, NULL));
+  size_t device_id_size = 0;
+  err = clGetContextInfo (context, CL_CONTEXT_DEVICES, 0, NULL,
+                          &device_id_size);
+  CHECK_OPENCL_ERROR_IN ("clGetContextInfo");
+  cl_device_id *devices = malloc (device_id_size);
+  TEST_ASSERT (devices != NULL && "out of host memory\n");
+  err = clGetContextInfo (context, CL_CONTEXT_DEVICES, device_id_size, devices,
+                          NULL);
+  CHECK_OPENCL_ERROR_IN ("clGetContextInfo");
 
   queue = clCreateCommandQueue (context, devices[0], 0, &err);
   CHECK_OPENCL_ERROR_IN ("clCreateCommandQueue");
@@ -137,6 +143,7 @@ int main(int argc, char **argv)
   free (source);
   free (filename);
   free (imageData);
+  free (devices);
 
   printf("OK\n");
   return EXIT_SUCCESS;

--- a/tests/kernel/kernel.c
+++ b/tests/kernel/kernel.c
@@ -18,7 +18,6 @@ int call_test(const char *name)
   size_t srcdir_length, name_length, filename_size;
   char *filename = NULL;
   char *source = NULL;
-  cl_device_id devices[1];
   cl_context context = NULL;
   cl_command_queue queue = NULL;
   cl_program program = NULL;
@@ -51,8 +50,18 @@ int call_test(const char *name)
     goto error;
   }
 
-  result = clGetContextInfo(context, CL_CONTEXT_DEVICES,
-      sizeof(cl_device_id), devices, NULL);
+  size_t device_id_size = 0;
+  result = clGetContextInfo (context, CL_CONTEXT_DEVICES, 0, NULL,
+                             &device_id_size);
+  if (result != CL_SUCCESS)
+    {
+      puts ("clGetContextInfo call failed while fetching size\n");
+      goto error;
+    }
+  cl_device_id *devices = malloc (device_id_size);
+  TEST_ASSERT (devices != NULL && "out of host memory\n");
+  result = clGetContextInfo (context, CL_CONTEXT_DEVICES, device_id_size,
+                             devices, NULL);
   if (result != CL_SUCCESS) {
     puts("clGetContextInfo call failed\n");
     goto error;
@@ -118,6 +127,7 @@ error:
   if (filename) {
     free(filename);
   }
+  free (devices);
 
   return retval;
 }

--- a/tests/runtime/test_buffer_migration.c
+++ b/tests/runtime/test_buffer_migration.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "config.h"
 #include "poclu.h"
 
 /*
@@ -64,8 +65,9 @@ main (int argc, char **argv)
       goto EARLY_EXIT;
     }
 
+  const char *sourcefile = SRCDIR "/tests/runtime/migration_test";
   const char *basename = "migration_test";
-  err = poclu_load_program_multidev (context, devices, num_devices, basename,
+  err = poclu_load_program_multidev (context, devices, num_devices, sourcefile,
                                      0, 0, 0, NULL, NULL, &program);
   if (err != CL_SUCCESS)
     goto ERROR;

--- a/tests/runtime/test_clCreateProgramWithBinary.c
+++ b/tests/runtime/test_clCreateProgramWithBinary.c
@@ -163,9 +163,10 @@ main(void){
   
   binary_sizes = (size_t*)malloc(num_binaries * sizeof(size_t));
   binaries = (const unsigned char**)calloc(num_binaries, sizeof(unsigned char*));
-  
-  err = clGetProgramInfo(program, CL_PROGRAM_BINARY_SIZES, 1*sizeof(size_t), 
-			 binary_sizes , &num_bytes_copied);
+
+  err = clGetProgramInfo (program, CL_PROGRAM_BINARY_SIZES,
+                          num_binaries * sizeof (size_t), binary_sizes,
+                          &num_bytes_copied);
   CHECK_OPENCL_ERROR_IN("clGetProgramInfo");
   
   binary_sizes[1] = binary_sizes[0];
@@ -174,9 +175,10 @@ main(void){
 					      sizeof(const unsigned char));
   binaries[1] = (const unsigned char*) malloc(binary_sizes[1] *
 					      sizeof(const unsigned char));
-  
-  err = clGetProgramInfo(program, CL_PROGRAM_BINARIES, 1 * sizeof(char*), 
-			 binaries, &num_bytes_copied);
+
+  err = clGetProgramInfo (program, CL_PROGRAM_BINARIES,
+                          num_binaries * sizeof (char *), binaries,
+                          &num_bytes_copied);
   CHECK_OPENCL_ERROR_IN("clGetProgramInfo");
   
   memcpy((void*)binaries[1], (void*)binaries[0], binary_sizes[0]);      

--- a/tests/runtime/test_clFinish.c
+++ b/tests/runtime/test_clFinish.c
@@ -40,7 +40,6 @@ int main()
   cl_platform_id platforms[1];
   cl_uint nplatforms;
   cl_device_id devices[1]; // + 1 for duplicate test
-  cl_uint num_devices;
   cl_program program = NULL;
   cl_kernel kernelA = NULL;
   cl_kernel kernelB = NULL;
@@ -70,13 +69,11 @@ int main()
   CHECK_OPENCL_ERROR_IN("clGetPlatformIDs");
   if (!nplatforms)
     return EXIT_FAILURE;
-  
-  err = clGetDeviceIDs(platforms[0], CL_DEVICE_TYPE_ALL, 1,
-                       devices, &num_devices);  
+
+  err = clGetDeviceIDs (platforms[0], CL_DEVICE_TYPE_ALL, 1, devices, NULL);
   CHECK_OPENCL_ERROR_IN("clGetDeviceIDs");
 
-  cl_context context = clCreateContext(NULL, num_devices, devices, NULL, 
-                                       NULL, &err);
+  cl_context context = clCreateContext (NULL, 1, devices, NULL, NULL, &err);
   CHECK_OPENCL_ERROR_IN("clCreateContext");
 
   err = clGetContextInfo(context, CL_CONTEXT_DEVICES,
@@ -122,7 +119,7 @@ int main()
                                        &kernel_size, &err);
   CHECK_OPENCL_ERROR_IN("clCreateProgramWithSource");
 
-  err = clBuildProgram (program, num_devices, devices, NULL, NULL, NULL);
+  err = clBuildProgram (program, 1, devices, NULL, NULL, NULL);
   CHECK_OPENCL_ERROR_IN("clBuildProgram");
 
   kernelA = clCreateKernel (program, "test_kernel", NULL); 


### PR DESCRIPTION
Many tests assumed that the platform can only have 1 device. This PR fixes them so that it is now possible to run e.g.
`POCL_DEVICES="pthread pthread" make check`
and the tests pass.

Also removed CLBlast from tier1, and updated documentation on tier1 testsuites.

Added _internal_ label to some short-running tests that had no good reason to omit it. (Found by ctest -LE internal).