### PR TITLE
Pocld socket rework

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -234,6 +234,46 @@ jobs:
           mkdir ${{ env.POCL_CACHE_DIR }}
           cd ${{ github.workspace }}/build && ${{ github.workspace }}/tools/scripts/run_remote_tests $CTEST_FLAGS -E test_command_buffer
 
+  rdma_matrix:
+    name: LLVM ${{ matrix.llvm }} - rdma
+    runs-on: [self-hosted, linux, x64, rdma]
+    strategy:
+      fail-fast: false
+      matrix:
+        llvm: [16]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: CMake
+        id: cmake
+        run: |
+          runCMake() {
+            BUILD_FLAGS="-O1 -march=native -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable"
+            cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DDEVELOPER_MODE=ON \
+            -DENABLE_HOST_CPU_DEVICES=1 -DENABLE_LEVEL0=0 -DENABLE_REMOTE_CLIENT=1 -DENABLE_REMOTE_SERVER=1 -DENABLE_RDMA=1 \
+            -DENABLE_LOADABLE_DRIVERS=0 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="$BUILD_FLAGS" \
+            -DCMAKE_CXX_FLAGS_RELEASE="$BUILD_FLAGS" -DWITH_LLVM_CONFIG=/usr/bin/llvm-config-${{ matrix.llvm }} \
+            -DENABLE_ICD=1 "$@" -B ${{ github.workspace }}/build ${{ github.workspace }}
+          }
+
+          rm -rf ${{ github.workspace }}/build
+          mkdir ${{ github.workspace }}/build
+          runCMake
+
+      - name: Build PoCL
+        id: build_pocl
+        timeout-minutes: 20
+        run: |
+          cd ${{ github.workspace }}/build && make -j4
+
+      - name: Run Tests
+        id: ctest
+        run: |
+          rm -rf ${{ env.POCL_CACHE_DIR }}
+          mkdir ${{ env.POCL_CACHE_DIR }}
+          cd ${{ github.workspace }}/build && ctest -L remote_rdma
+
   cuda_matrix:
     name: LLVM ${{ matrix.llvm }} - ${{ matrix.config }}
     runs-on: [self-hosted, linux, x64, cuda]

--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -564,7 +564,7 @@ pocl_network_connect (remote_server_data_t *data, int *fd, unsigned port,
   addrlen = ai->ai_addrlen;
 
   POCL_RETURN_ERROR_ON (
-      ((socket_fd = socket (ai->ai_family, ai->ai_socktype, 0)) == -1),
+      ((socket_fd = socket (ai->ai_family, ai->ai_socktype, IPPROTO_TCP)) == -1),
       CL_INVALID_DEVICE, "socket() returned errno: %i\n", errno);
   freeaddrinfo (ai);
 

--- a/lib/CL/devices/remote/communication.h
+++ b/lib/CL/devices/remote/communication.h
@@ -134,10 +134,10 @@ struct network_command
   const char *req_extra_data;
   const char *req_extra_data2;
   char *rep_extra_data;
-  size_t req_waitlist_size;
-  size_t req_extra_size;
-  size_t req_extra_size2;
-  size_t rep_extra_size;
+  uint64_t req_waitlist_size;
+  uint64_t req_extra_size;
+  uint64_t req_extra_size2;
+  uint64_t rep_extra_size;
   /* Points to an (optional) dynamic strings section appened after the message.
    */
   char *strings;

--- a/lib/CL/pocl_networking.c
+++ b/lib/CL/pocl_networking.c
@@ -39,9 +39,6 @@ pocl_resolve_address (const char *address, uint16_t port, int *error)
   memset (&hint, 0, sizeof (hint));
   hint.ai_family = AF_UNSPEC;
   hint.ai_socktype = SOCK_STREAM;
-  /* Apparently asking for AF_UNSPEC,SOCK_STREAM can return AF_UNIX addresses
-   * which won't work with TCP. Explicitly request TCP sockets instead. */
-  hint.ai_protocol = IPPROTO_TCP;
 
   int is_numeric = 0;
 #ifdef ANDROID
@@ -65,8 +62,6 @@ pocl_resolve_address (const char *address, uint16_t port, int *error)
   if (address == NULL)
     hint.ai_flags = AI_PASSIVE;
   hint.ai_flags |= AI_NUMERICSERV;
-  if (address == NULL)
-    hint.ai_flags = AI_PASSIVE;
 
   struct addrinfo *info;
   char portstr[6] = {};

--- a/lib/CL/pocl_networking.c
+++ b/lib/CL/pocl_networking.c
@@ -62,6 +62,8 @@ pocl_resolve_address (const char *address, uint16_t port, int *error)
   if (address == NULL)
     hint.ai_flags = AI_PASSIVE;
   hint.ai_flags |= AI_NUMERICSERV;
+  if (address == NULL)
+    hint.ai_flags = AI_PASSIVE;
 
   struct addrinfo *info;
   char portstr[6] = {};
@@ -133,6 +135,17 @@ pocl_remote_client_set_socket_options (int socket_fd, int bufsize, int is_fast)
                    &user_timeout, sizeof (user_timeout))),
       -1, "setsockopt(TCP_CONNECTIONTIMEOUT) returned errno: %i\n", errno);
 #endif
+  struct timeval tv;
+  tv.tv_sec = user_timeout;
+  tv.tv_usec = 0;
+  POCL_RETURN_ERROR_ON ((setsockopt (socket_fd, SOL_SOCKET, SO_RCVTIMEO,
+                                     (const char *)&tv, sizeof (tv))),
+                        -1, "setsockopt(SO_RCVTIMEO) returned errno: %i\n",
+                        errno);
+  POCL_RETURN_ERROR_ON ((setsockopt (socket_fd, SOL_SOCKET, SO_SNDTIMEO,
+                                     (const char *)&tv, sizeof (tv))),
+                        -1, "setsockopt(SO_SNDTIMEO) returned errno: %i\n",
+                        errno);
 
   int retries = 5;
 #ifdef TCP_SYNCNT

--- a/lib/CL/pocl_networking.c
+++ b/lib/CL/pocl_networking.c
@@ -39,6 +39,9 @@ pocl_resolve_address (const char *address, uint16_t port, int *error)
   memset (&hint, 0, sizeof (hint));
   hint.ai_family = AF_UNSPEC;
   hint.ai_socktype = SOCK_STREAM;
+  /* Apparently asking for AF_UNSPEC,SOCK_STREAM can return AF_UNIX addresses
+   * which won't work with TCP. Explicitly request TCP sockets instead. */
+  hint.ai_protocol = IPPROTO_TCP;
 
   int is_numeric = 0;
 #ifdef ANDROID

--- a/pocld/CMakeLists.txt
+++ b/pocld/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES pocld.cc cmdline.h cmdline.c
             shared_cl_context.cc shared_cl_context.hh
             virtual_cl_context.cc virtual_cl_context.hh
             cmd_queue.cc  cmd_queue.hh  common.cc  common.hh
+            request.hh request.cc
             reply_th.cc  reply_th.hh  request_th.cc request_th.hh
             peer_handler.cc  peer_handler.hh session.cc session.hh
             peer.cc peer.hh tracing.h traffic_monitor.hh traffic_monitor.cc)

