### PR TITLE
AlmaIF: Fix relativ addressing for external memory

### DIFF
--- a/lib/CL/devices/almaif/almaif.cc
+++ b/lib/CL/devices/almaif/almaif.cc
@@ -1115,7 +1115,13 @@ void submit_kernel_packet(AlmaifData *D, _cl_command_node *cmd) {
         size_t buffer = (size_t)chunk->start_address;
         buffer += al->offset;
         if (D->Dev->RelativeAddressing) {
-          buffer -= D->Dev->DataMemory->PhysAddress;
+          if (D->Dev->DataMemory->isInRange(buffer)) {
+            buffer -= D->Dev->DataMemory->PhysAddress;
+          } else if (D->Dev->ExternalMemory->isInRange(buffer)) {
+            buffer -= D->Dev->ExternalMemory->PhysAddress;
+          } else {
+            POCL_ABORT("almaif: buffer outside of memory");
+          }
         }
         *(size_t *)current_arg = buffer;
       }


### PR DESCRIPTION
Check which address region the address does belong to and use the base address of it, instead of always assuming it points to DMEM.