### PR TITLE
Somewhat usable remote CG SVM

### DIFF
--- a/include/pocl.h
+++ b/include/pocl.h
@@ -96,7 +96,7 @@ typedef struct pocl_mem_identifier
   int is_pinned;
 
   /* The device-side memory address (if known). If is_pinned is true, this
-     must be a valid value (note: 0 can be a valid address!). */
+     must be a valid value (note: 0 means invalid address). */
   void *device_addr;
 
   /* Content version tracking. Every write use (clEnqWriteBuffer,

--- a/lib/CL/clEnqueueNativeKernel.c
+++ b/lib/CL/clEnqueueNativeKernel.c
@@ -1,3 +1,26 @@
+/* OpenCL runtime library: clEnqueueNativeKernel()
+
+   Copyright (c) 2010-2023 PoCL developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
 #include "config.h"
 #include "pocl_cl.h"
 #include "pocl_util.h"

--- a/lib/CL/clSVMAlloc.c
+++ b/lib/CL/clSVMAlloc.c
@@ -1,12 +1,13 @@
 /* OpenCL runtime library: clSVMAlloc()
 
    Copyright (c) 2015 Michal Babej / Tampere University of Technology
+                 2023 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -16,12 +17,13 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #include "devices.h"
+#include "pocl_cl.h"
 #include "pocl_shared.h"
 #include "pocl_util.h"
 
@@ -105,11 +107,28 @@ POname(clSVMAlloc)(cl_context context,
       return NULL;
     }
 
+  /* Create a shadow cl_mem object for keeping track of the SVM
+     allocation and to implement automated migrations, cl_pocl_content_size,
+     etc. for CG SVM using the same code paths as with cl_mems. */
+
+  cl_int errcode = CL_SUCCESS;
+  cl_mem clmem_shadow = POname (clCreateBuffer) (
+      context, CL_MEM_PINNED | CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, size,
+      ptr, &errcode);
+
+  if (errcode != CL_SUCCESS)
+    {
+      POCL_MSG_ERR ("Failed to allocate memory a shadow cl_mem.");
+      return NULL;
+    }
+
   POCL_LOCK_OBJ (context);
   item->svm_ptr = ptr;
   item->size = size;
+  item->shadow_cl_mem = clmem_shadow;
   DL_APPEND (context->svm_ptrs, item);
   POCL_UNLOCK_OBJ (context);
