### PR TITLE
cl_pocl_pinned_buffers: Experimental extension for cl_mem pinning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1257,7 +1257,8 @@ endif()
 # Host CPU device: list of extensions that are always enabled, for both OpenCL 1.2 and 3.0
 set(HOST_DEVICE_EXTENSIONS "cl_khr_byte_addressable_store cl_khr_global_int32_base_atomics \
 cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics \
-cl_khr_local_int32_extended_atomics cl_khr_3d_image_writes cl_khr_command_buffer")
+cl_khr_local_int32_extended_atomics cl_khr_3d_image_writes cl_khr_command_buffer \
+cl_pocl_pinned_buffers")
 
 # Host CPU device: list of OpenCL 3.0 features that are always enabled
 set(HOST_DEVICE_FEATURES_30 "__opencl_c_3d_image_writes  __opencl_c_images \

--- a/include/CL/cl_ext_pocl.h
+++ b/include/CL/cl_ext_pocl.h
@@ -1,5 +1,8 @@
 /*******************************************************************************
  * Copyright (c) 2021 Tampere University
+ *               2023 Pekka Jääskeläinen / Intel Finland Oy
+ *
+ * PoCL-specific proof-of-concept (draft) or finalized OpenCL extensions.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and/or associated documentation files (the
@@ -53,6 +56,44 @@ typedef CL_API_ENTRY cl_int
     cl_mem    buffer,
     cl_mem    content_size_buffer) CL_API_SUFFIX__VERSION_1_2;
 
+#endif
+
+/* cl_pocl_pinned_buffers (proof-of-concept/draft) stage */
+
+#ifndef cl_pocl_pinned_buffers
+#define cl_pocl_pinned_buffers 1
+#define CL_POCL_PINNED_BUFFERS_EXTENSION_NAME "cl_pocl_pinned_buffers"
+
+/* TODO: We need also platform/runtime extension due to the new buffer
+   creation flags. */
+
+/* clCreateBuffer(): A new cl_mem_flag CL_MEM_PINNED:
+
+   This flag specifies that the buffer must be persistently allocated
+   in the device's physical memory for its lifetime. That is, the buffer's
+   device address will remain the same and the space is reserved until
+   the buffer is freed. The device-specific buffer content updates are
+   still performed by implicit or explicit buffer migrations performed by
+   the runtime or the client code. If any of the devices in the context
+   does not support pinning, an error (TO DEFINE) is returned.
+*/
+#define CL_MEM_PINNED (1 << 31)
+
+/* clGetMemObjectInfo(): A new query CL_MEM_DEVICE_PTR:
+
+Returns a list of pinned device addresses for a buffer allocated
+with CL_MEM_PINNED. If the buffer was not created with CL_MEM_PINNED,
+returns CL_INVALID_MEM_OBJECT.
+*/
+#define CL_MEM_DEVICE_PTRS 0xff01
+
+typedef struct _cl_mem_pinning
+{
+  cl_device_id device;
+  void *address;
+} cl_mem_pinning;
+
+/* cl_pocl_pinned_buffers */
 #endif
 
 #ifdef __cplusplus

--- a/include/messages.h
+++ b/include/messages.h
@@ -42,7 +42,7 @@ extern "C"
 
 #define ENUM_TYPE uint8_t
 
-#define MAX_PACKED_STRING_LEN 1024
+#define MAX_PACKED_STRING_LEN (4 * 1024)
 
 #define SESSION_ID_LENGTH 16
 
@@ -334,6 +334,11 @@ extern "C"
     uint64_t size;
     uint32_t flags;
   } CreateBufferMsg_t;
+
+  typedef struct __attribute__ ((packed, aligned (8))) CreateBufferReply_s
+  {
+    uint64_t device_addr;
+  } CreateBufferReply_t;
 
 #ifdef ENABLE_RDMA
   typedef struct __attribute__ ((packed, aligned (8))) CreateRdmaBufferReply_s
@@ -674,6 +679,10 @@ extern "C"
     uint64_t server_read_start_timestamp_ns;
     uint64_t server_read_end_timestamp_ns;
     uint64_t server_write_start_timestamp_ns;
+    union
+    {
+      CreateBufferReply_t create_buffer;
+    } m;
   } ReplyMsg_t;
 
   /* ########################## */

--- a/include/messages.h
+++ b/include/messages.h
@@ -42,7 +42,7 @@ extern "C"
 
 #define ENUM_TYPE uint8_t
 
-#define MAX_PACKED_STRING_LEN (4 * 1024)
+#define MAX_PACKED_STRING_LEN 1024
 
 #define SESSION_ID_LENGTH 16
 
@@ -213,14 +213,15 @@ extern "C"
 
     /* ######## device properties ############## */
 
-    STRING_TYPE (name);
-    STRING_TYPE (opencl_c_version);
-    STRING_TYPE (device_version);
-    STRING_TYPE (driver_version);
-    STRING_TYPE (vendor);
-    STRING_TYPE (extensions);
-    STRING_TYPE (builtin_kernels);
-    STRING_TYPE (supported_spir_v_versions);
+    /* Offsets to the strings-section. */
+    uint64_t name;
+    uint64_t opencl_c_version;
+    uint64_t device_version;
+    uint64_t driver_version;
+    uint64_t vendor;
+    uint64_t extensions;
+    uint64_t builtin_kernels;
+    uint64_t supported_spir_v_versions;
 
     uint32_t vendor_id;
     //  uint32_t device_id;
@@ -672,6 +673,12 @@ extern "C"
 
     uint64_t data_size;
     uint32_t obj_id;
+
+    /* If the reply has a dynamic pool of c-strings after the end of
+       the structure's fields, this is set to its size. */
+    /* The actual strings will be appended after the object as a sequence
+       of 0-terminated strings.*/
+    uint64_t strings_size;
 
     // remote server timing data from libOpenCL
     EventTiming_t timing;

--- a/include/pocl.h
+++ b/include/pocl.h
@@ -91,6 +91,14 @@ typedef struct pocl_mem_identifier
      it's not */
   void *mem_ptr;
 
