### PR TITLE
cpu selection

### DIFF
--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1660,13 +1660,19 @@ pocl_init_default_device_infos (cl_device_id dev)
 #ifdef ENABLE_LLVM
 
   dev->llvm_target_triplet = OCL_KERNEL_TARGET;
-#ifdef HOST_CPU_FORCED
+#if defined(KERNELLIB_HOST_DISTRO_VARIANTS)
+  dev->kernellib_name = pocl_get_distro_kernellib_name ();
+  dev->llvm_cpu = pocl_get_distro_cpu_name (dev->kernellib_name);
+#elif defined(HOST_CPU_FORCED)
+  dev->kernellib_name = OCL_KERNEL_TARGET_CPU;
   dev->llvm_cpu = OCL_KERNEL_TARGET_CPU;
 #else
+  dev->kernellib_name = NULL;
   dev->llvm_cpu = pocl_get_llvm_cpu_name ();
 #endif
 
 #else /* No compiler, no CPU info */
+  dev->kernellib_name = NULL;
   dev->llvm_cpu = NULL;
   dev->llvm_target_triplet = "";
 #endif

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1663,6 +1663,8 @@ pocl_init_default_device_infos (cl_device_id dev)
 #if defined(KERNELLIB_HOST_DISTRO_VARIANTS)
   dev->kernellib_name = pocl_get_distro_kernellib_name ();
   dev->llvm_cpu = pocl_get_distro_cpu_name (dev->kernellib_name);
+  if (!dev->kernellib_name || !dev->llvm_cpu)
+    dev->available = CL_FALSE;
 #elif defined(HOST_CPU_FORCED)
   dev->kernellib_name = OCL_KERNEL_TARGET_CPU;
   dev->llvm_cpu = OCL_KERNEL_TARGET_CPU;

--- a/lib/CL/devices/cpuinfo.c
+++ b/lib/CL/devices/cpuinfo.c
@@ -400,9 +400,12 @@ pocl_cpuinfo_get_cpu_name_and_vendor(cl_device_id device)
 #endif
 
   /* create the descriptive long_name for device */
-  int len = strlen (device->short_name) + (end-start) + 2;
+  int len = strlen (device->short_name) + 1
+            + (device->llvm_cpu ? strlen (device->llvm_cpu) : 0) + 1
+            + (end - start) + 1;
   char *new_name = (char*)malloc (len);
-  snprintf (new_name, len, "%s-%s", device->short_name, start);
+  snprintf (new_name, len, "%s-%s-%s", device->short_name,
+            (device->llvm_cpu ? device->llvm_cpu : ""), start);
   device->long_name = new_name;
 
   /* If the vendor_id field is still empty, we should get the PCI ID associated

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -1053,8 +1053,10 @@ struct _cl_device_id {
   void *data;
 
   const char* llvm_target_triplet; /* the llvm target triplet to use */
+  const char *kernellib_name;      /* the kernellib variant to use */
   const char* llvm_cpu; /* the llvm CPU variant to use */
   const char* llvm_fp_contract_mode; /* the floating point contract mde to use */
+
   /* A running number (starting from zero) across all the device instances.
      Used for indexing arrays in data structures with device specific
      entries. */

