### PR TITLE
Fix excessive retaining of mem objects

### DIFF
--- a/lib/CL/clCommandCopyBufferKHR.c
+++ b/lib/CL/clCommandCopyBufferKHR.c
@@ -53,11 +53,6 @@ POname (clCommandCopyBufferKHR) (
   if (errcode != CL_SUCCESS)
     goto ERROR;
 
-  POname (clRetainMemObject) (cmd->command.copy.src);
-  POname (clRetainMemObject) (cmd->command.copy.dst);
-  if (cmd->command.copy.src->size_buffer != NULL)
-    POname (clRetainMemObject) (cmd->command.copy.src->size_buffer);
-
   return CL_SUCCESS;
 
 ERROR:

--- a/lib/CL/clCommandCopyBufferRectKHR.c
+++ b/lib/CL/clCommandCopyBufferRectKHR.c
@@ -54,11 +54,6 @@ POname (clCommandCopyBufferRectKHR) (
   if (errcode != CL_SUCCESS)
     goto ERROR;
 
-  POname (clRetainMemObject) (cmd->command.copy_rect.src);
-  POname (clRetainMemObject) (cmd->command.copy_rect.dst);
-  if (cmd->command.copy_rect.src->size_buffer != NULL)
-    POname (clRetainMemObject) (cmd->command.copy_rect.src->size_buffer);
-
   return CL_SUCCESS;
 
 ERROR:

--- a/lib/CL/clCommandCopyBufferToImageKHR.c
+++ b/lib/CL/clCommandCopyBufferToImageKHR.c
@@ -56,11 +56,6 @@ POname (clCommandCopyBufferToImageKHR) (
         goto ERROR;
     }
 
-  POname (clRetainMemObject) (cmd->command.write_image.src);
-  POname (clRetainMemObject) (cmd->command.write_image.dst);
-  if (cmd->command.write_image.src->size_buffer != NULL)
-    POname (clRetainMemObject) (cmd->command.write_image.src->size_buffer);
-
   return CL_SUCCESS;
 
 ERROR:

--- a/lib/CL/clCommandCopyImageKHR.c
+++ b/lib/CL/clCommandCopyImageKHR.c
@@ -54,11 +54,6 @@ POname (clCommandCopyImageKHR) (
   if (errcode != CL_SUCCESS)
     goto ERROR;
 
-  POname (clRetainMemObject) (cmd->command.copy_image.src);
-  POname (clRetainMemObject) (cmd->command.copy_image.dst);
-  if (cmd->command.copy_image.src->size_buffer != NULL)
-    POname (clRetainMemObject) (cmd->command.copy_image.src->size_buffer);
-
   return CL_SUCCESS;
 
 ERROR:

--- a/lib/CL/clCommandCopyImageToBufferKHR.c
+++ b/lib/CL/clCommandCopyImageToBufferKHR.c
@@ -52,11 +52,6 @@ POname (clCommandCopyImageToBufferKHR) (
   if (errcode != CL_SUCCESS)
     goto ERROR;
 
-  POname (clRetainMemObject) (cmd->command.read_image.src);
-  POname (clRetainMemObject) (cmd->command.read_image.dst);
-  if (cmd->command.read_image.src->size_buffer != NULL)
-    POname (clRetainMemObject) (cmd->command.read_image.src->size_buffer);
-
   return CL_SUCCESS;
 
 ERROR:

--- a/lib/CL/clCommandFillBufferKHR.c
+++ b/lib/CL/clCommandFillBufferKHR.c
@@ -52,8 +52,6 @@ POname (clCommandFillBufferKHR) (
   if (errcode != CL_SUCCESS)
     goto ERROR;
 
-  POname (clRetainMemObject) (buffer);
-
   return CL_SUCCESS;
 
 ERROR:

--- a/lib/CL/clCommandFillImageKHR.c
+++ b/lib/CL/clCommandFillImageKHR.c
@@ -54,8 +54,6 @@ POname (clCommandFillImageKHR) (
   if (errcode != CL_SUCCESS)
     goto ERROR;
 
-  POname (clRetainMemObject) (image);
-
   return CL_SUCCESS;
 
 ERROR:

--- a/lib/CL/clCreateCommandBufferKHR.c
+++ b/lib/CL/clCreateCommandBufferKHR.c
@@ -108,6 +108,7 @@ POname (clCreateCommandBufferKHR) (
   POCL_INIT_OBJECT (cmdbuf);
 
   cmdbuf->state = CL_COMMAND_BUFFER_STATE_RECORDING_KHR;
+  cmdbuf->num_queues = num_queues;
   cmdbuf->queues
       = (cl_command_queue *)calloc (num_queues, sizeof (cl_command_queue));
   memcpy (cmdbuf->queues, queues, num_queues * sizeof (cl_command_queue));

--- a/lib/CL/clEnqueueCommandBufferKHR.c
+++ b/lib/CL/clEnqueueCommandBufferKHR.c
@@ -252,6 +252,10 @@ POname (clEnqueueCommandBufferKHR) (cl_uint num_queues,
         }
       POname (clRetainCommandBufferKHR) (command_buffer);
       pocl_command_enqueue (q, node);
+      for (unsigned i = 0; i < command_buffer->num_syncpoints; ++i)
+        {
+          POname (clReleaseEvent) (syncpoints[i]);
+        }
       errcode = POname (clSetEventCallback) (final_ev, CL_COMPLETE,
                                              buffer_finished_callback,
                                              (void *)command_buffer);

--- a/lib/CL/clReleaseCommandBufferKHR.c
+++ b/lib/CL/clReleaseCommandBufferKHR.c
@@ -35,7 +35,7 @@ POname (clReleaseCommandBufferKHR) (cl_command_buffer_khr command_buffer)
   int refc;
   int errcode_ret = CL_SUCCESS;
   POCL_RELEASE_OBJECT (command_buffer, refc);
-  POCL_MSG_PRINT_REFCOUNTS ("Retain Command Buffer %p  : %d\n", command_buffer,
+  POCL_MSG_PRINT_REFCOUNTS ("Release Command Buffer %p  : %d\n", command_buffer,
                             refc);
 
   if (refc == 0)

--- a/lib/CL/clReleaseCommandBufferKHR.c
+++ b/lib/CL/clReleaseCommandBufferKHR.c
@@ -58,17 +58,18 @@ POname (clReleaseCommandBufferKHR) (cl_command_buffer_khr command_buffer)
               if (freed_devs[j] == q->device)
                 is_freed = 1;
             }
-          if (is_freed)
-            continue;
+          if (!is_freed)
+            {
+              int errcode = CL_SUCCESS;
+              if (q->device->ops->free_command_buffer)
+                errcode = q->device->ops->free_command_buffer (q->device,
+                                                               command_buffer);
+              if (errcode != CL_SUCCESS)
+                errcode_ret = errcode;
 
-          int errcode = CL_SUCCESS;
-          if (q->device->ops->free_command_buffer)
-            errcode = q->device->ops->free_command_buffer (q->device,
-                                                           command_buffer);
-          if (errcode != CL_SUCCESS)
-            errcode_ret = errcode;
-
-          freed_devs[num_freed++] = q->device;
+              freed_devs[num_freed++] = q->device;
+            }
+          POname (clReleaseCommandQueue) (q);
         }
 
       _cl_command_node *cmd = command_buffer->cmds;
@@ -120,10 +121,6 @@ POname (clReleaseCommandBufferKHR) (cl_command_buffer_khr command_buffer)
         }
 
       POCL_DESTROY_OBJECT (command_buffer);
-      for (unsigned i = 0; i < command_buffer->num_queues; ++i)
-        {
-          POname (clReleaseCommandQueue) (command_buffer->queues[i]);
-        }
       POCL_MEM_FREE (command_buffer->queues);
       POCL_MEM_FREE (command_buffer->properties);
       POCL_MEM_FREE (command_buffer);

--- a/lib/CL/clReleaseCommandBufferKHR.c
+++ b/lib/CL/clReleaseCommandBufferKHR.c
@@ -88,6 +88,8 @@ POname (clReleaseCommandBufferKHR) (cl_command_buffer_khr command_buffer)
                   if (ai->type == POCL_ARG_TYPE_SAMPLER)
                     POname (clReleaseSampler) (
                         cmd->command.run.arguments[i].value);
+                  if (cmd->command.run.arguments[i].value != NULL)
+                    POCL_MEM_FREE (cmd->command.run.arguments[i].value);
                 }
               POCL_MEM_FREE (cmd->command.run.arguments);
               break;

--- a/lib/CL/clReleaseEvent.c
+++ b/lib/CL/clReleaseEvent.c
@@ -34,12 +34,14 @@ POname(clReleaseEvent)(cl_event event) CL_API_SUFFIX__VERSION_1_0
 
   POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (event)), CL_INVALID_EVENT);
 
-  POCL_RELEASE_OBJECT (event, new_refcount);
+  POCL_LOCK_OBJ (event);
+  POCL_RELEASE_OBJECT_UNLOCKED (event, new_refcount);
   POCL_MSG_PRINT_REFCOUNTS ("Release Event %" PRIu64 " (%p), Refcount: %d\n",
                             event->id, event, new_refcount);
 
   if (new_refcount == 0)
     {
+      POCL_UNLOCK_OBJ (event);
       VG_REFC_ZERO (event);
       event_callback_item *cb_ptr = NULL;
       event_callback_item *next = NULL;
@@ -76,6 +78,7 @@ POname(clReleaseEvent)(cl_event event) CL_API_SUFFIX__VERSION_1_0
   else
     {
       VG_REFC_NONZERO (event);
+      POCL_UNLOCK_OBJ (event);
     }
 
   return CL_SUCCESS;

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -266,6 +266,9 @@ void pocl_abort_on_pthread_error (int status, unsigned line, const char *func);
     }                                                                         \
   while (0)
 
+#define POCL_RELEASE_OBJECT_UNLOCKED(__OBJ__, __NEW_REFCOUNT__)               \
+      __NEW_REFCOUNT__ = --(__OBJ__)->pocl_refcount;
+
 #define POCL_RETAIN_OBJECT_UNLOCKED(__OBJ__)    \
     ++((__OBJ__)->pocl_refcount)
 

--- a/lib/CL/pocl_img_buf_cpy.c
+++ b/lib/CL/pocl_img_buf_cpy.c
@@ -186,7 +186,6 @@ pocl_rect_copy (cl_command_buffer_khr command_buffer,
                 cl_sync_point_khr *sync_point, _cl_command_node **cmd)
 {
   cl_int errcode;
-  cl_mem buffers[2] = { src, dst };
 
   if (command_buffer == NULL)
     {
@@ -216,7 +215,14 @@ pocl_rect_copy (cl_command_buffer_khr command_buffer,
   if (errcode != CL_SUCCESS)
     return errcode;
 
-  char rdonly[] = { 1, 0 };
+  cl_mem buffers[3] = { src, dst, NULL };
+  char rdonly[] = { 1, 0, 1 };
+  int n_bufs = 2;
+  if (src->size_buffer != NULL)
+    {
+      n_bufs = 3;
+      buffers[2] = src->size_buffer;
+    }
 
   if (command_buffer == NULL)
     {
@@ -227,13 +233,14 @@ pocl_rect_copy (cl_command_buffer_khr command_buffer,
 
       errcode = pocl_create_command (cmd, command_queue, command_type, event,
                                      num_items_in_wait_list, event_wait_list,
-                                     2, buffers, rdonly);
+                                     n_bufs, buffers, rdonly);
     }
   else
     {
       errcode = pocl_create_recorded_command (
           cmd, command_buffer, command_queue, command_type,
-          num_items_in_wait_list, sync_point_wait_list, 2, buffers, rdonly);
+          num_items_in_wait_list, sync_point_wait_list, n_bufs, buffers,
+          rdonly);
     }
 
   return errcode;

--- a/lib/CL/pocl_ndrange_kernel.c
+++ b/lib/CL/pocl_ndrange_kernel.c
@@ -250,7 +250,6 @@ pocl_kernel_collect_mem_objs (cl_command_queue command_queue, cl_kernel kernel,
             readonly_flag_list[*memobj_count] = 0;
 
           memobj_list[(*memobj_count)++] = buf;
-          POname (clRetainMemObject) (buf);
         }
     }
 

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -1145,6 +1145,10 @@ pocl_create_recorded_command (_cl_command_node **cmd,
 
       memcpy (memobjs, buffers, sizeof (cl_mem) * num_buffers);
       memcpy (flags, readonly_flags, sizeof (char) * num_buffers);
+      for (unsigned i = 0; i < num_buffers; ++i)
+        {
+          POname (clRetainMemObject) (memobjs[i]);
+        }
     }
 
   return CL_SUCCESS;


### PR DESCRIPTION
Fixes #1108

It seems events were just a red herring, the real culprit of the memory leak appears to have been that required mem objects are stored in two different places depending on whether the command is recorded to a command buffer or enqueued immediately. The latter store the list of mem objects in the event and release them in `pocl_update_event_finished` while the former store the list in the command node directly and release the mem objects only when the command is freed along with the command buffer it was recorded to.

Can you confirm that this patch fixes the problem @franz ? If it does then it's probably best to take some time to unify the mem object handling between the two code paths.