+  /* If mem_ptr represents an address in the device global memory which
+     is pinned for the lifetime of the buffer. */
+  int is_pinned;
+
+  /* The device-side memory address (if known). If is_pinned is true, this
+     must be a valid value (note: 0 can be a valid address!). */
+  void *device_addr;
+
   /* Content version tracking. Every write use (clEnqWriteBuffer,
    * clMapBuffer(CL_MAP_WRITE), write_only image, read/write buffers as kernel
    * args etc) increases the version; read uses do not. At command enqueue

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1831,7 +1831,8 @@ static const cl_name_version OPENCL_EXTENSIONS[]
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_image2d_from_buffer" },
         { CL_MAKE_VERSION (2, 1, 0), "cl_khr_spir" },
         { CL_MAKE_VERSION (2, 1, 0), "cl_khr_il_program" },
-        { CL_MAKE_VERSION (0, 9, 4), "cl_khr_command_buffer" } };
+        { CL_MAKE_VERSION (0, 9, 4), "cl_khr_command_buffer" },
+        { CL_MAKE_VERSION (0, 1, 0), "cl_pocl_pinned_buffers" }};
 
 const size_t OPENCL_EXTENSIONS_NUM
     = sizeof (OPENCL_EXTENSIONS) / sizeof (OPENCL_EXTENSIONS[0]);
@@ -1978,7 +1979,7 @@ pocl_setup_builtin_kernels_with_version (cl_device_id dev)
         {
           POCL_MSG_WARN ("Built-in kernel name cannot fit in to the "
                          "cl_name_version array. Length of built-in kernel "
-                         "name is %u, and the concatenated length is %u\n",
+                         "name is %zu, and the concatenated length is %d\n",
                          strlen (token), CL_NAME_VERSION_MAX_NAME_SIZE - 1);
           token[CL_NAME_VERSION_MAX_NAME_SIZE - 1] = '\0';
         }

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -746,8 +746,8 @@ pocl_broadcast (cl_event brc_event)
   while ((target = brc_event->notify_list))
     {
       cl_event target_event = target->event;
-      POname (clRetainEvent) (target_event);
       POCL_UNLOCK_OBJ (brc_event);
+      POname (clRetainEvent) (target_event);
 
       pocl_lock_events_inorder (brc_event, target_event);
       if (target != brc_event->notify_list)

--- a/lib/CL/devices/common_driver.c
+++ b/lib/CL/devices/common_driver.c
@@ -418,6 +418,12 @@ pocl_driver_alloc_mem_obj (cl_device_id device, cl_mem mem, void *host_ptr)
 
   p->version = mem->mem_host_ptr_version;
   p->mem_ptr = mem->mem_host_ptr;
+  p->device_addr = p->mem_ptr;
+
+  /* If requesting device pinned memory, mark the mem such so it won't
+     get migrated away before being freed. */
+  if (mem->is_device_pinned)
+    p->is_pinned = 1;
 
   POCL_MSG_PRINT_MEMORY ("Basic device ALLOC %p / size %zu \n", p->mem_ptr,
                          mem->size);

