### PR TITLE
Basic cl_khr_subgroups implementation for CPU

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,10 +4,11 @@
 Notable User Facing Changes
 ---------------------------
 
-- Support for Clang/LLVM 16.0
 - Dropped support for Clang/LLVM versions 6.0 to 9.0 (inclusive)
 - Added support for program-scope variables in the CPU drivers
-- Added support for generic Address Space in the CPU drivers
+- Added support for generic address spaces in the CPU drivers
+- Added basic support for cl_khr_subgroups for CPUs: A single
+  subgroup that always executes the whole X-dimension's WIs.
 
 3.1 December 2022
 =================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #=============================================================================
 #   CMake build system files
 #
-#   Copyright (c) 2014-2018 pocl developers
+#   Copyright (c) 2014-2023 pocl developers
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a copy
 #   of this software and associated documentation files (the "Software"), to deal
@@ -235,7 +235,7 @@ endif()
 
 option(ENABLE_EXTRA_VALIDITY_CHECKS "Enable extra checks on cl_* object validity" OFF)
 
-option(DEVELOPER_MODE "This will SIGNIFICANTLY slow down pocl (but speed up its compilation). Only turn on if you know what you're doing." OFF)
+option(DEVELOPER_MODE "This will SIGNIFICANTLY reduce PoCL's performance, but speeds up its compilation for faster development-test cycles. Only turn on if you know what you're doing." OFF)
 
 option(USE_POCL_MEMMANAGER "Enables custom memory manager. Except for special circumstances, this should be disabled." OFF)
 
@@ -1192,11 +1192,33 @@ else()
   set(HOST_DEVICE_CL_VERSION_MINOR 2)
 endif()
 
-# These are mandatory for OpenCL 1.1 (except for 3D writes and command buffers
-# but those are CPU-independent)
+# Extensions that are considered feature-complete (preferably CTS-tested).
+#
+# * cl_khr_subgroups: A simple implementation where SG is always the whole local
+# X-dimension. NOTE: Independent forward progress is not yet supported, but it's
+# not needed for compliance due to the corner case of only one SG in flight.
+# Passes the subgroups/test_subgroups CTS.
+
+
 set(HOST_DEVICE_EXTENSIONS "cl_khr_byte_addressable_store cl_khr_global_int32_base_atomics \
   cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics \
   cl_khr_local_int32_extended_atomics cl_khr_3d_image_writes cl_khr_command_buffer")
