### PR TITLE
ttasim: Fix name generation

### DIFF
--- a/lib/CL/devices/tce/ttasim/ttasim.cc
+++ b/lib/CL/devices/tce/ttasim/ttasim.cc
@@ -195,6 +195,7 @@ public:
 
     const char *adf = strrchr(adfName, '/');
     if (adf != NULL) adf++;
+    else adf = adfName; //name does not contain a slash, use as-is
     if (snprintf (dev_name, 256, "ttasim-%s", adf) < 0)
       POCL_ABORT("Unable to generate the device name string.\n");
     dev->long_name = strdup(dev_name);  


### PR DESCRIPTION
If adfFile would not contain a slash strrchr will return NULL, which causes undefined behavior in snprintf (usually printing "(null)"). We can just use the file as-in in this case.