### PR TITLE
Align integer type sizes in SubCFGFormation.cc.

### DIFF
--- a/lib/llvmopencl/SubCFGFormation.cc
+++ b/lib/llvmopencl/SubCFGFormation.cc
@@ -253,7 +253,7 @@ void insertLocalIdInit(llvm::BasicBlock *Entry) {
 
 // get the wg size values for the loop bounds
 llvm::SmallVector<llvm::Value *, 3>
-getLocalSizeValues(llvm::Function &F, llvm::ArrayRef<std::size_t> LocalSizes,
+getLocalSizeValues(llvm::Function &F, llvm::ArrayRef<unsigned long> LocalSizes,
                    bool DynSizes, int Dim) {
   auto &DL = F.getParent()->getDataLayout();
   llvm::IRBuilder<> Builder{F.getEntryBlock().getTerminator()};
@@ -384,7 +384,7 @@ class SubCFG {
   size_t Dim;
 
   llvm::BasicBlock *createExitWithID(
-      llvm::detail::DenseMapPair<llvm::BasicBlock *, unsigned long> BarrierPair,
+      llvm::detail::DenseMapPair<llvm::BasicBlock *, size_t> BarrierPair,
       llvm::BasicBlock *After, llvm::BasicBlock *TargetBB);
 
   void loadMultiSubCfgValues(
@@ -1356,7 +1356,7 @@ void formSubCfgs(llvm::Function &F, llvm::LoopInfo &LI, llvm::DominatorTree &DT,
   F.viewCFG();
 #endif
 
-  std::array<size_t, 3> LocalSizes;
+  std::array<unsigned long, 3> LocalSizes;
   getModuleIntMetadata(*F.getParent(), "WGLocalSizeX", LocalSizes[0]);
   getModuleIntMetadata(*F.getParent(), "WGLocalSizeY", LocalSizes[1]);
   getModuleIntMetadata(*F.getParent(), "WGLocalSizeZ", LocalSizes[2]);


### PR DESCRIPTION
Fixes: #1258

Seems, the CBS code needed just a bit massaging to align the types.. 

Note though, independent of this I am seeing 3 tests failing for both CBS and Loopvec in my kinda weird cross-compily setup:
```
The following tests FAILED:
         35 - kernel/test_ilogb_loopvec (Failed)
         36 - kernel/test_ilogb_cbs (Failed)
         37 - kernel/test_ldexp_loopvec (Failed)
         38 - kernel/test_ldexp_cbs (Failed)
        170 - regression/struct_kernel_arguments_loopvec (Failed)
        171 - regression/struct_kernel_arguments_cbs (Failed)
 ```
 Exemplary the log from running `kernel/test_ilogb_cbs` manually:
 ```
 POCL_BUILDING=1 POCL_DEBUG=1 POCL_WORK_GROUP_METHOD=cbs  ./tests/kernel/kernel test_ilogb
Running test test_ilogb...
[2023-06-20 14:40:39.697155447]POCL: in fn POclCreateCommandQueue at line 104:
  |   GENERAL |  Created Command Queue 3 (0x57ba09f0) on device 0
[2023-06-20 14:40:39.697272947]POCL: in fn POclCreateContext at line 233:
  |   GENERAL |  Created Context 2 (0x57b97fe0)
[2023-06-20 14:40:39.697279770]POCL: in fn POclCreateCommandQueue at line 104:
  |   GENERAL |  Created Command Queue 4 (0x57ba2530) on device 0
[2023-06-20 14:40:40.208645808]POCL: in fn void appendToProgramBuildLog(cl_program, unsigned int, std::string &) at line 110:
  |     ERROR |  Error(s) while linking: 
Referencing global in another module!
<2 x i64> (<2 x double>)* bitcast (<2 x i32> (<2 x double>)* @Sleef_ilogbd2_long to <2 x i64> (<2 x double>)*)
; ModuleID = '/home/joachimm/.cache/pocl/kcache/tempfile_RSbHI4.cl'
<2 x i32> (<2 x double>)* @Sleef_ilogbd2_long
; ModuleID = '/home/joachimm/Projekte/pocl/build_32bit/lib/kernel/host/kernel-i386-unknown-linux-gnu-znver3.bc'
[2023-06-20 14:40:40.210336528]POCL: in fn compile_and_link_program at line 837:
  |     ERROR |  Build log for device cpu-AMD Ryzen 7 PRO 5850U with Radeon Graphics:
Error(s) while linking: 
Referencing global in another module!
<2 x i64> (<2 x double>)* bitcast (<2 x i32> (<2 x double>)* @Sleef_ilogbd2_long to <2 x i64> (<2 x double>)*)
; ModuleID = '/home/joachimm/.cache/pocl/kcache/tempfile_RSbHI4.cl'
<2 x i32> (<2 x double>)* @Sleef_ilogbd2_long
; ModuleID = '/home/joachimm/Projekte/pocl/build_32bit/lib/kernel/host/kernel-i386-unknown-linux-gnu-znver3.bc'

[2023-06-20 14:40:40.210349843]POCL: in fn compile_and_link_program at line 841:
  |     ERROR | CL_BUILD_PROGRAM_FAILURE Device cpu-AMD Ryzen 7 PRO 5850U with Radeon Graphics failed to build the program
CL_BUILD_PROGRAM_FAILURE in clBuildProgram on line 617
Unknown OpenCL error 1 in clCreateProgram call failed
 on line 42
FAIL
```

Note, one alternative approach to the `getModuleIntMetadata` issue, would be to align `getModuleIntMetadata`'s type to the actual metadata type used by LLVM: `uint64_t`, see: https://github.com/pocl/pocl/compare/main...fodinabor:bugfix/i386?expand=1