### PR TITLE
Initial steps for CG SVM on PoCL-R

### DIFF
--- a/include/pocl.h
+++ b/include/pocl.h
@@ -394,6 +394,7 @@ typedef struct
 typedef struct
 {
   void* svm_ptr;
+  size_t size;
 } _cl_command_svm_unmap;
 
 typedef struct

--- a/lib/CL/clEnqueueSVMUnmap.c
+++ b/lib/CL/clEnqueueSVMUnmap.c
@@ -52,7 +52,8 @@ POname(clEnqueueSVMUnmap) (cl_command_queue command_queue,
   if (errcode != CL_SUCCESS)
     return errcode;
 
-  errcode = pocl_svm_check_pointer (context, svm_ptr, 1, NULL);
+  size_t svm_buf_size;
+  errcode = pocl_svm_check_pointer (context, svm_ptr, 1, &svm_buf_size);
   if (errcode != CL_SUCCESS)
     return errcode;
 
@@ -73,10 +74,10 @@ POname(clEnqueueSVMUnmap) (cl_command_queue command_queue,
     }
 
   cmd->command.svm_unmap.svm_ptr = svm_ptr;
+  cmd->command.svm_unmap.size = svm_buf_size;
   pocl_command_enqueue(command_queue, cmd);
 
   return CL_SUCCESS;
-
 }
 POsym(clEnqueueSVMUnmap)
 

--- a/lib/CL/devices/bufalloc.h
+++ b/lib/CL/devices/bufalloc.h
@@ -1,12 +1,13 @@
 /* OpenCL runtime/device driver library: custom buffer allocator
 
    Copyright (c) 2011 Tampere University of Technology
+                 2023 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -16,9 +17,9 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 /**
  * This file implements a customized memory allocator for OpenCL buffers.
@@ -27,10 +28,8 @@
  * @file bufalloc.h
  */
 
-#ifndef BUFALLOC_H
-#define BUFALLOC_H
-
-#include "pocl_cl.h"
+#ifndef POCL_BUFALLOC_H
+#define POCL_BUFALLOC_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,6 +39,7 @@ extern "C" {
 
 #ifndef __TCE_STANDALONE__
 
+#include "pocl_threads.h"
 
 typedef pocl_lock_t ba_lock_t;
 