+
   POname (clRetainContext) (context);
 
   POCL_MSG_PRINT_MEMORY ("Allocated SVM: PTR %p, SIZE %zu, FLAGS %" PRIu64

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -205,7 +205,7 @@ pocl_pthread_init (unsigned j, cl_device_id device, const char* parameters)
   /* OpenCL 2.0 properties */
   device->svm_caps = CL_DEVICE_SVM_COARSE_GRAIN_BUFFER
                      | CL_DEVICE_SVM_FINE_GRAIN_BUFFER
-                     | CL_DEVICE_SVM_ATOMICS;
+                     | CL_DEVICE_SVM_FINE_GRAIN_SYSTEM | CL_DEVICE_SVM_ATOMICS;
 
   if (strstr (HOST_DEVICE_EXTENSIONS, "cl_ext_float_atomics")
       != NULL) {

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -1143,6 +1143,9 @@ struct _pocl_svm_ptr
 {
   void *svm_ptr;
   size_t size;
+  /* A CL_MEM_PINNED cl_mem with device and host ptr the same. This is for
+     internal book keeping and automated migration purposes. */
+  cl_mem shadow_cl_mem;
   struct _pocl_svm_ptr *prev, *next;
 };
 

--- a/lib/CL/pocl_ndrange_kernel.c
+++ b/lib/CL/pocl_ndrange_kernel.c
@@ -227,9 +227,27 @@ pocl_kernel_collect_mem_objs (cl_command_queue command_queue, cl_kernel kernel,
 
       if (a->type == POCL_ARG_TYPE_IMAGE
           || (!ARGP_IS_LOCAL (a) && a->type == POCL_ARG_TYPE_POINTER
-              && al->value != NULL && al->is_svm == 0))
+              && al->value != NULL))
         {
-          cl_mem buf = *(cl_mem *)(al->value);
+          cl_mem buf;
+          if (al->is_svm)
+            {
+              void *ptr = *(void **)(al->value);
+              pocl_svm_ptr *svm_ptr
+                  = pocl_find_svm_ptr_in_context (command_queue->context, ptr);
+
+              if (svm_ptr == NULL)
+                {
+                  POCL_MSG_PRINT_MEMORY (
+                      "Couldn't find the shadow cl_mem for an SVM ptr, "
+                      "assuming system SVM.\n");
+                  continue;
+                }
+              else
+                buf = svm_ptr->shadow_cl_mem;
+            }
+          else
+            buf = *(cl_mem *)(al->value);
 
           if (a->type == POCL_ARG_TYPE_IMAGE)
             {

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -1874,7 +1874,7 @@ pocl_find_svm_ptr_in_context (cl_context context, const void *host_ptr)
   pocl_svm_ptr *item = NULL;
   DL_FOREACH (context->svm_ptrs, item)
   {
-    if (item->svm_ptr == host_ptr)
+    if (item->svm_ptr <= host_ptr && item->svm_ptr + item->size > host_ptr)
       {
         break;
       }

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -156,6 +156,11 @@ int pocl_buffer_boundcheck_3d(const size_t buffer_size, const size_t *origin,
                               const size_t *region, size_t *row_pitch,
                               size_t *slice_pitch, const char* prefix);
 
+/**
+ * Finds an SVM allocation where the host_ptr is mapped.
+ *
+ * @return an allocation where host_ptr is in, NULL if not found.
+ */
 pocl_svm_ptr *pocl_find_svm_ptr_in_context (cl_context context,
                                             const void *host_ptr);
 

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -564,8 +564,7 @@ SharedCLContext::SharedCLContext(cl::Platform *p, unsigned pid,
       MaxSVMAllocSize = MaxMemAllocSize;
   }
 
-  // The CG SVM support for PoCL-Remote is a WiP. Disable brutally for now.
-  if (false && CLDevicesWithSVMSupport.size() > 0) {
+  if (CLDevicesWithSVMSupport.size() > 0) {
     // Create a pinned contiguous region to map CG SVM allocations
     // to. Communicate the start address and the size to the client
     // so it can setup its own SVM region on its side.

--- a/tests/runtime/test_svm.cpp
+++ b/tests/runtime/test_svm.cpp
@@ -1,4 +1,4 @@
-/* Test the pinned buffers extension.
+/* Test coarse grain SVM.
 
    Copyright (c) 2023 Pekka Jääskeläinen / Intel Finland Oy
 
@@ -24,7 +24,6 @@
 // Enable OpenCL C++ exceptions
 #define CL_HPP_ENABLE_EXCEPTIONS
 
-#include "../../include/CL/cl_ext_pocl.h"
 #include <CL/opencl.hpp>
 
 #include <cstdio>
@@ -35,22 +34,25 @@
 
 #include "pocl_opencl.h"
 
-#define BUF_SIZE 16
+#define N_ELEMENTS 16
 
 static char GetAddrSourceCode[] = R"raw(
 
   __kernel void get_addr (__global int *svm_buffer,
                           __global ulong* addr) {
-    for (int i = 0; i < BUF_SIZE; ++i) {
+    for (int i = 0; i < N_ELEMENTS; ++i) {
       svm_buffer[i] += 1;
-      printf("kern-side svm_buffer[%d] == %d\n", i, svm_buffer[i]);
+//      printf("kern-side svm_buffer[%d] == %d\n", i, svm_buffer[i]);
     }
     *addr = (ulong)svm_buffer;
-    printf("kern-side addr %p\n", svm_buffer);
+//    printf("kern-side addr %p\n", svm_buffer);
   }
 )raw";
 
-int main(void) {
+#define STRINGIFY(X, Y) X #Y
+#define SET_N_ELEMENTS(NUM) STRINGIFY("-DN_ELEMENTS=", NUM)
+
+int TestCGSVM() {
 
   unsigned Errors = 0;
   bool AllOK = true;
@@ -80,7 +82,8 @@ int main(void) {
     }
 
     if (SuitableDevices.empty()) {
-      std::cout << "No devices with SVM coarse grain buffer capabilities found.";
+      std::cout << "No devices with SVM coarse grain buffer capabilities found."
+                << std::endl;
       return 77;
     }
 
@@ -113,7 +116,7 @@ int main(void) {
                     << " with size " << std::dec << AllocSize
                     << " overlaps with a previous one at " << std::hex
                     << (size_t)m.first << " with size " << m.second << std::endl;
-          return EXIT_FAILURE;
+          return false;
         }
       }
       Allocs[Buf] = AllocSize;
@@ -133,14 +136,12 @@ int main(void) {
     cl::Program::Sources Sources({GetAddrSourceCode});
     cl::Program Program(Context, Sources);
 
-#define STRINGIFY(X, Y) X #Y
-#define SET_BUF_SIZE(NUM) STRINGIFY("-DBUF_SIZE=", NUM)
 
-    Program.build(SuitableDevices, SET_BUF_SIZE(BUF_SIZE));
+    Program.build(SuitableDevices, SET_N_ELEMENTS(N_ELEMENTS));
 
     cl::Kernel GetAddrKernel(Program, "get_addr");
 
-    constexpr size_t BufSize = BUF_SIZE * sizeof(int);
+    constexpr size_t BufSize = N_ELEMENTS * sizeof(int);
     int *CGSVMBuf = (int*)::clSVMAlloc(Context.get(), CL_MEM_READ_WRITE,
                                        BufSize, 0);
 
@@ -157,17 +158,46 @@ int main(void) {
     ::clSetKernelArgSVMPointer(GetAddrKernel.get(), 0, CGSVMBuf);
     GetAddrKernel.setArg(1, AddrCLBuffer);
 
-    Queue.enqueueMapSVM(CGSVMBuf, true, CL_MAP_WRITE, BufSize);
+    int HostBuf[] = {0, 1, 2, 3};
+    // Initialize the first inputs via an SVM memcpy command.
 
-    for (int i = 0; i < BUF_SIZE; ++i) {
+    // Without the destination being host-mapped...
+    CHECK_CL_ERROR(::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &CGSVMBuf[0],
+                                        &HostBuf[0], 2 * sizeof(int), 0,
+                                        nullptr, nullptr));
+
+    Queue.enqueueMapSVM(&CGSVMBuf[0], true, CL_MAP_READ, 2 * sizeof(int));
+
+    for (int i = 0; i < 2; ++i) {
+      if (CGSVMBuf[i] != i) {
+        AllOK = false;
+        std::cerr << "CGSVMBuf[" << i << "] " << std::hex << &CGSVMBuf[i]
+                  << " expected to be " << i << " but got " << (int)CGSVMBuf[i]
+                  << std::endl;
+      }
+      if (HostBuf[i] != i) {
+        AllOK = false;
+        std::cerr << "HostBuf[" << i << "] expected to be " << i << " but got "
+                  << (int)HostBuf[i] << std::endl;
+      }
+    }
+
+    Queue.enqueueUnmapSVM(CGSVMBuf);
+
+    // ...and while it has been host-mapped.
+    ::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &CGSVMBuf[2], &HostBuf[2],
+                         2 * sizeof(int), 0, nullptr, nullptr);
+
+    Queue.enqueueMapSVM(CGSVMBuf, true, CL_MAP_WRITE, BufSize);
+    // Write the rest of the inputs directly.
+    for (int i = 4; i < N_ELEMENTS; ++i) {
       CGSVMBuf[i] = i;
     }
 
-    // Is this actually unneccessary because the kernel execution and finishing are
-    // syncpoints?
     Queue.enqueueUnmapSVM(CGSVMBuf);
     Queue.enqueueNDRangeKernel(GetAddrKernel, cl::NullRange, cl::NDRange(1),
                                cl::NullRange);
+    Queue.enqueueMapSVM(CGSVMBuf, true, CL_MAP_READ, BufSize);
 
     Queue.enqueueReadBuffer(AddrCLBuffer,
                             CL_TRUE, // block
@@ -180,19 +210,210 @@ int main(void) {
       AllOK = false;
     }
 
-    // Is not needed because the kernel execution and finishing are
-    // syncpoints.
-    Queue.enqueueMapSVM(CGSVMBuf, CL_TRUE, CL_MAP_READ, BufSize);
+    // Read some of the data with SVMMemcpy().
+    ::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &HostBuf[0], &CGSVMBuf[0],
+                         4 * sizeof(int), 0, nullptr, nullptr);
 
-    for (int i = 0; i < BUF_SIZE; ++i) {
+    std::cerr << std::dec;
+    for (int i = 0; i < N_ELEMENTS; ++i) {
       if (CGSVMBuf[i] != i + 1) {
         AllOK = false;
         std::cerr << "CGSVMBuf[" << i << "] expected to be " << i + 1
                   << " but got " << (int)CGSVMBuf[i] << std::endl;
       }
+      if (i < 4 && i + 1 != HostBuf[i]) {
+        AllOK = false;
+        std::cerr << "Wrong data in the memcopied buf at " << i << " expected "
+                  << i + 1 << " got " << HostBuf[i] << std::endl;
+      }
     }
     clSVMFree(Context.get(), CGSVMBuf);
+  } catch (cl::Error &err) {
+    std::cerr << "ERROR: " << err.what() << "(" << err.err() << ")"
+              << std::endl;
+    AllOK = false;
+  }
 
+  CHECK_CL_ERROR(clUnloadCompiler());
+
+  if (AllOK)
+    return EXIT_SUCCESS;
+  else
+    return EXIT_FAILURE;
+}
+
+int TestFGSVM() {
+
+  unsigned Errors = 0;
+  bool AllOK = true;
+
+  try {
+    std::vector<cl::Platform> PlatformList;
+
+    cl::Platform::get(&PlatformList);
+
+    cl_context_properties cprops[] = {
+        CL_CONTEXT_PLATFORM, (cl_context_properties)(PlatformList[0])(), 0};
+    cl::Context Context(CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU, cprops);
+
+    std::vector<cl::Device> Devices = Context.getInfo<CL_CONTEXT_DEVICES>();
+
+    std::vector<cl::Device> SuitableDevices;
+
+    for (cl::Device &Dev : Devices) {
+      if (Dev.getInfo<CL_DEVICE_SVM_CAPABILITIES>() &
+          CL_DEVICE_SVM_FINE_GRAIN_BUFFER) {
+        SuitableDevices.push_back(Dev);
+        break;
+      } else {
+        std::cout << "Device '" << Dev.getInfo<CL_DEVICE_NAME>()
+                  << "' doesn't support FG SVM." << std::endl;
+      }
+    }
+
+    if (SuitableDevices.empty()) {
+      std::cout << "No devices with SVM fine grain buffer capabilities found."
+                << std::endl;
+      return 77;
+    }
+
+    // Basics: Create a bunch of random-sized allocations and ensure their
+    // address ranges do not overlap.
+    constexpr size_t NumAllocs = 1000;
+    constexpr size_t MaxSize = 1024 * 1024;
+
+    std::mt19937 Gen(1234);
+    std::uniform_int_distribution<> Distrib(1, MaxSize);
+
+    std::map<char *, size_t> Allocs;
+    for (int i = 0; i < NumAllocs; ++i) {
+      size_t AllocSize = Distrib(Gen);
+
+      char *Buf = (char *)::clSVMAlloc(
+          Context.get(), CL_MEM_READ_WRITE | CL_MEM_SVM_FINE_GRAIN_BUFFER,
+          AllocSize, 0);
+
+      // If we exhaust the SVM space space, it's fine.
+      // Freeing the allocations should make the remainder of the test
+      // work still, unless there's a mem leak in the implementation
+      // side.
+      if (Buf == nullptr)
+        break;
+
+      // Check for overlap.
+      for (auto &m : Allocs) {
+        if (m.first <= Buf && m.first + m.second > Buf) {
+          std::cerr << "An SVM allocation at " << std::hex << (size_t)Buf
+                    << " with size " << std::dec << AllocSize
+                    << " overlaps with a previous one at " << std::hex
+                    << (size_t)m.first << " with size " << m.second
+                    << std::endl;
+          return false;
+        }
+      }
+      Allocs[Buf] = AllocSize;
+    }
+
+    if (Allocs.size() == 0) {
+      std::cerr << "Unable to allocate any SVM chunks." << std::endl;
+      return EXIT_FAILURE;
+    }
+    for (auto &m : Allocs) {
+      // std::cout << "Freeing " << std::hex << (size_t)m.first << std::endl;
+      clSVMFree(Context.get(), m.first);
+    }
+
+    cl::CommandQueue Queue(Context, SuitableDevices[0], 0);
+
+    cl::Program::Sources Sources({GetAddrSourceCode});
+    cl::Program Program(Context, Sources);
+
+    Program.build(SuitableDevices, SET_N_ELEMENTS(N_ELEMENTS));
+
+    cl::Kernel GetAddrKernel(Program, "get_addr");
+
+    constexpr size_t BufSize = N_ELEMENTS * sizeof(int);
+    int *FGSVMBuf = (int *)::clSVMAlloc(
+        Context.get(), CL_MEM_READ_WRITE | CL_MEM_SVM_FINE_GRAIN_BUFFER,
+        BufSize, 0);
+
+    if (FGSVMBuf == nullptr) {
+      std::cerr << "FG SVM allocation returned a nullptr." << std::endl;
+      return false;
+    }
+
+    cl_ulong AddrFromKernel = 1;
+
+    cl::Buffer AddrCLBuffer =
+        cl::Buffer(Context, CL_MEM_WRITE_ONLY, sizeof(cl_ulong), nullptr);
+
+    ::clSetKernelArgSVMPointer(GetAddrKernel.get(), 0, FGSVMBuf);
+    GetAddrKernel.setArg(1, AddrCLBuffer);
+
+    int HostBuf[] = {0, 1, 2, 3};
+    // Initialize the first inputs via an SVM memcpy command.
+
+    // Without the destination being host-mapped...
+    CHECK_CL_ERROR(::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &FGSVMBuf[0],
+                                        &HostBuf[0], 2 * sizeof(int), 0,
+                                        nullptr, nullptr));
+
+    for (int i = 0; i < 2; ++i) {
+      if (FGSVMBuf[i] != i) {
+        AllOK = false;
+        std::cerr << "FGSVMBuf[" << i << "] " << std::hex << &FGSVMBuf[i]
+                  << " expected to be " << i << " but got " << (int)FGSVMBuf[i]
+                  << std::endl;
+      }
+      if (HostBuf[i] != i) {
+        AllOK = false;
+        std::cerr << "HostBuf[" << i << "] expected to be " << i << " but got "
+                  << (int)HostBuf[i] << std::endl;
+      }
+    }
+
+    ::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &FGSVMBuf[2], &HostBuf[2],
+                         2 * sizeof(int), 0, nullptr, nullptr);
+
+    // Write the rest of the inputs directly.
+    for (int i = 4; i < N_ELEMENTS; ++i) {
+      FGSVMBuf[i] = i;
+    }
+
+    Queue.enqueueNDRangeKernel(GetAddrKernel, cl::NullRange, cl::NDRange(1),
+                               cl::NullRange);
+    Queue.enqueueReadBuffer(AddrCLBuffer,
+                            CL_TRUE, // block
+                            0, sizeof(cl_ulong), (void *)&AddrFromKernel);
+
+    if (FGSVMBuf != (void *)AddrFromKernel) {
+      std::cerr << "FG buffer's device address on kernel side and host "
+                   "side do not match. Host sees "
+                << std::hex << FGSVMBuf
+                << " while "
+                   "the device sees "
+                << AddrFromKernel << std::endl;
+      AllOK = false;
+    }
+
+    // Read some of the data with SVMMemcpy().
+    ::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &HostBuf[0], &FGSVMBuf[0],
+                         4 * sizeof(int), 0, nullptr, nullptr);
+
+    std::cerr << std::dec;
+    for (int i = 0; i < N_ELEMENTS; ++i) {
+      if (FGSVMBuf[i] != i + 1) {
+        AllOK = false;
+        std::cerr << "FGSVMBuf[" << i << "] expected to be " << i + 1
+                  << " but got " << (int)FGSVMBuf[i] << std::endl;
+      }
+      if (i < 4 && i + 1 != HostBuf[i]) {
+        AllOK = false;
+        std::cerr << "Wrong data in the memcopied buf at " << i << " expected "
+                  << i + 1 << " got " << HostBuf[i] << std::endl;
+      }
+    }
+    clSVMFree(Context.get(), FGSVMBuf);
   } catch (cl::Error &err) {
     std::cerr << "ERROR: " << err.what() << "(" << err.err() << ")"
               << std::endl;
@@ -201,9 +422,162 @@ int main(void) {
 
   CHECK_CL_ERROR (clUnloadCompiler ());
 
-  if (AllOK) {
-    std::cout << "OK" << std::endl;
-    return EXIT_SUCCESS;
-  } else
+  if (!AllOK)
     return EXIT_FAILURE;
+  else
+    return EXIT_SUCCESS;
+}
+
+int TestSSVM() {
+
+  unsigned Errors = 0;
+  bool AllOK = true;
+
+  try {
+    std::vector<cl::Platform> PlatformList;
+
+    cl::Platform::get(&PlatformList);
+
+    cl_context_properties cprops[] = {
+        CL_CONTEXT_PLATFORM, (cl_context_properties)(PlatformList[0])(), 0};
+    cl::Context Context(CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU, cprops);
+
+    std::vector<cl::Device> Devices = Context.getInfo<CL_CONTEXT_DEVICES>();
+
+    std::vector<cl::Device> SuitableDevices;
+
+    for (cl::Device &Dev : Devices) {
+      if (Dev.getInfo<CL_DEVICE_SVM_CAPABILITIES>() &
+          CL_DEVICE_SVM_FINE_GRAIN_SYSTEM) {
+        SuitableDevices.push_back(Dev);
+        break;
+      } else {
+        std::cout << "Device '" << Dev.getInfo<CL_DEVICE_NAME>()
+                  << "' doesn't support FG System SVM." << std::endl;
+      }
+    }
+
+    if (SuitableDevices.empty()) {
+      std::cout << "No devices with fine grain system SVM capabilities found."
+                << std::endl;
+      return 77;
+    }
+
+    cl::CommandQueue Queue(Context, SuitableDevices[0], 0);
+
+    cl::Program::Sources Sources({GetAddrSourceCode});
+    cl::Program Program(Context, Sources);
+
+    Program.build(SuitableDevices, SET_N_ELEMENTS(N_ELEMENTS));
+
+    cl::Kernel GetAddrKernel(Program, "get_addr");
+
+    constexpr size_t BufSize = N_ELEMENTS * sizeof(int);
+    int *SSVMBuf = (int *)::malloc(BufSize);
+
+    if (SSVMBuf == nullptr) {
+      std::cerr << "malloc() returned a nullptr." << std::endl;
+      return false;
+    }
+
+    cl_ulong AddrFromKernel = 1;
+
+    cl::Buffer AddrCLBuffer =
+        cl::Buffer(Context, CL_MEM_WRITE_ONLY, sizeof(cl_ulong), nullptr);
+
+    ::clSetKernelArgSVMPointer(GetAddrKernel.get(), 0, SSVMBuf);
+    GetAddrKernel.setArg(1, AddrCLBuffer);
+
+    int HostBuf[] = {0, 1, 2, 3};
+    // Initialize the first inputs via an SVM memcpy command.
+
+    // Without the destination being host-mapped...
+    CHECK_CL_ERROR(::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &SSVMBuf[0],
+                                        &HostBuf[0], 2 * sizeof(int), 0,
+                                        nullptr, nullptr));
+
+    for (int i = 0; i < 2; ++i) {
+      if (SSVMBuf[i] != i) {
+        AllOK = false;
+        std::cerr << "SSVMBuf[" << i << "] " << std::hex << &SSVMBuf[i]
+                  << " expected to be " << i << " but got " << (int)SSVMBuf[i]
+                  << std::endl;
+      }
+      if (HostBuf[i] != i) {
+        AllOK = false;
+        std::cerr << "HostBuf[" << i << "] expected to be " << i << " but got "
+                  << (int)HostBuf[i] << std::endl;
+      }
+    }
+
+    ::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &SSVMBuf[2], &HostBuf[2],
+                         2 * sizeof(int), 0, nullptr, nullptr);
+
+    // Write the rest of the inputs directly.
+    for (int i = 4; i < N_ELEMENTS; ++i) {
+      SSVMBuf[i] = i;
+    }
+
+    Queue.enqueueNDRangeKernel(GetAddrKernel, cl::NullRange, cl::NDRange(1),
+                               cl::NullRange);
+    Queue.enqueueReadBuffer(AddrCLBuffer,
+                            CL_TRUE, // block
+                            0, sizeof(cl_ulong), (void *)&AddrFromKernel);
+
+    if (SSVMBuf != (void *)AddrFromKernel) {
+      std::cerr << "FG system buffer's device address on kernel side and host "
+                   "side do not match. Host sees "
+                << std::hex << SSVMBuf
+                << " while "
+                   "the device sees "
+                << AddrFromKernel << std::endl;
+      AllOK = false;
+    }
+
+    // Read some of the data with SVMMemcpy().
+    ::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &HostBuf[0], &SSVMBuf[0],
+                         4 * sizeof(int), 0, nullptr, nullptr);
+
+    std::cerr << std::dec;
+    for (int i = 0; i < N_ELEMENTS; ++i) {
+      if (SSVMBuf[i] != i + 1) {
+        AllOK = false;
+        std::cerr << "SSVMBuf[" << i << "] expected to be " << i + 1
+                  << " but got " << (int)SSVMBuf[i] << std::endl;
+      }
+      if (i < 4 && i + 1 != HostBuf[i]) {
+        AllOK = false;
+        std::cerr << "Wrong data in the memcopied buf at " << i << " expected "
+                  << i + 1 << " got " << HostBuf[i] << std::endl;
+      }
+    }
+
+    free(SSVMBuf);
+  } catch (cl::Error &err) {
+    std::cerr << "ERROR: " << err.what() << "(" << err.err() << ")"
+              << std::endl;
+    AllOK = false;
+  }
+
+  CHECK_CL_ERROR(clUnloadCompiler());
+
+  if (!AllOK)
+    return EXIT_FAILURE;
+  else
+    return EXIT_SUCCESS;
+}
+
+int main() {
+
+  if (TestCGSVM() == EXIT_FAILURE)
+    return EXIT_FAILURE;
+
+  if (TestFGSVM() == EXIT_FAILURE)
+    return EXIT_FAILURE;
+
+  if (TestSSVM() == EXIT_FAILURE)
+    return EXIT_FAILURE;
+
+  std::cout << "OK" << std::endl;
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Not targeting for 5.0, but let's aim merging this in soon after the branch is done.

SVM is still enabled by luck (if the moon and both side mmaps are in the correct phase) only, but when the client and server-side offsets match, migrations, memcpys etc. seem to work for the simple test case by using the shadow cl_mem approach that reuses PoCL's buffer migration handling. Should be good enough for further testing to see where distributing chipStar fails next and start building mitigations for the offset != 0 case.

Also enabled FG system SVM for CPU which for some reason was not advertised. Let's see if any of the CTS tests explode with that.
