### PR TITLE
CPU: Replace OpenCL as cast builtins with addrspace casts

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -156,7 +156,7 @@ jobs:
         run: |
           rm -rf ${{ env.POCL_CACHE_DIR }}
           mkdir ${{ env.POCL_CACHE_DIR }}
-          cd ${{ github.workspace }}/build && ${{ github.workspace }}/tools/scripts/run_cuda_tests
+          cd ${{ github.workspace }}/build && ${{ github.workspace }}/tools/scripts/run_cuda_tests --output-on-failure
 
   openasip_test:
     env:

--- a/lib/kernel/host/addrspace_operators.ll
+++ b/lib/kernel/host/addrspace_operators.ll
@@ -1,17 +1,5 @@
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 
-define dso_local i8* @__to_local(i8* %address) local_unnamed_addr #0 {
-  ret i8* %address
-}
-
-define dso_local i8* @__to_global(i8* %address) local_unnamed_addr #0 {
-  ret i8* %address
-}
-
-define dso_local i8* @__to_private(i8* %address) local_unnamed_addr #0 {
-  ret i8* %address
-}
-
 define dso_local i32 @_Z9get_fencePU9CLgenericv(i8* %address) local_unnamed_addr #0 {
   ret i32 3
 }


### PR DESCRIPTION
Special handling for the AS cast built-ins: They do not type mangling, which complicates the CPU implementation which sometimes gets all-0 AS input and sometimes not (SPIR-V). Here, in case the target doesn't define these built-ins in the bitcode library, we replace the calls directly with address space casts. This works for uniform address space targets (CPUs), while the disjoint AS targets can override the implementation as needed. Fixes #1203.