### PR TITLE
CPU devices: flush printf() output after each call

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,7 @@ Notable User Facing Changes
 - Added support for generic address spaces in the CPU drivers
 - Added basic support for cl_khr_subgroups for CPUs: A single
   subgroup that always executes the whole X-dimension's WIs.
-- Added initial (incomplete) support for 
+- Added initial (incomplete) support for
   cl_intel_required_subgroup_size for CPUs
 - AlmaIF's OpenASIP backend now supports a standalone mode.
   It generates a standalone C program from a kernel launch, which
@@ -28,7 +28,10 @@ Notable User Facing Changes
   documentation, see doc/sphinx/source/level0.rst.
 - Support for cl_intel_unified_shared_memory (only with
   the Level Zero driver).
-  
+- CPU devices now flush printf() output after each call instead of waiting
+  for the end of the kernel command. This makes it (again) useful for debugging
+  kernel segfaults.
+
 Notable Fixes
 -------------
 

--- a/doc/sphinx/source/debug.rst
+++ b/doc/sphinx/source/debug.rst
@@ -8,11 +8,21 @@ differing in debugging coverage and impact on speed.
 This document chapter describes means for debugging OpenCL kernel code by using
 the CPU drivers of PoCL.
 
-"Offline" debugging
---------------------
+Basic printf debugging
+----------------------
 
-Offline debugging ca be done by setting ``POCL_LEAVE_KERNEL_COMPILER_TEMP_FILES`` env
-var to 1. This causes the intermediate output files from the kernel
+The CPU drivers of PoCL flush the OpenCL 1.2 printf() API output immediately
+at the end of the printf call. This is in contrast to some other drivers which
+flush the output only at the end of the kernel command's execution, making
+debugging crashing (segfaulting) kernels difficult since they never finish
+the command, thus any debug printouts won't get printed out.
+
+Kernel compiler debugging
+-------------------------
+
+Inspecting the kernel compiler intermediate results can be done by
+setting ``POCL_LEAVE_KERNEL_COMPILER_TEMP_FILES`` env var to 1.
+This causes the intermediate output files from the kernel
 compilation process to be left in PoCL's disk cache for inspection.
 By default these files are deleted, and only the final executable output is left
 in the cache.

--- a/lib/kernel/host/CMakeLists.txt
+++ b/lib/kernel/host/CMakeLists.txt
@@ -1,7 +1,7 @@
 #=============================================================================
 #   CMake build system files
 #
-#   Copyright (c) 2014 pocl developers
+#   Copyright (c) 2014-2023 pocl developers
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a copy
 #   of this software and associated documentation files (the "Software"), to deal
@@ -523,7 +523,7 @@ endif()
 separate_arguments(CLANG_CPUFLAGS)
 separate_arguments(LLC_CPUFLAGS)
 set(CLANG_FLAGS ${HOST_CLANG_FLAGS} ${CLANG_CPUFLAGS}
-                "-emit-llvm" "-ffp-contract=off")
+                "-emit-llvm" "-ffp-contract=off" "-DPRINTF_IMMEDIATE_FLUSH")
 
 set(LLC_FLAGS ${HOST_LLC_FLAGS} ${LLC_CPUFLAGS})
 

--- a/lib/kernel/printf.c
+++ b/lib/kernel/printf.c
@@ -28,6 +28,10 @@
 
 #include <stdarg.h>
 
+#ifdef PRINTF_IMMEDIATE_FLUSH
+#include <unistd.h>
+#endif
+
 #define OCL_C_AS
 
 /* The OpenCL printf routine.
@@ -707,6 +711,14 @@ __pocl_printf (char *restrict __buffer, uint32_t *__buffer_index,
   int r = __pocl_printf_format_full (fmt, &p, va);
   va_end (va);
 
+#ifdef PRINTF_IMMEDIATE_FLUSH
+  if (p.printf_buffer_index > 0)
+    {
+      write (STDOUT_FILENO, p.printf_buffer, p.printf_buffer_index);
+      p.printf_buffer_index = 0;
+    }
+#endif
+
   *(PRINTF_BUFFER_AS uint32_t *)__buffer_index = p.printf_buffer_index;
 
   return r;
@@ -743,6 +755,7 @@ printf (const PRINTF_FMT_STR_AS char *restrict fmt, ...)
 
   *(PRINTF_BUFFER_AS uint32_t *)_printf_buffer_position
       = p.printf_buffer_index;
+
   return r;
 }
 


### PR DESCRIPTION
...instead of waiting for the end of the kernel command. This makes it (again) useful for debugging kernel segfaults.