### PR TITLE
Fix for the PoCL-R SPIR-V arg MD detection

### DIFF
--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -2224,6 +2224,9 @@ pocl_network_setup_metadata (char *buffer, size_t total_size,
               case Image:
                 t = POCL_ARG_TYPE_IMAGE;
                 break;
+              default:
+                POCL_MSG_ERR ("Couldn't detect argument type?");
+                return CL_BUILD_ERROR;
               }
             p[i].arg_info[j].type = t;
 

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -1345,7 +1345,7 @@ int SharedCLContext::buildProgram(
 
       if (is_spirv) {
         updateKernelArgMDFromSPIRV(temp_arg,
-                                   KernelInfoMap[kernel_name]->ArgTypeInfo[0]);
+                                   KernelInfoMap[kernel_name]->ArgTypeInfo[arg_index]);
         continue;
       }
 


### PR DESCRIPTION
It just replicated the arg 0's MD.

Didn't appear before getting to run more complex SPIR-V tests from chipStar.