### PR TITLE
OpenVINO fixes

### DIFF
--- a/lib/CL/pocl_build.c
+++ b/lib/CL/pocl_build.c
@@ -1,7 +1,7 @@
 /* OpenCL runtime library: compile_and_link_program()
 
    Copyright (c) 2011-2013 Universidad Rey Juan Carlos,
-                 2011-2019 Pekka Jääskeläinen
+                 2011-2023 Pekka Jääskeläinen
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to
@@ -91,8 +91,15 @@ static const char cl_program_link_options[] =
   "-cl-finite-math-only "
   "-cl-fast-relaxed-math ";
 
-static const char cl_parameters_not_yet_supported_by_clang[] =
-  "-cl-uniform-work-group-size ";
+/* TODO: In case of a PoCL-R, we should pass on unhandled
+   target-specific/extension-specific options to the
+   native driver's clBuildProgram() call. Might be difficult
+   to filter the kept ones as the set of target devices can
+   be diverse. */
+static const char cl_parameters_not_yet_supported_by_clang[]
+    = "-cl-uniform-work-group-size "
+      "-cl-no-subgroup-ifp "
+      "-cl-intel-no-prera-scheduling";
 
 #define MEM_ASSERT(x, err_jmp) do{ if (x){errcode = CL_OUT_OF_HOST_MEMORY;goto err_jmp;}} while(0)
 

--- a/lib/kernel/subgroups.c
+++ b/lib/kernel/subgroups.c
@@ -135,6 +135,16 @@ SUB_GROUP_SHUFFLE_T (int)
 SUB_GROUP_SHUFFLE_T (uint)
 SUB_GROUP_SHUFFLE_T (long)
 SUB_GROUP_SHUFFLE_T (ulong)
+#ifdef cl_khr_fp16
+SUB_GROUP_SHUFFLE_T (half)
+/* OpenCL C mangles half 'h' whereas C (clang) mangles it 'fp16'.
+   We need to provide a wrapper for the OpenCL C compatible mangling. */
+half
+_Z23intel_sub_group_shuffleDhj (half val, uint mask)
+{
+  return intel_sub_group_shuffle (val, mask);
+}
+#endif
 SUB_GROUP_SHUFFLE_T (float)
 SUB_GROUP_SHUFFLE_T (double)
 
@@ -213,6 +223,23 @@ SUB_GROUP_BROADCAST_T (double)
 SUB_GROUP_REDUCE_T (add, a + b)
 SUB_GROUP_REDUCE_T (min, a > b ? b : a)
 SUB_GROUP_REDUCE_T (max, a > b ? a : b)
+
+#ifdef cl_khr_fp16
+SUB_GROUP_REDUCE_OT (add, a + b, half)
+SUB_GROUP_REDUCE_OT (max, a > b ? a : b, half)
+
+half
+_Z20sub_group_reduce_maxDh (half val)
+{
+  return sub_group_reduce_max (val);
+}
+
+half
+_Z20sub_group_reduce_addDh (half val)
+{
+  return sub_group_reduce_add (val);
+}
+#endif
 
 #define SUB_GROUP_SCAN_INCLUSIVE_OT(OPNAME, OPERATION, TYPE)                  \
   __attribute__ ((always_inline))                                             \

--- a/lib/kernel/subgroups.cl
+++ b/lib/kernel/subgroups.cl
@@ -59,3 +59,14 @@ sub_group_all (int predicate)
 {
   return sub_group_reduce_min ((unsigned)predicate);
 }
+#ifdef cl_intel_subgroups
+uint _CL_OVERLOADABLE
+intel_sub_group_shuffle_down(uint current, uint next, uint delta) {
+  int idx = get_sub_group_local_id() + delta;
+  uint cur_idx = (idx >= get_max_sub_group_size()) ? 0 : idx;
+  uint other_cur = sub_group_shuffle(current, cur_idx);
+  int next_idx = (idx > get_max_sub_group_size()) ? idx - get_sub_group_size() : 0;
+  uint other_next = sub_group_shuffle(next, next_idx);
+  return idx >= get_sub_group_size() ? other_cur : other_next;
+}
+#endif

--- a/lib/kernel/subgroups.cl
+++ b/lib/kernel/subgroups.cl
@@ -59,14 +59,48 @@ sub_group_all (int predicate)
 {
   return sub_group_reduce_min ((unsigned)predicate);
 }
+
+uint2 _CL_OVERLOADABLE
+intel_sub_group_block_read2 (const global uint *p)
+{
+  return (uint2)(p[get_sub_group_local_id ()],
+                 p[get_sub_group_local_id () + get_max_sub_group_size ()]);
+}
+
+uint8 _CL_OVERLOADABLE
+intel_sub_group_block_read8 (const global uint *p)
+{
+  uint sglid = get_sub_group_local_id ();
+  uint sgsize = get_max_sub_group_size ();
+  return (uint8)(p[sglid], p[sglid + sgsize], p[sglid + 2 * sgsize],
+                 p[sglid + 3 * sgsize], p[sglid + 4 * sgsize],
+                 p[sglid + 5 * sgsize], p[sglid + 6 * sgsize],
+                 p[sglid + 7 * sgsize]);
+}
+
 #ifdef cl_intel_subgroups
+/* https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroups_short.html
+ */
+ushort8 _CL_OVERLOADABLE
+intel_sub_group_block_read_us8 (const global ushort *p)
+{
+  uint sglid = get_sub_group_local_id ();
+  uint sgsize = get_max_sub_group_size ();
+  return (ushort8)(p[sglid], p[sglid + sgsize], p[sglid + 2 * sgsize],
+                   p[sglid + 3 * sgsize], p[sglid + 4 * sgsize],
+                   p[sglid + 5 * sgsize], p[sglid + 6 * sgsize],
+                   p[sglid + 7 * sgsize]);
+}
+
 uint _CL_OVERLOADABLE
-intel_sub_group_shuffle_down(uint current, uint next, uint delta) {
-  int idx = get_sub_group_local_id() + delta;
-  uint cur_idx = (idx >= get_max_sub_group_size()) ? 0 : idx;
-  uint other_cur = sub_group_shuffle(current, cur_idx);
-  int next_idx = (idx > get_max_sub_group_size()) ? idx - get_sub_group_size() : 0;
-  uint other_next = sub_group_shuffle(next, next_idx);
-  return idx >= get_sub_group_size() ? other_cur : other_next;
+intel_sub_group_shuffle_down (uint current, uint next, uint delta)
+{
+  int idx = get_sub_group_local_id () + delta;
+  uint cur_idx = (idx >= get_max_sub_group_size ()) ? 0 : idx;
+  uint other_cur = sub_group_shuffle (current, cur_idx);
+  int next_idx
+      = (idx > get_max_sub_group_size ()) ? idx - get_sub_group_size () : 0;
+  uint other_next = sub_group_shuffle (next, next_idx);
+  return idx >= get_sub_group_size () ? other_cur : other_next;
 }
 #endif


### PR DESCRIPTION
Small fixes to enable offloading OpenVINO across PoCL-R. Also a few initial fixes to make OpenVINO kernels run on PoCL-CPU. It lacks at least the half precision image datatype handling still for that part.