--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -1988,7 +1988,8 @@ pocl_network_free_device (cl_device_id device)
 
 cl_int
 pocl_network_create_buffer (remote_device_data_t *ddata, uint32_t mem_id,
-                            uint32_t mem_flags, uint64_t mem_size)
+                            uint32_t mem_flags, uint64_t mem_size,
+                            void **device_addr)
 {
   // = (remote_device_data_t *)device->data;
   REMOTE_SERV_DATA2;
@@ -2017,6 +2018,12 @@ pocl_network_create_buffer (remote_device_data_t *ddata, uint32_t mem_id,
   CHECK_REPLY (CreateBuffer);
 
   SET_REMOTE_ID (buffer, mem_id);
+
+  if (mem_flags & CL_MEM_PINNED)
+    {
+      assert (device_addr != NULL);
+      *device_addr = (void *)netcmd->reply.m.create_buffer.device_addr;
+    }
 
 #ifdef ENABLE_RDMA
   rdma_buffer_info_t *s = malloc (sizeof (rdma_buffer_info_t));

--- a/lib/CL/devices/remote/communication.h
+++ b/lib/CL/devices/remote/communication.h
@@ -138,6 +138,9 @@ struct network_command
   size_t req_extra_size;
   size_t req_extra_size2;
   size_t rep_extra_size;
+  /* Points to an (optional) dynamic strings section appened after the message.
+   */
+  char *strings;
   network_command_status_t status;
   uint64_t client_write_start_timestamp_ns;
   uint64_t client_write_end_timestamp_ns;

--- a/lib/CL/devices/remote/communication.h
+++ b/lib/CL/devices/remote/communication.h
@@ -323,7 +323,8 @@ cl_int pocl_network_setup_devinfo (cl_device_id device,
                                    uint32_t did);
 
 cl_int pocl_network_create_buffer (remote_device_data_t *d, uint32_t mem_id,
-                                   uint32_t mem_flags, uint64_t mem_size);
+                                   uint32_t mem_flags, uint64_t mem_size,
+                                   void **device_addr);
 
 cl_int pocl_network_free_buffer (remote_device_data_t *d, uint32_t mem_id);
 

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -79,7 +79,8 @@ pocl_remote_alloc_mem_obj (cl_device_id device, cl_mem mem, void *host_ptr)
     }
   else
     {
-      r = pocl_network_create_buffer (d, mem->id, mem->flags, mem->size);
+      r = pocl_network_create_buffer (d, mem->id, mem->flags, mem->size,
+                                      &p->device_addr);
     }
 
   if (r != 0)

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -952,8 +952,9 @@ struct _cl_device_id {
      Used for indexing arrays in data structures with device specific
      entries. */
   int dev_id;
-  int global_mem_id; /* identifier for device global memory */
-  /* pointer to an accounting struct for global memory */
+  /* Identifier for a physical device global memory. */
+  int global_mem_id;
+  /* Pointer to an accounting struct for global memory */
   pocl_global_mem_t *global_memory;
   /* Does the device have 64bit longs */
   int has_64bit_long;
@@ -1391,7 +1392,7 @@ struct _cl_mem {
   uint mem_host_ptr_refcount;
   int mem_host_ptr_is_svm;
 
-  /* array of device-specific memory bookkeeping structs.
+  /* Array of device-specific memory allocation bookkeeping structs.
      The location of some device's struct is determined by
      the device's global_mem_id. */
   pocl_mem_identifier *device_ptrs;
@@ -1440,6 +1441,11 @@ struct _cl_mem {
    * valid through the entire lifetime of the buffer,
    * we can make some assumptions and optimizations */
   cl_bool mem_host_ptr_is_permanent;
+
+  /* If the allocation was requested to be permanent on the device
+     global memory (until freed). This is set via CL_MEM_PINNED
+     flag of cl_pocl_pinned_buffers extension. */
+  cl_bool is_device_pinned;
 
   /* Image flags */
   cl_bool                 is_image;

--- a/lib/CL/pocl_debug.c
+++ b/lib/CL/pocl_debug.c
@@ -1,7 +1,29 @@
+/* OpenCL runtime library: PoCL debug functions
+
+   Copyright (c) 2015-2023 PoCL developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
 #include <ctype.h>
-#include <string.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "pocl_debug.h"
 #include "pocl_threads.h"
@@ -14,202 +36,172 @@ int pocl_stderr_is_a_tty;
 
 static pocl_lock_t console_mutex;
 
-    void
-    pocl_debug_output_lock (void)
-    {
-      POCL_LOCK (console_mutex);
-    }
+void pocl_debug_output_lock(void) { POCL_LOCK(console_mutex); }
 
-    void
-    pocl_debug_output_unlock (void)
-    {
-      POCL_UNLOCK (console_mutex);
-    }
+void pocl_debug_output_unlock(void) { POCL_UNLOCK(console_mutex); }
 
-    void
-    pocl_debug_messages_setup (const char* debug)
-    {
-      POCL_INIT_LOCK (console_mutex);
-      pocl_debug_messages_filter = 0;
-      if (strlen (debug) == 1)
-        {
-          if (debug[0] == '1')
-            pocl_debug_messages_filter = POCL_DEBUG_FLAG_GENERAL
-                                         | POCL_DEBUG_FLAG_WARNING
-                                         | POCL_DEBUG_FLAG_ERROR;
-          return;
-        }
-      /* else parse */
-      char* tokenize = strdup (debug);
-      for(int i =0; i < strlen (tokenize); i++){
-          tokenize[i] = tolower(tokenize[i]);
-        }
-      char* ptr = NULL;
-      ptr = strtok (tokenize, ",");
+void pocl_debug_messages_setup(const char *debug) {
+  POCL_INIT_LOCK(console_mutex);
+  pocl_debug_messages_filter = 0;
+  if (strlen(debug) == 1) {
+    if (debug[0] == '1')
+      pocl_debug_messages_filter = POCL_DEBUG_FLAG_GENERAL |
+                                   POCL_DEBUG_FLAG_WARNING |
+                                   POCL_DEBUG_FLAG_ERROR;
+    return;
+  }
+  /* else parse */
+  char *tokenize = strdup(debug);
+  for (int i = 0; i < strlen(tokenize); i++) {
+    tokenize[i] = tolower(tokenize[i]);
+  }
+  char *ptr = NULL;
+  ptr = strtok(tokenize, ",");
 
-      while (ptr != NULL)
-      {
-        if (strncmp (ptr, "general", 7) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_GENERAL;
-        else if (strncmp (ptr, "level0", 6) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_LEVEL0;
-        else if (strncmp (ptr, "vulkan", 6) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_VULKAN;
-        else if (strncmp (ptr, "remote", 6) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_REMOTE;
-        else if (strncmp (ptr, "event", 5) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_EVENTS;
-        else if (strncmp (ptr, "cache", 5) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_CACHE;
-        else if (strncmp (ptr, "proxy", 5) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_PROXY;
-        else if (strncmp (ptr, "llvm", 4) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_LLVM;
-        else if (strncmp (ptr, "refc", 4) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_REFCOUNTS;
-        else if (strncmp (ptr, "lock", 4) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_LOCKING;
-        else if (strncmp (ptr, "cuda", 4) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_CUDA;
-        else if (strncmp (ptr, "almaif", 6) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_ALMAIF;
-        else if (strncmp (ptr, "mmap", 4) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_ALMAIF_MMAP;
-        else if (strncmp (ptr, "warn", 4) == 0)
-          pocl_debug_messages_filter |= (POCL_DEBUG_FLAG_WARNING | POCL_DEBUG_FLAG_ERROR);
-        else if (strncmp (ptr, "hsa", 3) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_HSA;
-        else if (strncmp (ptr, "tce", 3) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_TCE;
-        else if (strncmp (ptr, "mem", 3) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_MEMORY;
-        else if (strncmp (ptr, "tim", 3) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_TIMING;
-        else if (strncmp (ptr, "all", 3) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_ALL;
-        else if (strncmp (ptr, "err", 3) == 0)
-          pocl_debug_messages_filter |= POCL_DEBUG_FLAG_ERROR;
-        else
-          POCL_MSG_WARN ("Unknown token in POCL_DEBUG env var: %s", ptr);
+  while (ptr != NULL) {
+    if (strncmp(ptr, "general", 7) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_GENERAL;
+    else if (strncmp(ptr, "level0", 6) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_LEVEL0;
+    else if (strncmp(ptr, "vulkan", 6) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_VULKAN;
+    else if (strncmp(ptr, "remote", 6) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_REMOTE;
+    else if (strncmp(ptr, "event", 5) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_EVENTS;
+    else if (strncmp(ptr, "cache", 5) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_CACHE;
+    else if (strncmp(ptr, "proxy", 5) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_PROXY;
+    else if (strncmp(ptr, "llvm", 4) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_LLVM;
+    else if (strncmp(ptr, "refc", 4) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_REFCOUNTS;
+    else if (strncmp(ptr, "lock", 4) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_LOCKING;
+    else if (strncmp(ptr, "cuda", 4) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_CUDA;
+    else if (strncmp(ptr, "almaif", 6) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_ALMAIF;
+    else if (strncmp(ptr, "mmap", 4) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_ALMAIF_MMAP;
+    else if (strncmp(ptr, "warn", 4) == 0)
+      pocl_debug_messages_filter |=
+          (POCL_DEBUG_FLAG_WARNING | POCL_DEBUG_FLAG_ERROR);
+    else if (strncmp(ptr, "hsa", 3) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_HSA;
+    else if (strncmp(ptr, "tce", 3) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_TCE;
+    else if (strncmp(ptr, "mem", 3) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_MEMORY;
+    else if (strncmp(ptr, "tim", 3) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_TIMING;
+    else if (strncmp(ptr, "all", 3) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_ALL;
+    else if (strncmp(ptr, "err", 3) == 0)
+      pocl_debug_messages_filter |= POCL_DEBUG_FLAG_ERROR;
+    else
+      POCL_MSG_WARN("Unknown token in POCL_DEBUG env var: %s", ptr);
 
-        ptr = strtok (NULL,",");
-      }
+    ptr = strtok(NULL, ",");
+  }
 
-      free (tokenize);
-      if (pocl_debug_messages_filter)
-        log_printf ("** Final POCL_DEBUG flags: %" PRIX64 " \n",
-                    pocl_debug_messages_filter);
-    }
+  free(tokenize);
+}
 
-    void
-    pocl_debug_print_header (const char* func, unsigned line,
-                             const char *filter, int filter_type)
-    {
+void pocl_debug_print_header(const char *func, unsigned line,
+                             const char *filter, int filter_type) {
 
-        int year, mon, day, hour, min, sec, nanosec;
-        pocl_gettimereal(&year, &mon, &day, &hour, &min, &sec, &nanosec);
+  int year, mon, day, hour, min, sec, nanosec;
+  pocl_gettimereal(&year, &mon, &day, &hour, &min, &sec, &nanosec);
 
-        const char *filter_type_str;
-        const char *formatstring;
+  const char *filter_type_str;
+  const char *formatstring;
 
-        if (filter_type == POCL_FILTER_TYPE_ERR)
-          filter_type_str = (pocl_stderr_is_a_tty ? POCL_COLOR_RED : " *** ERROR *** ");
-        else if (filter_type == POCL_FILTER_TYPE_WARN)
-          filter_type_str = (pocl_stderr_is_a_tty ? POCL_COLOR_YELLOW : " *** WARNING *** ");
-        else if (filter_type == POCL_FILTER_TYPE_INFO)
-          filter_type_str = (pocl_stderr_is_a_tty ? POCL_COLOR_GREEN : " *** INFO *** ");
-        else
-          filter_type_str = (pocl_stderr_is_a_tty ? POCL_COLOR_GREEN : " *** UNKNOWN *** ");
+  if (filter_type == POCL_FILTER_TYPE_ERR)
+    filter_type_str =
+        (pocl_stderr_is_a_tty ? POCL_COLOR_RED : " *** ERROR *** ");
+  else if (filter_type == POCL_FILTER_TYPE_WARN)
+    filter_type_str =
+        (pocl_stderr_is_a_tty ? POCL_COLOR_YELLOW : " *** WARNING *** ");
+  else if (filter_type == POCL_FILTER_TYPE_INFO)
+    filter_type_str =
+        (pocl_stderr_is_a_tty ? POCL_COLOR_GREEN : " *** INFO *** ");
+  else
+    filter_type_str =
+        (pocl_stderr_is_a_tty ? POCL_COLOR_GREEN : " *** UNKNOWN *** ");
 
-        if (pocl_stderr_is_a_tty)
-          formatstring = POCL_COLOR_BLUE
-              "[%04i-%02i-%02i %02i:%02i:%02i.%09li]"
-              POCL_COLOR_RESET "POCL: in fn %s "
-              POCL_COLOR_RESET "at line %u:\n %s | %9s | ";
-        else
-          formatstring = "[%04i-%02i-%02i %02i:%02i:%02i.%09i] "
-              "POCL: in fn %s at line %u:\n %s | %9s | ";
+  if (pocl_stderr_is_a_tty)
+    formatstring = POCL_COLOR_BLUE
+        "[%04i-%02i-%02i %02i:%02i:%02i.%09li]" POCL_COLOR_RESET
+        "POCL: in fn %s " POCL_COLOR_RESET "at line %u:\n %s | %9s | ";
+  else
+    formatstring = "[%04i-%02i-%02i %02i:%02i:%02i.%09i] "
+                   "POCL: in fn %s at line %u:\n %s | %9s | ";
 
-        log_printf (formatstring, year, mon, day, hour, min, sec, nanosec,
-                    func, line, filter_type_str, filter);
-    }
+  log_printf(formatstring, year, mon, day, hour, min, sec, nanosec, func, line,
+             filter_type_str, filter);
+}
 
-    void pocl_debug_measure_start(uint64_t *start) {
-      *start = pocl_gettimemono_ns();
-    }
+void pocl_debug_measure_start(uint64_t *start) {
+  *start = pocl_gettimemono_ns();
+}
 
-#define PRINT_DURATION(func, line, ...)                                       \
-  do                                                                          \
-    {                                                                         \
-      pocl_debug_output_lock ();                                              \
-      pocl_debug_print_header (func, line, "TIMING", POCL_FILTER_TYPE_INFO);  \
-      log_printf (__VA_ARGS__);                                               \
-      pocl_debug_output_unlock ();                                            \
-    }                                                                         \
-  while (0)
+#define PRINT_DURATION(func, line, ...)                                        \
+  do {                                                                         \
+    pocl_debug_output_lock();                                                  \
+    pocl_debug_print_header(func, line, "TIMING", POCL_FILTER_TYPE_INFO);      \
+    log_printf(__VA_ARGS__);                                                   \
+    pocl_debug_output_unlock();                                                \
+  } while (0)
 
-    void pocl_debug_print_duration(const char* func, unsigned line,
-                                   const char* msg, uint64_t nanosecs)
-    {
-      if (!(pocl_debug_messages_filter & POCL_DEBUG_FLAG_TIMING))
-        return;
-      const char* formatstring;
-      if (pocl_stderr_is_a_tty)
-        formatstring = "      >>>  " POCL_COLOR_MAGENTA "     %3" PRIu64
-                       ".%03" PRIu64 " " POCL_COLOR_RESET " %s    %s\n";
-      else
-        formatstring = "      >>>       %3" PRIu64 ".%03"
-                       PRIu64 "  %s    %s\n";
+void pocl_debug_print_duration(const char *func, unsigned line, const char *msg,
+                               uint64_t nanosecs) {
+  if (!(pocl_debug_messages_filter & POCL_DEBUG_FLAG_TIMING))
+    return;
+  const char *formatstring;
+  if (pocl_stderr_is_a_tty)
+    formatstring = "      >>>  " POCL_COLOR_MAGENTA "     %3" PRIu64
+                   ".%03" PRIu64 " " POCL_COLOR_RESET " %s    %s\n";
+  else
+    formatstring = "      >>>       %3" PRIu64 ".%03" PRIu64 "  %s    %s\n";
 
-      uint64_t nsec = nanosecs % 1000000000;
-      uint64_t sec = nanosecs / 1000000000;
-      uint64_t a, b;
+  uint64_t nsec = nanosecs % 1000000000;
+  uint64_t sec = nanosecs / 1000000000;
+  uint64_t a, b;
 
-      if ((sec == 0) && (nsec < 1000))
-        {
-          b = nsec % 1000;
-          if (pocl_stderr_is_a_tty)
-            formatstring = "      >>>      " POCL_COLOR_MAGENTA
-                    "     %3" PRIu64 " " POCL_COLOR_RESET " ns    %s\n";
-          else
-            formatstring = "      >>>           %3" PRIu64 "  ns    %s\n";
-          PRINT_DURATION (func, line, formatstring, b, msg);
-        }
-      else if ((sec == 0) && (nsec < 1000000))
-        {
-          a = nsec / 1000;
-          b = nsec % 1000;
-          PRINT_DURATION (func, line, formatstring, a, b, "us", msg);
-        }
-      else if (sec == 0)
-        {
-          a = nsec / 1000000;
-          b = (nsec % 1000000) / 1000;
-          PRINT_DURATION (func, line, formatstring, a, b, "ms", msg);
-        }
-      else
-        {
-          if (pocl_stderr_is_a_tty)
-            formatstring = "      >>>  " POCL_COLOR_MAGENTA "     %3" PRIu64
-                           ".%09" PRIu64 " " POCL_COLOR_RESET " %s    %s\n";
-          else
-            formatstring = "      >>>       %3" PRIu64 ".%09"
-                           PRIu64 "  %s    %s\n";
+  if ((sec == 0) && (nsec < 1000)) {
+    b = nsec % 1000;
+    if (pocl_stderr_is_a_tty)
+      formatstring = "      >>>      " POCL_COLOR_MAGENTA "     %3" PRIu64
+                     " " POCL_COLOR_RESET " ns    %s\n";
+    else
+      formatstring = "      >>>           %3" PRIu64 "  ns    %s\n";
+    PRINT_DURATION(func, line, formatstring, b, msg);
+  } else if ((sec == 0) && (nsec < 1000000)) {
+    a = nsec / 1000;
+    b = nsec % 1000;
+    PRINT_DURATION(func, line, formatstring, a, b, "us", msg);
+  } else if (sec == 0) {
+    a = nsec / 1000000;
+    b = (nsec % 1000000) / 1000;
+    PRINT_DURATION(func, line, formatstring, a, b, "ms", msg);
+  } else {
+    if (pocl_stderr_is_a_tty)
+      formatstring = "      >>>  " POCL_COLOR_MAGENTA "     %3" PRIu64
+                     ".%09" PRIu64 " " POCL_COLOR_RESET " %s    %s\n";
+    else
+      formatstring = "      >>>       %3" PRIu64 ".%09" PRIu64 "  %s    %s\n";
 
-          PRINT_DURATION (func, line, formatstring, sec, nsec, "s", msg);
-        }
+    PRINT_DURATION(func, line, formatstring, sec, nsec, "s", msg);
+  }
+}
 
-    }
-
-
-
-    void pocl_debug_measure_finish(uint64_t *start, uint64_t *finish,
-                                   const char* msg,
-                                   const char* func,
-                                   unsigned line) {
-      *finish = pocl_gettimemono_ns();
-      pocl_debug_print_duration(func, line, msg, (*finish - *start) );
-    }
-
+void pocl_debug_measure_finish(uint64_t *start, uint64_t *finish,
+                               const char *msg, const char *func,
+                               unsigned line) {
+  *finish = pocl_gettimemono_ns();
+  pocl_debug_print_duration(func, line, msg, (*finish - *start));
+}
 
 #endif

--- a/lib/CL/pocl_networking.c
+++ b/lib/CL/pocl_networking.c
@@ -59,6 +59,8 @@ pocl_resolve_address (const char *address, uint16_t port, int *error)
 
   hint.ai_flags = is_numeric ? AI_NUMERICHOST
                              : (AI_ADDRCONFIG | AI_CANONNAME | AI_V4MAPPED);
+  if (address == NULL)
+    hint.ai_flags = AI_PASSIVE;
   hint.ai_flags |= AI_NUMERICSERV;
 
   struct addrinfo *info;

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -341,6 +341,27 @@ void pocl_str_tolower (char *out, const char *in);
     }                                                                         \
   while (0)
 
+/* Version for handling only the size checking and returning.
+   Assigning the data and returning is left to the caller. */
+#define POCL_RETURN_GETINFO_SIZE_CHECK(__SIZE__)                              \
+do                                                                            \
+  {                                                                           \
+    if (param_value)                                                          \
+      {                                                                       \
+        POCL_RETURN_ERROR_ON (                                                \
+            (param_value_size < __SIZE__), CL_INVALID_VALUE,                  \
+            "param_value_size (%zu) smaller than actual size (%zu)\n",        \
+            param_value_size, __SIZE__);                                      \
+      }                                                                       \
+    if (param_value_size_ret)                                                 \
+      {                                                                       \
+        *param_value_size_ret = __SIZE__;                                     \
+        if (param_value == NULL)                                              \
+          return CL_SUCCESS;                                                  \
+      }                                                                       \
+  }                                                                           \
+while (0)
+
 #define POCL_RETURN_GETINFO_SIZE(__SIZE__, __POINTER__)                 \
   POCL_RETURN_GETINFO_INNER(__SIZE__,                                   \
     memcpy(param_value, __POINTER__, __SIZE__))

--- a/pocld/common.hh
+++ b/pocld/common.hh
@@ -441,6 +441,9 @@ struct EventPair {
 
 std::string hexstr(const std::string &);
 
+// Type for the buffer allocation identifier.
+typedef uint32_t BufferId_t;
+
 #ifdef __GNUC__
 #pragma GCC visibility pop
 #endif

--- a/pocld/shared_cl_context.hh
+++ b/pocld/shared_cl_context.hh
@@ -68,7 +68,7 @@ public:
   /************************************************************************/
 
   virtual int createBuffer(uint32_t buffer_id, size_t size, uint64_t flags,
-                           void *host_ptr) = 0;
+                           void *host_ptr, void **device_addr) = 0;
 
   virtual int freeBuffer(uint32_t buffer_id) = 0;
 

--- a/pocld/shared_cl_context.hh
+++ b/pocld/shared_cl_context.hh
@@ -92,7 +92,8 @@ public:
 
   virtual int freeQueue(uint32_t queue_id) = 0;
 
-  virtual int getDeviceInfo(uint32_t device_id, DeviceInfo_t &i) = 0;
+  virtual int getDeviceInfo(uint32_t device_id, DeviceInfo_t &i,
+                            std::vector<std::string>& strings) = 0;
 
   virtual int createSampler(uint32_t sampler_id, uint32_t normalized,
                             uint32_t address, uint32_t filter) = 0;

--- a/pocld/virtual_cl_context.cc
+++ b/pocld/virtual_cl_context.cc
@@ -1111,10 +1111,9 @@ void VirtualCLContext::DeviceInfo(Request *req, Reply *rep) {
   for (const std::string& str : strings) {
     // Append the strings to the string part of the reply, and
     // ensure that the strings are separated with \0.
-    std::memcpy(strings_pos, str.c_str(), str.size());
-    strings_pos += str.size();
-    *strings_pos = 0;
-    strings_pos++;
+    // str.c_str() is guaranteed to have a null byte after its last position
+    std::memcpy(strings_pos, str.c_str(), str.size() + 1);
+    strings_pos += str.size() + 1;
   }
 
   replyData(rep, MessageType_DeviceInfoReply, rep->extra_size);

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -34,7 +34,7 @@ endif ()
 
 include_directories(${CMAKE_SOURCE_DIR})
 
-set(PROGRAMS_TO_BUILD test_clFinish test_clGetDeviceInfo test_clGetEventInfo
+set(C_PROGRAMS_TO_BUILD test_clFinish test_clGetDeviceInfo test_clGetEventInfo
   test_clCreateProgramWithBinary test_clGetSupportedImageFormats
   test_clSetEventCallback test_clEnqueueNativeKernel test_clBuildProgram
   test_clCreateKernelsInProgram test_clCreateKernel test_clGetKernelArgInfo
@@ -46,13 +46,21 @@ set(PROGRAMS_TO_BUILD test_clFinish test_clGetDeviceInfo test_clGetEventInfo
   test_cl_pocl_content_size test_cl_pocl_content_size_migration
   test_deviceside_enqueue test_command_buffer test_command_buffer_images)
 
+set(CXX_PROGRAMS_TO_BUILD test_pinned_buffers)
+
 add_compile_options(${OPENCL_CFLAGS})
 
-foreach(PROG ${PROGRAMS_TO_BUILD})
+foreach(PROG ${C_PROGRAMS_TO_BUILD})
   if(MSVC)
     set_source_files_properties( "${PROG}.c" PROPERTIES LANGUAGE CXX )
   endif(MSVC)
   add_executable("${PROG}" "${PROG}.c")
+  target_link_libraries("${PROG}" ${POCLU_LINK_OPTIONS})
+endforeach()
+
+foreach(PROG ${CXX_PROGRAMS_TO_BUILD})
+  set_source_files_properties( "${PROG}.cpp" PROPERTIES LANGUAGE CXX )
+  add_executable("${PROG}" "${PROG}.cpp")
   target_link_libraries("${PROG}" ${POCLU_LINK_OPTIONS})
 endforeach()
 
@@ -126,6 +134,8 @@ add_test(NAME "runtime/test_command_buffer" COMMAND "test_command_buffer")
 
 add_test(NAME "runtime/test_command_buffer_images" COMMAND "test_command_buffer_images")
 
+add_test(NAME "runtime/test_pinned_buffers" COMMAND "test_pinned_buffers")
+
 set_tests_properties( "runtime/clGetDeviceInfo" "runtime/clEnqueueNativeKernel"
   "runtime/clGetEventInfo" "runtime/clCreateProgramWithBinary"
   "runtime/clBuildProgram" "runtime/clFinish" "runtime/clSetEventCallback"
@@ -141,6 +151,7 @@ set_tests_properties( "runtime/clGetDeviceInfo" "runtime/clEnqueueNativeKernel"
   "runtime/clSetMemObjectDestructorCallback" "runtime/test_link_error"
   "runtime/test_cl_pocl_content_size" "runtime/test_deviceside_enqueue"
   "runtime/test_command_buffer" "runtime/test_command_buffer_images"
+  "runtime/test_pinned_buffers"
   PROPERTIES
     COST 2.0
     PROCESSORS 1
@@ -157,6 +168,7 @@ set_tests_properties(
   "runtime/clEnqueueNativeKernel"
   "runtime/test_command_buffer"
   "runtime/test_command_buffer_images"
+  "runtime/test_pinned_buffers"
   PROPERTIES SKIP_RETURN_CODE 77)
 
 if(ENABLE_REMOTE_CLIENT AND ENABLE_REMOTE_SERVER AND ENABLE_HOST_CPU_DEVICES)
@@ -214,6 +226,8 @@ if(ENABLE_REMOTE_CLIENT AND ENABLE_REMOTE_SERVER AND ENABLE_HOST_CPU_DEVICES)
            COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/scripts/test_remote_runner_single.sh" "${CMAKE_BINARY_DIR}" "tests/runtime/test_command_buffer")
   add_test(NAME "remote/test_command_buffer_images"
            COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/scripts/test_remote_runner_single.sh" "${CMAKE_BINARY_DIR}" "tests/runtime/test_command_buffer_images")
+  add_test(NAME "remote/test_pinned_buffers"
+           COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/scripts/test_remote_runner_single.sh" "${CMAKE_BINARY_DIR}" "tests/runtime/test_pinned_buffers")
 
   set_tests_properties(
     "remote/clCreateSubDevices"
@@ -227,6 +241,7 @@ if(ENABLE_REMOTE_CLIENT AND ENABLE_REMOTE_SERVER AND ENABLE_HOST_CPU_DEVICES)
     "remote/clEnqueueNativeKernel"
     "remote/test_command_buffer"
     "remote/test_command_buffer_images"
+    "remote/test_pinned_buffers"
     PROPERTIES SKIP_RETURN_CODE 77)
 
   set_tests_properties(
@@ -245,6 +260,7 @@ if(ENABLE_REMOTE_CLIENT AND ENABLE_REMOTE_SERVER AND ENABLE_HOST_CPU_DEVICES)
     "remote/test_cl_pocl_content_size_migration_remote_remote"
     "remote/test_deviceside_enqueue"
     "remote/test_command_buffer" "remote/test_command_buffer_images"
+    "remote/test_pinned_buffers"
     PROPERTIES
       PASS_REGULAR_EXPRESSION "OK"
       COST 2.0

--- a/tests/runtime/test_pinned_buffers.cpp
+++ b/tests/runtime/test_pinned_buffers.cpp
@@ -23,12 +23,8 @@
 
 // Enable OpenCL C++ exceptions
 #define CL_HPP_ENABLE_EXCEPTIONS
-#define CL_TARGET_OPENCL_VERSION 300
-#define CL_HPP_MINIMUM_OPENCL_VERSION 300
-#define CL_HPP_TARGET_OPENCL_VERSION 300
 
-// Ensure we use the PoCL's headers since the system headers might be too
-// old for getting the OpenCL v3.0 version in.
+#include "../../include/CL/cl_ext_pocl.h"
 #include <CL/opencl.hpp>
 
 #include <cstdio>

--- a/tests/runtime/test_pinned_buffers.cpp
+++ b/tests/runtime/test_pinned_buffers.cpp
@@ -1,0 +1,209 @@
+/* Test the pinned buffers extension.
+
+   Copyright (c) 2023 Pekka Jääskeläinen / Intel Finland Oy
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+// Enable OpenCL C++ exceptions
+#define CL_HPP_ENABLE_EXCEPTIONS
+#define CL_TARGET_OPENCL_VERSION 300
+#define CL_HPP_MINIMUM_OPENCL_VERSION 300
+#define CL_HPP_TARGET_OPENCL_VERSION 300
+
+// Ensure we use the PoCL's headers since the system headers might be too
+// old for getting the OpenCL v3.0 version in.
+#include <CL/opencl.hpp>
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <random>
+
+#include "pocl_opencl.h"
+
+#define BUF_SIZE 16
+
+static char GetAddrSourceCode[] = R"raw(
+
+  __kernel void get_addr (__global int *pinned_buffer,
+                          __global ulong* addr) {
+    for (int i = 0; i < BUF_SIZE; ++i)
+      pinned_buffer[i] += 1;
+    *addr = (ulong)pinned_buffer;
+  }
+)raw";
+
+void *getDeviceAddressFromHost(cl::Buffer &Buf) {
+  cl_mem_pinning Pinning;
+
+  Buf.getInfo(CL_MEM_DEVICE_PTRS, &Pinning);
+  return Pinning.address;
+}
+
+int main(void) {
+
+  unsigned Errors = 0;
+  bool AllOK = true;
+
+  try {
+    std::vector<cl::Platform> PlatformList;
+
+    cl::Platform::get(&PlatformList);
+
+    cl_context_properties cprops[] = {
+        CL_CONTEXT_PLATFORM, (cl_context_properties)(PlatformList[0])(), 0};
+    cl::Context Context(CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU, cprops);
+
+    std::vector<cl::Device> Devices = Context.getInfo<CL_CONTEXT_DEVICES>();
+
+    std::vector<cl::Device> SuitableDevices;
+
+    for (cl::Device &Dev : Devices) {
+      std::string Exts = Dev.getInfo<CL_DEVICE_EXTENSIONS>();
+      if (Exts.find("cl_pocl_pinned_buffers") != std::string::npos) {
+        SuitableDevices.push_back(Dev);
+        break;
+      }
+    }
+
+    if (SuitableDevices.empty()) {
+      std::cout << "No devices with cl_pocl_pinned_buffers found.";
+      return 77;
+    }
+    int PinnedBufferHost[BUF_SIZE];
+    int PinnedBufferHost2[BUF_SIZE];
+
+    for (int i = 0; i < BUF_SIZE; ++i) {
+      PinnedBufferHost[i] = i;
+      PinnedBufferHost2[i] = i + 1;
+    }
+
+    cl_ulong DeviceAddrFromKernel = 1;
+
+    cl::CommandQueue Queue(Context, SuitableDevices[0], 0);
+
+    cl::Program::Sources Sources({GetAddrSourceCode});
+    cl::Program Program(Context, Sources);
+
+#define STRINGIFY(X, Y) X #Y
+#define SET_BUF_SIZE(NUM) STRINGIFY("-DBUF_SIZE=", NUM)
+
+    Program.build(SuitableDevices, SET_BUF_SIZE(BUF_SIZE));
+
+    cl::Kernel GetAddrKernel(Program, "get_addr");
+
+    cl::Buffer PinnedCLBuffer = cl::Buffer(
+        Context, CL_MEM_READ_WRITE | CL_MEM_PINNED | CL_MEM_COPY_HOST_PTR,
+        BUF_SIZE * sizeof(cl_int), (void *)&PinnedBufferHost[0]);
+
+    if (getDeviceAddressFromHost(PinnedCLBuffer) == nullptr) {
+      std::cerr << "Pinned buffers should get allocated immediately to get the "
+                   "address assigned."
+                << std::endl;
+      return EXIT_FAILURE;
+    }
+
+    cl::Buffer AddrCLBuffer =
+        cl::Buffer(Context, CL_MEM_WRITE_ONLY, sizeof(cl_ulong), nullptr);
+
+    GetAddrKernel.setArg(0, PinnedCLBuffer);
+    GetAddrKernel.setArg(1, AddrCLBuffer);
+
+    Queue.enqueueNDRangeKernel(GetAddrKernel, cl::NullRange, cl::NDRange(1),
+                               cl::NullRange);
+
+    Queue.enqueueReadBuffer(PinnedCLBuffer,
+                            CL_TRUE, // block
+                            0, BUF_SIZE * sizeof(cl_int),
+                            (void *)&PinnedBufferHost[0]);
+
+    Queue.enqueueReadBuffer(AddrCLBuffer,
+                            CL_TRUE, // block
+                            0, sizeof(cl_ulong), (void *)&DeviceAddrFromKernel);
+
+    AllOK = true;
+    for (int i = 0; i < BUF_SIZE; ++i) {
+      if (PinnedBufferHost[i] != i + 1) {
+        AllOK = false;
+        std::cerr << "PinnedBufferHost[" << i << "] expected to be " << i + 1
+                  << " but got " << PinnedBufferHost[i] << std::endl;
+      }
+    }
+
+    if (getDeviceAddressFromHost(PinnedCLBuffer) !=
+        (void *)DeviceAddrFromKernel) {
+      std::cerr << "Pinned buffer's device address on kernel side and host "
+                   "side do not match"
+                << std::endl;
+      return EXIT_FAILURE;
+    }
+
+    // Test a buffer which doesn't have any hostptr associated with it.
+    cl::Buffer PinnedCLBufferNoHostCopy =
+        cl::Buffer(Context, CL_MEM_PINNED, BUF_SIZE * sizeof(cl_int), nullptr);
+
+    GetAddrKernel.setArg(0, PinnedCLBufferNoHostCopy);
+
+    Queue.enqueueWriteBuffer(PinnedCLBufferNoHostCopy,
+                             CL_TRUE, // block
+                             0, BUF_SIZE * sizeof(cl_int),
+                             (void *)&PinnedBufferHost[0]);
+
+    Queue.enqueueNDRangeKernel(GetAddrKernel, cl::NullRange, cl::NDRange(1),
+                               cl::NullRange);
+
+    Queue.enqueueReadBuffer(PinnedCLBufferNoHostCopy,
+                            CL_TRUE, // block
+                            0, BUF_SIZE * sizeof(cl_int),
+                            (void *)&PinnedBufferHost2[0]);
+
+    Queue.enqueueReadBuffer(AddrCLBuffer,
+                            CL_TRUE, // block
+                            0, sizeof(cl_ulong), (void *)&DeviceAddrFromKernel);
+
+    for (int i = 0; i < BUF_SIZE; ++i) {
+      if (PinnedBufferHost2[i] != i + 2) {
+        AllOK = false;
+        std::cerr << "PinnedBufferHost2[" << i << "] expected to be " << i + 2
+                  << " but got " << PinnedBufferHost2[i] << std::endl;
+      }
+    }
+
+    if (getDeviceAddressFromHost(PinnedCLBufferNoHostCopy) !=
+        (void *)DeviceAddrFromKernel) {
+      std::cerr << "Pinned buffer's device address on kernel side and host "
+                   "side do not match"
+                << std::endl;
+      return EXIT_FAILURE;
+    }
+
+  } catch (cl::Error &err) {
+    std::cerr << "ERROR: " << err.what() << "(" << err.err() << ")"
+              << std::endl;
+  }
+
+  CHECK_CL_ERROR (clUnloadCompiler ());
+
+  if (AllOK) {
+    std::cout << "OK" << std::endl;
+    return EXIT_SUCCESS;
+  } else
+    return EXIT_FAILURE;
+}

--- a/tools/scripts/run_remote_tests
+++ b/tools/scripts/run_remote_tests
@@ -27,4 +27,7 @@
 #
 # The current tests are run through a wrapper script that handles setting the
 # necessary environment variables so there is not much left to do here.
-ctest -L remote
+#
+# Parallel testing doesn't seem to work reliably due to pocld not always
+# dying fast enough (?).
+ctest -j1 -L remote


### PR DESCRIPTION
This is a first step to support raw pointer-type of memory management on remote. It provides cudaMalloc()-level of functionality where the implementation can return a device pointer without needing to map it to the host virtual memory. It's done via an experimental `pocl_pinned_buffers` extensions to the basic clCreateBuffer() API: With CL_MEM_PINNED, the buffer is allocated permanently to the device's global memory with a fixed address until the buffer is freed. The address can be queried with clGetMemObjectInfo().

This (to my understanding) should be sufficient to also support minimal (buffer based) SYCL with AdaptiveCpp.

It's implemented for PoCL-CPU by trivially setting the device address to the allocated host ptr. PoCL-remote uses the target driver's coarse grained SVM for the permanent allocation.