+
+if(LLVM_VERSION VERSION_GREATER_EQUAL 14.0)
+  set(HOST_DEVICE_EXTENSIONS "${HOST_DEVICE_EXTENSIONS} cl_khr_subgroups")
+endif()
+
+# Extensions that are work-in-progress with known unfinished aspects.
+# These are not advertised with a conformant build.
+#
+# * cl_khr_shuffle: Passes the CTS, but only because it doesn't test non-uniform
+# (lock-step) behavior: https://github.com/KhronosGroup/OpenCL-CTS/issues/1236
+#
+# * cl_khr_subgroup_ballot: sub_group_ballot() works for uniform calls, the rest
+# are unimplemented.
+if(NOT ENABLE_CONFORMANCE)
+  set(HOST_DEVICE_EXTENSIONS "${HOST_DEVICE_EXTENSIONS} cl_khr_subgroup_ballot cl_khr_subgroup_shuffle")
+endif()
 
 set(HOST_DEVICE_FEATURES_30 "__opencl_c_3d_image_writes  __opencl_c_images \
   __opencl_c_atomic_order_acq_rel __opencl_c_atomic_order_seq_cst \

--- a/examples/conformance/CMakeLists.txt
+++ b/examples/conformance/CMakeLists.txt
@@ -80,12 +80,15 @@ endif()
 if(CUSTOM_CTS_GIT_REPO)
   set(CTS_GIT_REPO "${CUSTOM_CTS_GIT_REPO}")
 else()
-  set(CTS_GIT_REPO "https://github.com/KhronosGroup/OpenCL-CTS")
+  # Use PoCL's fork which has pending fixes.
+  set(CTS_GIT_REPO "https://github.com/pocl/OpenCL-CTS")
+#  set(CTS_GIT_REPO "https://github.com/KhronosGroup/OpenCL-CTS")
 endif()
 if(CUSTOM_CTS_GIT_TAG)
   set(CTS_GIT_TAG "${CUSTOM_CTS_GIT_TAG}")
 else()
-  set(CTS_GIT_TAG "v2022-10-27-00")
+  # Use PoCL's fork which has pending fixes.
+  set(CTS_GIT_TAG "cl30")
 endif()
 
 ExternalProject_Add(

--- a/lib/CL/clGetDeviceInfo.c
+++ b/lib/CL/clGetDeviceInfo.c
@@ -1,17 +1,18 @@
 /* OpenCL runtime library: clGetDeviceInfo()
 
    Copyright (c) 2011-2012 Kalle Raiskila and Pekka Jääskeläinen
-   
+                 2022-2023 Pekka Jääskeläinen / Intel Finland Oy
+
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
    in the Software without restriction, including without limitation the rights
    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
    copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
-   
+
    The above copyright notice and this permission notice shall be included in
    all copies or substantial portions of the Software.
-   
+
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/lib/CL/clGetKernelSubGroupInfo.c
+++ b/lib/CL/clGetKernelSubGroupInfo.c
@@ -1,6 +1,7 @@
 /* OpenCL runtime library: clGetKernelSubGroupInfo()
 
    Copyright (c) 2021 Väinö Liukko
+                 2022 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to
@@ -53,12 +54,79 @@ CL_API_ENTRY cl_int CL_API_ENTRY POname (clGetKernelSubGroupInfo) (
       return CL_INVALID_OPERATION;
     }
 
-  /* Subgroups are not currently supported,
-     but in case device reports subgroup support
-  */
-  POCL_ABORT_UNIMPLEMENTED (
-      "device associated with the kernel falsely indicates "
-      "subgroup support\n");
+  switch (param_name)
+    {
+    case CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE:
+      POCL_RETURN_ERROR_ON ((input_value == NULL
+                             || input_value_size < sizeof (size_t)
+                             || input_value_size > sizeof (size_t) * 3),
+                            CL_INVALID_VALUE, "NDRange not given.");
+      break;
+    default:
+      break;
+    }
+
+  switch (param_name)
+    {
+    case CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE:
+      {
+        /* For now assume SG == WG_x. */
+        POCL_RETURN_GETINFO (size_t, ((size_t *)input_value)[0]);
+        break;
+      }
+    case CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE:
+      {
+        /* For now assume SG == WG_x and thus we have WG_size_y*WG_size_z of
+           them per WG. */
+        POCL_RETURN_GETINFO (size_t,
+                             min (device->max_num_sub_groups,
+                                  (input_value_size > sizeof (size_t)
+                                       ? ((size_t *)input_value)[1]
+                                       : 1)
+                                      * (input_value_size > sizeof (size_t) * 2
+                                             ? ((size_t *)input_value)[2]
+                                             : 1)));
+        break;
+      }
+    case CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT:
+      {
+        POCL_RETURN_ERROR_ON ((input_value == NULL), CL_INVALID_VALUE,
+                              "SG size wish not given.");
+        size_t n_wish = *(size_t *)input_value;
+        /* For now assume SG == WG_x and the simplest way of looping only at
+           y dimension. Use magic number 32 as the preferred SG size for now.
+         */
+        size_t nd[3];
+        if (n_wish > device->max_num_sub_groups ||
+            (n_wish > 1 && param_value_size / sizeof(size_t) == 1))
+          {
+            nd[0] = nd[1] = nd[2] = 0;
+            POCL_RETURN_GETINFO_ARRAY (size_t,
+                                       param_value_size / sizeof(size_t),
+                                       nd);
+          }
+        else
+          {
+            nd[0] = device->max_work_group_size / n_wish;
+            nd[1] = n_wish;
+            nd[2] = 1;
+            POCL_RETURN_GETINFO_ARRAY (size_t,
+                                       param_value_size / sizeof(size_t),
+                                       nd);
+          }
+        break;
+      }
+    case CL_KERNEL_MAX_NUM_SUB_GROUPS:
+      POCL_RETURN_GETINFO (size_t, device->max_num_sub_groups);
+      break;
+    case CL_KERNEL_COMPILE_NUM_SUB_GROUPS:
+      POCL_RETURN_GETINFO (size_t, 0);
+      break;
+    default:
+      break;
+    }
+
+  POCL_ABORT_UNIMPLEMENTED ("clGetKernelSubGroupInfo unfinished");
   return CL_INVALID_OPERATION;
 }
 POsym(clGetKernelSubGroupInfo)

--- a/lib/CL/clGetPlatformIDs.c
+++ b/lib/CL/clGetPlatformIDs.c
@@ -174,7 +174,7 @@ struct _cl_icd_dispatch pocl_dispatch = {
   &POname(clCreateSamplerWithProperties),
   &POname(clSetKernelArgSVMPointer),
   &POname(clSetKernelExecInfo),
-  NULL, /* clGetKernelSubGroupInfoKHR */
+  &POname(clGetKernelSubGroupInfo),
   &POname(clCloneKernel),
   &POname(clCreateProgramWithIL),
   &POname(clEnqueueSVMMigrateMem),

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -185,6 +185,15 @@ pocl_basic_init (unsigned j, cl_device_id device, const char* parameters)
   device->data = d;
 
   pocl_init_default_device_infos (device);
+
+  /* In reality there is no independent SG progress implemented in this version
+     because we can only have one SG in flight at a time, but it's a corner
+     case which allows us to advertise it for full CTS compliance. */
+  device->sub_group_independent_forward_progress = CL_TRUE;
+
+  /* Just an arbitrary number here based on assumption of SG size 32. */
+  device->max_num_sub_groups = device->max_work_group_size / 32;
+
   /* 0 is the host memory shared with all drivers that use it */
   device->global_mem_id = 0;
 

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1614,7 +1614,6 @@ pocl_init_default_device_infos (cl_device_id dev)
   dev->global_var_pref_size = 0;
   dev->non_uniform_work_group_support = CL_FALSE;
   dev->max_num_sub_groups = 0;
-  dev->sub_group_independent_forward_progress = CL_FALSE;
 
 #ifdef ENABLE_LLVM
 
@@ -1749,17 +1748,15 @@ static const cl_name_version OPENCL_EXTENSIONS[]
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_local_int32_extended_atomics" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_int64_base_atomics" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_int64_extended_atomics" },
+        { CL_MAKE_VERSION (1, 0, 0), "cl_khr_subgroups" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_3d_image_writes" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_fp16" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_fp64" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_nv_device_attribute_query" },
-
         { CL_MAKE_VERSION (2, 0, 0), "cl_khr_depth_images" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_image2d_from_buffer" },
-
         { CL_MAKE_VERSION (2, 1, 0), "cl_khr_spir" },
         { CL_MAKE_VERSION (2, 1, 0), "cl_khr_il_program" },
-
         { CL_MAKE_VERSION (0, 9, 0), "cl_khr_command_buffer" } };
 
 const size_t OPENCL_EXTENSIONS_NUM

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -127,6 +127,8 @@ static int scheduler_initialized = 0;
 cl_int
 pocl_pthread_init (unsigned j, cl_device_id device, const char* parameters)
 {
+  /* TODO: call pocl_basic_init() to avoid duplicating a lot of the
+     initializations here. */
   struct data *d;
   int err;
 
@@ -138,6 +140,15 @@ pocl_pthread_init (unsigned j, cl_device_id device, const char* parameters)
   device->data = d;
 
   pocl_init_default_device_infos (device);
+
+  /* In reality there is no independent SG progress implemented in this version
+     because we can only have one SG in flight at a time, but it's a corner
+     case which allows us to advertise it for full CTS compliance. */
+  device->sub_group_independent_forward_progress = CL_TRUE;
+
+  /* Just an arbitrary number here based on assumption of SG size 32. */
+  device->max_num_sub_groups = device->max_work_group_size / 32;
+
   /* 0 is the host memory shared with all drivers that use it */
   device->global_mem_id = 0;
 

--- a/lib/kernel/CMakeLists.txt
+++ b/lib/kernel/CMakeLists.txt
@@ -1,7 +1,7 @@
 #=============================================================================
 #   CMake build system files
 #
-#   Copyright (c) 2014-2018 pocl developers
+#   Copyright (c) 2014-2022 pocl developers
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a copy
 #   of this software and associated documentation files (the "Software"), to deal

--- a/lib/kernel/host/CMakeLists.txt
+++ b/lib/kernel/host/CMakeLists.txt
@@ -240,6 +240,11 @@ sleef-pocl/tgamma.cl
 sleef-pocl/trunc.cl
 )
 
+if(LLVM_VERSION VERSION_GREATER_EQUAL 14.0)
+  list(APPEND SOURCES_WITH_SLEEF subgroups.c subgroups.cl)
+endif()
+
+
 include("bitcode_rules")
 
 foreach(FILE "host/addrspace_operators.ll")

--- a/lib/kernel/subgroups.c
+++ b/lib/kernel/subgroups.c
@@ -1,0 +1,290 @@
+/* OpenCL built-in library: subgroup basic functionality
+
+   Copyright (c) 2022-2023 Pekka Jääskeläinen / Intel Finland Oy
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+/* The default implementation of subgroups is the simplest possible one of
+   always having one subgroup executing the innermost dimension.
+
+   Next, the plan is to allow the default to be changed explicitly by
+   means of the intel_reqd_sub_group_size annotation as described in
+   https://registry.khronos.org/OpenCL/extensions/intel/
+   cl_intel_required_subgroup_size.html
+
+   This forms a minimal viable feature set sufficient to emulate different
+   warp sizes for CUDA/HIP execution. Performance via efficient vectorization
+   is not a priority for now.
+ */
+
+#include <math.h>
+
+/**
+ * \brief Internal pseudo function which allocates space from the work-group
+ * thread's stack (basically local memory) for each work-item.
+ *
+ * It's expanded in WorkitemLoops.cc to an alloca().
+ *
+ * @param element_size The size of an element to allocate (for all WIs in the
+ * WG).
+ * @param align The alignment of the start of chunk.
+ * @return pointer to the allocated stack space (freed at unwind).
+ */
+void *__pocl_work_group_alloca (size_t element_size, size_t align);
+
+/**
+ * \brief Internal pseudo function which allocates space from the work-group
+ * thread's stack (basically local memory).
+ *
+ * It's expanded in WorkitemLoops.cc to an alloca().
+ *
+ * @param bytes The size of data to allocate in bytes.
+ * @param align The alignment of the start of chunk.
+ * @return pointer to the allocated stack space (freed at unwind).
+ */
+void *__pocl_local_mem_alloca (size_t bytes, size_t align);
+
+size_t _CL_OVERLOADABLE get_local_size (unsigned int dimindx);
+
+size_t _CL_OVERLOADABLE get_local_id (unsigned int dimindx);
+
+uint _CL_OVERLOADABLE
+get_sub_group_size (void)
+{
+  /* By default 1 SG per WG_x. */
+  return get_local_size (0);
+}
+
+uint _CL_OVERLOADABLE
+get_max_sub_group_size (void)
+{
+  return get_sub_group_size ();
+}
+
+uint _CL_OVERLOADABLE
+get_num_sub_groups (void)
+{
+  return (uint)get_local_size (1) * get_local_size (2);
+}
+
+uint _CL_OVERLOADABLE
+get_enqueued_num_sub_groups (void)
+{
+  return 1;
+}
+
+uint _CL_OVERLOADABLE
+get_sub_group_id (void)
+{
+  return get_local_id (2) * get_local_size (1) + get_local_id (1);
+}
+
+uint _CL_OVERLOADABLE
+get_sub_group_local_id (void)
+{
+  return (uint)get_local_id (0);
+}
+
+void _CL_OVERLOADABLE sub_group_barrier (cl_mem_fence_flags flags);
+
+#define SUB_GROUP_SHUFFLE_T(TYPE)                                             \
+  __attribute__ ((always_inline)) TYPE _CL_OVERLOADABLE sub_group_shuffle (   \
+      TYPE val, uint index)                                                   \
+  {                                                                           \
+    volatile TYPE *temp_storage                                               \
+        = __pocl_work_group_alloca (sizeof (TYPE), sizeof (TYPE));            \
+    temp_storage[get_sub_group_local_id ()] = val;                            \
+    sub_group_barrier (CLK_LOCAL_MEM_FENCE);                                  \
+    return temp_storage[index % get_sub_group_size ()];                       \
+  }
+
+SUB_GROUP_SHUFFLE_T (char)
+SUB_GROUP_SHUFFLE_T (uchar)
+SUB_GROUP_SHUFFLE_T (short)
+SUB_GROUP_SHUFFLE_T (ushort)
+SUB_GROUP_SHUFFLE_T (int)
+SUB_GROUP_SHUFFLE_T (uint)
+SUB_GROUP_SHUFFLE_T (long)
+SUB_GROUP_SHUFFLE_T (ulong)
+SUB_GROUP_SHUFFLE_T (float)
+SUB_GROUP_SHUFFLE_T (double)
+
+#define SUB_GROUP_SHUFFLE_XOR_T(TYPE)                                         \
+  __attribute__ ((always_inline)) TYPE _CL_OVERLOADABLE                       \
+  sub_group_shuffle_xor (TYPE val, uint mask)                                 \
+  {                                                                           \
+    volatile TYPE *temp_storage                                               \
+        = __pocl_work_group_alloca (sizeof (TYPE), sizeof (TYPE));            \
+    temp_storage[get_sub_group_local_id ()] = val;                            \
+    sub_group_barrier (CLK_LOCAL_MEM_FENCE);                                  \
+    return temp_storage[(get_sub_group_local_id () ^ mask)                    \
+                        % get_sub_group_size ()];                             \
+  }
+
+SUB_GROUP_SHUFFLE_XOR_T (char)
+SUB_GROUP_SHUFFLE_XOR_T (uchar)
+SUB_GROUP_SHUFFLE_XOR_T (short)
+SUB_GROUP_SHUFFLE_XOR_T (ushort)
+SUB_GROUP_SHUFFLE_XOR_T (int)
+SUB_GROUP_SHUFFLE_XOR_T (uint)
+SUB_GROUP_SHUFFLE_XOR_T (long)
+SUB_GROUP_SHUFFLE_XOR_T (ulong)
+SUB_GROUP_SHUFFLE_XOR_T (float)
+SUB_GROUP_SHUFFLE_XOR_T (double)
+
+#define SUB_GROUP_BROADCAST_T(TYPE)                                           \
+  __attribute__ ((always_inline)) TYPE _CL_OVERLOADABLE sub_group_broadcast ( \
+      TYPE val, uint id)                                                      \
+  {                                                                           \
+    return sub_group_shuffle (val, id);                                       \
+  }
+
+SUB_GROUP_BROADCAST_T (int)
+SUB_GROUP_BROADCAST_T (uint)
+SUB_GROUP_BROADCAST_T (long)
+SUB_GROUP_BROADCAST_T (ulong)
+SUB_GROUP_BROADCAST_T (float)
+SUB_GROUP_BROADCAST_T (double)
+
+#define SUB_GROUP_REDUCE_OT(OPNAME, OPERATION, TYPE)                          \
+  __attribute__ ((always_inline))                                             \
+  TYPE _CL_OVERLOADABLE sub_group_reduce_##OPNAME (TYPE val)                  \
+  {                                                                           \
+    volatile TYPE *temp_storage                                               \
+        = __pocl_work_group_alloca (sizeof (TYPE), sizeof (TYPE));            \
+    temp_storage[get_sub_group_local_id ()] = val;                            \
+    sub_group_barrier (CLK_LOCAL_MEM_FENCE);                                  \
+    if (get_sub_group_local_id () == 0)                                       \
+      {                                                                       \
+        for (uint i = 1; i < get_sub_group_size (); ++i)                      \
+          {                                                                   \
+            TYPE a = temp_storage[0], b = temp_storage[i];                    \
+            temp_storage[0] = OPERATION;                                      \
+          }                                                                   \
+      }                                                                       \
+    sub_group_barrier (CLK_LOCAL_MEM_FENCE);                                  \
+    return temp_storage[0];                                                   \
+  }
+
+#define SUB_GROUP_REDUCE_T(OPNAME, OPERATION)                                 \
+  SUB_GROUP_REDUCE_OT (OPNAME, OPERATION, int)                                \
+  SUB_GROUP_REDUCE_OT (OPNAME, OPERATION, uint)                               \
+  SUB_GROUP_REDUCE_OT (OPNAME, OPERATION, long)                               \
+  SUB_GROUP_REDUCE_OT (OPNAME, OPERATION, ulong)                              \
+  SUB_GROUP_REDUCE_OT (OPNAME, OPERATION, float)                              \
+  SUB_GROUP_REDUCE_OT (OPNAME, OPERATION, double)
+
+SUB_GROUP_REDUCE_T (add, a + b)
+SUB_GROUP_REDUCE_T (min, a > b ? b : a)
+SUB_GROUP_REDUCE_T (max, a > b ? a : b)
+
+#define SUB_GROUP_SCAN_INCLUSIVE_OT(OPNAME, OPERATION, TYPE)                  \
+  __attribute__ ((always_inline))                                             \
+  TYPE _CL_OVERLOADABLE sub_group_scan_inclusive_##OPNAME (TYPE val)          \
+  {                                                                           \
+    volatile TYPE *data                                                       \
+        = __pocl_work_group_alloca (sizeof (TYPE), sizeof (TYPE));            \
+    data[get_sub_group_local_id ()] = val;                                    \
+    sub_group_barrier (CLK_LOCAL_MEM_FENCE);                                  \
+    if (get_sub_group_local_id () == 0)                                       \
+      {                                                                       \
+        for (uint i = 1; i < get_sub_group_size (); ++i)                      \
+          {                                                                   \
+            TYPE a = data[i - 1], b = data[i];                                \
+            data[i] = OPERATION;                                              \
+          }                                                                   \
+      }                                                                       \
+    sub_group_barrier (CLK_LOCAL_MEM_FENCE);                                  \
+    return data[get_sub_group_local_id ()];                                   \
+  }
+
+#define SUB_GROUP_SCAN_INCLUSIVE_T(OPNAME, OPERATION)                         \
+  SUB_GROUP_SCAN_INCLUSIVE_OT (OPNAME, OPERATION, int)                        \
+  SUB_GROUP_SCAN_INCLUSIVE_OT (OPNAME, OPERATION, uint)                       \
+  SUB_GROUP_SCAN_INCLUSIVE_OT (OPNAME, OPERATION, long)                       \
+  SUB_GROUP_SCAN_INCLUSIVE_OT (OPNAME, OPERATION, ulong)                      \
+  SUB_GROUP_SCAN_INCLUSIVE_OT (OPNAME, OPERATION, float)                      \
+  SUB_GROUP_SCAN_INCLUSIVE_OT (OPNAME, OPERATION, double)
+
+SUB_GROUP_SCAN_INCLUSIVE_T (add, a + b)
+SUB_GROUP_SCAN_INCLUSIVE_T (min, a > b ? b : a)
+SUB_GROUP_SCAN_INCLUSIVE_T (max, a > b ? a : b)
+
+#define SUB_GROUP_SCAN_EXCLUSIVE_OT(OPNAME, OPERATION, TYPE, ID)              \
+  __attribute__ ((always_inline))                                             \
+  TYPE _CL_OVERLOADABLE sub_group_scan_exclusive_##OPNAME (TYPE val)          \
+  {                                                                           \
+    volatile TYPE *data                                                       \
+        = __pocl_work_group_alloca (sizeof (TYPE), sizeof (TYPE));            \
+    data[get_sub_group_local_id () + 1] = val;                                \
+    data[0] = ID;                                                             \
+    sub_group_barrier (CLK_LOCAL_MEM_FENCE);                                  \
+    if (get_sub_group_local_id () == 0)                                       \
+      {                                                                       \
+        for (uint i = 1; i < get_sub_group_size (); ++i)                      \
+          {                                                                   \
+            TYPE a = data[i - 1], b = data[i];                                \
+            data[i] = OPERATION;                                              \
+          }                                                                   \
+      }                                                                       \
+    sub_group_barrier (CLK_LOCAL_MEM_FENCE);                                  \
+    return data[get_sub_group_local_id ()];                                   \
+  }
+
+SUB_GROUP_SCAN_EXCLUSIVE_OT (add, a + b, int, 0)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (add, a + b, uint, 0)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (add, a + b, long, 0)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (add, a + b, ulong, 0)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (add, a + b, float, 0.0f)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (add, a + b, double, 0.0)
+
+SUB_GROUP_SCAN_EXCLUSIVE_OT (min, a > b ? b : a, int, INT_MAX)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (min, a > b ? b : a, uint, UINT_MAX)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (min, a > b ? b : a, long, LONG_MAX)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (min, a > b ? b : a, ulong, ULONG_MAX)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (min, a > b ? b : a, float, +INFINITY)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (min, a > b ? b : a, double, +INFINITY)
+
+SUB_GROUP_SCAN_EXCLUSIVE_OT (max, a > b ? a : b, int, INT_MIN)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (max, a > b ? a : b, uint, 0)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (max, a > b ? a : b, long, LONG_MIN)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (max, a > b ? a : b, ulong, 0)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (max, a > b ? a : b, float, -INFINITY)
+SUB_GROUP_SCAN_EXCLUSIVE_OT (max, a > b ? a : b, double, -INFINITY)
+
+__attribute__ ((always_inline)) uint4 _CL_OVERLOADABLE
+sub_group_ballot (int predicate)
+{
+  uint *flags = __pocl_local_mem_alloca (sizeof (uint) * 4, sizeof (uint) * 4);
+  char *res = __pocl_work_group_alloca (sizeof (char), 4);
+  if (get_sub_group_local_id () < 128)
+    res[get_sub_group_local_id ()] = !!predicate;
+  sub_group_barrier (CLK_LOCAL_MEM_FENCE);
+  if (get_sub_group_local_id () == 0)
+    {
+      flags[0] = flags[1] = flags[2] = flags[3] = ~0;
+      for (uint i = 0; i < get_sub_group_size () && i < 128; ++i)
+        {
+          flags[i / 32] |= res[i] << (i % 32);
+        }
+    }
+  sub_group_barrier (CLK_LOCAL_MEM_FENCE);
+  return *(uint4 *)flags;
+}

--- a/lib/kernel/subgroups.cl
+++ b/lib/kernel/subgroups.cl
@@ -1,0 +1,45 @@
+/* OpenCL built-in library: subgroup basic functionality
+
+   Copyright (c) 2022-2023 Pekka Jääskeläinen / Intel Finland Oy
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+/* See subgroups.c for further documentation. */
+
+void _CL_OVERLOADABLE
+sub_group_barrier (cl_mem_fence_flags flags)
+{
+  /* This should work as long as there are no diverging
+     subgroups -- right? It models all subgroups of the WG
+     stepping in lockstep. */
+  work_group_barrier (flags);
+}
+
+int _CL_OVERLOADABLE
+sub_group_any (int predicate)
+{
+  return sub_group_reduce_max ((unsigned)predicate);
+}
+
+int _CL_OVERLOADABLE
+sub_group_all (int predicate)
+{
+  return sub_group_reduce_min ((unsigned)predicate);
+}

--- a/lib/llvmopencl/Kernel.cc
+++ b/lib/llvmopencl/Kernel.cc
@@ -274,8 +274,8 @@ Kernel::getParallelRegions(llvm::LoopInfo *LI) {
 
 }
 
-void
-Kernel::addLocalSizeInitCode(size_t LocalSizeX, size_t LocalSizeY, size_t LocalSizeZ) {
+void Kernel::addLocalSizeInitCode(size_t LocalSizeX, size_t LocalSizeY,
+                                  size_t LocalSizeZ) {
 
   IRBuilder<> Builder(getEntryBlock().getFirstNonPHI());
 
@@ -289,8 +289,9 @@ Kernel::addLocalSizeInitCode(size_t LocalSizeX, size_t LocalSizeY, size_t LocalS
   llvm::Type *SizeT = IntegerType::get(M->getContext(), address_bits);
 
   GV = M->getGlobalVariable("_local_size_x");
-  if (GV != NULL)
+  if (GV != NULL) {
     Builder.CreateStore(ConstantInt::get(SizeT, LocalSizeX), GV);
+  }
 
   GV = M->getGlobalVariable("_local_size_y");
   if (GV != NULL)
@@ -300,4 +301,3 @@ Kernel::addLocalSizeInitCode(size_t LocalSizeX, size_t LocalSizeY, size_t LocalS
   if (GV != NULL)
     Builder.CreateStore(ConstantInt::get(SizeT, LocalSizeZ), GV);
 }
-

--- a/lib/llvmopencl/Kernel.h
+++ b/lib/llvmopencl/Kernel.h
@@ -39,15 +39,25 @@ namespace pocl {
     ParallelRegion::ParallelRegionVector*
       getParallelRegions(llvm::LoopInfo *LI);
 
-    void addLocalSizeInitCode(size_t LocalSizeX, size_t LocalSizeY, size_t LocalSizeZ);
+    void addLocalSizeInitCode(size_t LocalSizeX, size_t LocalSizeY,
+                              size_t LocalSizeZ);
+
+    // Returns an instruction in the entry block which computes the
+    // total size of work-items in the work-group. If it doesn't
+    // exist, creates it to the end of the entry block.
+    llvm::Instruction *getWorkGroupSizeInstr();
 
     static bool isKernel(const llvm::Function &F);
 
     static bool classof(const Kernel *) { return true; }
     // We assume any function can be a kernel. This could be used
-    // to check for metadata (but would need to be overrideable somehow
+    // to check for metadata but would need to be overrideable somehow
     // to honor the forced kernel name(s) parameter in command line.
     static bool classof(const llvm::Function *) { return true; }
+
+  private:
+    // Instruction that computes the work-group size
+    llvm::Instruction *WGSizeInstr;
   };
 
 }

--- a/tools/scripts/format-branch.sh
+++ b/tools/scripts/format-branch.sh
@@ -20,4 +20,4 @@ SCRIPTPATH=$( realpath "$0"  )
 RELPATH=$(dirname "$SCRIPTPATH")
 
 $RELPATH/clang-format-diff.py -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 -style GNU <$PATCHY
-$RELPATH/clang-format-diff.py -regex '(.*(\.hh$|\.cc$))|(lib/llvmopencl/.*\.h)|(lib/CL/devices/tce/.*)' -i -p1 -style LLVM <$PATCHY
+$RELPATH/clang-format-diff.py -regex '(.*(\.hh$|\.cc$))|(lib/llvmopencl/.*)|(lib/CL/devices/tce/.*)' -i -p1 -style LLVM <$PATCHY

--- a/tools/scripts/format-last-commit.sh
+++ b/tools/scripts/format-last-commit.sh
@@ -19,7 +19,7 @@ git show -U0 --no-color >$PATCHY
 SCRIPTPATH=$( realpath "$0"  )
 RELPATH=$(dirname "$SCRIPTPATH")
 
-$RELPATH/clang-format-diff.py -regex '(.*(\.hpp$|\.cc$|\.cpp$))|(lib/llvmopencl/.*\.h)' -i -p1 -style LLVM <$PATCHY
+$RELPATH/clang-format-diff.py -regex '(.*(\.hpp$|\.cc$|\.cpp$))|(lib/llvmopencl/.*)' -i -p1 -style LLVM <$PATCHY
 $RELPATH/clang-format-diff.py -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 -style GNU <$PATCHY
 
 if [ -z "$(git diff)" ]; then


### PR DESCRIPTION
The subgroup is always the X dimension, and there is only one subgroup in flight at the same time. Thus there are Z*Y SGs per WG. It passes the CTS test even though independent progress is not supported because there's only one SG in flight at the same time making progress.

Also preliminary shuffle and ballot implementations which work only with uniform execution for now.

The cross-WI data exchange is implemented via __pocl_{wg,local_mem}_alloca(), an internal function that allocates "local memory" (thread stack) dynamically.