### PR TITLE
add support for SPIR-V fmax_common and fmin_common

### DIFF
--- a/include/_builtin_renames.h
+++ b/include/_builtin_renames.h
@@ -88,7 +88,9 @@
 #define floor          _cl_floor
 #define fma            _cl_fma
 #define fmax           _cl_fmax
+#define fmax_common    _cl_fmax_common
 #define fmin           _cl_fmin
+#define fmin_common    _cl_fmin_common
 #define fmod           _cl_fmod
 #define fract          _cl_fract
 #define frexp          _cl_frexp

--- a/lib/kernel/CMakeLists.txt
+++ b/lib/kernel/CMakeLists.txt
@@ -75,7 +75,9 @@ fdim.cl
 floor.cl
 fma.cl
 fmax.cl
+fmax_common.cl
 fmin.cl
+fmin_common.cl
 fmod.cl
 fract.cl
 frexp.cl

--- a/lib/kernel/SPIR/generate_spir_wrapper.py
+++ b/lib/kernel/SPIR/generate_spir_wrapper.py
@@ -119,7 +119,7 @@ SINGLE_ARG_I = [
 DUAL_ARG = [
 	"atan2", "atan2pi",
 	"copysign",
-	"fdim", "fmax", "fmin", "fmod",
+	"fdim", "fmax", "fmax_common", "fmin", "fmin_common", "fmod",
 	"hypot", "nextafter", "pow", "powr",
 	"maxmag", "minmag", "remainder",
 	"native_divide", "native_powr",

--- a/lib/kernel/fmax_common.cl
+++ b/lib/kernel/fmax_common.cl
@@ -1,0 +1,26 @@
+/* OpenCL built-in library: fmax_common()
+
+   Copyright (c) 2023 Ben Ashbaugh <ben.ashbaugh@intel.com>
+   
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+   
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+   
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+#include "templates.h"
+
+DEFINE_EXPR_F_FF(_cl_fmax_common, a < b ? b : a)

--- a/lib/kernel/fmax_common.cl
+++ b/lib/kernel/fmax_common.cl
@@ -23,4 +23,4 @@
 
 #include "templates.h"
 
-DEFINE_EXPR_F_FF(_cl_fmax_common, a < b ? b : a)
+DEFINE_EXPR_F_FF(fmax_common, a < b ? b : a)

--- a/lib/kernel/fmin_common.cl
+++ b/lib/kernel/fmin_common.cl
@@ -23,4 +23,4 @@
 
 #include "templates.h"
 
-DEFINE_EXPR_F_FF(_cl_fmin_common, a < b ? a : b)
+DEFINE_EXPR_F_FF(fmin_common, a < b ? a : b)

--- a/lib/kernel/fmin_common.cl
+++ b/lib/kernel/fmin_common.cl
@@ -1,0 +1,26 @@
+/* OpenCL built-in library: fmin_common()
+
+   Copyright (c) 2023 Ben Ashbaugh <ben.ashbaugh@intel.com>
+   
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+   
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+   
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+#include "templates.h"
+
+DEFINE_EXPR_F_FF(_cl_fmin_common, a < b ? a : b)

--- a/lib/kernel/host/CMakeLists.txt
+++ b/lib/kernel/host/CMakeLists.txt
@@ -46,6 +46,8 @@ dot.cl
 fast_distance.cl
 fast_length.cl
 fast_normalize.cl
+fmax_common.cl
+fmin_common.cl
 fract.cl
 get_global_id.c
 get_linear_id.c


### PR DESCRIPTION
Fixes #1172 

Adds support for the SPIR-V `fmin_common` and `fmax_common` extended instructions.

Signed-off-by: Ben Ashbaugh <ben.ashbaugh@intel.com>