--- a/lib/CL/pocl_llvm.h
+++ b/lib/CL/pocl_llvm.h
@@ -43,6 +43,10 @@ extern "C" {
   POCL_EXPORT
   const char *pocl_get_distro_kernellib_name ();
 
+  /* For distro builds, return the target cpu name for a kernellib name */
+  POCL_EXPORT
+  const char *pocl_get_distro_cpu_name (const char *kernellib_name);
+
   /* Returns if the cpu supports FMA instruction (uses LLVM). */
   int cpu_has_fma ();
 

--- a/lib/CL/pocl_llvm.h
+++ b/lib/CL/pocl_llvm.h
@@ -38,6 +38,11 @@ extern "C" {
   /* Returns the cpu name as reported by LLVM. */
   POCL_EXPORT
   char *pocl_get_llvm_cpu_name ();
+
+  /* For distro builds, return the kernellib name based on the host CPU */
+  POCL_EXPORT
+  const char *pocl_get_distro_kernellib_name ();
+
   /* Returns if the cpu supports FMA instruction (uses LLVM). */
   int cpu_has_fma ();
 

--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -942,48 +942,6 @@ int pocl_llvm_link_program(cl_program program, unsigned device_i,
   return CL_SUCCESS;
 }
 
-/* for "distro" style kernel libs, return which kernellib to use, at runtime */
-#ifdef KERNELLIB_HOST_DISTRO_VARIANTS
-const char *pocl_get_distro_kernellib_name() {
-  StringMap<bool> Features;
-  const char *res = NULL;
-
-  if (!llvm::sys::getHostCPUFeatures(Features)) {
-    POCL_MSG_WARN("LLVM can't get host CPU flags!\n");
-    return NULL;
-  }
-
-#if defined(__x86_64__)
-  if (Features["sse2"])
-    res = "sse2";
-  if (Features["ssse3"] && Features["cx16"])
-    res = "ssse3";
-  if (Features["sse4.1"] && Features["cx16"])
-    res = "sse41";
-  if (Features["avx"] && Features["cx16"] && Features["popcnt"])
-    res = "avx";
-  if (Features["avx"] && Features["cx16"] && Features["popcnt"] && Features["f16c"])
-    res = "avx_f16c";
-  if (Features["avx"] && Features["cx16"] && Features["popcnt"]
-      && Features["xop"] && Features["fma4"])
-    res = "avx_fma4";
-  if (Features["avx"] && Features["avx2"] && Features["cx16"]
-      && Features["popcnt"] && Features["lzcnt"] && Features["f16c"]
-      && Features["fma"] && Features["bmi"] && Features["bmi2"])
-    res = "avx2";
-  if (Features["avx512f"] )
-    res = "avx512";
-#endif
-
-  if (!res)
-    POCL_MSG_WARN("Can't find a kernellib supported by the host CPU (%s)\n",
-                  llvm::sys::getHostCPUName());
-
-  return res;
-}
-#endif
-
-
 /**
  * Return the OpenCL C built-in function library bitcode
  * for the given device.

--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -1006,10 +1006,8 @@ static llvm::Module *getKernelLibrary(cl_device_id device,
 
   if (is_host) {
     kernellib += '-';
-#ifdef KERNELLIB_HOST_DISTRO_VARIANTS
-    kernellib += pocl_get_distro_kernellib_name();
-#elif defined(HOST_CPU_FORCED)
-    kernellib += OCL_KERNEL_TARGET_CPU;
+#if defined(KERNELLIB_HOST_DISTRO_VARIANTS) || defined(HOST_CPU_FORCED)
+    kernellib += device->kernellib_name;
 #else
     kernellib_fallback = kernellib;
     kernellib_fallback += OCL_KERNEL_TARGET_CPU;

--- a/lib/CL/pocl_llvm_utils.cc
+++ b/lib/CL/pocl_llvm_utils.cc
@@ -205,6 +205,8 @@ const char *pocl_get_distro_kernellib_name() {
     return NULL;
   }
 
+  const char *custom = pocl_get_string_option("POCL_KERNELLIB_NAME", NULL);
+
   const kernellib_features *best_match = NULL;
   for (const kernellib_features *kf = kernellib_feature_map; kf->kernellib_name;
        ++kf) {
@@ -213,6 +215,8 @@ const char *pocl_get_distro_kernellib_name() {
       matches &= Features[*f];
     if (matches) {
       best_match = kf;
+      if (custom && !strcmp(custom, kf->kernellib_name))
+        break;
     }
   }
 

--- a/lib/CL/pocl_llvm_utils.cc
+++ b/lib/CL/pocl_llvm_utils.cc
@@ -136,7 +136,8 @@ static int getModuleTriple(const char *input_stream, size_t size,
 }
 
 char *pocl_get_llvm_cpu_name() {
-  StringRef r = llvm::sys::getHostCPUName();
+  const char *custom = pocl_get_string_option("POCL_LLVM_CPU_NAME", NULL);
+  StringRef r = custom ? StringRef(custom) : llvm::sys::getHostCPUName();
 
   // LLVM may return an empty string -- treat as generic
   if (r.empty())
@@ -146,7 +147,7 @@ char *pocl_get_llvm_cpu_name() {
   if (r.str() == "generic" && strlen(OCL_KERNEL_TARGET_CPU)) {
     POCL_MSG_WARN("LLVM does not recognize your cpu, trying to use "
                    OCL_KERNEL_TARGET_CPU " for -target-cpu\n");
-    r = llvm::StringRef(OCL_KERNEL_TARGET_CPU);
+    r = StringRef(OCL_KERNEL_TARGET_CPU);
   }
 #endif
 

--- a/lib/CL/pocl_llvm_utils.cc
+++ b/lib/CL/pocl_llvm_utils.cc
@@ -160,29 +160,39 @@ char *pocl_get_llvm_cpu_name() {
 #ifdef KERNELLIB_HOST_DISTRO_VARIANTS
 const struct kernellib_features {
   const char *kernellib_name;
+  const char *cpu_name;
   const char *features[12];
 } kernellib_feature_map[] = {
 // order the entries s.t. if a cpu matches multiple entries, the "best" match
 // comes last
 #if defined(__x86_64__)
     "sse2",
+    "athlon64",
     {"sse2", NULL},
     "ssse3",
+    "core2",
     {"sse2", "ssse3", "cx16", NULL},
     "sse41",
+    "penryn",
     {"sse2", "sse4.1", "cx16", NULL},
     "avx",
+    "sandybridge",
     {"sse2", "avx", "cx16", "popcnt", NULL},
     "avx_f16c",
+    "ivybridge",
     {"sse2", "avx", "cx16", "popcnt", "f16c", NULL},
     "avx_fma4",
+    "bdver1",
     {"sse2", "avx", "cx16", "popcnt", "xop", "fma4", NULL},
     "avx2",
+    "haswell",
     {"sse2", "avx", "avx2", "cx16", "popcnt", "lzcnt", "f16c", "fma", "bmi",
      "bmi2", NULL},
     "avx512",
+    "skylake-avx512",
     {"sse2", "avx512f", NULL},
 #endif
+    NULL,
     NULL,
     {NULL}};
 
@@ -192,7 +202,7 @@ const char *pocl_get_distro_kernellib_name() {
 
   if (!llvm::sys::getHostCPUFeatures(Features)) {
     POCL_MSG_WARN("LLVM can't get host CPU flags!\n");
-    return "";
+    return NULL;
   }
 
   const kernellib_features *best_match = NULL;
@@ -209,10 +219,32 @@ const char *pocl_get_distro_kernellib_name() {
   if (!best_match) {
     POCL_MSG_WARN("Can't find a kernellib supported by the host CPU (%s)\n",
                   llvm::sys::getHostCPUName());
-    return "";
+    return NULL;
   }
 
   return best_match->kernellib_name;
+}
+
+/* for "distro" style kernel libs, return which target cpu to use for a given
+ * kernellib */
+const char *pocl_get_distro_cpu_name(const char *kernellib_name) {
+  StringMap<bool> Features;
+
+  if (!llvm::sys::getHostCPUFeatures(Features)) {
+    POCL_MSG_WARN("LLVM can't get host CPU flags!\n");
+    return NULL;
+  }
+
+  const kernellib_features *best_match = NULL;
+  for (const kernellib_features *kf = kernellib_feature_map; kf->kernellib_name;
+       ++kf) {
+    if (!strcmp(kernellib_name, kf->kernellib_name))
+      return kf->cpu_name;
+  }
+
+  POCL_MSG_WARN("Can't find a cpu name matching the kernellib (%s)\n",
+                kernellib_name);
+  return NULL;
 }
 #endif
 


### PR DESCRIPTION
These patches have been part of the Debian packages for more than a year already with no known problems.

With my distribution maintainer hat on ... I like the PoCL distro build (performance wise, makes good use of the cpu) and at the same time dislike compiling stuff for the native target since it may make debugging target dependent bugs difficult (not that I'm aware of any such bug, yet). Also the tests only cover one of the many targets of the distro build - that best matches the buildd CPU.
Targets that require only a subset of the features provided by the host CPU should be testable on that machine, too. E.g. a CPU capable of AVX512 can test SSE2 (only), AVX, AVX2, ... too.

I've therefore implemented some changes ... allowing overriding the CPU detection at runtime (but only to targets supported on the host CPU, falling back to the host CPU).

For each kernellib variant that gets built, tie it to a target cpu (i.e. the one used as target for building the kernellib) and use that cpu as code generation target instead of `native`. The differences should only be marginal, since the kernellib selection tries to do a best match for the host cpu. But it significantly reduces the possible runtime code generation targets and would allow testing all of them with only a minimal number of (physical) CPUs (ideally an Intel one and an AMD one).

Running the tests for all targets is currently only part of the Debian build scripts, I haven't tried doing that in CMake, yet.
(Effectively its a loop over all targets, setting an environment variable and running the tests for each target.)

I can also rebase that on release_4_0 if you prefer.