### PR TITLE
Almaif: qol fixes

### DIFF
--- a/bin/poclcc.c
+++ b/bin/poclcc.c
@@ -140,6 +140,8 @@ process_opencl_device(int arg, char **argv, int argc)
   char *opencl_string = argv[arg];
   if (!strcmp(opencl_string, "CL_DEVICE_TYPE_CPU"))
     opencl_device = CL_DEVICE_TYPE_CPU;
+  else if (!strcmp(opencl_string, "CL_DEVICE_TYPE_CUSTOM"))
+    opencl_device = CL_DEVICE_TYPE_CUSTOM;
   else if (!strcmp(opencl_string, "CL_DEVICE_TYPE_GPU"))
     opencl_device = CL_DEVICE_TYPE_GPU;
   else if (!strcmp(opencl_string, "CL_DEVICE_TYPE_ACCELERATOR"))

--- a/examples/example1/example1.c
+++ b/examples/example1/example1.c
@@ -60,7 +60,7 @@ main (int argc, char **argv)
 
   srand ((unsigned int)time (NULL));
 
-  err = poclu_get_multiple_devices (&platform, &context, &num_devices,
+  err = poclu_get_multiple_devices (&platform, &context, 0, &num_devices,
                                     &devices, &queues);
 
   CHECK_OPENCL_ERROR_IN ("clCreateContext");

--- a/lib/CL/devices/almaif/EmulationDevice.cc
+++ b/lib/CL/devices/almaif/EmulationDevice.cc
@@ -131,7 +131,7 @@ void *emulate_almaif(void *E_void) {
   // (in hardware this signal is probably not needed, since the values are
   // initialized in hw reset)
   E->emulate_init_done = 1;
-  POCL_MSG_PRINT_ALMAIF("almaif emulate: Emulator initialized");
+  POCL_MSG_PRINT_ALMAIF("almaif emulate: Emulator initialized \n");
 
   int read_iter = 0;
   CQ[ALMAIF_CQ_READ / 4] = read_iter;

--- a/lib/CL/devices/almaif/almaif.cc
+++ b/lib/CL/devices/almaif/almaif.cc
@@ -475,9 +475,9 @@ cl_int pocl_almaif_init(unsigned j, cl_device_id dev, const char *parameters) {
   POCL_UNLOCK(runningDeviceLock);
 
   if (D->BaseAddress == EMULATING_ADDRESS) {
-    POCL_MSG_PRINT_ALMAIF("Custom emulation device %d initialized", j);
+    POCL_MSG_PRINT_ALMAIF("Custom emulation device %d initialized \n", j);
   } else {
-    POCL_MSG_PRINT_ALMAIF("Custom device %d initialized", j);
+    POCL_MSG_PRINT_ALMAIF("Custom device %d initialized \n", j);
   }
   return CL_SUCCESS;
 }

--- a/lib/CL/pocl_build.c
+++ b/lib/CL/pocl_build.c
@@ -912,8 +912,7 @@ compile_and_link_program(int compile_program,
           goto ERROR;
         }
 
-      if (program->builtin_kernel_names == NULL)
-        setup_device_kernel_hashes (program);
+      setup_device_kernel_hashes (program);
     }
 
   for (device_i = 0; device_i < program->num_devices; device_i++)

--- a/poclu/misc.c
+++ b/poclu/misc.c
@@ -83,14 +83,21 @@ poclu_get_any_device2 (cl_context *context, cl_device_id *device,
 
   err = clGetDeviceIDs (*platform, CL_DEVICE_TYPE_ALL, 1, device, NULL);
   if (err != CL_SUCCESS)
-    return err;
+    {
+
+      err = clGetDeviceIDs (*platform, CL_DEVICE_TYPE_CUSTOM, 1, device, NULL);
+      if (err != CL_SUCCESS)
+        {
+          return err;
+        }
+    }
 
   *context = clCreateContext (NULL, 1, device, NULL, NULL, &err);
   if (err != CL_SUCCESS)
     return err;
 
   *queue = clCreateCommandQueue (*context, *device,
-                                  CL_QUEUE_PROFILING_ENABLE, &err);
+                                 CL_QUEUE_PROFILING_ENABLE, &err);
   if (err != CL_SUCCESS)
     return err;
 
@@ -99,11 +106,13 @@ poclu_get_any_device2 (cl_context *context, cl_device_id *device,
 
 cl_int
 poclu_get_multiple_devices (cl_platform_id *platform, cl_context *context,
+                            cl_char include_custom_dev,
                             cl_uint *num_devices, cl_device_id **devices,
                             cl_command_queue **queues)
 {
   cl_int err;
-  *num_devices = 0;
+  cl_uint num_dev_all = 0;
+  cl_uint num_dev_custom = 0;
   size_t i;
 
   if (context == NULL || devices == NULL || queues == NULL || platform == NULL)
@@ -113,19 +122,57 @@ poclu_get_multiple_devices (cl_platform_id *platform, cl_context *context,
   if (err != CL_SUCCESS)
     return err;
 
-  err = clGetDeviceIDs (*platform, CL_DEVICE_TYPE_ALL, 0, NULL, num_devices);
-  if (err != CL_SUCCESS)
-    return err;
+  err = clGetDeviceIDs (*platform, CL_DEVICE_TYPE_ALL, 0, NULL, &num_dev_all);
+
+  // if custom devices are excluded, continue as normal
+  if (include_custom_dev != 1)
+    {
+      if (err != CL_SUCCESS)
+        return err;
+    }
+  else
+    {
+      cl_int err_custom;
+      err_custom = clGetDeviceIDs (*platform, CL_DEVICE_TYPE_CUSTOM, 0, NULL, &num_dev_custom);
+
+      if (err != CL_SUCCESS && err_custom != CL_SUCCESS)
+        {
+          return err_custom;
+        }
+      if (err != CL_SUCCESS)
+        {
+          num_dev_all = 0;
+        }
+      if (err_custom != CL_SUCCESS)
+        {
+          num_dev_custom = 0;
+        }
+
+    }
+
+  *num_devices = num_dev_all + num_dev_custom;
 
   cl_device_id *devs
-      = (cl_device_id *)calloc (*num_devices, sizeof (cl_device_id));
+      = (cl_device_id *) calloc (*num_devices, sizeof (cl_device_id));
   cl_command_queue *ques
-      = (cl_command_queue *)calloc (*num_devices, sizeof (cl_command_queue));
+      = (cl_command_queue *) calloc (*num_devices, sizeof (cl_command_queue));
 
-  err = clGetDeviceIDs (*platform, CL_DEVICE_TYPE_ALL, *num_devices, devs,
-                        NULL);
-  if (err != CL_SUCCESS)
-    return err;
+  if (num_dev_all != 0)
+    {
+      err = clGetDeviceIDs (*platform, CL_DEVICE_TYPE_ALL, num_dev_all, devs,
+                            NULL);
+      if (err != CL_SUCCESS)
+        return err;
+    }
+
+  if (num_dev_custom != 0)
+    {
+      // add devs to the end of the array
+      err = clGetDeviceIDs (*platform, CL_DEVICE_TYPE_CUSTOM, num_dev_custom, &devs[num_dev_all],
+                            NULL);
+      if (err != CL_SUCCESS)
+        return err;
+    }
 
   *context = clCreateContext (NULL, *num_devices, devs, NULL, NULL, &err);
   if (err != CL_SUCCESS)

--- a/poclu/poclu.h
+++ b/poclu/poclu.h
@@ -217,7 +217,8 @@ POCLU_API cl_int POCLU_CALL poclu_get_any_device (cl_context *context,
  * @return CL_SUCCESS on success, or a descriptive OpenCL error code upon failure.
  */
 POCLU_API cl_int POCLU_CALL poclu_get_multiple_devices (
-    cl_platform_id *platform, cl_context *context, cl_uint *num_devices,
+    cl_platform_id *platform, cl_context *context,
+    cl_char include_custom_dev, cl_uint *num_devices,
     cl_device_id **devices, cl_command_queue **queues);
 
 /**

--- a/tests/runtime/test_buffer_migration.c
+++ b/tests/runtime/test_buffer_migration.c
@@ -53,7 +53,7 @@ main (int argc, char **argv)
   cl_program program = NULL;
   cl_kernel kernel = NULL;
 
-  err = poclu_get_multiple_devices (&platform, &context, &num_devices,
+  err = poclu_get_multiple_devices (&platform, &context, 0, &num_devices,
                                     &devices, &queues);
   CHECK_OPENCL_ERROR_IN ("poclu_get_multiple_devices");
 

--- a/tests/runtime/test_buffer_ping_pong.c
+++ b/tests/runtime/test_buffer_ping_pong.c
@@ -70,7 +70,7 @@ main (int argc, char **argv)
   cl_kernel kernel_a = NULL, kernel_b = NULL, kernel_c = NULL;
   const char *kernel_buffer = NULL;
 
-  err = poclu_get_multiple_devices (&platform, &context, &num_devices,
+  err = poclu_get_multiple_devices (&platform, &context, 0, &num_devices,
                                     &devices, &queues);
   CHECK_OPENCL_ERROR_IN ("poclu_get_multiple_devices");
 


### PR DESCRIPTION
* poclcc support for cl_device_type_custom
* couple new lines in error messages of almaif
* poclu_get_multiple_devices has toggle for custom devices
* poclu_get_any_device_2 will look for custom if no normal found
* device kernel hashes are also calculated for builtin kernels (pthread bi)