### PR TITLE
CUDA fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1723,8 +1723,11 @@ if(ENABLE_CUDA)
   set(CUDA_DEVICE_EXTENSIONS "cl_khr_byte_addressable_store cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_nv_device_attribute_query")
 
   # CUDA device: list of OpenCL 3.0 features that are always enabled
-  # __opencl_c_3d_image_writes  __opencl_c_images
-  set(CUDA_DEVICE_FEATURES_30 "__opencl_c_atomic_order_acq_rel __opencl_c_atomic_order_seq_cst \
+  # __opencl_c_images should not be included since we don't support images yet,
+  # but is needed to work around an issue with the opencl-c.h header in Clang versions from 14 onwards
+  # https://github.com/llvm/llvm-project/issues/58017
+  # __opencl_c_3d_image_writes and other image-related extensions are disabled because not supported yet
+  set(CUDA_DEVICE_FEATURES_30 "__opencl_c_images __opencl_c_atomic_order_acq_rel __opencl_c_atomic_order_seq_cst \
     __opencl_c_atomic_scope_device __opencl_c_program_scope_global_variables \
     __opencl_c_generic_address_space")
 

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -39,7 +39,6 @@
 #include "pocl_runtime_config.h"
 #include "pocl_timing.h"
 #include "pocl_util.h"
-#include "builtin_kernels.hh"
 
 #include <string.h>
 #include <fcntl.h>


### PR DESCRIPTION
This patchset removes a header double inclusion, and adds the `__opencl_c_images` extension to the ones declared by the CUDA devices, to work around the upstream `opencl-c.h` header issue discussed in issue #1339.