### PR TITLE
Add missing addrspace_operators.ll to kernel

### DIFF
--- a/lib/kernel/CMakeLists.txt
+++ b/lib/kernel/CMakeLists.txt
@@ -29,6 +29,7 @@ acos.cl
 acosh.cl
 acospi.cl
 add_sat.cl
+addrspace_operators.ll
 all.cl
 any.cl
 as_type.cl

--- a/lib/kernel/host/CMakeLists.txt
+++ b/lib/kernel/host/CMakeLists.txt
@@ -27,6 +27,7 @@
 set(SOURCES_WITH_SLEEF abs.cl
 abs_diff.cl
 add_sat.cl
+addrspace_operators.ll
 all.cl
 any.cl
 as_type.cl


### PR DESCRIPTION
Closes #1288 

Not sure how this ever worked. The functions that implement this were simply missing. The file was unused.