### PR TITLE
Almaif: fix argbuffer scalar sizes

### DIFF
--- a/lib/CL/devices/almaif/almaif.cc
+++ b/lib/CL/devices/almaif/almaif.cc
@@ -1073,7 +1073,8 @@ void submit_kernel_packet(AlmaifData *D, _cl_command_node *cmd) {
     if (meta->arg_info[i].type == POCL_ARG_TYPE_POINTER) {
       arg_size += D->Dev->PointerSize;
     } else {
-      arg_size += meta->arg_info[i].type_size;
+      al = &(cmd->command.run.arguments[i]);
+      arg_size += al->size;
     }
   }
   void *arguments = malloc(arg_size);
@@ -1113,10 +1114,8 @@ void submit_kernel_packet(AlmaifData *D, _cl_command_node *cmd) {
     } else if (meta->arg_info[i].type == POCL_ARG_TYPE_SAMPLER) {
       POCL_ABORT_UNIMPLEMENTED("almaif: sampler arguments");
     } else {
-      size_t size = meta->arg_info[i].type_size;
-      memcpy(current_arg, al->value, size);
-
-      current_arg += size;
+      memcpy(current_arg, al->value, al->size);
+      current_arg += al->size;
     }
   }
 


### PR DESCRIPTION
Almaif used type_size to check for the scalar size which returns 0 if it cannot find the type from
pocl_llvm_metadata.c's type_data_map. This was happening for e.g. typedeffed scalar arguments. 

Now instead use the size coming from clSetKernelArg.