### PR TITLE
Fix runtime error 'undefined symbol: pocl_ignore_sigfpe_for_thread' on aarch64

### DIFF
--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -131,7 +131,9 @@ pthread_scheduler_init (cl_device_id device)
       PTHREAD_CHECK (pthread_create (&scheduler.thread_pool[i].thread, NULL,
                                      pocl_pthread_driver_thread,
                                      (void *)&scheduler.thread_pool[i]));
+#ifdef __x86_64__
       pocl_ignore_sigfpe_for_thread (scheduler.thread_pool[i].thread);
+#endif
     }
 
   PTHREAD_CHECK2 (PTHREAD_BARRIER_SERIAL_THREAD,

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -59,8 +59,10 @@ void pocl_restore_ftz (unsigned ftz);
 
 void pocl_install_sigfpe_handler ();
 void pocl_install_sigusr2_handler ();
+#ifdef __x86_64__
 POCL_EXPORT
 void pocl_ignore_sigfpe_for_thread (pthread_t thr);
+#endif
 
 void bzero_s (void *v, size_t n);
 


### PR DESCRIPTION
Solves #1196 