### PR TITLE
update install.rst to note specifying random hash in case of almaif devices

### DIFF
--- a/doc/sphinx/source/almaif.rst
+++ b/doc/sphinx/source/almaif.rst
@@ -131,6 +131,8 @@ As a practical example, enqueuing a kernel dispatch packet proceeds as follows:
   - The driver sees the completion signal change, and can consider the command
     completed.
 
+.. _almaif_usage:
+
 Usage
 -----
 

--- a/doc/sphinx/source/install.rst
+++ b/doc/sphinx/source/install.rst
@@ -283,8 +283,8 @@ The string after "HSTR:" is the device build hash.
   This is required because pocl binaries contain a device hash, and the LLVM-less
   pocl needs to know which binaries it can load.
 
-**NOTE**: If you've enabled the `almaif <http://portablecl.org/docs/html/almaif.html#usage>`_ 
-device, `HOST_DEVICE_BUILD_HASH` can be set to anything you want. Reason being, fixed function
+**NOTE**: If you've enabled the :ref:`almaif device <almaif_usage>`
+, `HOST_DEVICE_BUILD_HASH` can be set to anything you want. Reason being, fixed function
 accelerators don't require compiling OpenCL kernels, therefore, no hash will ever be matched. 
 
 Cross-compile pocl

--- a/doc/sphinx/source/install.rst
+++ b/doc/sphinx/source/install.rst
@@ -283,6 +283,9 @@ The string after "HSTR:" is the device build hash.
   This is required because pocl binaries contain a device hash, and the LLVM-less
   pocl needs to know which binaries it can load.
 
+**NOTE**: If you've enabled the `almaif <http://portablecl.org/docs/html/almaif.html#usage>`_ 
+device, `HOST_DEVICE_BUILD_HASH` can be set to anything you want. Reason being, fixed function
+accelerators don't require compiling OpenCL kernels, therefore, no hash will ever be matched. 
 
 Cross-compile pocl
 ------------------


### PR DESCRIPTION
`accel.rst` [had](https://github.com/pocl/pocl/commit/74b46f46be9c8205e1931983164c7f6770f96c2a) such a note. I don't know why it was not copied to current document