### PR TITLE
TCE: fix consequent launches with different global offset

### DIFF
--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -283,7 +283,10 @@ bool TCEDevice::isNewKernel(const _cl_command_run *runCmd) {
   bool newKernel = true;
   if (runCmd->pc.local_size[0] != curLocalX ||
       runCmd->pc.local_size[1] != curLocalY ||
-      runCmd->pc.local_size[2] != curLocalZ)
+      runCmd->pc.local_size[2] != curLocalZ ||
+      runCmd->pc.global_offset[0] != curGoffsX ||
+      runCmd->pc.global_offset[1] != curGoffsY ||
+      runCmd->pc.global_offset[2] != curGoffsZ)
     newKernel = true;
   else
     newKernel = false;
@@ -297,6 +300,9 @@ void TCEDevice::updateCurrentKernel(const _cl_command_run *runCmd,
   curLocalX = runCmd->pc.local_size[0];
   curLocalY = runCmd->pc.local_size[1];
   curLocalZ = runCmd->pc.local_size[2];
+  curGoffsX = runCmd->pc.global_offset[0];
+  curGoffsY = runCmd->pc.global_offset[1];
+  curGoffsZ = runCmd->pc.global_offset[2];
 }
 
 cl_int

--- a/lib/CL/devices/tce/tce_common.h
+++ b/lib/CL/devices/tce/tce_common.h
@@ -129,6 +129,10 @@ class TCEDevice {
   size_t curLocalY;
   size_t curLocalZ;
 
+  size_t curGoffsX;
+  size_t curGoffsY;
+  size_t curGoffsZ;
+
   uint64_t globalCycleCount;
 
   pocl_lock_t wq_lock;


### PR DESCRIPTION
Take global offset into account when determining whether the kernel is the same as the one already loaded on to the device.

TODO: still a bit fragile to the kernel address being the same. (Kernel address comparison can break if the kernel is freed and a new kernel is created with same local size and global offset, and it happens to have the same pointer value.)

Fixes: #1135