### PR TITLE
basic: don't assume other threads won't notify events

### DIFF
--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -652,7 +652,9 @@ pocl_basic_notify (cl_device_id device, cl_event event, cl_event finished)
           POCL_LOCK (d->cq_lock);
           CDL_DELETE (d->command_list, node);
           CDL_PREPEND (d->ready_list, node);
+          POCL_UNLOCK_OBJ (event);
           basic_command_scheduler (d);
+          POCL_LOCK_OBJ (event);
           POCL_UNLOCK (d->cq_lock);
         }
       return;

--- a/tools/scripts/format-branch.sh
+++ b/tools/scripts/format-branch.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 
-if [ ! -e .git ]; then
+GITROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ $? -ne 0 ]; then
   echo "must be run in git repo"
   exit 1
 fi
+
+# cd to root directory of the git repo
+pushd ${GITROOT} > /dev/null
 
 case "$(git describe --always --dirty=-DIRTY)" in
   *-DIRTY)
@@ -21,3 +25,6 @@ RELPATH=$(dirname "$SCRIPTPATH")
 
 $RELPATH/clang-format-diff.py -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 -style GNU <$PATCHY
 $RELPATH/clang-format-diff.py -regex '(.*(\.hpp$|\.hh$|\.cc$|\.cpp$))|(lib/llvmopencl/.*)|(lib/CL/devices/tce/.*)' -i -p1 -style LLVM <$PATCHY
+
+# cd back whence we were previously
+popd > /dev/null

--- a/tools/scripts/format-last-commit.sh
+++ b/tools/scripts/format-last-commit.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 
-if [ ! -e .git ]; then
+GITROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ $? -ne 0 ]; then
   echo "must be run in git repo"
   exit 1
 fi
+
+# cd to root directory of the git repo
+pushd ${GITROOT} > /dev/null
 
 case "$(git describe --always --dirty=-DIRTY)" in
   *-DIRTY)
@@ -26,3 +30,6 @@ if [ -z "$(git diff)" ]; then
   echo "No changes."
   exit 0
 fi
+
+# cd back whence we were previously
+popd > /dev/null


### PR DESCRIPTION
Events are notified in locked state so unlock them before scheduling which tries to notify them again which in turn tries to lock the event.