### PR TITLE
clCreateKernel: Fix segfault with invalid kernel name

### DIFF
--- a/lib/CL/clCreateKernel.c
+++ b/lib/CL/clCreateKernel.c
@@ -133,9 +133,12 @@ ERROR:
     }
   POCL_MEM_FREE (kernel);
   kernel = NULL;
+  goto OUT;
 
 SUCCESS:
   POCL_MSG_PRINT_GENERAL ("Created Kernel %s (%p)\n", kernel->name, kernel);
+
+OUT:
   if(errcode_ret != NULL)
   {
     *errcode_ret = errcode;


### PR DESCRIPTION
The debug message "Created kernel ..." would be printed even when the kernel name was invalid. In this case `kernel` is null, leading to a segfault.