### PR TITLE
fixing llvm-less builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,9 +494,11 @@ if(ENABLE_LLVM)
   endif()
 
   if(ENABLE_HOST_CPU_DEVICES)
-  if(NOT DEFINED HOST_DEVICE_BUILD_HASH)
-      set(HOST_DEVICE_BUILD_HASH "${LLC_TRIPLE}")
-  endif()
+
+#    TODO: remove this since it's not being used anywhere
+#  if(NOT DEFINED HOST_DEVICE_BUILD_HASH)
+#      set(HOST_DEVICE_BUILD_HASH "${LLC_TRIPLE}")
+#  endif()
 
   if(INTEL_SDE_AVX512)
     set(HOST_CPU_FORCED 1 CACHE INTERNAL "CPU is forced by user" FORCE)

--- a/lib/CL/devices/almaif/almaif.cc
+++ b/lib/CL/devices/almaif/almaif.cc
@@ -505,7 +505,7 @@ unsigned int pocl_almaif_probe(struct pocl_device_ops *ops) {
 
 char *pocl_almaif_build_hash(cl_device_id /*device*/) {
   char *res = (char *)calloc(1000, sizeof(char));
-  snprintf(res, 1000, "almaif-%s", HOST_DEVICE_BUILD_HASH);
+  snprintf(res, 1000, "almaif-%s", OCL_KERNEL_TARGET);
   return res;
 }
 

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -145,7 +145,7 @@ char *
 pocl_basic_build_hash (cl_device_id device)
 {
   char* res = calloc(1000, sizeof(char));
-  snprintf (res, 1000, "basic-%s-%s", HOST_DEVICE_BUILD_HASH,
+  snprintf (res, 1000, "basic-%s-%s", device->llvm_target_triplet,
             device->llvm_cpu);
   return res;
 }

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1590,9 +1590,23 @@ pocl_init_default_device_infos (cl_device_id dev)
   dev->llvm_cpu = pocl_get_llvm_cpu_name ();
 #endif
 
-#else /* No compiler, no CPU info */
+#else
+  /* No compiler, so no CPU info
+   * however, if they are set in cmake, use those.
+   */
+
+#ifdef OCL_KERNEL_TARGET_CPU
+  dev->llvm_cpu = OCL_KERNEL_TARGET_CPU;
+#else
   dev->llvm_cpu = NULL;
+#endif
+
+#ifdef OCL_KERNEL_TARGET
+  dev->llvm_target_triplet = OCL_KERNEL_TARGET;
+#else
   dev->llvm_target_triplet = "";
+#endif
+
 #endif
 
 #ifdef ENABLE_SPIRV
@@ -1608,7 +1622,7 @@ pocl_init_default_device_infos (cl_device_id dev)
   dev->atomic_fence_capabilities = CL_DEVICE_ATOMIC_ORDER_RELAXED
                                     | CL_DEVICE_ATOMIC_ORDER_ACQ_REL
                                     | CL_DEVICE_ATOMIC_SCOPE_WORK_GROUP;
-
+#ifdef ENABLE_LLVM
   if (dev->llvm_cpu != NULL)
     {
       dev->builtin_kernel_list
@@ -1618,6 +1632,8 @@ pocl_init_default_device_infos (cl_device_id dev)
                     "org.khronos.openvx.tensor_convert_depth.wrap.u8.f32");
       dev->num_builtin_kernels = 4;
     }
+#endif
+
 }
 
 /*

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -101,7 +101,7 @@ char *
 pocl_pthread_build_hash (cl_device_id device)
 {
   char* res = calloc(1000, sizeof(char));
-  snprintf (res, 1000, "pthread-%s-%s", HOST_DEVICE_BUILD_HASH,
+  snprintf (res, 1000, "pthread-%s-%s", device->llvm_target_triplet,
             device->llvm_cpu);
   return res;
 }


### PR DESCRIPTION
This is a work in progress pr regarding compiling kernels with poclcc and using them in builds that do not have llvm.

 -DHOST_DEVICE_BUILD_HASH is not used anymore and should possibly be removed. It was only used to create device hashes but would result in nested hashes when set.

Instead, for an llvm-less build; set :  `-DLLC_HOST_CPU` and `-DLLC_TRIPLE`  in cmake. keeping these loose instead of a -dhost_device_build_hash should allow for easier future cross compilation options.

On a related note; the pocl documentation should possibly be updated. `llc -mcpu=help`  could be changed to `llc --version` since on ubuntu llvm version 14.0.0 `llc -mcpu=help` errors and `llc -march=help` hangs but `llc --version` will show the default triple and host cpu. Fortunately, commands like `llc -march=arm -mcpu=help` does still work.

### working example config

build poclcc with cmake flags:
`-DENABLE_LOADABLE_DRIVERS=1`

llvm-less build:
`-DENABLE_LOADABLE_DRIVERS=1 -DENABLE_LLVM=0 -DHOST_DEVICE_BUILD_HASH=pthread-x86_64-pc-linux-gnu-broadwell -DLLC_HOST_CPU=broadwell -DLLC_TRIPLE=x86_64-pc-linux-gnu` 
ofc  the llc options are device specific and will need to be changed.

running example0 with the following env variables:
```
OCL_ICD_VENDORS=/home/rabijl/Projects/pocl/cmake-build-debug-no-llvm/ocl-vendors \
POCL_BUILDING=1 \
POCL_DEBUG=all \
POCL_DEVICES=pthread \
POCL_WORK_GROUP_SPECIALIZATION=0
```
and passing `b` as argument