### PR TITLE
builtin_kernels.hh: allow POCL_CDBI_LAST to be automatically assigned

### DIFF
--- a/lib/CL/devices/builtin_kernels.hh
+++ b/lib/CL/devices/builtin_kernels.hh
@@ -4,7 +4,7 @@
 /*
   steps to add a new builtin kernel:
 
-  1) add it to the end of BuiltinKernelId enum in this file
+  1) add it to the end of BuiltinKernelId enum in this file, before POCL_CDBI_LAST
 
   2) open builtin_kernels.cc and edit pocl_BIDescriptors, add a new struct
      for the new kernel, with argument metadata
@@ -68,7 +68,7 @@ enum BuiltinKernelId : uint16_t
   POCL_CDBI_OPENVX_SCALEIMAGE_BL_U8 = 22,
   POCL_CDBI_OPENVX_TENSORCONVERTDEPTH_WRAP_U8_F32 = 23,
   POCL_CDBI_OPENVX_MINMAXLOC_R1_U8 = 24,
-  POCL_CDBI_LAST = 25,
+  POCL_CDBI_LAST,
   POCL_CDBI_JIT_COMPILER = 0xFFFF
 };
 


### PR DESCRIPTION
POCL_CDBI_LAST is used as the size parameter for pocl_BIKernels. Since, integers in enums are automatically assinged a value of previous-integer + 1, POCL_CDBI_LAST's value should be assigned in such a way as opposed to being hard-coded.

Furthermore, comment on the top vaguely directs to add new kernel definitions to the end of the enum. Adding anything after POCL_CDBI_LAST will go undetected as it is used for size. This is corrected.