### PR TITLE
proxy: add pocl extensions to rename_opencl.h

### DIFF
--- a/include/rename_opencl.h
+++ b/include/rename_opencl.h
@@ -152,4 +152,7 @@
 #define clCommandFillBufferKHR POclCommandFillBufferKHR
 #define clCommandFillImageKHR POclCommandFillImageKHR
 
+/* PoCL extensions */
+#define clSetContentSizeBufferPoCL POclSetContentSizeBufferPoCL
+
 #endif


### PR DESCRIPTION
This allows access to pocl extensions in scenarios where you make use of rename_opencl.h