### PR TITLE
cuda: use PCIe P2P copies when migrating between cuda devices

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,8 @@ Notable User Facing Changes
   kernel segfaults.
 - Added a new POCL_CPU_LOCAL_MEM_SIZE environment for overriding the
   local memory size for the CPU devices.
+- CUDA: Added Direct Peer-to-Peer buffer migrations for much better performance
+  scaling in multi-GPU scenarios
 
 Notable Fixes
 -------------


### PR DESCRIPTION
In which the [improved FluidX3D](https://github.com/ProjectPhysX/FluidX3D/tree/experimental-p2p) runs on an 8 GPU setup* 3.6x as fast as with the Nvidia proprietary OpenCL driver.

It seems Nvidia's driver takes a huge performance hit if buffers are migrated between devices, as the previous FluidX3D release (2.4) runs much better despite doing buffer migrations manually by downloading buffer contents to host memory and reuploading to the target device. Still, even compared to the old approach this new FluidX3D running on PoCL-CUDA with this patch applied is 2.0x faster.

In other words, this massively improves multi-GPU scaling of PoCL-CUDA (but does not affect single GPU performance in any way).

Some unrelated fixes to PoCL-CUDA are still needed to make FluidX3D interactive graphics work but benchmark mode and rendering to disk works.

Closes #1187

*8x RTX A6000, FluidX3D in benchmark mode the memory limit set to 8192MB.