@@ -126,6 +126,7 @@ struct chunk_info
    itself. */
 struct memory_region
 {
+  /* TODO: Enable dynamic number of chunks for host-side allocation. */
   chunk_info_t all_chunks[MAX_CHUNKS_IN_REGION];
   chunk_info_t *chunks;
   chunk_info_t *free_chunks; /* A pointer to a head of a linked list of
@@ -159,6 +160,13 @@ memory_region_t *pocl_free_buffer (memory_region_t *regions, memory_address_t ad
 POCL_EXPORT
 void pocl_free_chunk (chunk_info_t *chunk);
 
+/**
+ * Initializes a memory allocation region (address space) with default
+ * attributes.
+ *
+ * @param start The starting address.
+ * @param size Size of the address space.
+ */
 POCL_EXPORT
 void pocl_init_mem_region (
     memory_region_t *region, memory_address_t start, size_t size);

--- a/pocld/CMakeLists.txt
+++ b/pocld/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SOURCES pocld.cc cmdline.h cmdline.c
             ../lib/CL/pocl_threads.c ../lib/CL/pocl_threads.h
             ../lib/CL/pocl_timing.c ../lib/CL/pocl_timing.h
             ../lib/CL/devices/spirv_parser.hh ../lib/CL/devices/spirv_parser.cc
+            ../lib/CL/devices/bufalloc.h ../lib/CL/devices/bufalloc.c
             ../lib/CL/pocl_networking.c ../lib/CL/pocl_networking.h
             shared_cl_context.cc shared_cl_context.hh
             virtual_cl_context.cc virtual_cl_context.hh

--- a/pocld/common.hh
+++ b/pocld/common.hh
@@ -145,7 +145,7 @@ uint64_t transfer_size(const RequestMsg_t &msg);
 #define CHECK_ID_NOT_EXISTS(set, err)                                          \
   do {                                                                         \
     if (set.find(id) != set.end()) {                                           \
-      POCL_MSG_ERR("FOUND object with ID %" PRIu32 "; reply FAIL with: %d\n",  \
+      POCL_MSG_ERR("FOUND object with ID %" PRIu64 "; reply FAIL with: %d\n",  \
                    id, err);                                                   \
       rep->rep.data_size = 0;                                                  \
       rep->rep.fail_details = err;                                             \

--- a/pocld/request.cc
+++ b/pocld/request.cc
@@ -215,7 +215,11 @@ bool Request::read(int fd) {
     break;
   case MessageType_RunKernel:
     if (req->m.run_kernel.has_new_args) {
-      request->extra_size = req->m.run_kernel.args_num * sizeof(uint64_t);
+      /* The arguments itself come in through extra data, as well as an array of
+         flags which inform whether an argument (buffer) is an
+         SVM pointer or not. */
+      request->extra_size = req->m.run_kernel.args_num * sizeof(uint64_t) +
+                            req->m.run_kernel.args_num * sizeof(unsigned char);
       request->extra_size2 = req->m.run_kernel.pod_arg_size;
     }
     break;

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -564,7 +564,8 @@ SharedCLContext::SharedCLContext(cl::Platform *p, unsigned pid,
       MaxSVMAllocSize = MaxMemAllocSize;
   }
 
-  if (CLDevicesWithSVMSupport.size() > 0) {
+  // The CG SVM support for PoCL-Remote is a WiP. Disable brutally for now.
+  if (false && CLDevicesWithSVMSupport.size() > 0) {
     // Create a pinned contiguous region to map CG SVM allocations
     // to. Communicate the start address and the size to the client
     // so it can setup its own SVM region on its side.

--- a/pocld/shared_cl_context.hh
+++ b/pocld/shared_cl_context.hh
@@ -2,6 +2,7 @@
 
    Copyright (c) 2018 Michal Babej / Tampere University of Technology
    Copyright (c) 2019-2023 Jan Solanti / Tampere University
+   Copyright (c) 2023 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to
@@ -70,7 +71,7 @@ public:
   virtual int createBuffer(uint32_t buffer_id, size_t size, uint64_t flags,
                            void *host_ptr, void **device_addr) = 0;
 
-  virtual int freeBuffer(uint32_t buffer_id) = 0;
+  virtual int freeBuffer(uint64_t buffer_id, bool is_svm) = 0;
 
   virtual int buildProgram(
       uint32_t program_id, std::vector<uint32_t> &DeviceList, char *source,
@@ -121,16 +122,16 @@ public:
   /**********************************************************************/
   /**********************************************************************/
 
-  virtual int readBuffer(uint64_t ev_id, uint32_t cq_id, uint32_t buffer_id,
-                         uint32_t size_id, size_t size, size_t offset,
-                         void *host_ptr, uint64_t *content_size,
+  virtual int readBuffer(uint64_t ev_id, uint32_t cq_id, uint64_t buffer_id,
+                         int is_svm, uint32_t size_id, size_t size,
+                         size_t offset, void *host_ptr, uint64_t *content_size,
                          EventTiming_t &evt, uint32_t waitlist_size,
                          uint64_t *waitlist) = 0;
 
-  virtual int writeBuffer(uint64_t ev_id, uint32_t cq_id, uint32_t buffer_id,
-                          size_t size, size_t offset, void *host_ptr,
-                          EventTiming_t &evt, uint32_t waitlist_size,
-                          uint64_t *waitlist) = 0;
+  virtual int writeBuffer(uint64_t ev_id, uint32_t cq_id, uint64_t buffer_id,
+                          int is_svm, size_t size, size_t offset,
+                          void *host_ptr, EventTiming_t &evt,
+                          uint32_t waitlist_size, uint64_t *waitlist) = 0;
 
   virtual int copyBuffer(uint64_t ev_id, uint32_t cq_id, uint32_t src_buffer_id,
                          uint32_t dst_buffer_id,
@@ -168,10 +169,11 @@ public:
 
   virtual int runKernel(uint64_t ev_id, uint32_t cq_id, uint32_t device_id,
                         uint16_t has_new_args, size_t arg_count, uint64_t *args,
-                        size_t pod_size, char *pod_buf, EventTiming_t &evt,
-                        uint32_t kernel_id, uint32_t waitlist_size,
-                        uint64_t *waitlist, unsigned dim,
-                        const sizet_vec3 &offset, const sizet_vec3 &global,
+                        unsigned char *is_svm_ptr, size_t pod_size,
+                        char *pod_buf, EventTiming_t &evt, uint32_t kernel_id,
+                        uint32_t waitlist_size, uint64_t *waitlist,
+                        unsigned dim, const sizet_vec3 &offset,
+                        const sizet_vec3 &global,
                         const sizet_vec3 *local = nullptr) = 0;
 
   /**********************************************************************/

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -1,7 +1,7 @@
 #=============================================================================
 #   CMake build system files
 #
-#   Copyright (c) 2014 pocl developers
+#   Copyright (c) 2014-2023 pocl developers
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a copy
 #   of this software and associated documentation files (the "Software"), to deal
@@ -46,7 +46,7 @@ set(C_PROGRAMS_TO_BUILD test_clFinish test_clGetDeviceInfo test_clGetEventInfo
   test_cl_pocl_content_size test_cl_pocl_content_size_migration
   test_deviceside_enqueue test_command_buffer test_command_buffer_images)
 
-set(CXX_PROGRAMS_TO_BUILD test_pinned_buffers)
+set(CXX_PROGRAMS_TO_BUILD test_pinned_buffers test_svm)
 
 add_compile_options(${OPENCL_CFLAGS})
 
@@ -136,6 +136,8 @@ add_test(NAME "runtime/test_command_buffer_images" COMMAND "test_command_buffer_
 
 add_test(NAME "runtime/test_pinned_buffers" COMMAND "test_pinned_buffers")
 
+add_test(NAME "runtime/test_svm" COMMAND "test_svm")
+
 set_tests_properties( "runtime/clGetDeviceInfo" "runtime/clEnqueueNativeKernel"
   "runtime/clGetEventInfo" "runtime/clCreateProgramWithBinary"
   "runtime/clBuildProgram" "runtime/clFinish" "runtime/clSetEventCallback"
@@ -151,7 +153,7 @@ set_tests_properties( "runtime/clGetDeviceInfo" "runtime/clEnqueueNativeKernel"
   "runtime/clSetMemObjectDestructorCallback" "runtime/test_link_error"
   "runtime/test_cl_pocl_content_size" "runtime/test_deviceside_enqueue"
   "runtime/test_command_buffer" "runtime/test_command_buffer_images"
-  "runtime/test_pinned_buffers"
+  "runtime/test_pinned_buffers" "runtime/test_svm"
   PROPERTIES
     COST 2.0
     PROCESSORS 1
@@ -169,6 +171,7 @@ set_tests_properties(
   "runtime/test_command_buffer"
   "runtime/test_command_buffer_images"
   "runtime/test_pinned_buffers"
+  "runtime/test_svm"
   PROPERTIES SKIP_RETURN_CODE 77)
 
 if(ENABLE_REMOTE_CLIENT AND ENABLE_REMOTE_SERVER AND ENABLE_HOST_CPU_DEVICES)
@@ -228,6 +231,8 @@ if(ENABLE_REMOTE_CLIENT AND ENABLE_REMOTE_SERVER AND ENABLE_HOST_CPU_DEVICES)
            COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/scripts/test_remote_runner_single.sh" "${CMAKE_BINARY_DIR}" "tests/runtime/test_command_buffer_images")
   add_test(NAME "remote/test_pinned_buffers"
            COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/scripts/test_remote_runner_single.sh" "${CMAKE_BINARY_DIR}" "tests/runtime/test_pinned_buffers")
+  add_test(NAME "remote/test_svm"
+           COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../../tools/scripts/test_remote_runner_single.sh" "${CMAKE_BINARY_DIR}" "tests/runtime/test_svm")
 
   set_tests_properties(
     "remote/clCreateSubDevices"
@@ -242,6 +247,7 @@ if(ENABLE_REMOTE_CLIENT AND ENABLE_REMOTE_SERVER AND ENABLE_HOST_CPU_DEVICES)
     "remote/test_command_buffer"
     "remote/test_command_buffer_images"
     "remote/test_pinned_buffers"
+    "remote/test_svm"
     PROPERTIES SKIP_RETURN_CODE 77)
 
   set_tests_properties(
@@ -260,7 +266,7 @@ if(ENABLE_REMOTE_CLIENT AND ENABLE_REMOTE_SERVER AND ENABLE_HOST_CPU_DEVICES)
     "remote/test_cl_pocl_content_size_migration_remote_remote"
     "remote/test_deviceside_enqueue"
     "remote/test_command_buffer" "remote/test_command_buffer_images"
-    "remote/test_pinned_buffers"
+    "remote/test_pinned_buffers" "remote/test_svm"
     PROPERTIES
       PASS_REGULAR_EXPRESSION "OK"
       COST 2.0

--- a/tests/runtime/test_svm.cpp
+++ b/tests/runtime/test_svm.cpp
@@ -1,0 +1,209 @@
+/* Test the pinned buffers extension.
+
+   Copyright (c) 2023 Pekka Jääskeläinen / Intel Finland Oy
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+// Enable OpenCL C++ exceptions
+#define CL_HPP_ENABLE_EXCEPTIONS
+
+#include "../../include/CL/cl_ext_pocl.h"
+#include <CL/opencl.hpp>
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <random>
+
+#include "pocl_opencl.h"
+
+#define BUF_SIZE 16
+
+static char GetAddrSourceCode[] = R"raw(
+
+  __kernel void get_addr (__global int *svm_buffer,
+                          __global ulong* addr) {
+    for (int i = 0; i < BUF_SIZE; ++i) {
+      svm_buffer[i] += 1;
+      printf("kern-side svm_buffer[%d] == %d\n", i, svm_buffer[i]);
+    }
+    *addr = (ulong)svm_buffer;
+    printf("kern-side addr %p\n", svm_buffer);
+  }
+)raw";
+
+int main(void) {
+
+  unsigned Errors = 0;
+  bool AllOK = true;
+
+  try {
+    std::vector<cl::Platform> PlatformList;
+
+    cl::Platform::get(&PlatformList);
+
+    cl_context_properties cprops[] = {
+        CL_CONTEXT_PLATFORM, (cl_context_properties)(PlatformList[0])(), 0};
+    cl::Context Context(CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU, cprops);
+
+    std::vector<cl::Device> Devices = Context.getInfo<CL_CONTEXT_DEVICES>();
+
+    std::vector<cl::Device> SuitableDevices;
+
+    for (cl::Device &Dev : Devices) {
+      if (Dev.getInfo<CL_DEVICE_SVM_CAPABILITIES>() &
+          CL_DEVICE_SVM_COARSE_GRAIN_BUFFER) {
+        SuitableDevices.push_back(Dev);
+        break;
+      } else {
+        std::cout << "Device '" << Dev.getInfo<CL_DEVICE_NAME>() << "' doesn't support CG SVM."
+                  << std::endl;
+      }
+    }
+
+    if (SuitableDevices.empty()) {
+      std::cout << "No devices with SVM coarse grain buffer capabilities found.";
+      return 77;
+    }
+
+    // Basics: Create a bunch of random-sized allocations and ensure their address
+    // ranges do not overlap.
+    constexpr size_t NumAllocs = 1000;
+    constexpr size_t MaxSize = 1024*1024;
+
+    std::mt19937 Gen(1234);
+    std::uniform_int_distribution<> Distrib(1, MaxSize);
+
+    std::map<char*, size_t> Allocs;
+    for (int i = 0; i < NumAllocs; ++i) {
+      size_t AllocSize = Distrib(Gen);
+
+      char *Buf = (char*)::clSVMAlloc(Context.get(), CL_MEM_READ_WRITE,
+                                      AllocSize, 0);
+
+      // If we exhaust the SVM space space, it's fine.
+      // Freeing the allocations should make the remainder of the test
+      // work still, unless there's a mem leak in the implementation
+      // side.
+      if (Buf == nullptr)
+        break;
+
+      // Check for overlap.
+      for (auto& m : Allocs) {
+        if (m.first <= Buf && m.first + m.second > Buf) {
+          std::cerr << "An SVM allocation at " << std::hex << (size_t)Buf
+                    << " with size " << std::dec << AllocSize
+                    << " overlaps with a previous one at " << std::hex
+                    << (size_t)m.first << " with size " << m.second << std::endl;
+          return EXIT_FAILURE;
+        }
+      }
+      Allocs[Buf] = AllocSize;
+    }
+
+    if (Allocs.size() == 0) {
+      std::cerr << "Unable to allocate any SVM chunks." << std::endl;
+      return EXIT_FAILURE;
+    }
+    for (auto& m : Allocs) {
+      // std::cout << "Freeing " << std::hex << (size_t)m.first << std::endl;
+      clSVMFree(Context.get(), m.first);
+    }
+
+    cl::CommandQueue Queue(Context, SuitableDevices[0], 0);
+
+    cl::Program::Sources Sources({GetAddrSourceCode});
+    cl::Program Program(Context, Sources);
+
+#define STRINGIFY(X, Y) X #Y
+#define SET_BUF_SIZE(NUM) STRINGIFY("-DBUF_SIZE=", NUM)
+
+    Program.build(SuitableDevices, SET_BUF_SIZE(BUF_SIZE));
+
+    cl::Kernel GetAddrKernel(Program, "get_addr");
+
+    constexpr size_t BufSize = BUF_SIZE * sizeof(int);
+    int *CGSVMBuf = (int*)::clSVMAlloc(Context.get(), CL_MEM_READ_WRITE,
+                                       BufSize, 0);
+
+    if (CGSVMBuf == nullptr) {
+      std::cerr << "CG SVM allocation returned a nullptr." << std::endl;
+      return EXIT_FAILURE;
+    }
+
+    cl_ulong AddrFromKernel = 1;
+
+    cl::Buffer AddrCLBuffer =
+        cl::Buffer(Context, CL_MEM_WRITE_ONLY, sizeof(cl_ulong), nullptr);
+
+    ::clSetKernelArgSVMPointer(GetAddrKernel.get(), 0, CGSVMBuf);
+    GetAddrKernel.setArg(1, AddrCLBuffer);
+
+    Queue.enqueueMapSVM(CGSVMBuf, true, CL_MAP_WRITE, BufSize);
+
+    for (int i = 0; i < BUF_SIZE; ++i) {
+      CGSVMBuf[i] = i;
+    }
+
+    // Is this actually unneccessary because the kernel execution and finishing are
+    // syncpoints?
+    Queue.enqueueUnmapSVM(CGSVMBuf);
+    Queue.enqueueNDRangeKernel(GetAddrKernel, cl::NullRange, cl::NDRange(1),
+                               cl::NullRange);
+
+    Queue.enqueueReadBuffer(AddrCLBuffer,
+                            CL_TRUE, // block
+                            0, sizeof(cl_ulong), (void *)&AddrFromKernel);
+
+    if (CGSVMBuf != (void *)AddrFromKernel) {
+      std::cerr << "CG buffer's device address on kernel side and host "
+        "side do not match. Host sees " << std::hex << CGSVMBuf << " while "
+        "the device sees " << AddrFromKernel << std::endl;
+      AllOK = false;
+    }
+
+    // Is not needed because the kernel execution and finishing are
+    // syncpoints.
+    Queue.enqueueMapSVM(CGSVMBuf, CL_TRUE, CL_MAP_READ, BufSize);
+
+    for (int i = 0; i < BUF_SIZE; ++i) {
+      if (CGSVMBuf[i] != i + 1) {
+        AllOK = false;
+        std::cerr << "CGSVMBuf[" << i << "] expected to be " << i + 1
+                  << " but got " << (int)CGSVMBuf[i] << std::endl;
+      }
+    }
+    clSVMFree(Context.get(), CGSVMBuf);
+
+  } catch (cl::Error &err) {
+    std::cerr << "ERROR: " << err.what() << "(" << err.err() << ")"
+              << std::endl;
+    AllOK = false;
+  }
+
+  CHECK_CL_ERROR (clUnloadCompiler ());
+
+  if (AllOK) {
+    std::cout << "OK" << std::endl;
+    return EXIT_SUCCESS;
+  } else
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
Still a WiP so disabled in code meanwhile. It currently works only if both the server and the client manage to map the SVM pool to the same address range. This seems to happen often enough for this state to be useful for testing and further development.

