### PR TITLE
remote+pocld: deduplicate hostname resolution and socket options code

### DIFF
--- a/lib/CL/devices/remote/CMakeLists.txt
+++ b/lib/CL/devices/remote/CMakeLists.txt
@@ -24,7 +24,12 @@
 #=============================================================================
 
 if(MSVC)
-  set_source_files_properties( remote.h remote.c communication.h communication.c PROPERTIES LANGUAGE CXX )
+  set_source_files_properties(
+      remote.h remote.c communication.h communication.c
+      ../../pocl_networking.h ../../pocl_networking.c
+      PROPERTIES LANGUAGE CXX )
 endif(MSVC)
 
-add_pocl_device_library("pocl-devices-remote" remote.h remote.c communication.h communication.c)
+add_pocl_device_library("pocl-devices-remote"
+    remote.h remote.c communication.h communication.c ../../pocl_networking.h
+    ../../pocl_networking.c)

--- a/lib/CL/pocl_networking.c
+++ b/lib/CL/pocl_networking.c
@@ -1,0 +1,156 @@
+/* pocl_networking.c - Shared helper functions for working with networks and
+   sockets
+
+   Copyright (c) 2018 Michal Babej / Tampere University of Technology
+   Copyright (c) 2019-2023 Jan Solanti / Tampere University
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#include <errno.h>
+#include <netdb.h>
+#include <netinet/tcp.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "pocl_debug.h"
+#include "pocl_networking.h"
+
+struct addrinfo *
+pocl_resolve_address (const char *address, uint16_t port, int *error)
+{
+  struct addrinfo hint;
+  memset (&hint, 0, sizeof (hint));
+  hint.ai_family = AF_UNSPEC;
+  hint.ai_socktype = SOCK_STREAM;
+
+  int is_numeric = 0;
+#ifdef ANDROID
+  /* Check whether address is an IP or a host name since Android apparently
+   * can't resolve IP addresses without working DNS unless explicitly told
+   * that it is a numeric address. This heuristic is of course rather brittle
+   * but having a domain name that happens to be fully representable as hex
+   * digits is hopefully less common than ipv6 addresses. */
+  is_numeric = 1;
+  for (const char *c = address; c && *c != 0; ++c)
+    {
+      if (!isxdigit (*c) && *c != '.' && *c != ':' && *c != '[' && *c != ']')
+        {
+          is_numeric = 0;
+        }
+    }
+#endif
+
+  hint.ai_flags = is_numeric ? AI_NUMERICHOST
+                             : (AI_ADDRCONFIG | AI_CANONNAME | AI_V4MAPPED);
+  hint.ai_flags |= AI_NUMERICSERV;
+
+  struct addrinfo *info;
+  char portstr[6] = {};
+  snprintf (portstr, 6, "%5d", port);
+
+  int err = getaddrinfo (address, portstr, &hint, &info);
+  if (error)
+    *error = err;
+
+  return info;
+}
+
+#define SECONDS_TO_MS 1000
+int
+pocl_remote_client_set_socket_options (int socket_fd, int bufsize, int is_fast)
+{
+  const int one = 1;
+  const int zero = 0;
+  POCL_RETURN_ERROR_ON (
+      (setsockopt (socket_fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof (one))),
+      -1, "setsockopt(TCP_NODELAY) returned errno: %i\n", errno);
+
+#ifdef SO_PRIORITY
+  // 1- low priority, 7 - high priority (7 reserved for root)
+  int prio = 0; // valid values are in the range [1,7]
+  if (is_fast)
+    {
+      prio = 6;
+    }
+  else
+    {
+      prio = 1;
+    }
+  POCL_RETURN_ERROR_ON (
+      (setsockopt (socket_fd, SOL_SOCKET, SO_PRIORITY, &prio, sizeof (prio))),
+      -1, "setsockopt(SO_PRIORITY) returned errno: %i\n", errno);
+#endif
+
+  // disable delayed_ack on both
+#ifdef TCP_QUICKACK
+  POCL_RETURN_ERROR_ON (
+      (setsockopt (socket_fd, IPPROTO_TCP, TCP_QUICKACK, &one, sizeof (one))),
+      -1, "setsockopt(TCP_QUICKACK) returned errno: %i\n", errno);
+#endif
+
+  POCL_RETURN_ERROR_ON ((setsockopt (socket_fd, SOL_SOCKET, SO_RCVBUF,
+                                     &bufsize, sizeof (bufsize))),
+                        -1, "setsockopt(SO_RCVBUF) returned errno: %i\n",
+                        errno);
+
+  POCL_RETURN_ERROR_ON ((setsockopt (socket_fd, SOL_SOCKET, SO_SNDBUF,
+                                     &bufsize, sizeof (bufsize))),
+                        -1, "setsockopt(SO_SNDBUF) returned errno: %i\n",
+                        errno);
+
+  POCL_RETURN_ERROR_ON (
+      (setsockopt (socket_fd, SOL_SOCKET, SO_KEEPALIVE, &one, sizeof (one))),
+      -1, "setsockopt(SO_KEEPALIVE) returned errno: %i\n", errno);
+
+  unsigned int user_timeout = 10 * SECONDS_TO_MS;
+#if defined(TCP_USER_TIMEOUT)
+  POCL_RETURN_ERROR_ON (
+      (setsockopt (socket_fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &user_timeout,
+                   sizeof (user_timeout))),
+      -1, "setsockopt(TCP_USER_TIMEOUT) returned errno: %i\n", errno);
+#elif defined(TCP_CONNECTIONTIMEOUT)
+  POCL_RETURN_ERROR_ON (
+      (setsockopt (socket_fd, IPPROTO_TCP, TCP_CONNECTIONTIMEOUT,
+                   &user_timeout, sizeof (user_timeout))),
+      -1, "setsockopt(TCP_CONNECTIONTIMEOUT) returned errno: %i\n", errno);
+#endif
+
+  int retries = 5;
+#ifdef TCP_SYNCNT
+  POCL_RETURN_ERROR_ON (setsockopt (socket_fd, IPPROTO_TCP, TCP_SYNCNT,
+                                    &retries, sizeof (retries)),
+                        -1, "setsockopt(TCP_SYNCNT) returned errno: %i\n",
+                        errno);
+#endif
+  POCL_RETURN_ERROR_ON (setsockopt (socket_fd, IPPROTO_TCP, TCP_KEEPCNT,
+                                    &retries, sizeof (retries)),
+                        -1, "setsockopt(TCP_KEEPCNT) returned errno: %i\n",
+                        errno);
+  POCL_RETURN_ERROR_ON (
+      setsockopt (socket_fd, IPPROTO_TCP, TCP_KEEPINTVL, &one, sizeof (one)),
+      -1, "setsockopt(TCP_KEEPINTVL) returned errno: %i\n", errno);
+#ifdef TCP_KEEPIDLE
+  POCL_RETURN_ERROR_ON (
+      setsockopt (socket_fd, IPPROTO_TCP, TCP_KEEPIDLE, &one, sizeof (one)),
+      -1, "setsockopt(TCP_KEEPINTVL) returned errno: %i\n", errno);
+#endif
+
+  return 0;
+}

