### PR TITLE
Enforce requirement of c++11 compiler for device library

### DIFF
--- a/lib/CL/devices/CMakeLists.txt
+++ b/lib/CL/devices/CMakeLists.txt
@@ -23,6 +23,9 @@
 #
 #=============================================================================
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
 if(ENABLE_LOADABLE_DRIVERS)
 
   function(add_pocl_device_library name)


### PR DESCRIPTION
C++ required here (other similar cases exist), for creating an `std::vector` in arguments:

https://github.com/pocl/pocl/blob/5a99e12d0bb78427ad948ac368589135507f1b59/lib/CL/devices/builtin_kernels.cc#L23-L25

This fails on the default settings for some compilers / toolchains with older standard.
On macOS, [the brew package manager actually used a different compiler for building pocl](https://github.com/Homebrew/homebrew-core/blob/191b3918d53ae9f1527315755f7282bc0c6a7022/Formula/p/pocl.rb#L34-L44).