### PR TITLE
util: call clWaitForEvents for content size migrations

### DIFF
--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -1108,7 +1108,7 @@ pocl_create_command_full (_cl_command_node **cmd,
           if (size_events[i] != NULL)
             {
               cl_device_id d = size_events[i]->queue->device;
-              d->ops->wait_event (d, size_events[i]);
+              POname (clWaitForEvents) (1, &size_events[i]);
               if (buffers[i]->size_buffer->mem_host_ptr != NULL)
                 {
                   migration_size


### PR DESCRIPTION
some devices (like the basic device) do not have
a wait_event function

@jansol here is the fix we discussed