--- a/pocld/common.cc
+++ b/pocld/common.cc
@@ -171,7 +171,7 @@ std::string describe_sockaddr(struct sockaddr *addr, unsigned addr_size) {
     inet_ntop(addr->sa_family, &((struct sockaddr_in6 *)addr)->sin6_addr,
               ip_str.data(), ip_str.capacity());
   else
-    ip_str = "[unknown address family]";
+    ip_str = "[unknown address family " + std::to_string(addr->sa_family) + "]";
   const char *end =
       (const char *)memchr(ip_str.c_str(), '\0', ip_str.capacity());
   if (end)

--- a/pocld/common.hh
+++ b/pocld/common.hh
@@ -281,6 +281,9 @@ struct peer_connection_t {
 
 class VirtualContextBase;
 
+/** Holds the port numbers for the peer listener threads as well as some state
+ * that is shared between the client and peer listeners in order to match up
+ * peer connections with the client sessions they belong to. */
 struct peer_listener_data_t {
   unsigned short port;
   unsigned short peer_rdma_port;

--- a/pocld/common.hh
+++ b/pocld/common.hh
@@ -31,21 +31,19 @@
 #include <dlfcn.h>
 
 #include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <condition_variable>
 #include <deque>
+#include <iostream>
+#include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-#include <atomic>
-#include <condition_variable>
-#include <mutex>
-
-#include <algorithm>
-#include <chrono>
-#include <iostream>
-#include <memory>
-#include <thread>
 
 using Time = std::chrono::steady_clock;
 using ms = std::chrono::milliseconds;

--- a/pocld/common.hh
+++ b/pocld/common.hh
@@ -311,13 +311,22 @@ public:
   // server host timestamps for network comm
   uint64_t write_start_timestamp_ns;
 
-  Reply()
-      : rep(), req(nullptr), extra_data(nullptr), extra_size(0),
-        event(nullptr) {}
+  /** Explicitly delete default constructor since there is no need for it and
+   * actually using it is likely to lead to accessing uninitialized fields. */
+  Reply() = delete;
+  Reply(Request *r)
+      : rep(), req(r), extra_data(nullptr), extra_size(0), event(nullptr) {
+    assert(req);
+    rep.client_did = req->req.client_did;
+    rep.did = req->req.did;
+    rep.pid = req->req.pid;
+    rep.msg_id = req->req.msg_id;
+    rep.server_read_start_timestamp_ns = req->read_start_timestamp_ns;
+    rep.server_read_end_timestamp_ns = req->read_end_timestamp_ns;
+  }
 
   ~Reply() {
-    if (req)
-      delete req;
+    delete req;
     if (extra_data)
       delete[] extra_data;
   }

--- a/pocld/peer.cc
+++ b/pocld/peer.cc
@@ -105,7 +105,7 @@ void Peer::writerThread() {
     assert((r->waitlist_size > 0 && r->waitlist) ^
            ((!r->waitlist_size) && (!r->waitlist)));
     if (r->waitlist_size > 0 && r->waitlist) {
-      POCL_MSG_PRINT_GENERAL("PHW: WRITING WAIT LIST: %" PRIu32 "\n",
+      POCL_MSG_PRINT_GENERAL("PHW: WRITING WAIT LIST: %" PRIu64 "\n",
                              r->waitlist_size);
       CHECK_WRITE(write_full(fd, r->waitlist,
                              r->waitlist_size * sizeof(uint64_t), netstat),

--- a/pocld/peer_handler.cc
+++ b/pocld/peer_handler.cc
@@ -107,7 +107,7 @@ cl_int PeerHandler::connectPeer(uint64_t msg_id, const char *const address,
   }
   PERROR_CHECK404((err != 0), "getaddrinfo()");
 
-  int peer_fd = socket(ai->ai_family, ai->ai_socktype, 0);
+  int peer_fd = socket(ai->ai_family, ai->ai_socktype, IPPROTO_TCP);
   PERROR_CHECK404((peer_fd < 0), "peer socket");
 
   set_socket_options(peer_fd, "PH_outgoing");

--- a/pocld/pocld.cc
+++ b/pocld/pocld.cc
@@ -37,6 +37,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/un.h>
@@ -66,9 +67,10 @@
 #include "rdma.hh"
 #endif
 
-VirtualContextBase *createVirtualContext(client_connections_t conns,
-                                         ClientHandshake_t handshake);
-void startVirtualContextMainloop(VirtualContextBase *ctx);
+#ifndef POLLRDHUP
+#define PULLRDHUP 0
+#endif
+#define POLLFD_ERROR_BITS (POLLHUP | POLLERR | POLLNVAL | POLLRDHUP)
 
 #define PERROR_CHECK(cond, str)                                                \
   do {                                                                         \
@@ -77,6 +79,10 @@ void startVirtualContextMainloop(VirtualContextBase *ctx);
       return 1;                                                                \
     }                                                                          \
   } while (0)
+
+VirtualContextBase *createVirtualContext(client_connections_t conns,
+                                         ClientHandshake_t handshake);
+void startVirtualContextMainloop(VirtualContextBase *ctx);
 
 /***************************************************************************/
 /***************************************************************************/
@@ -116,8 +122,8 @@ in_addr_t find_default_ip_address() {
     freeifaddrs(ifa);
   } else
     POCL_MSG_ERR("getifaddrs() failed or returned no data.\n");
-
 #endif
+
   return listen_addr.s_addr;
 }
 
@@ -138,18 +144,6 @@ int listen_peers(void *data) {
   if (setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)))
     POCL_MSG_ERR("peer listener: failed to set REUSEADDR on socket\n");
 #endif
-  if (setsockopt(listen_sock, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one)))
-    POCL_MSG_ERR("peer listener: failed to set NODELAY on socket\n");
-#ifdef TCP_QUICKACK
-  if (setsockopt(listen_sock, IPPROTO_TCP, TCP_QUICKACK, &one, sizeof(one)))
-    POCL_MSG_ERR("peer listener: failed to set QUICKACK on socket\n");
-#endif
-  int bufsize = 9 * 1024 * 1024;
-  if (setsockopt(listen_sock, SOL_SOCKET, SO_RCVBUF, &bufsize, sizeof(bufsize)))
-    POCL_MSG_ERR("peer listener: failed to set RCVBUF on socket\n");
-  if (setsockopt(listen_sock, SOL_SOCKET, SO_SNDBUF, &bufsize, sizeof(bufsize)))
-    POCL_MSG_ERR("peer listener: failed to set SNDBUF on socket\n");
-
   unsigned len = sizeof(listen_addr);
   PERROR_CHECK((bind(listen_sock, (struct sockaddr *)&listen_addr, len) < 0),
                "peer listener bind");
@@ -161,10 +155,11 @@ int listen_peers(void *data) {
 #endif
 
   do {
-    struct sockaddr_storage peer_addr;
-    unsigned addr_size = sizeof(peer_addr);
-    int peer_fd =
-        accept(listen_sock, (struct sockaddr *)&peer_addr, &addr_size);
+    struct sockaddr peer_addr;
+    socklen_t addr_size = sizeof(peer_addr);
+    /* NOTE: size argument must be initialized to length of actual size of the
+     * addr argument */
+    int peer_fd = accept(listen_sock, &peer_addr, &addr_size);
     assert(peer_fd != -1);
     std::string addr_string =
         describe_sockaddr((struct sockaddr *)&peer_addr, addr_size);
@@ -184,6 +179,12 @@ int listen_peers(void *data) {
     // session
 #endif
 
+    if (setsockopt(peer_fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one)))
+      POCL_MSG_ERR("peer listener: failed to set NODELAY on socket\n");
+#ifdef TCP_QUICKACK
+    if (setsockopt(peer_fd, IPPROTO_TCP, TCP_QUICKACK, &one, sizeof(one)))
+      POCL_MSG_ERR("peer listener: failed to set QUICKACK on socket\n");
+#endif
     std::unique_lock<std::mutex> l(d->mutex);
     if (d->incoming_peers.find(session_hex) == d->incoming_peers.end()) {
       POCL_MSG_WARN(
@@ -191,8 +192,9 @@ int listen_peers(void *data) {
           session_hex.c_str(), addr_string.c_str());
       close(peer_fd);
     } else {
-      POCL_MSG_PRINT_INFO("PL: Peer connection from %s to session %s\n",
-                          addr_string.c_str(), session_hex.c_str());
+      POCL_MSG_PRINT_INFO(
+          "PL: Peer connection from %s to session %s, fd_peer=%d\n",
+          addr_string.c_str(), session_hex.c_str(), peer_fd);
       d->incoming_peers.at(session_hex)
           ->second.push_back({peer_fd
 #ifdef ENABLE_RDMA
@@ -237,8 +239,500 @@ int listen_rdmacm_events(rdmacm::EventChannelPtr cm_channel,
 }
 #endif
 
-int main(int argc, char *argv[]) {
+struct ServerPorts {
+  uint16_t command;
+  uint16_t stream;
+  uint16_t peer;
+#ifdef ENABLE_RDMA
+  uint16_t peer_rdma;
+  uint16_t rdma;
+#endif
+};
 
+class PoclDaemon {
+public:
+  ~PoclDaemon();
+
+  int setup(struct sockaddr &base_addr, socklen_t base_addrlen,
+            struct ServerPorts &ports);
+
+  int run();
+
+  void readAllClientSocketsThread();
+
+  /* returns client context on success, nullptr on error */
+  VirtualContextBase *performClientSetup(int command_fd, int stream_fd);
+
+private:
+  int clients_listen_command_fd;
+  int clients_listen_stream_fd;
+  struct ServerPorts listen_ports;
+  ExitHelper exit_helper;
+  std::unordered_map<std::string, VirtualContextBase *> client_contexts;
+  std::unordered_map<std::string, std::thread> client_session_threads;
+  std::thread client_sockets_th;
+  peer_listener_data_t peer_listener_data;
+  std::thread peer_listener_th;
+#ifdef ENABLE_RDMA
+  RdmaListener rdma_listener;
+  std::thread pl_rdma_event_th;
+  std::thread client_rdma_event_th;
+  GuardedQueue<rdma_cm_event *> cm_event_queue;
+  std::unordered_map<rdma_cm_id *, VirtualContextBase *> cm_id_to_vctx;
+  std::mutex cm_id_to_vctx_mutex;
+#endif
+};
+
+PoclDaemon::~PoclDaemon() {
+  if (client_sockets_th.joinable())
+    client_sockets_th.join();
+  if (peer_listener_th.joinable())
+    peer_listener_th.join();
+#ifdef ENABLE_RDMA
+  if (client_rdma_event_th.joinable())
+    client_rdma_event_th.join();
+  if (pl_rdma_event_th.joinable())
+    pl_rdma_event_th.join();
+#endif
+  for (auto &t : client_session_threads) {
+    if (t.second.joinable())
+      t.second.join();
+  }
+}
+
+int PoclDaemon::setup(struct sockaddr &base_addr, socklen_t base_addrlen,
+                      struct ServerPorts &ports) {
+  listen_ports = {ports};
+  struct sockaddr server_addr_command, server_addr_stream;
+  memcpy(&server_addr_command, &base_addr, base_addrlen);
+  if (server_addr_command.sa_family == AF_INET)
+    ((struct sockaddr_in *)&server_addr_command)->sin_port =
+        htons(ports.command);
+  else if (server_addr_command.sa_family == AF_INET6)
+    ((struct sockaddr_in6 *)&server_addr_command)->sin6_port =
+        htons(ports.command);
+  else {
+    POCL_MSG_ERR("SERVER: unsupported socket address family\n");
+    return -1;
+  }
+  clients_listen_command_fd =
+      socket(server_addr_command.sa_family, SOCK_STREAM, 0);
+  PERROR_CHECK((clients_listen_command_fd < 0), "command socket");
+
+  memcpy(&server_addr_stream, &base_addr, base_addrlen);
+  if (server_addr_stream.sa_family == AF_INET)
+    ((struct sockaddr_in *)&server_addr_stream)->sin_port = htons(ports.stream);
+  else if (server_addr_stream.sa_family == AF_INET6)
+    ((struct sockaddr_in6 *)&server_addr_stream)->sin6_port =
+        htons(ports.stream);
+  else {
+    POCL_MSG_ERR("SERVER: unsupported socket address family\n");
+    return -1;
+  }
+  clients_listen_stream_fd =
+      socket(server_addr_stream.sa_family, SOCK_STREAM, 0);
+  PERROR_CHECK((clients_listen_stream_fd < 0), "stream socket");
+
+  int one = 1;
+#ifdef SO_REUSEADDR
+  if (setsockopt(clients_listen_command_fd, SOL_SOCKET, SO_REUSEADDR, &one,
+                 sizeof(one)))
+    POCL_MSG_ERR("SERVER: failed to set REUSEADDR on command socket\n");
+  if (setsockopt(clients_listen_stream_fd, SOL_SOCKET, SO_REUSEADDR, &one,
+                 sizeof(one)))
+    POCL_MSG_ERR("SERVER: failed to set REUSEADDR on stream socket\n");
+#endif
+
+  PERROR_CHECK(
+      (bind(clients_listen_command_fd, &server_addr_command, base_addrlen) < 0),
+      "command bind");
+  pocl_remote_client_set_socket_options(clients_listen_command_fd, 4 * 1024, 1);
+  PERROR_CHECK((listen(clients_listen_command_fd, 10) < 0), "command listen");
+
+  PERROR_CHECK(
+      (bind(clients_listen_stream_fd, &server_addr_stream, base_addrlen) < 0),
+      "stream bind");
+  pocl_remote_client_set_socket_options(clients_listen_stream_fd,
+                                        4 * 1024 * 1024, 0);
+  PERROR_CHECK((listen(clients_listen_stream_fd, 10) < 0), "stream listen");
+
+  std::string addr_string = describe_sockaddr(&base_addr, base_addrlen);
+
+  peer_listener_data.port = listen_ports.peer;
+#ifdef ENABLE_RDMA
+  peer_listener_data.peer_rdma_port = listen_ports.peer_rdma;
+  peer_listener_data.rdma_listener.reset(new RdmaListener);
+  rdma_listener.listen(listen_ports.rdma);
+#endif
+
+  pid_t server_pid;
+  server_pid = getpid();
+
+  POCL_MSG_PRINT_INFO(
+      "SERVER: PID %d Listening on command=%s:%d, stream=%s:%d, peers=%s:%d"
+#ifdef ENABLE_RDMA
+      ", peer_rdma=%s:%d, rdma=%s:%d"
+#endif
+      "\n",
+      (int)server_pid, addr_string.c_str(), listen_ports.command,
+      addr_string.c_str(), listen_ports.stream, "0.0.0.0", listen_ports.peer
+#ifdef ENABLE_RDMA
+      ,
+      "0.0.0.0", listen_ports.peer_rdma, "0.0.0.0", listen_ports.rdma
+#endif
+  );
+
+  return 0;
+}
+
+int PoclDaemon::run() {
+#ifdef ENABLE_RDMA
+  pl_rdma_event_th = std::move(
+      std::thread(listen_rdmacm_events<VirtualContextBase *>,
+                  peer_listener_data.rdma_listener->eventChannel(),
+                  std::ref(peer_listener_data.peer_cm_id_to_vctx),
+                  std::ref(peer_listener_data.peer_cm_id_to_vctx_mutex)));
+  client_rdma_event_th = std::move(std::thread(
+      listen_rdmacm_events<VirtualContextBase *>, rdma_listener.eventChannel(),
+      std::ref(cm_id_to_vctx), std::ref(cm_id_to_vctx_mutex)));
+#endif
+  peer_listener_th =
+      std::move(std::thread(listen_peers, (void *)&peer_listener_data));
+  client_sockets_th =
+      std::move(std::thread(&PoclDaemon::readAllClientSocketsThread, this));
+
+  return 0;
+}
+
+VirtualContextBase *PoclDaemon::performClientSetup(int command_fd,
+                                                   int stream_fd) {
+  ClientHandshake_t handshake;
+  ClientHandshake_t hs_reply = {};
+  hs_reply.peer_port = listen_ports.peer;
+  uint8_t initial_session_id[SESSION_ID_LENGTH] = {0};
+  client_connections_t connections = {};
+  bool is_reconnecting = false;
+  std::string id;
+  std::string session_hex;
+  VirtualContextBase *ctx = nullptr;
+
+  if (read_full(command_fd, &handshake, sizeof(ClientHandshake_t), nullptr) <
+      sizeof(ClientHandshake_t)) {
+    goto HANDSHAKE_ERROR;
+  }
+
+  POCL_MSG_PRINT_GENERAL("Handshake on fd %d\n", command_fd);
+
+#ifdef ENABLE_RDMA
+  hs_reply.rdma_supported = handshake.rdma_supported;
+#endif
+
+  if (memcmp(handshake.session_id, initial_session_id, SESSION_ID_LENGTH) ==
+      0) {
+    connections = register_new_session(command_fd, stream_fd, id);
+    memcpy(hs_reply.session_id, id.data(), SESSION_ID_LENGTH);
+    session_hex = hexstr(id);
+
+    std::unique_lock<std::mutex> l(peer_listener_data.mutex);
+    auto p = new std::pair<std::condition_variable,
+                           std::vector<peer_connection_t>>();
+    connections.incoming_peer_mutex = &peer_listener_data.mutex;
+    connections.incoming_peer_queue = p;
+    peer_listener_data.incoming_peers.insert({session_hex, p});
+    POCL_MSG_PRINT_INFO(
+        "Registered new client session %s, fd_command=%d, fd_stream=%d\n",
+        session_hex.c_str(), command_fd, stream_fd);
+  } else {
+    session_hex = hexstr(id);
+    is_reconnecting = true;
+    POCL_MSG_PRINT_INFO("Attempting to attach client to existing session %s\n, "
+                        "fd_command=%d, fd_stream=%d",
+                        session_hex.c_str(), command_fd, stream_fd);
+
+    if (!pass_new_client_fds(command_fd, stream_fd, session_hex))
+      goto HANDSHAKE_ERROR;
+    memcpy(hs_reply.session_id, handshake.session_id, SESSION_ID_LENGTH);
+  }
+
+  if (write_full(command_fd, &hs_reply, sizeof(ClientHandshake_t), nullptr) <
+      0) {
+    goto HANDSHAKE_ERROR;
+  }
+
+#ifdef ENABLE_RDMA
+  if (hs_reply.rdma_supported) {
+    // Accept RDMA connection
+    POCL_MSG_PRINT_GENERAL("Accepting client RDMAcm connection\n");
+
+    connections.rdma.reset(new RdmaConnection(rdma_listener.accept()));
+  }
+#endif
+
+  if (!is_reconnecting) {
+    // Start virtual_cl_context thread
+    ctx = createVirtualContext(connections, hs_reply);
+    std::thread t(startVirtualContextMainloop, ctx);
+#ifdef ENABLE_RDMA
+    if (hs_reply.rdma_supported) {
+      {
+        std::unique_lock<std::mutex> l(cm_id_to_vctx_mutex);
+        cm_id_to_vctx.insert({*connections.rdma->id(), ctx});
+      }
+      {
+        std::unique_lock<std::mutex> l(
+            peer_listener_data.peer_cm_id_to_vctx_mutex);
+        peer_listener_data.peer_cm_id_to_vctx.insert(
+            {*connections.rdma->id(), ctx});
+      }
+    }
+    {
+      std::unique_lock<std::mutex> l(peer_listener_data.vctx_map_mutex);
+      peer_listener_data.vctx_map.insert({session_hex, ctx});
+    }
+#endif
+    client_contexts.insert({session_hex, ctx});
+    client_session_threads.insert({session_hex, std::move(t)});
+  } else {
+    ctx = client_contexts.at(session_hex);
+  }
+  return ctx;
+
+HANDSHAKE_ERROR:
+  POCL_MSG_ERR("Client handshake error, dropping client: %s\n",
+               strerror(errno));
+  return nullptr;
+}
+
+void PoclDaemon::readAllClientSocketsThread() {
+  /* keep our listening sockets in the list to streamline the polling code */
+  std::vector<int> open_client_fds = {clients_listen_command_fd,
+                                      clients_listen_stream_fd};
+  std::vector<VirtualContextBase *> socket_contexts = {nullptr, nullptr};
+  std::vector<Request *> incomplete_requests = {nullptr, nullptr};
+  bool fds_changed = true;
+  std::vector<struct pollfd> pfds;
+
+  int pending_client_command = 0;
+  int pending_client_stream = 0;
+
+  while (!exit_helper.exit_requested()) {
+    /* Changes to the list of sockets should be relatively rare so let's
+     * just rewrite the whole thing when it happens; it's a trivial
+     * operation anyway. */
+    if (fds_changed) {
+      pfds.clear();
+      pfds.reserve(open_client_fds.size());
+      for (const int &fd : open_client_fds) {
+        /* Unlike the other error flags POLLRDHUP is only returned if explicitly
+         * polled for */
+        pfds.push_back({fd, POLLIN | POLLRDHUP, 0});
+      }
+      fds_changed = false;
+    }
+
+    /* Just block forever. If/when a socket is closed - including the client
+     * listeners - it triggers a POLLERR/POLLHUP/POLLRDHUP/POLLNVAL. */
+    int num_event_fds = poll(pfds.data(), pfds.size(), -1);
+    POCL_MSG_PRINT_GENERAL("Client socket poll returned %d fds with events\n",
+                           num_event_fds);
+
+    if (num_event_fds < 0) {
+      int e = errno;
+      exit_helper.requestExit(strerror(e), e);
+      continue;
+    } else if (num_event_fds == 0) {
+      continue;
+    }
+
+    auto accept_new_connection = [&](struct pollfd &pfd, int bufsize,
+                                     int is_fast, int &hack) {
+      int ev = pfd.revents;
+      pfd.revents = 0; // reset revents to 0 for the next polling round
+      if (ev) {
+        --num_event_fds;
+        if (ev & POLLFD_ERROR_BITS) {
+          exit_helper.requestExit("Client listener socket closed", 0);
+          return false;
+        } else if (ev & POLLIN) {
+          struct sockaddr client_address;
+          socklen_t client_address_length = sizeof(client_address);
+          /* NOTE: address length MUST be initialized to the size of the storage
+           * given as the addr argument */
+          int newfd = accept(pfd.fd, &client_address, &client_address_length);
+          if (newfd > 0) {
+            // XXX: rework (eliminate?) handshakes and just store new fds
+            hack = newfd;
+            // open_client_fds.push_back(newfd);
+            // fds_changed = true;
+            pocl_remote_client_set_socket_options(newfd, bufsize, 1);
+            std::string client_address_string =
+                describe_sockaddr(&client_address, client_address_length);
+            POCL_MSG_PRINT_INFO("Accepted client %s connection from %s\n",
+                                is_fast ? "command" : "stream",
+                                client_address_string.c_str());
+          }
+        }
+      }
+      return true;
+    };
+
+    /* We always put our client listener sockets in the list first so let's
+     * handle accepting incoming connections separately here. */
+    /* clients_listen_command_fd */
+    if (!accept_new_connection(pfds[0], 4 * 1024, 1, pending_client_command))
+      continue;
+
+    /* clients_listen_stream_fd */
+    if (!accept_new_connection(pfds[1], 9 * 1024 * 1024, 0,
+                               pending_client_stream))
+      continue;
+
+    /* XXX: would be nice to also handle new client RDMA connections here but
+     * for now they are in performClientSetup */
+    std::vector<int> dead_fds;
+    if (pending_client_command && pending_client_stream) {
+      /* XXX: client handshake needs to be reworked, maybe dropped entirely,
+       * doing it here for now */
+      VirtualContextBase *vctx = nullptr;
+      if ((vctx = performClientSetup(pending_client_command,
+                                     pending_client_stream))) {
+        open_client_fds.push_back(pending_client_command);
+        incomplete_requests.push_back(new Request);
+        socket_contexts.push_back(vctx);
+        open_client_fds.push_back(pending_client_stream);
+        incomplete_requests.push_back(new Request);
+        socket_contexts.push_back(vctx);
+        fds_changed = true;
+      } else {
+        dead_fds.push_back(pending_client_command);
+        dead_fds.push_back(pending_client_stream);
+      }
+      pending_client_command = 0;
+      pending_client_stream = 0;
+    }
+
+    /* Incoming connections have been handled, take care of pending reads on
+     * connected client sockets. */
+    for (size_t i = 2; i < pfds.size() && num_event_fds > 0; ++i) {
+      int ev = pfds[i].revents;
+      pfds[i].revents = 0; /* reset to 0 for the next polling round */
+      if (ev) {
+        --num_event_fds;
+        /* Collect dead fds but don't remove them from the list of open fds yet
+         * lest the indices of pfds no logner match */
+        if (ev & POLLFD_ERROR_BITS) {
+          POCL_MSG_PRINT_GENERAL(
+              "Poll says fd=%d is dead (0x%X), removing it.\n", pfds[i].fd, ev);
+          dead_fds.push_back(pfds[i].fd);
+          continue;
+        }
+
+        if (ev & POLLIN) {
+          Request *r = incomplete_requests.at(i);
+          if (r->read(pfds[i].fd)) {
+            if (!r->fully_read)
+              continue;
+
+            // TODO: add session ID field to all messages
+            // auto it = client_contexts.find(hexstring(r->req.session_id));
+            VirtualContextBase *ctx = socket_contexts.at(i);
+            if (ctx) {
+              switch (r->req.message_type) {
+              case MessageType_ConnectPeer:
+              case MessageType_DeviceInfo:
+              case MessageType_CreateBuffer:
+              case MessageType_FreeBuffer:
+              case MessageType_CreateCommandQueue:
+              case MessageType_FreeCommandQueue:
+              case MessageType_CreateSampler:
+              case MessageType_FreeSampler:
+              case MessageType_CreateImage:
+              case MessageType_FreeImage:
+              case MessageType_CreateKernel:
+              case MessageType_FreeKernel:
+              case MessageType_BuildProgramFromSource:
+              case MessageType_BuildProgramFromBinary:
+              case MessageType_BuildProgramFromSPIRV:
+              case MessageType_BuildProgramWithBuiltins:
+              case MessageType_FreeProgram:
+              case MessageType_MigrateD2D:
+              case MessageType_RdmaBufferRegistration:
+              case MessageType_Shutdown: {
+                ctx->nonQueuedPush(r);
+                break;
+              }
+              case MessageType_ReadBuffer:
+              case MessageType_WriteBuffer:
+              case MessageType_CopyBuffer:
+              case MessageType_FillBuffer:
+              case MessageType_ReadBufferRect:
+              case MessageType_WriteBufferRect:
+              case MessageType_CopyBufferRect:
+              case MessageType_CopyImage2Buffer:
+              case MessageType_CopyBuffer2Image:
+              case MessageType_CopyImage2Image:
+              case MessageType_ReadImageRect:
+              case MessageType_WriteImageRect:
+              case MessageType_FillImageRect:
+              case MessageType_RunKernel: {
+                ctx->queuedPush(r);
+                break;
+              }
+              case MessageType_NotifyEvent: {
+                // TODO: this message should probably contain an actual
+                // status... (see also rdma thread)
+                ctx->notifyEvent(r->req.event_id, CL_COMPLETE);
+                delete r;
+                break;
+              }
+
+              default: {
+                ctx->unknownRequest(r);
+                break;
+              }
+              }
+
+              /* r is now someone else's problem */
+              incomplete_requests[i] = new Request;
+            } else {
+              POCL_MSG_ERR("Client sent request for nonexistent context, "
+                           "closing connection\n");
+              dead_fds.push_back(pfds[i].fd);
+            }
+          } else {
+            POCL_MSG_ERR("Something went wrong while reading request, closing "
+                         "connection\n");
+            dead_fds.push_back(pfds[i].fd);
+          }
+        }
+      }
+    }
+
+    /* reap dead fds */
+    for (size_t i = 0; i < open_client_fds.size(); ++i) {
+      int fd = open_client_fds[i];
+      for (int d : dead_fds) {
+        if (d == fd) {
+          fds_changed = true;
+          close(fd);
+          std::swap(open_client_fds[i], open_client_fds.back());
+          open_client_fds.pop_back();
+          std::swap(socket_contexts[i], socket_contexts.back());
+          socket_contexts.pop_back();
+          std::swap(incomplete_requests[i], incomplete_requests.back());
+          delete incomplete_requests.back();
+          incomplete_requests.pop_back();
+          --i;
+        }
+      }
+    }
+  }
+
+  /* Close all remaining sockets, including the client listeners */
+  std::for_each(open_client_fds.cbegin(), open_client_fds.cend(), &close);
+}
+
+int main(int argc, char *argv[]) {
   struct gengetopt_args_info ai;
   memset(&ai, 0, sizeof(struct gengetopt_args_info));
 
@@ -252,16 +746,11 @@ int main(int argc, char *argv[]) {
   else
     logfilter = getenv("POCLD_LOGLEVEL");
   if (!logfilter)
-    logfilter = "warn,err";
+    logfilter = "";
   pocl_stderr_is_a_tty = isatty(fileno(stderr));
   pocl_debug_messages_setup(logfilter);
 
-  unsigned short command_port = 0;
-  unsigned short stream_port = 0;
-  unsigned short peer_port = 0;
 #ifdef ENABLE_RDMA
-  unsigned short rdma_port = 0;
-  unsigned short peer_rdma_port = 0;
   std::unordered_map<rdma_cm_id *, VirtualContextBase *> cm_id_to_vctx;
   std::mutex cm_id_to_vctx_mutex;
 #endif
@@ -273,17 +762,31 @@ int main(int argc, char *argv[]) {
   if (setrlimit(RLIMIT_CORE, &core_limit) != 0)
     POCL_MSG_ERR("setting rlimit_core failed!\n");
 
-  // ignore sigpipe, because we want to properly shutdown on closed sockets
+  // ignore sigpipe, because we don't want to shutdown on closed sockets
   signal(SIGPIPE, SIG_IGN);
 
+  struct ServerPorts listen_ports = {};
+  if (ai.port_arg)
+    listen_ports.command = (unsigned short)ai.port_arg;
+  else
+    listen_ports.command = DEFAULT_POCL_REMOTE_PORT;
+
+  assert(listen_ports.command > 0);
+  listen_ports.stream = listen_ports.command + 1;
+  listen_ports.peer = listen_ports.command + 2;
+#ifdef ENABLE_RDMA
+  listen_ports.peer_rdma = listen_ports.command + 3;
+  listen_ports.rdma = listen_ports.command + 4;
+#endif
+
   int error;
-  struct sockaddr_storage base_addr;
+  struct sockaddr base_addr;
   std::string addr;
   socklen_t base_addrlen;
   memset(&base_addr, 0, sizeof(base_addr));
   if (ai.address_arg) {
     addrinfo *resolved_address =
-        pocl_resolve_address(ai.address_arg, command_port, &error);
+        pocl_resolve_address(ai.address_arg, listen_ports.command, &error);
     if (!error) {
       memcpy(&base_addr, resolved_address->ai_addr,
              resolved_address->ai_addrlen);
@@ -300,260 +803,12 @@ int main(int argc, char *argv[]) {
     fallback->sin_addr.s_addr = find_default_ip_address();
     base_addrlen = sizeof(struct sockaddr_in);
   }
-  addr = describe_sockaddr((struct sockaddr *)&base_addr, base_addrlen);
 
-  if (ai.port_arg)
-    command_port = (unsigned short)ai.port_arg;
-  else
-    command_port = DEFAULT_POCL_REMOTE_PORT;
+  PoclDaemon server;
+  if ((error = server.setup(base_addr, base_addrlen, listen_ports)))
+    return error;
+  if ((error = server.run()))
+    return error;
 
-  assert(command_port > 0);
-  stream_port = command_port + 1;
-  peer_port = command_port + 2;
-#ifdef ENABLE_RDMA
-  peer_rdma_port = command_port + 3;
-  rdma_port = command_port + 4;
-#endif
-
-  struct sockaddr server_addr_command, server_addr_stream;
-  struct sockaddr client_addr_command, client_addr_stream;
-  int server_sock_stream;
-  int server_sock_command;
-
-  memcpy(&server_addr_command, &base_addr, base_addrlen);
-  if (server_addr_command.sa_family == AF_INET)
-    ((struct sockaddr_in *)&server_addr_command)->sin_port =
-        htons(command_port);
-  else if (server_addr_command.sa_family == AF_INET6)
-    ((struct sockaddr_in6 *)&server_addr_command)->sin6_port =
-        htons(command_port);
-  else {
-    POCL_MSG_ERR("SERVER: unsupported socket address family\n");
-    return -1;
-  }
-  server_sock_command = socket(server_addr_command.sa_family, SOCK_STREAM, 0);
-  PERROR_CHECK((server_sock_command < 0), "command socket");
-
-  memcpy(&server_addr_stream, &base_addr, base_addrlen);
-  if (server_addr_stream.sa_family == AF_INET)
-    ((struct sockaddr_in *)&server_addr_stream)->sin_port = htons(stream_port);
-  else if (server_addr_stream.sa_family == AF_INET6)
-    ((struct sockaddr_in6 *)&server_addr_stream)->sin6_port =
-        htons(stream_port);
-  else {
-    POCL_MSG_ERR("SERVER: unsupported socket address family\n");
-    return -1;
-  }
-  server_sock_stream = socket(server_addr_stream.sa_family, SOCK_STREAM, 0);
-  PERROR_CHECK((server_sock_stream < 0), "stream socket");
-
-  int one = 1;
-#ifdef SO_REUSEADDR
-  if (setsockopt(server_sock_command, SOL_SOCKET, SO_REUSEADDR, &one,
-                 sizeof(one)))
-    POCL_MSG_ERR("SERVER: failed to set REUSEADDR on command socket\n");
-  if (setsockopt(server_sock_stream, SOL_SOCKET, SO_REUSEADDR, &one,
-                 sizeof(one)))
-    POCL_MSG_ERR("SERVER: failed to set REUSEADDR on stream socket\n");
-#endif
-
-  PERROR_CHECK(
-      (bind(server_sock_command, (struct sockaddr *)&server_addr_command,
-            base_addrlen) < 0),
-      "command bind");
-  pocl_remote_client_set_socket_options(server_sock_command, 4 * 1024, 1);
-  PERROR_CHECK((listen(server_sock_command, 10) < 0), "command listen");
-
-  PERROR_CHECK((bind(server_sock_stream, (struct sockaddr *)&server_addr_stream,
-                     base_addrlen) < 0),
-               "stream bind");
-  pocl_remote_client_set_socket_options(server_sock_stream, 4 * 1024 * 1024, 0);
-  PERROR_CHECK((listen(server_sock_stream, 10) < 0), "stream listen");
-
-
-  /***************************************************************************/
-
-  peer_listener_data_t peer_listener_data = {peer_port
-#ifdef ENABLE_RDMA
-                                             ,
-                                             peer_rdma_port
-#endif
-  };
-#ifdef ENABLE_RDMA
-  peer_listener_data.rdma_listener.reset(new RdmaListener());
-  std::thread pl_rdma_event_th(
-      listen_rdmacm_events<VirtualContextBase *>,
-      peer_listener_data.rdma_listener->eventChannel(),
-      std::ref(peer_listener_data.peer_cm_id_to_vctx),
-      std::ref(peer_listener_data.peer_cm_id_to_vctx_mutex));
-#endif
-  std::thread peer_listener_thread(listen_peers, (void *)&peer_listener_data);
-
-  /***************************************************************************/
-
-#ifdef ENABLE_RDMA
-  RdmaListener rdma_listener;
-  POCL_MSG_PRINT_INFO("Listening for RDMAcm connections on port %d\n",
-                      rdma_port);
-  rdma_listener.listen(rdma_port);
-  GuardedQueue<rdma_cm_event *> cm_event_queue;
-  std::thread client_rdma_event_th(
-      listen_rdmacm_events<VirtualContextBase *>, rdma_listener.eventChannel(),
-      std::ref(cm_id_to_vctx), std::ref(cm_id_to_vctx_mutex));
-#endif
-
-  /***************************************************************************/
-
-  int fd_stream, fd_command;
-  pid_t server_pid;
-  server_pid = getpid();
-
-  POCL_MSG_PRINT_INFO(
-      "SERVER: PID %d Listening on command=%s:%d, stream=%s:%d, peers=%s:%d"
-#ifdef ENABLE_RDMA
-      ", peer_rdma=%s:%d"
-      ", rdma=%s:%d"
-#endif
-      "\n",
-      (int)server_pid, addr.c_str(), command_port, addr.c_str(), stream_port,
-      "0.0.0.0", peer_port
-#ifdef ENABLE_RDMA
-      ,
-      "0.0.0.0", peer_rdma_port, "0.0.0.0", rdma_port
-#endif
-  );
-
-  while (true) {
-    socklen_t len;
-  RESTART1:
-    fd_command = accept(server_sock_command,
-                        (struct sockaddr *)&client_addr_command, &len);
-    if (fd_command == -1) {
-      int e = errno;
-
-      // TODO what here ? otther error
-      if (e == EAGAIN)
-        goto RESTART1;
-      else {
-        POCL_MSG_ERR("accept(fd_command): %s\n", strerror(e));
-        goto EXIT;
-      }
-    }
-    addr = describe_sockaddr((struct sockaddr *)&client_addr_command, len);
-
-  RESTART2:
-    fd_stream = accept(server_sock_stream,
-                       (struct sockaddr *)&client_addr_stream, &len);
-    if (fd_stream == -1) {
-      int e = errno;
-
-      if (e == EAGAIN)
-        goto RESTART2;
-      else {
-        POCL_MSG_ERR("accept(fd_stream): %s\n", strerror(e));
-        goto EXIT;
-      }
-    }
-
-    POCL_MSG_PRINT_GENERAL("Connection from %s, FD STREAM: %d  COMMAND: %d\n",
-                           addr.c_str(), fd_stream, fd_command);
-
-    ClientHandshake_t handshake;
-    if (read_full(fd_command, &handshake, sizeof(ClientHandshake_t), nullptr) <
-        sizeof(ClientHandshake_t)) {
-      POCL_MSG_ERR("read client handshake: %s\n", strerror(errno));
-      goto EXIT;
-    }
-    ClientHandshake_t hs_reply;
-    memset(&hs_reply, 0, sizeof(ClientHandshake_t));
-    hs_reply.peer_port = peer_port;
-#ifdef ENABLE_RDMA
-    hs_reply.rdma_supported = handshake.rdma_supported;
-#endif
-    uint8_t initial_session_id[SESSION_ID_LENGTH] = {0};
-    client_connections_t connections = {};
-    bool is_reconnecting = false;
-    std::string id;
-    std::string session_hex;
-
-    if (memcmp(handshake.session_id, initial_session_id, SESSION_ID_LENGTH) ==
-        0) {
-      connections = register_new_session(fd_command, fd_stream, id);
-      memcpy(hs_reply.session_id, id.data(), SESSION_ID_LENGTH);
-      session_hex = hexstr(id);
-
-      std::unique_lock<std::mutex> l(peer_listener_data.mutex);
-      auto p = new std::pair<std::condition_variable,
-                             std::vector<peer_connection_t>>();
-      connections.incoming_peer_mutex = &peer_listener_data.mutex;
-      connections.incoming_peer_queue = p;
-      peer_listener_data.incoming_peers.insert({session_hex, p});
-      POCL_MSG_PRINT_INFO("Registered new client session %s\n",
-                          session_hex.c_str());
-    } else {
-      session_hex = hexstr(id);
-      is_reconnecting = true;
-      POCL_MSG_PRINT_INFO(
-          "Attempting to attach client to existing session %s\n",
-          session_hex.c_str());
-
-      pass_new_client_fds(fd_command, fd_stream, session_hex);
-      memcpy(hs_reply.session_id, handshake.session_id, SESSION_ID_LENGTH);
-    }
-    PERROR_CHECK(write_full(fd_command, &hs_reply, sizeof(ClientHandshake_t),
-                            nullptr) != 0,
-                 "client handshake reply");
-
-    struct timeval tv;
-    tv.tv_sec = 3;
-    tv.tv_usec = 0;
-
-    if (setsockopt(fd_command, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv,
-                   sizeof tv))
-      POCL_MSG_ERR("failed to set RCVTIMEO on command socket\n");
-    if (setsockopt(fd_stream, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv,
-                   sizeof tv))
-      POCL_MSG_ERR("failed to set RCVTIMEO on stream socket\n");
-
-#ifdef ENABLE_RDMA
-    if (hs_reply.rdma_supported) {
-      // Accept RDMA connection
-      POCL_MSG_PRINT_GENERAL("Accepting client RDMAcm connection\n");
-
-      connections.rdma.reset(new RdmaConnection(rdma_listener.accept()));
-    }
-#endif
-
-    if (!is_reconnecting) {
-      // Start virtual_cl_context thread
-      VirtualContextBase *ctx = createVirtualContext(connections, hs_reply);
-      std::thread t(startVirtualContextMainloop, ctx);
-#ifdef ENABLE_RDMA
-      if (hs_reply.rdma_supported) {
-        {
-          std::unique_lock<std::mutex> l(cm_id_to_vctx_mutex);
-          cm_id_to_vctx.insert({*connections.rdma->id(), ctx});
-        }
-        {
-          std::unique_lock<std::mutex> l(
-              peer_listener_data.peer_cm_id_to_vctx_mutex);
-          peer_listener_data.peer_cm_id_to_vctx.insert(
-              {*connections.rdma->id(), ctx});
-        }
-      }
-      {
-        std::unique_lock<std::mutex> l(peer_listener_data.vctx_map_mutex);
-        peer_listener_data.vctx_map.insert({session_hex, ctx});
-      }
-#endif
-      // destroying the thread handle terminates the thread unless it is
-      // detached
-      t.detach();
-    }
-  }
-EXIT:
-  POCL_MSG_PRINT_INFO("SERVER exiting\n");
-  close(server_sock_command);
-  close(server_sock_stream);
   return 0;
 }

--- a/pocld/pocld.cc
+++ b/pocld/pocld.cc
@@ -130,7 +130,7 @@ in_addr_t find_default_ip_address() {
 int listen_peers(void *data) {
   peer_listener_data_t *d = (peer_listener_data_t *)data;
 
-  int listen_sock = socket(AF_INET, SOCK_STREAM, 0);
+  int listen_sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
   PERROR_CHECK((listen_sock < 0), "peer listener socket");
 
   struct sockaddr_in listen_addr = {};
@@ -373,7 +373,7 @@ int PoclDaemon::launch(struct sockaddr &base_addr, socklen_t base_addrlen,
     return -1;
   }
   clients_listen_command_fd =
-      socket(server_addr_command.sa_family, SOCK_STREAM, 0);
+      socket(server_addr_command.sa_family, SOCK_STREAM, IPPROTO_TCP);
   PERROR_CHECK((clients_listen_command_fd < 0), "command socket");
 
   memcpy(&server_addr_stream, &base_addr, base_addrlen);
@@ -387,7 +387,7 @@ int PoclDaemon::launch(struct sockaddr &base_addr, socklen_t base_addrlen,
     return -1;
   }
   clients_listen_stream_fd =
-      socket(server_addr_stream.sa_family, SOCK_STREAM, 0);
+      socket(server_addr_stream.sa_family, SOCK_STREAM, IPPROTO_TCP);
   PERROR_CHECK((clients_listen_stream_fd < 0), "stream socket");
 
   int one = 1;

--- a/pocld/rdma.cc
+++ b/pocld/rdma.cc
@@ -298,7 +298,7 @@ QueuePair::~QueuePair() { rdma_destroy_qp(*cm_id); }
 } // namespace ibverbs
 
 ScatterGatherEntry::ScatterGatherEntry(ibverbs::MemoryRegionPtr mr)
-    : sge{((mr->accessFlags() | ibverbs::MemoryRegion::Access::ZeroBased).val
+    : sge{((mr->accessFlags() & ibverbs::MemoryRegion::Access::ZeroBased).val
                ? 0
                : (uint64_t)((ibv_mr *)**mr)->addr),
           (uint32_t)mr->handle->length, mr->handle->lkey},
@@ -306,7 +306,7 @@ ScatterGatherEntry::ScatterGatherEntry(ibverbs::MemoryRegionPtr mr)
 
 ScatterGatherEntry::ScatterGatherEntry(ibverbs::MemoryRegionPtr mr,
                                        ptrdiff_t offset, uint32_t length)
-    : sge{((mr->accessFlags() | ibverbs::MemoryRegion::Access::ZeroBased).val
+    : sge{((mr->accessFlags() & ibverbs::MemoryRegion::Access::ZeroBased).val
                ? 0
                : (uint64_t)((ibv_mr *)**mr)->addr) +
               (int64_t)offset,

--- a/pocld/rdma.hh
+++ b/pocld/rdma.hh
@@ -332,10 +332,10 @@ private:
   friend class ::ScatterGatherEntry;
 
   MemoryRegion(ProtectionDomainPtr pd, void *addr, size_t length,
-               Access access = Access::LocalRead | Access::ZeroBased);
+               Access access = Access::LocalRead);
 
   MemoryRegion(ProtectionDomainPtr pd, uint64_t offset, size_t length, int fd,
-               Access access = Access::LocalRead | Access::ZeroBased);
+               Access access = Access::LocalRead);
 
   ibv_mr *operator*() { return handle; }
 
@@ -353,9 +353,9 @@ public:
    * @param length Length of the memory region to be registered
    * @param access Bitfield of access qualifiers
    */
-  static MemoryRegionPtr
-  register_ptr(ProtectionDomainPtr pd, void *addr, size_t length,
-               Access access = Access::LocalRead | Access::ZeroBased) {
+  static MemoryRegionPtr register_ptr(ProtectionDomainPtr pd, void *addr,
+                                      size_t length,
+                                      Access access = Access::LocalRead) {
     return std::shared_ptr<MemoryRegion>(
         new MemoryRegion(pd, addr, length, access));
   }
@@ -370,8 +370,7 @@ public:
    */
   static MemoryRegionPtr register_dmabuf(ProtectionDomainPtr pd,
                                          uint64_t offset, size_t length, int fd,
-                                         Access access = Access::LocalRead |
-                                                         Access::ZeroBased) {
+                                         Access access = Access::LocalRead) {
     return std::shared_ptr<MemoryRegion>(
         new MemoryRegion(pd, offset, length, fd, access));
   }
@@ -395,8 +394,7 @@ private:
 public:
   RdmaBuffer(ibverbs::ProtectionDomainPtr pd, size_t elements,
              ibverbs::MemoryRegion::Access access =
-                 ibverbs::MemoryRegion::Access::LocalRead |
-                 ibverbs::MemoryRegion::Access::ZeroBased) {
+                 ibverbs::MemoryRegion::Access::LocalRead) {
     ptr.reset(new T[elements]);
     size = elements;
     mr = ibverbs::MemoryRegion::register_ptr(pd, (void *)ptr.get(),
@@ -654,7 +652,7 @@ public:
   AtomicCompareAndSwap(uint64_t wr_id,
                        const std::vector<ScatterGatherEntry> &sg_list,
                        uint64_t remote_addr, uint32_t rkey, uint64_t compare,
-                       uint64_t swap, Flags flags);
+                       uint64_t swap, Flags = Flags::None);
 
   /**
    * Constructs a WorkRequest with opcode IBV_WR_ATOMIC_FETCH_AND_ADD: A 64
@@ -676,7 +674,7 @@ public:
    */
   static WorkRequest AtomicFetchAndAdd(
       uint64_t wr_id, const std::vector<ScatterGatherEntry> &sg_list,
-      uint64_t remote_addr, uint32_t rkey, uint64_t add, Flags flags);
+      uint64_t remote_addr, uint32_t rkey, uint64_t add, Flags = Flags::None);
 
   /**
    * @param next WorkRequest that should be performed after this. A copy of

--- a/pocld/rdma_request_th.cc
+++ b/pocld/rdma_request_th.cc
@@ -121,6 +121,7 @@ void RdmaRequestThread::rdmaReaderThread() {
     case MessageType_FreeKernel:
     case MessageType_BuildProgramFromSource:
     case MessageType_BuildProgramFromBinary:
+    case MessageType_BuildProgramFromSPIRV:
     case MessageType_BuildProgramWithBuiltins:
     case MessageType_FreeProgram:
     case MessageType_MigrateD2D:

--- a/pocld/rdma_request_th.cc
+++ b/pocld/rdma_request_th.cc
@@ -46,8 +46,10 @@ void RdmaRequestThread::rdmaReaderThread() {
   /************ Prepare & enqueue work requests for commands ****************/
   // must be <= qp_init_attr.cap.max_recv_wr
   const size_t NUM_OUTSTANDING_REQUESTS = 5;
-  RdmaBuffer<RequestMsg_t> requests_buf(connection->protectionDomain(),
-                                        NUM_OUTSTANDING_REQUESTS);
+  RdmaBuffer<RequestMsg_t> requests_buf(
+      connection->protectionDomain(), NUM_OUTSTANDING_REQUESTS,
+      ibverbs::MemoryRegion::Access::LocalRead |
+          ibverbs::MemoryRegion::Access::LocalWrite);
 
   // When the other end attempts to make an IBV_SEND request, there must be an
   // outstanding work request on the receiving end, else the send request

--- a/pocld/reply_th.cc
+++ b/pocld/reply_th.cc
@@ -234,10 +234,6 @@ void ReplyQueueThread::writeThread() {
                 .count();
 
         reply->rep.timing = timing;
-        reply->rep.server_read_start_timestamp_ns =
-            reply->req->read_start_timestamp_ns;
-        reply->rep.server_read_end_timestamp_ns =
-            reply->req->read_end_timestamp_ns;
         reply->rep.server_write_start_timestamp_ns =
             reply->write_start_timestamp_ns;
 

--- a/pocld/request.cc
+++ b/pocld/request.cc
@@ -1,0 +1,297 @@
+/* request.cc - class representing a command received from a client or peer
+
+   Copyright (c) 2023 Jan Solanti / Tampere University
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#include <cassert>
+
+#include "common.hh"
+#include "messages.h"
+#include "request.hh"
+#include "tracing.h"
+
+#define CL_INVALID_OPERATION -59
+
+const char *request_to_str(RequestMessageType type) {
+  switch (type) {
+  case MessageType_ServerInfo:
+    return "ServerInfo";
+  case MessageType_DeviceInfo:
+    return "DeviceInfo";
+  case MessageType_ConnectPeer:
+    return "ConnectPeer";
+  case MessageType_PeerHandshake:
+    return "PeerHandshake";
+
+  case MessageType_CreateBuffer:
+    return "CreateBuffer";
+  case MessageType_FreeBuffer:
+    return "FreeBuffer";
+
+  case MessageType_CreateCommandQueue:
+    return "CreateCommandQueue";
+  case MessageType_FreeCommandQueue:
+    return "FreeCommandQueue";
+
+  case MessageType_CreateSampler:
+    return "CreateSampler";
+  case MessageType_FreeSampler:
+    return "FreeSampler";
+
+  case MessageType_CreateImage:
+    return "CreateImage";
+  case MessageType_FreeImage:
+    return "FreeImage";
+
+  case MessageType_CreateKernel:
+    return "CreateKernel";
+  case MessageType_FreeKernel:
+    return "FreeKernel";
+
+  case MessageType_BuildProgramFromSource:
+    return "BuildProgramFromSource";
+  case MessageType_BuildProgramFromBinary:
+    return "BuildProgramFromBinary";
+  case MessageType_BuildProgramFromSPIRV:
+    return "BuildProgramFromSPIRV";
+  case MessageType_BuildProgramWithBuiltins:
+    return "BuildProgramWithBuiltins";
+  case MessageType_FreeProgram:
+    return "FreeProgram";
+
+  case MessageType_MigrateD2D:
+    return "MigrateD2D";
+
+  case MessageType_ReadBuffer:
+    return "ReadBuffer";
+  case MessageType_WriteBuffer:
+    return "WriteBuffer";
+  case MessageType_CopyBuffer:
+    return "CopyBuffer";
+  case MessageType_FillBuffer:
+    return "FillBuffer";
+
+  case MessageType_ReadBufferRect:
+    return "ReadBufferRect";
+  case MessageType_WriteBufferRect:
+    return "WriteBufferRect";
+  case MessageType_CopyBufferRect:
+    return "CopyBufferRect";
+
+  case MessageType_CopyImage2Buffer:
+    return "CopyImage2Buffer";
+  case MessageType_CopyBuffer2Image:
+    return "CopyBuffer2Image";
+  case MessageType_CopyImage2Image:
+    return "CopyImage2Image";
+  case MessageType_ReadImageRect:
+    return "ReadImageRect";
+  case MessageType_WriteImageRect:
+    return "WriteImageRect";
+  case MessageType_FillImageRect:
+    return "FillImageRect";
+
+  case MessageType_RunKernel:
+    return "RunKernel";
+
+  case MessageType_NotifyEvent:
+    return "NotifyEvent";
+
+  case MessageType_RdmaBufferRegistration:
+    return "RdmaBufferRegistration";
+
+  case MessageType_Finish:
+    return "Finish";
+
+  case MessageType_Shutdown:
+    return "Shutdown";
+
+  default:
+    return "UNKNOWN";
+  }
+}
+
+/* Returns 0 on success and no-op, otherwise errno */
+static int reentrant_read(int fd, void *dest, size_t size, size_t *tracker) {
+  if (*tracker == size)
+    return 0;
+
+  ssize_t readb;
+  readb = ::read(fd, (char *)dest + *tracker, size - *tracker);
+  if (readb < 0)
+    return errno;
+
+  if (readb == 0)
+    return EPIPE;
+
+  *tracker += readb;
+  if (*tracker != size)
+    return EAGAIN;
+  return 0;
+}
+
+#define RETURN_UNLESS_DONE(call)                                               \
+  do {                                                                         \
+    int ret = (call);                                                          \
+    if (ret) {                                                                 \
+      if (ret == EAGAIN || ret == EWOULDBLOCK)                                 \
+        return true;                                                           \
+      POCL_MSG_ERR("Read error on " #call ", fd=%d, reason: %s\n", fd,         \
+                   strerror(ret));                                             \
+      return false;                                                            \
+    }                                                                          \
+  } while (0);
+
+bool Request::read(int fd) {
+  ssize_t readb;
+  Request *request = this;
+  RequestMsg_t *req = &request->req;
+
+  RETURN_UNLESS_DONE(reentrant_read(fd, &request->req_size,
+                                    sizeof(request->req_size),
+                                    &request->req_size_read));
+
+  if (!request->read_start_timestamp_ns) {
+    auto now1 = std::chrono::system_clock::now();
+    request->read_start_timestamp_ns =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            now1.time_since_epoch())
+            .count();
+  }
+
+  RETURN_UNLESS_DONE(
+      reentrant_read(fd, req, request->req_size, &request->req_read));
+
+  TP_MSG_RECEIVED(req->msg_id, req->did, req->cq_id, req->message_type);
+
+  RequestMessageType t = static_cast<RequestMessageType>(req->message_type);
+  POCL_MSG_PRINT_GENERAL("---------------------------------------------------"
+                         "----------------------------\n");
+  POCL_MSG_PRINT_GENERAL("MESSAGE RECEIVED, ID: %" PRIu64
+                         " TYPE: %s SIZE: %" PRIu64 "/%" PRIu32 " \n",
+                         uint64_t(req->msg_id), request_to_str(t),
+                         request->req_read, request->req_size);
+
+  request->waitlist_size = req->waitlist_size;
+  switch (req->message_type) {
+  case MessageType_WriteBuffer:
+    request->extra_size = req->m.write.size;
+    break;
+  case MessageType_WriteBufferRect:
+    request->extra_size = req->m.write_rect.host_bytes;
+    break;
+  case MessageType_WriteImageRect:
+    request->extra_size = req->m.write_image_rect.host_bytes;
+    break;
+  case MessageType_MigrateD2D:
+    if (req->m.migrate.is_external) {
+      request->extra_size = req->m.migrate.size;
+    }
+    break;
+  case MessageType_FillBuffer:
+    request->extra_size = req->m.fill_buffer.pattern_size;
+    assert(request->extra_size <= (16 * sizeof(uint64_t)));
+    break;
+  case MessageType_FillImageRect:
+    request->extra_size = 16;
+    break;
+  case MessageType_RunKernel:
+    if (req->m.run_kernel.has_new_args) {
+      request->extra_size = req->m.run_kernel.args_num * sizeof(uint64_t);
+      request->extra_size2 = req->m.run_kernel.pod_arg_size;
+    }
+    break;
+  /*****************************/
+  case MessageType_BuildProgramFromBinary:
+  case MessageType_BuildProgramFromSource:
+  case MessageType_BuildProgramFromSPIRV:
+    request->extra_size2 = req->m.build_program.options_len;
+  case MessageType_BuildProgramWithBuiltins:
+    request->extra_size = req->m.build_program.payload_size;
+    break;
+  /*****************************/
+  case MessageType_CreateKernel:
+    request->extra_size = req->m.create_kernel.name_len;
+    break;
+  default:
+    break;
+  }
+
+  /*****************************/
+  if (req->waitlist_size > 0) {
+    if (!request->waitlist)
+      request->waitlist = new uint64_t[request->waitlist_size];
+    POCL_MSG_PRINT_GENERAL(
+        "READING WAIT LIST FOR ID: %" PRIu64 " = %" PRIuS "/%" PRIu64 "\n",
+        uint64_t(req->msg_id), request->waitlist_read, request->waitlist_size);
+    RETURN_UNLESS_DONE(reentrant_read(fd, request->waitlist,
+                                      request->waitlist_size * sizeof(uint64_t),
+                                      &request->waitlist_read));
+  }
+  /*****************************/
+
+  /*****************************/
+  if (request->extra_size > 0) {
+    if (!request->extra_data)
+      request->extra_data = new char[request->extra_size + 1];
+
+    POCL_MSG_PRINT_GENERAL(
+        "READING EXTRA FOR ID: %" PRIu64 " = %" PRIuS "/%" PRIu64 "\n",
+        uint64_t(req->msg_id), request->extra_read, request->extra_size);
+    RETURN_UNLESS_DONE(reentrant_read(
+        fd, request->extra_data, request->extra_size, &request->extra_read));
+    /* Always add a null byte at the end - it is needed for strings and it does
+     * not harm other things */
+    request->extra_data[request->extra_size] = 0;
+  }
+  /*****************************/
+
+  /*****************************/
+  if (request->extra_size2 > 0) {
+    if (!request->extra_data2)
+      request->extra_data2 = new char[request->extra_size2 + 1];
+
+    POCL_MSG_PRINT_GENERAL(
+        "READING EXTRA2 FOR ID:%" PRIu64 " = %" PRIuS "/%" PRIu64 "\n",
+        uint64_t(req->msg_id), request->extra_read2, request->extra_size2);
+    RETURN_UNLESS_DONE(reentrant_read(
+        fd, request->extra_data2, request->extra_size2, &request->extra_read2));
+    /* Always add null byte here too, just in case extra2 is a string */
+    request->extra_data2[request->extra_size2] = 0;
+  }
+  /*****************************/
+
+  if (!request->read_end_timestamp_ns) {
+    auto now2 = std::chrono::system_clock::now();
+    request->read_end_timestamp_ns =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            now2.time_since_epoch())
+            .count();
+  }
+
+  POCL_MSG_PRINT_GENERAL("ALL READS COMPLETE FOR ID: %" PRIu64 ", fd=%d\n",
+                         uint64_t(req->msg_id), fd);
+
+  fully_read = true;
+  return true;
+}
+
+#undef CHECK_READ_RETURN

--- a/pocld/request.cc
+++ b/pocld/request.cc
@@ -165,10 +165,6 @@ bool Request::read(int fd) {
   Request *request = this;
   RequestMsg_t *req = &request->req;
 
-  RETURN_UNLESS_DONE(reentrant_read(fd, &request->req_size,
-                                    sizeof(request->req_size),
-                                    &request->req_size_read));
-
   if (!request->read_start_timestamp_ns) {
     auto now1 = std::chrono::system_clock::now();
     request->read_start_timestamp_ns =
@@ -176,6 +172,10 @@ bool Request::read(int fd) {
             now1.time_since_epoch())
             .count();
   }
+
+  RETURN_UNLESS_DONE(reentrant_read(fd, &request->req_size,
+                                    sizeof(request->req_size),
+                                    &request->req_size_read));
 
   RETURN_UNLESS_DONE(
       reentrant_read(fd, req, request->req_size, &request->req_read));

--- a/pocld/request.hh
+++ b/pocld/request.hh
@@ -35,29 +35,54 @@
 class Request {
 
 public:
+  /** Size, in bytes, of the main request body (up to sizeof RequestMsg_t) */
   uint32_t req_size;
+  /** Tracker for how many bytes of req_size have been read from the network
+   * socket */
   size_t req_size_read;
+  /** Main body of the reuqest */
   RequestMsg_t req;
+  /** Tracker for how many bytes of the main request body have been read from
+   * the network socket */
   size_t req_read;
 
+  /** List of event ids that must complete before this Request can be processed
+   */
   uint64_t *waitlist;
+  /** Number of items in the waitlist */
   uint64_t waitlist_size;
+  /** Tracker for how many bytes of the waitlist have been read */
   size_t waitlist_read;
 
+  /** Auxiliary data required for the Request (buffer contents, program binaries
+   * etc) */
   char *extra_data;
+  /** Size of the auxiliary data buffer */
   uint64_t extra_size;
+  /** Tracker for how many bytes of the auxiliary data buffer have been read
+   * from the network socket */
   size_t extra_read;
 
+  /** Second auxiliary data required for the Request */
   char *extra_data2;
+  /** Size of the second auxiliary data buffer */
   uint64_t extra_size2;
+  /** Tracker for how many bytes of the second auxiliary data buffer have been
+   * read from the network socket */
   size_t extra_read2;
 
-  // server host timestamps for network comm
+  /** Server side timestamp for when reading the request from the network socket
+   * started */
   uint64_t read_start_timestamp_ns;
+  /** Server side timestamp for when the last bit of data for the request has
+   * been successfully read from the network socket. */
   uint64_t read_end_timestamp_ns;
 
+  /** Flag indicating that the request has been fully read from the network
+   * socket. Set at the very end of the read() function. */
   bool fully_read;
 
+  /// Default constructor that initializes all  fields to zero
   Request()
       : req_size(0), req_size_read(0), req(), req_read(0), waitlist(nullptr),
         waitlist_size(0), waitlist_read(0), extra_data(nullptr), extra_size(0),
@@ -65,7 +90,7 @@ public:
         read_start_timestamp_ns(0), read_end_timestamp_ns(0),
         fully_read(false) {}
 
-  // Deep copying constructor
+  /// Deep copying constructor
   Request(const Request &r)
       : req_size(r.req_size), req(r.req), req_size_read(r.req_size_read),
         waitlist(nullptr), waitlist_size(r.waitlist_size),
@@ -101,6 +126,9 @@ public:
       delete[] extra_data2;
   }
 
+  /** Incrementally reads the request from given fd. Returns true on success and
+   * false if an error occurs while reading. Call repeatedly until `fully_read`
+   * gets set to true. */
   bool read(int fd);
 };
 

--- a/pocld/request.hh
+++ b/pocld/request.hh
@@ -1,0 +1,111 @@
+/* request.hh - class that represents a command received from the client
+
+   Copyright (c) 2018 Michal Babej / Tampere University of Technology
+   Copyright (c) 2019-2023 Jan Solanti / Tampere University
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#ifndef POCL_REMOTE_REQUEST_HH
+#define POCL_REMOTE_REQUEST_HH
+
+#include "messages.h"
+#include <cstring>
+
+#ifdef __GNUC__
+#pragma GCC visibility push(hidden)
+#endif
+
+class Request {
+
+public:
+  uint32_t req_size;
+  size_t req_size_read;
+  RequestMsg_t req;
+  size_t req_read;
+
+  uint64_t *waitlist;
+  uint64_t waitlist_size;
+  size_t waitlist_read;
+
+  char *extra_data;
+  uint64_t extra_size;
+  size_t extra_read;
+
+  char *extra_data2;
+  uint64_t extra_size2;
+  size_t extra_read2;
+
+  // server host timestamps for network comm
+  uint64_t read_start_timestamp_ns;
+  uint64_t read_end_timestamp_ns;
+
+  bool fully_read;
+
+  Request()
+      : req_size(0), req_size_read(0), req(), req_read(0), waitlist(nullptr),
+        waitlist_size(0), waitlist_read(0), extra_data(nullptr), extra_size(0),
+        extra_read(0), extra_data2(nullptr), extra_size2(0), extra_read2(0),
+        read_start_timestamp_ns(0), read_end_timestamp_ns(0),
+        fully_read(false) {}
+
+  // Deep copying constructor
+  Request(const Request &r)
+      : req_size(r.req_size), req(r.req), req_size_read(r.req_size_read),
+        waitlist(nullptr), waitlist_size(r.waitlist_size),
+        waitlist_read(r.waitlist_read), extra_data(nullptr),
+        extra_size(r.extra_size), extra_read(r.extra_read),
+        extra_data2(nullptr), extra_size2(r.extra_size2),
+        extra_read2(r.extra_read2),
+        read_start_timestamp_ns(r.read_start_timestamp_ns),
+        read_end_timestamp_ns(r.read_end_timestamp_ns),
+        fully_read(r.fully_read) {
+    if (r.waitlist) {
+      waitlist = new uint64_t[waitlist_size];
+      std::memcpy(waitlist, r.waitlist, sizeof(uint64_t) * waitlist_size);
+    }
+
+    if (r.extra_data) {
+      extra_data = new char[extra_size];
+      std::memcpy(extra_data, r.extra_data, extra_size);
+    }
+
+    if (r.extra_data2) {
+      extra_data = new char[extra_size2];
+      std::memcpy(extra_data2, r.extra_data2, extra_size2);
+    }
+  }
+
+  ~Request() {
+    if (waitlist)
+      delete[] waitlist;
+    if (extra_data)
+      delete[] extra_data;
+    if (extra_data2)
+      delete[] extra_data2;
+  }
+
+  bool read(int fd);
+};
+
+#ifdef __GNUC__
+#pragma GCC visibility pop
+#endif
+
+#endif

--- a/pocld/request_th.cc
+++ b/pocld/request_th.cc
@@ -33,105 +33,9 @@
 #include "tracing.h"
 
 #define CL_INVALID_OPERATION -59
-
-const char *request_to_str(RequestMessageType type) {
-  switch (type) {
-  case MessageType_ServerInfo:
-    return "ServerInfo";
-  case MessageType_DeviceInfo:
-    return "DeviceInfo";
-  case MessageType_ConnectPeer:
-    return "ConnectPeer";
-  case MessageType_PeerHandshake:
-    return "PeerHandshake";
-
-  case MessageType_CreateBuffer:
-    return "CreateBuffer";
-  case MessageType_FreeBuffer:
-    return "FreeBuffer";
-
-  case MessageType_CreateCommandQueue:
-    return "CreateCommandQueue";
-  case MessageType_FreeCommandQueue:
-    return "FreeCommandQueue";
-
-  case MessageType_CreateSampler:
-    return "CreateSampler";
-  case MessageType_FreeSampler:
-    return "FreeSampler";
-
-  case MessageType_CreateImage:
-    return "CreateImage";
-  case MessageType_FreeImage:
-    return "FreeImage";
-
-  case MessageType_CreateKernel:
-    return "CreateKernel";
-  case MessageType_FreeKernel:
-    return "FreeKernel";
-
-  case MessageType_BuildProgramFromSource:
-    return "BuildProgramFromSource";
-  case MessageType_BuildProgramFromBinary:
-    return "BuildProgramFromBinary";
-  case MessageType_BuildProgramFromSPIRV:
-    return "BuildProgramFromSPIRV";
-  case MessageType_BuildProgramWithBuiltins:
-    return "BuildProgramWithBuiltins";
-  case MessageType_FreeProgram:
-    return "FreeProgram";
-
-  case MessageType_MigrateD2D:
-    return "MigrateD2D";
-
-  case MessageType_ReadBuffer:
-    return "ReadBuffer";
-  case MessageType_WriteBuffer:
-    return "WriteBuffer";
-  case MessageType_CopyBuffer:
-    return "CopyBuffer";
-  case MessageType_FillBuffer:
-    return "FillBuffer";
-
-  case MessageType_ReadBufferRect:
-    return "ReadBufferRect";
-  case MessageType_WriteBufferRect:
-    return "WriteBufferRect";
-  case MessageType_CopyBufferRect:
-    return "CopyBufferRect";
-
-  case MessageType_CopyImage2Buffer:
-    return "CopyImage2Buffer";
-  case MessageType_CopyBuffer2Image:
-    return "CopyBuffer2Image";
-  case MessageType_CopyImage2Image:
-    return "CopyImage2Image";
-  case MessageType_ReadImageRect:
-    return "ReadImageRect";
-  case MessageType_WriteImageRect:
-    return "WriteImageRect";
-  case MessageType_FillImageRect:
-    return "FillImageRect";
-
-  case MessageType_RunKernel:
-    return "RunKernel";
-
-  case MessageType_NotifyEvent:
-    return "NotifyEvent";
-
-  case MessageType_RdmaBufferRegistration:
-    return "RdmaBufferRegistration";
-
-  case MessageType_Finish:
-    return "Finish";
-
-  case MessageType_Shutdown:
-    return "Shutdown";
-
-  default:
-    return "UNKNOWN";
-  }
-}
+#ifndef POLLRDHUP
+#define POLLRDHUP 0
+#endif
 
 RequestQueueThread::RequestQueueThread(std::atomic_int *f,
                                        VirtualContextBase *c, ExitHelper *e,
@@ -150,7 +54,7 @@ void RequestQueueThread::readThread() {
   ssize_t readb;
 
   struct pollfd pfd;
-  pfd.events = POLLIN;
+  pfd.events = POLLIN | POLLRDHUP;
   int nevs;
 
   int fd = *this->fd;
@@ -161,7 +65,6 @@ void RequestQueueThread::readThread() {
     if (fd != oldfd) {
       POCL_MSG_PRINT_GENERAL("%s: FD change detected: %d -> %d\n",
                              id_str.c_str(), oldfd, fd);
-      close(oldfd);
     }
     oldfd = fd;
     if (eh->exit_requested())
@@ -171,144 +74,20 @@ void RequestQueueThread::readThread() {
     nevs = poll(&pfd, 1, 3 * MS_PER_S);
     if (nevs < 1)
       continue;
-    else if (!(pfd.revents & POLLIN))
+    if (pfd.revents & (POLLERR | POLLNVAL | POLLHUP | POLLRDHUP))
+      continue;
+    if (!(pfd.revents & POLLIN))
       continue;
 
-    uint32_t msg_size;
     Request *request = new Request;
-    RequestMsg_t *req = &request->req;
-    CHECK_READ_RETRY(readb, read_full(fd, &msg_size, sizeof(uint32_t), netstat),
-                     id_str.c_str());
-    CHECK_READ_RETRY(readb, read_full(fd, req, msg_size, netstat),
-                     id_str.c_str());
-
-    auto now1 = std::chrono::system_clock::now();
-    request->read_start_timestamp_ns =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(
-            now1.time_since_epoch())
-            .count();
-
-    TP_MSG_RECEIVED(req->msg_id, req->did, req->cq_id, req->message_type);
-
-    RequestMessageType t = static_cast<RequestMessageType>(req->message_type);
-    POCL_MSG_PRINT_GENERAL("%s: "
-                           "---------------------------------------------------"
-                           "----------------------------\n",
-                           id_str.c_str());
-    POCL_MSG_PRINT_GENERAL("%s: MESSAGE RECEIVED, ID: %" PRIu64
-                           " TYPE: %s SIZE: %" PRId64 "/%" PRIu32 " \n",
-                           id_str.c_str(), uint64_t(req->msg_id),
-                           request_to_str(t), int64_t(readb), msg_size);
-
-    assert(static_cast<uint32_t>(readb) == msg_size);
-
-    // read extra parts of requests
-    if (req->message_type == MessageType_WriteBuffer) {
-      request->extra_size = req->m.write.size;
-    }
-    if (req->message_type == MessageType_WriteBufferRect) {
-      request->extra_size = req->m.write_rect.host_bytes;
-    }
-    if (req->message_type == MessageType_WriteImageRect) {
-      request->extra_size = req->m.write_image_rect.host_bytes;
-    }
-    if (req->message_type == MessageType_MigrateD2D &&
-        req->m.migrate.is_external) {
-      request->extra_size = req->m.migrate.size;
-    }
-    // END of commands with RDMA transferable data
-
-    if (req->message_type == MessageType_FillBuffer) {
-      request->extra_size = req->m.fill_buffer.pattern_size;
-      assert(request->extra_size <= (16 * sizeof(uint64_t)));
-    }
-    if (req->message_type == MessageType_FillImageRect) {
-      request->extra_size = 16;
+    while (!request->fully_read) {
+      if (!request->read(fd)) {
+        delete request;
+        continue;
+      }
     }
 
-    if (req->message_type == MessageType_RunKernel &&
-        req->m.run_kernel.has_new_args) {
-      // read args
-      //      uint64_t *args = new uint64_t [arg_num];
-      //      read(args, arg_num * sizeof(uint64_t));
-      request->extra_size = req->m.run_kernel.args_num * sizeof(uint64_t);
-      request->extra_size2 = req->m.run_kernel.pod_arg_size;
-    }
-    if (req->message_type == MessageType_BuildProgramFromBinary ||
-        req->message_type == MessageType_BuildProgramFromSource ||
-        req->message_type == MessageType_BuildProgramFromSPIRV ||
-        req->message_type == MessageType_BuildProgramWithBuiltins) {
-      request->extra_size = req->m.build_program.payload_size;
-    }
-
-    /*****************************/
-    request->waitlist_size = req->waitlist_size;
-    if (req->waitlist_size > 0) {
-      POCL_MSG_PRINT_GENERAL("%s: READING WAIT LIST: %" PRIu32 " \n",
-                             id_str.c_str(), request->waitlist_size);
-      request->waitlist = new uint64_t[request->waitlist_size];
-      CHECK_READ_RETRY(readb,
-                       read_full(fd, request->waitlist,
-                                 request->waitlist_size * sizeof(uint64_t),
-                                 netstat),
-                       id_str.c_str());
-    }
-    /*****************************/
-
-    /*****************************/
-    if (request->extra_size > 0) {
-      request->extra_data = new char[request->extra_size];
-
-      POCL_MSG_PRINT_GENERAL("%s: READING EXTRA: %" PRIuS " \n",
-                             id_str.c_str(), request->extra_size);
-      CHECK_READ_RETRY(
-          readb,
-          read_full(fd, request->extra_data, request->extra_size, netstat),
-          id_str.c_str());
-    }
-    /*****************************/
-
-    // name string
-    if (req->message_type == MessageType_CreateKernel) {
-      request->extra_size = req->m.create_kernel.name_len;
-      request->extra_data = new char[request->extra_size + 1];
-      POCL_MSG_PRINT_GENERAL("%s: READING EXTRA: %" PRIuS " \n", id_str.c_str(),
-                             request->extra_size);
-      CHECK_READ_RETRY(
-          readb,
-          read_full(fd, request->extra_data, request->extra_size, netstat),
-          id_str.c_str());
-      request->extra_data[request->extra_size] = 0;
-    }
-
-    // options
-    if (req->message_type == MessageType_BuildProgramFromBinary ||
-        req->message_type == MessageType_BuildProgramFromSource ||
-        req->message_type == MessageType_BuildProgramFromSPIRV) {
-      request->extra_size2 = req->m.build_program.options_len;
-    }
-    /*****************************/
-    if (request->extra_size2 > 0) {
-      request->extra_data2 = new char[request->extra_size2 + 1];
-      POCL_MSG_PRINT_GENERAL("%s: READING EXTRA2: %" PRIuS "\n", id_str.c_str(),
-                             request->extra_size2);
-      CHECK_READ_RETRY(
-          readb,
-          read_full(fd, request->extra_data2, request->extra_size2, netstat),
-          id_str.c_str());
-      request->extra_data2[request->extra_size2] = 0;
-    }
-    /*****************************/
-    POCL_MSG_PRINT_GENERAL("%s: ALL READS COMPLETE FOR ID: %" PRIu64 "\n",
-                           id_str.c_str(), uint64_t(req->msg_id));
-
-    auto now2 = std::chrono::system_clock::now();
-    request->read_end_timestamp_ns =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(
-            now2.time_since_epoch())
-            .count();
-
-    switch (req->message_type) {
+    switch (request->req.message_type) {
     case MessageType_ConnectPeer:
     case MessageType_DeviceInfo:
     case MessageType_CreateBuffer:

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -268,6 +268,15 @@ if(ENABLE_REMOTE_CLIENT AND ENABLE_REMOTE_SERVER AND ENABLE_HOST_CPU_DEVICES)
       DEPENDS "pocl_version_check"
       LABELS "remote"
       RESOURCE_LOCK "pocld_ports")
+
+  if(ENABLE_RDMA)
+    set_tests_properties(
+      "remote/test_buffer_migration"
+      "remote/test_buffer_ping_pong"
+      "remote/test_cl_pocl_content_size_migration_remote_remote"
+      PROPERTIES
+        LABELS "remote_rdma")
+  endif()
 endif()
 
 if(NOT ENABLE_ANYSAN)

--- a/tools/scripts/format-branch.sh
+++ b/tools/scripts/format-branch.sh
@@ -6,6 +6,9 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+SCRIPTPATH=$( realpath "$0"  )
+RELPATH=$(dirname "$SCRIPTPATH")
+
 # cd to root directory of the git repo
 pushd ${GITROOT} > /dev/null
 
@@ -19,9 +22,6 @@ PATCHY=$(mktemp /tmp/pocl.XXXXXXXX.patch)
 trap "rm -f $PATCHY" EXIT
 
 git diff main -U0 --no-color >$PATCHY
-
-SCRIPTPATH=$( realpath "$0"  )
-RELPATH=$(dirname "$SCRIPTPATH")
 
 $RELPATH/clang-format-diff.py -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 -style GNU <$PATCHY
 $RELPATH/clang-format-diff.py -regex '(.*(\.hpp$|\.hh$|\.cc$|\.cpp$))|(lib/llvmopencl/.*)|(lib/CL/devices/tce/.*)' -i -p1 -style LLVM <$PATCHY

--- a/tools/scripts/format-diff.sh
+++ b/tools/scripts/format-diff.sh
@@ -6,6 +6,9 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+SCRIPTPATH=$( realpath "$0"  )
+RELPATH=$(dirname "$SCRIPTPATH")
+
 # cd to root directory of the git repo
 pushd ${GITROOT} > /dev/null
 
@@ -13,9 +16,6 @@ PATCHY=$(mktemp /tmp/pocl.XXXXXXXX.patch)
 trap "rm -f $PATCHY" EXIT
 
 git diff -U0 --no-color >$PATCHY
-
-SCRIPTPATH=$( realpath "$0"  )
-RELPATH=$(dirname "$SCRIPTPATH")
 
 $RELPATH/clang-format-diff.py -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 -style GNU <$PATCHY
 $RELPATH/clang-format-diff.py -regex '(.*(\.hpp$|\.hh$|\.cc$|\.cpp$))|(lib/llvmopencl/.*)|(lib/CL/devices/tce/.*)' -i -p1 -style LLVM <$PATCHY

--- a/tools/scripts/format-last-commit.sh
+++ b/tools/scripts/format-last-commit.sh
@@ -6,6 +6,9 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+SCRIPTPATH=$( realpath "$0"  )
+RELPATH=$(dirname "$SCRIPTPATH")
+
 # cd to root directory of the git repo
 pushd ${GITROOT} > /dev/null
 
@@ -19,9 +22,6 @@ PATCHY=$(mktemp /tmp/pocl.XXXXXXXX.patch)
 trap "rm -f $PATCHY" EXIT
 
 git show -U0 --no-color >$PATCHY
-
-SCRIPTPATH=$( realpath "$0"  )
-RELPATH=$(dirname "$SCRIPTPATH")
 
 $RELPATH/clang-format-diff.py -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 -style GNU <$PATCHY
 $RELPATH/clang-format-diff.py -regex '(.*(\.hpp$|\.hh$|\.cc$|\.cpp$))|(lib/llvmopencl/.*)|(lib/CL/devices/tce/.*)' -i -p1 -style LLVM <$PATCHY

--- a/tools/scripts/run_remote_tests
+++ b/tools/scripts/run_remote_tests
@@ -27,7 +27,4 @@
 #
 # The current tests are run through a wrapper script that handles setting the
 # necessary environment variables so there is not much left to do here.
-#
-# Parallel testing doesn't seem to work reliably due to pocld not always
-# dying fast enough (?).
-ctest -j1 -L remote
+ctest -L remote $@

--- a/tools/scripts/test_remote_runner_multi.sh
+++ b/tools/scripts/test_remote_runner_multi.sh
@@ -23,6 +23,7 @@ BUILD_DIR=$1
 TEST_BINARY=$2
 shift 2
 
+PUBLIC_IP=$(ip route get 9.9.9.9 | tr -s ' ' | cut -d' ' -f7)
 PORT1=12000
 PORT2=22000
 
@@ -43,12 +44,12 @@ export POCL_BUILDING=1
 export POCL_DEVICES="cpu"
 export POCL_DEBUG=
 
-$BUILD_DIR/pocld/pocld -a 127.0.0.1 -p $PORT1 -v error,warn,general &
+$BUILD_DIR/pocld/pocld -a $PUBLIC_IP -p $PORT1 -v error,warn,general &
 POCLD_PID1=$!
 
 echo "Pocld running with PID: $POCLD_PID1"
 
-$BUILD_DIR/pocld/pocld -a 127.0.0.1 -p $PORT2 -v error,warn,general &
+$BUILD_DIR/pocld/pocld -a $PUBLIC_IP -p $PORT2 -v error,warn,general &
 POCLD_PID2=$!
 
 echo "Pocld running with PID: $POCLD_PID2"
@@ -56,8 +57,8 @@ echo "Pocld running with PID: $POCLD_PID2"
 sleep 1
 
 export POCL_DEVICES="remote remote"
-export POCL_REMOTE0_PARAMETERS="127.0.0.1:$PORT1/0"
-export POCL_REMOTE1_PARAMETERS="127.0.0.1:$PORT2/0"
+export POCL_REMOTE0_PARAMETERS="$PUBLIC_IP:$PORT1/0"
+export POCL_REMOTE1_PARAMETERS="$PUBLIC_IP:$PORT2/0"
 export POCL_DEBUG=warn,err,remote
 unset POCL_ENABLE_UNINIT
 

--- a/tools/scripts/test_remote_runner_multi.sh
+++ b/tools/scripts/test_remote_runner_multi.sh
@@ -102,4 +102,6 @@ kill -9 $EXAMPLE_PID 1>/dev/null 2>&1
 kill -9 $POCLD_PID1 1>/dev/null 2>&1
 kill -9 $POCLD_PID2 1>/dev/null 2>&1
 
+wait -f
+
 exit $RESULT

--- a/tools/scripts/test_remote_runner_single.sh
+++ b/tools/scripts/test_remote_runner_single.sh
@@ -90,4 +90,6 @@ sleep 2
 kill -9 $EXAMPLE_PID 1>/dev/null 2>&1
 kill -9 $POCLD_PID 1>/dev/null 2>&1
 
+wait -f
+
 exit $RESULT

--- a/tools/scripts/test_remote_runner_with_local.sh
+++ b/tools/scripts/test_remote_runner_with_local.sh
@@ -90,4 +90,6 @@ sleep 2
 kill -9 $EXAMPLE_PID 1>/dev/null 2>&1
 kill -9 $POCLD_PID 1>/dev/null 2>&1
 
+wait -f
+
 exit $RESULT

--- a/tools/scripts/test_remote_runner_with_local.sh
+++ b/tools/scripts/test_remote_runner_with_local.sh
@@ -42,7 +42,7 @@ export POCL_BUILDING=1
 export POCL_DEVICES="cpu"
 export POCL_DEBUG=
 
-$BUILD_DIR/pocld/pocld -a 127.0.0.1 -p $PORT -v error,warn,general &
+$BUILD_DIR/pocld/pocld -a localhost -p $PORT -v error,warn,general &
 POCLD_PID=$!
 
 echo "Pocld running with PID: $POCLD_PID"
@@ -50,7 +50,7 @@ echo "Pocld running with PID: $POCLD_PID"
 sleep 1
 
 export POCL_DEVICES="cpu remote"
-export POCL_REMOTE0_PARAMETERS="127.0.0.1:$PORT/0"
+export POCL_REMOTE0_PARAMETERS="localhost:$PORT/0"
 export POCL_DEBUG="warn,err,remote"
 unset POCL_ENABLE_UNINIT
 


### PR DESCRIPTION
Move from per-client per-socket threads to a single thread that `poll()`s all client sockets. Additionally requests are now read incrementally to avoid large requests from blocking smaller commands.