### PR TITLE
Almaif parameter overflow

### DIFF
--- a/examples/accel/CMakeLists.txt
+++ b/examples/accel/CMakeLists.txt
@@ -141,22 +141,23 @@ endif ()
 
     add_dependencies(bitstreams ${core_name}_bs)
 
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/../example0/${core_name}_example0.poclbin
+    add_custom_command(OUTPUT ${core_name}_example0.poclbin
+        DEPENDS ${CMAKE_SOURCE_DIR}/examples/example0/example0.cl poclcc ${POCL_LIBRARY_NAME} pocl-devices-almaif
         COMMAND
         POCL_BUILDING=1
         OCL_ICD_VENDORS=${CMAKE_BINARY_DIR}/ocl-vendors/
         POCL_DEVICES=almaif
         POCL_ALMAIF0_PARAMETERS=0xB,${CMAKE_SOURCE_DIR}/tools/data/tta_test_machines/${core_name},65535
         POCL_DEBUG=almaif
-        ${CMAKE_BINARY_DIR}/bin/poclcc -o ${CMAKE_CURRENT_BINARY_DIR}/../example0/${core_name}_example0.poclbin ${CMAKE_CURRENT_SOURCE_DIR}/../example0/example0.cl 2>&1
+        ${CMAKE_BINARY_DIR}/bin/poclcc -o ${core_name}_example0.poclbin ${CMAKE_SOURCE_DIR}/examples/example0/example0.cl 2>&1
         | grep "TCE DEVICE HASH"
         | cut -d "=" -f 2
         | cut -d "[" -f 1
         )
 
-    add_custom_target(${core_name}_poclbin ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/../example0/${core_name}_example0.poclbin)
-    add_test_pocl(NAME "examples/example0/ttasim_poclbin_${core_name}"
-        COMMAND "../example0/example0" "b" "../example0/${core_name}_example0.poclbin")
+    add_custom_target(${core_name}_poclbin ALL DEPENDS ${core_name}_example0.poclbin)
+    add_test(NAME "examples/example0/ttasim_poclbin_${core_name}"
+        COMMAND "${CMAKE_BINARY_DIR}/examples/example0/example0" "b" "${CMAKE_BINARY_DIR}/examples/accel/${core_name}_example0.poclbin")
 
 
 

--- a/lib/CL/devices/almaif/MMAPDevice.cc
+++ b/lib/CL/devices/almaif/MMAPDevice.cc
@@ -46,8 +46,10 @@ MMAPDevice::MMAPDevice(size_t base_address, char *kernel_name) {
   CQMemory = new MMAPRegion(cq_start, cq_size, mem_fd);
   DataMemory = new MMAPRegion(dmem_start, dmem_size, mem_fd);
 
-  char file_name[120];
-  snprintf(file_name, sizeof(file_name), "%s.img", kernel_name);
+  unsigned img_file_name_length = strlen(kernel_name) + 5;
+  char *file_name = (char *)malloc(img_file_name_length);
+  assert(file_name);
+  snprintf(file_name, img_file_name_length, "%s.img", kernel_name);
 
   if (pocl_exists(file_name)) {
     POCL_MSG_PRINT_ALMAIF(
@@ -56,6 +58,7 @@ MMAPDevice::MMAPDevice(size_t base_address, char *kernel_name) {
   } else {
     POCL_MSG_PRINT_ALMAIF("Almaif: No default firmware found. Skipping\n");
   }
+  free(file_name);
 
   if (pocl_is_option_set("POCL_ALMAIF_EXTERNALREGION")) {
     char *region_params =

--- a/lib/CL/devices/almaif/XrtDevice.cc
+++ b/lib/CL/devices/almaif/XrtDevice.cc
@@ -30,19 +30,29 @@
 
 XrtDevice::XrtDevice(char *xrt_kernel_name) {
 
-  char xclbin_char[120];
-  snprintf(xclbin_char, sizeof(xclbin_char), "%s.xclbin", xrt_kernel_name);
+  unsigned xclbin_char_length = strlen(xrt_kernel_name) + 8;
+  char *xclbin_char = (char *)malloc(xclbin_char_length);
+  assert(xclbin_char);
+  snprintf(xclbin_char, xclbin_char_length, "%s.xclbin", xrt_kernel_name);
 
-  char kernel_char[120];
-  snprintf(kernel_char, sizeof(kernel_char), "%s:{%s_1}", xrt_kernel_name,
-           xrt_kernel_name);
+  // TODO: Fix the case when the kernel name contains a path
+  // Needs to tokenize the last part of the path and use that
+  // as the kernel name
+  unsigned xrt_kernel_name_length = 2 * strlen(xrt_kernel_name) + 6;
+  char *xrt_kernel_name = (char *)malloc(xrt_kernel_name_length);
+  assert(xrt_kernel_name);
+  snprintf(xrt_kernel_name, xrt_kernel_name_length, "%s:{%s_1}",
+           xrt_kernel_name, xrt_kernel_name);
 
   auto devicehandle = new xrt::device(0);
   assert(devicehandle != NULL && "devicehandle null\n");
 
   auto uuid = devicehandle->load_xclbin(xclbin_char);
-  auto kernel = new xrt::kernel(*devicehandle, uuid, kernel_char,
+  auto kernel = new xrt::kernel(*devicehandle, uuid, xrt_kernel_name,
                                 xrt::kernel::cu_access_mode::exclusive);
+
+  free(xclbin_char);
+  free(xrt_kernel_name);
 
   assert(kernel != XRT_NULL_HANDLE &&
          "xrtKernelHandle NULL, is the kernel opened properly?");

--- a/tools/scripts/run_almaif_tests
+++ b/tools/scripts/run_almaif_tests
@@ -72,8 +72,8 @@ then
     fi
 
     # Files needed for the cross-compilation example0
-    if [ ! -f $PWD/examples/example0/${val}_example0.poclbin ]; then
-      echo "$PWD/examples/example0/${val}_example0.poclbin doesn't exist.\
+    if [ ! -f $PWD/examples/accel/${val}_example0.poclbin ]; then
+      echo "$PWD/examples/accel/${val}_example0.poclbin doesn't exist.\
             Please copy it from the host machine"
       exit 1
     fi


### PR DESCRIPTION
AlmaIF parameter would overflow if the device initialization file path was too long. Fixed it by dynamically allocating the strings instead.

Also fixed another issue with dependencies which affected the AlmaIF's poclbin test cases.