--- a/lib/CL/pocl_networking.h
+++ b/lib/CL/pocl_networking.h
@@ -1,0 +1,60 @@
+/* pocl_networking.h - Shared helper functions for working with networks &
+   sockets
+
+   Copyright (c) 2023 Jan Solanti / Tampere University
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#include <stdint.h>
+
+#include "pocl_export.h"
+
+#ifndef POCL_NETWORKING_H
+#define POCL_NETWORKING_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  /*
+   * Helper for calling getaddrinfo. Returns NULL on error, with the error code
+   * in 'error'. Human-readable explanations can be obtained by passing the
+   * error code to gai_strerror(). The caller is responsible for freeing the
+   * addrinfo chain by calling freeaddrinfo() on the first item of the chain.
+   */
+  extern struct addrinfo *pocl_resolve_address (const char *address,
+                                                uint16_t port, int *error);
+
+  /*
+   * Set socket options for PoCL-Remote client connections
+   * \param fd the socket fd to set options on
+   * \param bufsize size of the desired driver-side send and receive buffers
+   * \param is_fast whether this is the "fast" or "slow" socket of the
+   * connection
+   */
+  extern int pocl_remote_client_set_socket_options (int fd, int bufsize,
+                                                    int is_fast);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* POCL_NETWORKING_H */

--- a/pocld/CMakeLists.txt
+++ b/pocld/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCES pocld.cc cmdline.h cmdline.c
             ../lib/CL/pocl_debug.c ../lib/CL/pocl_debug.h
             ../lib/CL/pocl_threads.c ../lib/CL/pocl_threads.h
             ../lib/CL/pocl_timing.c ../lib/CL/pocl_timing.h
+            ../lib/CL/pocl_networking.c ../lib/CL/pocl_networking.h
             shared_cl_context.cc shared_cl_context.hh
             virtual_cl_context.cc virtual_cl_context.hh
             cmd_queue.cc  cmd_queue.hh  common.cc  common.hh

--- a/pocld/common.hh
+++ b/pocld/common.hh
@@ -258,6 +258,8 @@ ssize_t read_full(int fd, void *p, size_t total, TrafficMonitor *);
 
 int write_full(int fd, void *p, size_t total, TrafficMonitor *);
 
+std::string describe_sockaddr(struct sockaddr *addr, unsigned addr_size);
+
 #ifdef ENABLE_RDMA
 struct RdmaBufferData {
   char *shadow_buf;


### PR DESCRIPTION
This should unify the behaviour everywhere, particularly when passing `localhost` or `ip6-localhost` as the server address. Also deduplicated the client socket options setting code while I was at it.

Fixes #1304