### PR TITLE
AlmaIF: guard TCE compile options in no-TCE builds

### DIFF
--- a/lib/CL/devices/almaif/CMakeLists.txt
+++ b/lib/CL/devices/almaif/CMakeLists.txt
@@ -24,10 +24,6 @@
 #
 #=============================================================================
 
-add_compile_options("-std=c++14")
-
-add_compile_options(${TCE_INCLUDES})
-add_compile_options(${TCE_CXXFLAGS})
 
 set(ALMAIF_SOURCES "AlmaifShared.hh"
                   "almaif.cc"
@@ -84,6 +80,9 @@ endif()
 
 if(ENABLE_TCE)
     target_link_libraries(pocl-devices-almaif PRIVATE ${TCE_LIBS})
+
+    target_compile_options(pocl-devices-almaif PRIVATE ${TCE_INCLUDES})
+    target_compile_options(pocl-devices-almaif PRIVATE ${TCE_CXXFLAGS})
 endif()
 
 install(FILES "tce_builtins.cl"


### PR DESCRIPTION
Also removed the separate std-arg, since it's only for TCE compatibility and will come from TCE_CXXFLAGS.

This attempts to fix @pjaaskel 's bug:
>The build of AlmaIF (when I enable it) fails with:
>
>g++: error: unrecognized debug output level ‘ -O3 -Wall -Wextra -Wno-long-long  -std=c++14’
>
>The Cmake does some trickery? My CXXFLAGS is -g -O3 -Wall -Wextra -Wno-long-longso it likely converts it to -g'-O3 -Wall >-Wextra -Wno-long-long' somehow?