### PR TITLE
clGetContextInfo: param_value_size_ret may be NULL

### DIFF
--- a/lib/CL/clGetContextInfo.c
+++ b/lib/CL/clGetContextInfo.c
@@ -56,7 +56,8 @@ POname(clGetContextInfo)(cl_context context,
       }
     else
       {
-        *param_value_size_ret = 0;
+        if (param_value_size_ret != NULL)
+          *param_value_size_ret = 0;
         return CL_SUCCESS;
       }
   default:


### PR DESCRIPTION
According to the OpenCL spec, param_value_size_ret may be NULL and should be ignored in that case. This commit fixes one case that did not check if the pointer is NULL before writing to it.