### PR TITLE
examples: fix cmake error caused by `-E rm` option

### DIFF
--- a/examples/example1/CMakeLists.txt
+++ b/examples/example1/CMakeLists.txt
@@ -81,9 +81,8 @@ endif()
 add_test(NAME "examples/example1_poclbin"
          COMMAND ${CMAKE_COMMAND}
             "-DCMD1=${CMAKE_BINARY_DIR}/bin/poclcc####-o####${CMAKE_BINARY_DIR}/example1.bin####${CMAKE_CURRENT_SOURCE_DIR}/example1.cl"
-            "-DCMD2=${CMAKE_COMMAND}####-E####rm####-rf####${CMAKE_BINARY_DIR}/Testing/Cache"
-            "-DCMD3=${CMAKE_BINARY_DIR}/examples/example1/example1####b####${CMAKE_BINARY_DIR}/example1.bin"
-            "-DCMD4=${CMAKE_COMMAND}####-E####remove####-f####${CMAKE_BINARY_DIR}/example1.bin"
+            "-DCMD2=${CMAKE_BINARY_DIR}/examples/example1/example1####b####${CMAKE_BINARY_DIR}/example1.bin"
+            "-DCMD3=${CMAKE_COMMAND}####-E####remove####-f####${CMAKE_BINARY_DIR}/example1.bin"
             -P ${CMAKE_SOURCE_DIR}/cmake/multi_exec_test.cmake)
 
 set_tests_properties( "examples/example1_poclbin"

--- a/examples/example2/CMakeLists.txt
+++ b/examples/example2/CMakeLists.txt
@@ -68,9 +68,8 @@ set_property(TEST "examples/example2"
 add_test(NAME "examples/example2_poclbin"
          COMMAND ${CMAKE_COMMAND}
             "-DCMD1=${CMAKE_BINARY_DIR}/bin/poclcc####-o####${CMAKE_BINARY_DIR}/example2.bin####${CMAKE_CURRENT_SOURCE_DIR}/example2.cl"
-            "-DCMD2=${CMAKE_COMMAND}####-E####rm####-rf####${CMAKE_BINARY_DIR}/Testing/Cache"
-            "-DCMD3=${CMAKE_BINARY_DIR}/examples/example2/example2####b####${CMAKE_BINARY_DIR}/example2.bin"
-            "-DCMD4=${CMAKE_COMMAND}####-E####remove####-f####${CMAKE_BINARY_DIR}/example2.bin"
+            "-DCMD2=${CMAKE_BINARY_DIR}/examples/example2/example2####b####${CMAKE_BINARY_DIR}/example2.bin"
+            "-DCMD3=${CMAKE_COMMAND}####-E####remove####-f####${CMAKE_BINARY_DIR}/example2.bin"
             -P ${CMAKE_SOURCE_DIR}/cmake/multi_exec_test.cmake)
 
 set_tests_properties( "examples/example2_poclbin"

--- a/examples/example2a/CMakeLists.txt
+++ b/examples/example2a/CMakeLists.txt
@@ -67,9 +67,8 @@ set_property(TEST "examples/example2a"
 add_test(NAME "examples/example2a_poclbin"
          COMMAND ${CMAKE_COMMAND}
             "-DCMD1=${CMAKE_BINARY_DIR}/bin/poclcc####-o####${CMAKE_BINARY_DIR}/example2a.bin####${CMAKE_CURRENT_SOURCE_DIR}/example2a.cl"
-            "-DCMD2=${CMAKE_COMMAND}####-E####rm####-rf####${CMAKE_BINARY_DIR}/Testing/Cache"
-            "-DCMD3=${CMAKE_BINARY_DIR}/examples/example2a/example2a####b####${CMAKE_BINARY_DIR}/example2a.bin"
-            "-DCMD4=${CMAKE_COMMAND}####-E####remove####-f####${CMAKE_BINARY_DIR}/example2a.bin"
+            "-DCMD2=${CMAKE_BINARY_DIR}/examples/example2a/example2a####b####${CMAKE_BINARY_DIR}/example2a.bin"
+            "-DCMD3=${CMAKE_COMMAND}####-E####remove####-f####${CMAKE_BINARY_DIR}/example2a.bin"
             -P ${CMAKE_SOURCE_DIR}/cmake/multi_exec_test.cmake)
 
 set_tests_properties( "examples/example2a_poclbin"


### PR DESCRIPTION
#1311 