### PR TITLE
Add stub macro POCL_MSG_PRINT_ALMAIF_MMAP without POCL_DEBUG_MESSAGES

### DIFF
--- a/lib/CL/pocl_debug.h
+++ b/lib/CL/pocl_debug.h
@@ -284,6 +284,7 @@ POCL_EXPORT
 
     #define POCL_MSG_PRINT_ALMAIF2(...)  do {} while (0)
     #define POCL_MSG_PRINT_ALMAIF(...)  do {} while (0)
+    #define POCL_MSG_PRINT_ALMAIF_MMAP(...)  do {} while (0)
     #define POCL_MSG_PRINT_PROXY2(...)  do {} while (0)
     #define POCL_MSG_PRINT_PROXY(...)  do {} while (0)
     #define POCL_MSG_PRINT_VULKAN2(...)  do {} while (0)


### PR DESCRIPTION
Without this the build fails with the following error when built without POCL_DEBUG_MESSAGES:
```
../lib/CL/devices/almaif/MMAPRegion.cc: In constructor ‘MMAPRegion::MMAPRegion(size_t, size_t, int)’:
../lib/CL/devices/almaif/MMAPRegion.cc:43:3: error: ‘POCL_MSG_PRINT_ALMAIF_MMAP’ was not declared
in this scope; did you mean ‘POCL_MSG_PRINT_ALMAIF2’?
   43 |   POCL_MSG_PRINT_ALMAIF_MMAP(
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |   POCL_MSG_PRINT_ALMAIF2
```
and about 10 more.