### PR TITLE
add shared lib version of pocl for android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1092,7 +1092,7 @@ if (APPLE AND NOT ENABLE_ICD AND VISIBILITY_HIDDEN)
   add_compile_definitions("-DCL_API_CALL=__attribute__ ((visibility (\"default\")))")
 endif()
 
-if(ENABLE_ICD OR ENABLE_PROXY_DEVICE)
+if(ENABLE_ICD OR ENABLE_PROXY_DEVICE OR ANDROID)
   set(POCL_LIBRARY_NAME "pocl")
 else()
   set(POCL_LIBRARY_NAME "OpenCL")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,8 @@ option(ENABLE_RDMA "Enable usage of RDMA libraries for memory allocations. Requi
 
 option(ENABLE_TRAFFIC_MONITOR "Enable network traffic monitoring & logging in remote device" OFF)
 
+OPTION(RENAME_POCL "rename PoCL's ocl functions to PO<ocl_function>. Allows an user to call both PoCL and another ocl application" OFF)
+
 ##########################################################
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
@@ -1506,7 +1508,14 @@ if(ENABLE_PROXY_DEVICE)
     endif()
 
   endif()
+  if(NOT DEFINED PROXY_USE_LIBOPENCL_STUB)
+    set(RENAME_POCL 1)
+  endif()
+  if(RENAME_POCL AND PROXY_USE_LIBOPENCL_STUB)
+    message(FATAL_ERROR "RENAME_POCL and PROXY_USE_LIBOPENCL_STUB can not be used together")
+  endif()
   set(BUILD_PROXY 1)
+
   set(OCL_DRIVERS "${OCL_DRIVERS} proxy")
 endif()
 
@@ -2266,6 +2275,7 @@ MESSAGE(STATUS " ")
 MESSAGE(STATUS "DEVELOPER_MODE: ${DEVELOPER_MODE}")
 MESSAGE(STATUS "ENABLE_CONFORMANCE: ${ENABLE_CONFORMANCE}")
 MESSAGE(STATUS "ENABLE_HWLOC: ${ENABLE_HWLOC}")
+MESSAGE(STATUS "RENAME_POCL: ${RENAME_POCL}")
 if(ARM)
 MESSAGE(STATUS "ENABLE_FP64: ${ENABLE_FP64}")
 endif()

--- a/bin/poclcc.c
+++ b/bin/poclcc.c
@@ -30,7 +30,7 @@
 #include <errno.h>
 
 #include "config.h"
-#ifdef BUILD_PROXY
+#ifdef RENAME_POCL
 #include "rename_opencl.h"
 #endif
 #include "poclu.h"

--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -280,4 +280,6 @@
 
 #cmakedefine LLVM_OPAQUE_POINTERS
 
+#cmakedefine RENAME_POCL
+
 #endif

--- a/lib/CL/CMakeLists.txt
+++ b/lib/CL/CMakeLists.txt
@@ -285,6 +285,11 @@ if(HAVE_64BIT_ATOMICS_WITH_LIB)
   list(APPEND POCL_PRIVATE_LINK_LIST "atomic")
 endif()
 
+if(ANDROID)
+  find_library(ANDROID_LOG_LIB log)
+  list(APPEND POCL_PRIVATE_LINK_LIST ${ANDROID_LOG_LIB})
+endif()
+
 list(APPEND POCL_PRIVATE_LINK_LIST ${LIBMATH} ${CMAKE_DL_LIBS} ${PTHREAD_LIBRARY})
 
 # see lib/CMakeLists.txt
@@ -292,15 +297,8 @@ set(POCL_TRANSITIVE_LIBS ${POCL_PRIVATE_LINK_LIST} PARENT_SCOPE)
 
 #################################################################
 
-# most Android systems have their own libOpenCL, often directly linked
-# to the graphics drivers, which in turn are linked into every GUI program
-# ...and the libOpenCL is not an ICD, therefore building dynamically
-# on Android is pointless.
-if(ANDROID)
-  add_library("${POCL_LIBRARY_NAME}" STATIC ${LIBPOCL_OBJS})
-else()
-  add_library("${POCL_LIBRARY_NAME}" ${LIBPOCL_OBJS})
-endif()
+add_library("${POCL_LIBRARY_NAME}" ${LIBPOCL_OBJS})
+
 harden("${POCL_LIBRARY_NAME}")
 
 set_target_properties("${POCL_LIBRARY_NAME}" PROPERTIES SOVERSION "${LIB_API_VERSION}"

--- a/lib/CL/CMakeLists.txt
+++ b/lib/CL/CMakeLists.txt
@@ -23,6 +23,7 @@
 #
 #=============================================================================
 
+
 include_directories(AFTER "devices" ".")
 
 add_subdirectory("devices")

--- a/lib/CL/devices/CMakeLists.txt
+++ b/lib/CL/devices/CMakeLists.txt
@@ -105,8 +105,9 @@ if(ENABLE_PROXY_DEVICE)
   add_subdirectory("proxy")
   set(POCL_DEVICES_OBJS "${POCL_DEVICES_OBJS}"
     "$<TARGET_OBJECTS:pocl-devices-proxy>")
-  # link to libOpenCL, TODO disable for ANDROID ?
+  # link to libOpenCL(-stub)
   list(APPEND POCL_DEVICES_LINK_LIST OpenCL)
+
 endif()
 
 if(ENABLE_HSA)

--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -534,8 +534,7 @@ pocl_init_devices ()
     sleep (delay);
 #endif
 
-
-#ifdef __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
 
 #ifdef ENABLE_HOST_CPU_DEVICES
   if (pocl_get_bool_option ("POCL_SIGFPE_HANDLER", 1))

--- a/lib/CL/devices/proxy/libopencl_stub/CMakeLists.txt
+++ b/lib/CL/devices/proxy/libopencl_stub/CMakeLists.txt
@@ -1,7 +1,7 @@
 #=============================================================================
 #   CMake build system files
 #
-#   Copyright (c) 2021 Michal Babej / Tampere University
+#   Copyright (c) 2023 PoCL Developers
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a copy
 #   of this software and associated documentation files (the "Software"), to deal
@@ -23,18 +23,8 @@
 #
 #=============================================================================
 
-if(MSVC)
-  set_source_files_properties( pocl_proxy.h pocl_proxy.c PROPERTIES LANGUAGE CXX )
-endif(MSVC)
+# create the libopencl stub library and call it libOpenCL so that PoCL can link
+# to it. This is fine since the stub is only intended to be used when there is
+# system lib to be found
+add_library(OpenCL STATIC libopencl.c libopencl.h)
 
-add_pocl_device_library("pocl-devices-proxy" pocl_proxy.h pocl_proxy.c )
-
-# an option parameter to link to libopencl-stub instead.
-# source code: https://github.com/krrishnarraj/libopencl-stub
-OPTION(PROXY_USE_LIBOPENCL_STUB "link the proxy device to libopencl-stub instead of system opencl" OFF)
-if(PROXY_USE_LIBOPENCL_STUB)
-
-    add_subdirectory(libopencl_stub)
-    target_link_libraries("pocl-devices-proxy" libopencl_stub/libOpenCL.a)
-
-endif()

--- a/lib/CL/devices/proxy/libopencl_stub/libopencl.c
+++ b/lib/CL/devices/proxy/libopencl_stub/libopencl.c
@@ -1,0 +1,2355 @@
+/* libopencl.c - Stub libopencl that dlsyms into actual library based on
+   environment variable
+
+   LIBOPENCL_SO_PATH      -- Path to opencl so that will be searched first
+   LIBOPENCL_SO_PATH_2    -- Searched second
+   LIBOPENCL_SO_PATH_3    -- Searched third
+   LIBOPENCL_SO_PATH_4    -- Searched fourth
+
+   If none of these are set, default system paths will be considered
+
+   Copyright (c) 2023 PoCL Developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+
+
+*/
+
+#define stubname(name) stub##name
+
+#include "libopencl.h"
+#include <dlfcn.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+
+#if defined(__APPLE__) || defined(__MACOSX)
+static const char *default_so_paths[]
+    = { "libOpenCL.so", "/System/Library/Frameworks/OpenCL.framework/OpenCL" };
+#elif defined(__ANDROID__)
+static const char *default_so_paths[]
+    = { "/system/lib64/libOpenCL.so",
+        "/system/vendor/lib64/libOpenCL.so",
+        "/system/vendor/lib64/egl/libGLES_mali.so",
+        "/system/vendor/lib64/libPVROCL.so",
+        "/data/data/org.pocl.libs/files/lib64/libpocl.so",
+        "/system/lib/libOpenCL.so",
+        "/system/vendor/lib/libOpenCL.so",
+        "/system/vendor/lib/egl/libGLES_mali.so",
+        "/system/vendor/lib/libPVROCL.so",
+        "/data/data/org.pocl.libs/files/lib/libpocl.so",
+        "libOpenCL.so" };
+#elif defined(_WIN32)
+static const char *default_so_paths[] = { "OpenCL.dll" };
+#elif defined(__linux__)
+static const char *default_so_paths[]
+    = { "/usr/lib/libOpenCL.so",     "/usr/local/lib/libOpenCL.so",
+        "/usr/local/lib/libpocl.so", "/usr/lib64/libOpenCL.so",
+        "/usr/lib32/libOpenCL.so",   "libOpenCL.so" };
+#endif
+
+static void *so_handle = NULL;
+
+static int
+access_file (const char *filename)
+{
+  struct stat buffer;
+  return (stat (filename, &buffer) == 0);
+}
+
+static int
+open_libopencl_so ()
+{
+  char *path = NULL, *str = NULL;
+  int i;
+
+  if ((str = getenv ("LIBOPENCL_SO_PATH")) && access_file (str))
+    {
+      path = str;
+    }
+  else if ((str = getenv ("LIBOPENCL_SO_PATH_2")) && access_file (str))
+    {
+      path = str;
+    }
+  else if ((str = getenv ("LIBOPENCL_SO_PATH_3")) && access_file (str))
+    {
+      path = str;
+    }
+  else if ((str = getenv ("LIBOPENCL_SO_PATH_4")) && access_file (str))
+    {
+      path = str;
+    }
+
+  if (!path)
+    {
+      for (i = 0; i < (sizeof (default_so_paths) / sizeof (char *)); i++)
+        {
+          if (access_file (default_so_paths[i]))
+            {
+              path = (char *)default_so_paths[i];
+              break;
+            }
+        }
+    }
+
+  if (path)
+    {
+      so_handle = dlopen (path, RTLD_LAZY);
+      return 0;
+    }
+  else
+    {
+      return -1;
+    }
+}
+
+void
+stubOpenclReset ()
+{
+  if (so_handle)
+    dlclose (so_handle);
+
+  so_handle = NULL;
+}
+
+cl_int
+stubname (clGetPlatformIDs) (cl_uint num_entries, cl_platform_id *platforms,
+                             cl_uint *num_platforms)
+{
+  f_clGetPlatformIDs func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetPlatformIDs)dlsym (so_handle, "clGetPlatformIDs");
+  if (func)
+    {
+      return func (num_entries, platforms, num_platforms);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetPlatformInfo) (cl_platform_id platform,
+                              cl_platform_info param_name,
+                              size_t param_value_size, void *param_value,
+                              size_t *param_value_size_ret)
+{
+  f_clGetPlatformInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetPlatformInfo)dlsym (so_handle, "clGetPlatformInfo");
+  if (func)
+    {
+      return func (platform, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetDeviceIDs) (cl_platform_id platform, cl_device_type device_type,
+                           cl_uint num_entries, cl_device_id *devices,
+                           cl_uint *num_devices)
+{
+  f_clGetDeviceIDs func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetDeviceIDs)dlsym (so_handle, "clGetDeviceIDs");
+  if (func)
+    {
+      return func (platform, device_type, num_entries, devices, num_devices);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetDeviceInfo) (cl_device_id device, cl_device_info param_name,
+                            size_t param_value_size, void *param_value,
+                            size_t *param_value_size_ret)
+{
+  f_clGetDeviceInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetDeviceInfo)dlsym (so_handle, "clGetDeviceInfo");
+  if (func)
+    {
+      return func (device, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clCreateSubDevices) (cl_device_id in_device,
+                               const cl_device_partition_property *properties,
+                               cl_uint num_devices, cl_device_id *out_devices,
+                               cl_uint *num_devices_ret)
+{
+  f_clCreateSubDevices func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateSubDevices)dlsym (so_handle, "clCreateSubDevices");
+  if (func)
+    {
+      return func (in_device, properties, num_devices, out_devices,
+                   num_devices_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clRetainDevice) (cl_device_id device)
+{
+  f_clRetainDevice func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clRetainDevice)dlsym (so_handle, "clRetainDevice");
+  if (func)
+    {
+      return func (device);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clReleaseDevice) (cl_device_id device)
+{
+  f_clReleaseDevice func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clReleaseDevice)dlsym (so_handle, "clReleaseDevice");
+  if (func)
+    {
+      return func (device);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_context
+stubname (clCreateContext) (const cl_context_properties *properties,
+                            cl_uint num_devices, const cl_device_id *devices,
+                            void (*pfn_notify) (const char *, const void *,
+                                                size_t, void *),
+                            void *user_data, cl_int *errcode_ret)
+{
+  f_clCreateContext func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateContext)dlsym (so_handle, "clCreateContext");
+  if (func)
+    {
+      return func (properties, num_devices, devices, pfn_notify, user_data,
+                   errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_context
+stubname (clCreateContextFromType) (
+    const cl_context_properties *properties, cl_device_type device_type,
+    void (*pfn_notify) (const char *, const void *, size_t, void *),
+    void *user_data, cl_int *errcode_ret)
+{
+  f_clCreateContextFromType func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateContextFromType)dlsym (so_handle,
+                                           "clCreateContextFromType");
+  if (func)
+    {
+      return func (properties, device_type, pfn_notify, user_data,
+                   errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_int
+stubname (clRetainContext) (cl_context context)
+{
+  f_clRetainContext func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clRetainContext)dlsym (so_handle, "clRetainContext");
+  if (func)
+    {
+      return func (context);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clReleaseContext) (cl_context context)
+{
+  f_clReleaseContext func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clReleaseContext)dlsym (so_handle, "clReleaseContext");
+  if (func)
+    {
+      return func (context);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetContextInfo) (cl_context context, cl_context_info param_name,
+                             size_t param_value_size, void *param_value,
+                             size_t *param_value_size_ret)
+{
+  f_clGetContextInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetContextInfo)dlsym (so_handle, "clGetContextInfo");
+  if (func)
+    {
+      return func (context, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_command_queue
+stubname (clCreateCommandQueue) (cl_context context, cl_device_id device,
+                                 cl_command_queue_properties properties,
+                                 cl_int *errcode_ret)
+{
+  f_clCreateCommandQueue func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateCommandQueue)dlsym (so_handle, "clCreateCommandQueue");
+  if (func)
+    {
+      return func (context, device, properties, errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+#ifdef CL_VERSION_2_0
+cl_command_queue
+clCreateCommandQueueWithProperties (cl_context context, cl_device_id device,
+                                    const cl_queue_properties *properties,
+                                    cl_int *errcode_ret)
+{
+  f_clCreateCommandQueueWithProperties func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateCommandQueueWithProperties)dlsym (
+      so_handle, "clCreateCommandQueueWithProperties");
+  if (func)
+    {
+      return func (context, device, properties, errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+#endif
+
+cl_int
+stubname (clRetainCommandQueue) (cl_command_queue command_queue)
+{
+  f_clRetainCommandQueue func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clRetainCommandQueue)dlsym (so_handle, "clRetainCommandQueue");
+  if (func)
+    {
+      return func (command_queue);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clReleaseCommandQueue) (cl_command_queue command_queue)
+{
+  f_clReleaseCommandQueue func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clReleaseCommandQueue)dlsym (so_handle, "clReleaseCommandQueue");
+  if (func)
+    {
+      return func (command_queue);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetCommandQueueInfo) (cl_command_queue command_queue,
+                                  cl_command_queue_info param_name,
+                                  size_t param_value_size, void *param_value,
+                                  size_t *param_value_size_ret)
+{
+  f_clGetCommandQueueInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetCommandQueueInfo)dlsym (so_handle, "clGetCommandQueueInfo");
+  if (func)
+    {
+      return func (command_queue, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_mem
+stubname (clCreateBuffer) (cl_context context, cl_mem_flags flags, size_t size,
+                           void *host_ptr, cl_int *errcode_ret)
+{
+  f_clCreateBuffer func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateBuffer)dlsym (so_handle, "clCreateBuffer");
+  if (func)
+    {
+      return func (context, flags, size, host_ptr, errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_mem
+stubname (clCreateSubBuffer) (cl_mem buffer, cl_mem_flags flags,
+                              cl_buffer_create_type buffer_create_type,
+                              const void *buffer_create_info,
+                              cl_int *errcode_ret)
+{
+  f_clCreateSubBuffer func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateSubBuffer)dlsym (so_handle, "clCreateSubBuffer");
+  if (func)
+    {
+      return func (buffer, flags, buffer_create_type, buffer_create_info,
+                   errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_mem
+stubname (clCreateImage) (cl_context context, cl_mem_flags flags,
+                          const cl_image_format *image_format,
+                          const cl_image_desc *image_desc, void *host_ptr,
+                          cl_int *errcode_ret)
+{
+  f_clCreateImage func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateImage)dlsym (so_handle, "clCreateImage");
+  if (func)
+    {
+      return func (context, flags, image_format, image_desc, host_ptr,
+                   errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_int
+stubname (clRetainMemObject) (cl_mem memobj)
+{
+  f_clRetainMemObject func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clRetainMemObject)dlsym (so_handle, "clRetainMemObject");
+  if (func)
+    {
+      return func (memobj);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clReleaseMemObject) (cl_mem memobj)
+{
+  f_clReleaseMemObject func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clReleaseMemObject)dlsym (so_handle, "clReleaseMemObject");
+  if (func)
+    {
+      return func (memobj);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetSupportedImageFormats) (cl_context context, cl_mem_flags flags,
+                                       cl_mem_object_type image_type,
+                                       cl_uint num_entries,
+                                       cl_image_format *image_formats,
+                                       cl_uint *num_image_formats)
+{
+  f_clGetSupportedImageFormats func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetSupportedImageFormats)dlsym (so_handle,
+                                              "clGetSupportedImageFormats");
+  if (func)
+    {
+      return func (context, flags, image_type, num_entries, image_formats,
+                   num_image_formats);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetMemObjectInfo) (cl_mem memobj, cl_mem_info param_name,
+                               size_t param_value_size, void *param_value,
+                               size_t *param_value_size_ret)
+{
+  f_clGetMemObjectInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetMemObjectInfo)dlsym (so_handle, "clGetMemObjectInfo");
+  if (func)
+    {
+      return func (memobj, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetImageInfo) (cl_mem image, cl_image_info param_name,
+                           size_t param_value_size, void *param_value,
+                           size_t *param_value_size_ret)
+{
+  f_clGetImageInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetImageInfo)dlsym (so_handle, "clGetImageInfo");
+  if (func)
+    {
+      return func (image, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clSetMemObjectDestructorCallback) (
+    cl_mem memobj, void (*pfn_notify) (cl_mem memobj, void *user_data),
+    void *user_data)
+{
+  f_clSetMemObjectDestructorCallback func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clSetMemObjectDestructorCallback)dlsym (
+      so_handle, "clSetMemObjectDestructorCallback");
+  if (func)
+    {
+      return func (memobj, pfn_notify, user_data);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_sampler
+stubname (clCreateSampler) (cl_context context, cl_bool normalized_coords,
+                            cl_addressing_mode addressing_mode,
+                            cl_filter_mode filter_mode, cl_int *errcode_ret)
+{
+  f_clCreateSampler func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateSampler)dlsym (so_handle, "clCreateSampler");
+  if (func)
+    {
+      return func (context, normalized_coords, addressing_mode, filter_mode,
+                   errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_int
+stubname (clRetainSampler) (cl_sampler sampler)
+{
+  f_clRetainSampler func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clRetainSampler)dlsym (so_handle, "clRetainSampler");
+  if (func)
+    {
+      return func (sampler);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clReleaseSampler) (cl_sampler sampler)
+{
+  f_clReleaseSampler func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clReleaseSampler)dlsym (so_handle, "clReleaseSampler");
+  if (func)
+    {
+      return func (sampler);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetSamplerInfo) (cl_sampler sampler, cl_sampler_info param_name,
+                             size_t param_value_size, void *param_value,
+                             size_t *param_value_size_ret)
+{
+  f_clGetSamplerInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetSamplerInfo)dlsym (so_handle, "clGetSamplerInfo");
+  if (func)
+    {
+      return func (sampler, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_program
+stubname (clCreateProgramWithSource) (cl_context context, cl_uint count,
+                                      const char **strings,
+                                      const size_t *lengths,
+                                      cl_int *errcode_ret)
+{
+  f_clCreateProgramWithSource func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateProgramWithSource)dlsym (so_handle,
+                                             "clCreateProgramWithSource");
+  if (func)
+    {
+      return func (context, count, strings, lengths, errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_program
+stubname (clCreateProgramWithBinary) (cl_context context, cl_uint num_devices,
+                                      const cl_device_id *device_list,
+                                      const size_t *lengths,
+                                      const unsigned char **binaries,
+                                      cl_int *binary_status,
+                                      cl_int *errcode_ret)
+{
+  f_clCreateProgramWithBinary func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateProgramWithBinary)dlsym (so_handle,
+                                             "clCreateProgramWithBinary");
+  if (func)
+    {
+      return func (context, num_devices, device_list, lengths, binaries,
+                   binary_status, errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_program
+stubname (clCreateProgramWithBuiltInKernels) (cl_context context,
+                                              cl_uint num_devices,
+                                              const cl_device_id *device_list,
+                                              const char *kernel_names,
+                                              cl_int *errcode_ret)
+{
+  f_clCreateProgramWithBuiltInKernels func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateProgramWithBuiltInKernels)dlsym (
+      so_handle, "clCreateProgramWithBuiltInKernels");
+  if (func)
+    {
+      return func (context, num_devices, device_list, kernel_names,
+                   errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_int
+stubname (clRetainProgram) (cl_program program)
+{
+  f_clRetainProgram func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clRetainProgram)dlsym (so_handle, "clRetainProgram");
+  if (func)
+    {
+      return func (program);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clReleaseProgram) (cl_program program)
+{
+  f_clReleaseProgram func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clReleaseProgram)dlsym (so_handle, "clReleaseProgram");
+  if (func)
+    {
+      return func (program);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clBuildProgram) (
+    cl_program program, cl_uint num_devices, const cl_device_id *device_list,
+    const char *options,
+    void (*pfn_notify) (cl_program program, void *user_data), void *user_data)
+{
+  f_clBuildProgram func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clBuildProgram)dlsym (so_handle, "clBuildProgram");
+  if (func)
+    {
+      return func (program, num_devices, device_list, options, pfn_notify,
+                   user_data);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clCompileProgram) (
+    cl_program program, cl_uint num_devices, const cl_device_id *device_list,
+    const char *options, cl_uint num_input_headers,
+    const cl_program *input_headers, const char **header_include_names,
+    void (*pfn_notify) (cl_program program, void *user_data), void *user_data)
+{
+  f_clCompileProgram func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCompileProgram)dlsym (so_handle, "clCompileProgram");
+  if (func)
+    {
+      return func (program, num_devices, device_list, options,
+                   num_input_headers, input_headers, header_include_names,
+                   pfn_notify, user_data);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_program
+stubname (clLinkProgram) (cl_context context, cl_uint num_devices,
+                          const cl_device_id *device_list, const char *options,
+                          cl_uint num_input_programs,
+                          const cl_program *input_programs,
+                          void (*pfn_notify) (cl_program program,
+                                              void *user_data),
+                          void *user_data, cl_int *errcode_ret)
+{
+  f_clLinkProgram func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clLinkProgram)dlsym (so_handle, "clLinkProgram");
+  if (func)
+    {
+      return func (context, num_devices, device_list, options,
+                   num_input_programs, input_programs, pfn_notify, user_data,
+                   errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_int
+stubname (clUnloadPlatformCompiler) (cl_platform_id platform)
+{
+  f_clUnloadPlatformCompiler func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clUnloadPlatformCompiler)dlsym (so_handle,
+                                            "clUnloadPlatformCompiler");
+  if (func)
+    {
+      return func (platform);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetProgramInfo) (cl_program program, cl_program_info param_name,
+                             size_t param_value_size, void *param_value,
+                             size_t *param_value_size_ret)
+{
+  f_clGetProgramInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetProgramInfo)dlsym (so_handle, "clGetProgramInfo");
+  if (func)
+    {
+      return func (program, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetProgramBuildInfo) (cl_program program, cl_device_id device,
+                                  cl_program_build_info param_name,
+                                  size_t param_value_size, void *param_value,
+                                  size_t *param_value_size_ret)
+{
+  f_clGetProgramBuildInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetProgramBuildInfo)dlsym (so_handle, "clGetProgramBuildInfo");
+  if (func)
+    {
+      return func (program, device, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_kernel
+stubname (clCreateKernel) (cl_program program, const char *kernel_name,
+                           cl_int *errcode_ret)
+{
+  f_clCreateKernel func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateKernel)dlsym (so_handle, "clCreateKernel");
+  if (func)
+    {
+      return func (program, kernel_name, errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_int
+stubname (clCreateKernelsInProgram) (cl_program program, cl_uint num_kernels,
+                                     cl_kernel *kernels,
+                                     cl_uint *num_kernels_ret)
+{
+  f_clCreateKernelsInProgram func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateKernelsInProgram)dlsym (so_handle,
+                                            "clCreateKernelsInProgram");
+  if (func)
+    {
+      return func (program, num_kernels, kernels, num_kernels_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clRetainKernel) (cl_kernel kernel)
+{
+  f_clRetainKernel func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clRetainKernel)dlsym (so_handle, "clRetainKernel");
+  if (func)
+    {
+      return func (kernel);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clReleaseKernel) (cl_kernel kernel)
+{
+  f_clReleaseKernel func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clReleaseKernel)dlsym (so_handle, "clReleaseKernel");
+  if (func)
+    {
+      return func (kernel);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clSetKernelArg) (cl_kernel kernel, cl_uint arg_index,
+                           size_t arg_size, const void *arg_value)
+{
+  f_clSetKernelArg func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clSetKernelArg)dlsym (so_handle, "clSetKernelArg");
+  if (func)
+    {
+      return func (kernel, arg_index, arg_size, arg_value);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetKernelInfo) (cl_kernel kernel, cl_kernel_info param_name,
+                            size_t param_value_size, void *param_value,
+                            size_t *param_value_size_ret)
+{
+  f_clGetKernelInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetKernelInfo)dlsym (so_handle, "clGetKernelInfo");
+  if (func)
+    {
+      return func (kernel, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetKernelArgInfo) (cl_kernel kernel, cl_uint arg_indx,
+                               cl_kernel_arg_info param_name,
+                               size_t param_value_size, void *param_value,
+                               size_t *param_value_size_ret)
+{
+  f_clGetKernelArgInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetKernelArgInfo)dlsym (so_handle, "clGetKernelArgInfo");
+  if (func)
+    {
+      return func (kernel, arg_indx, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetKernelWorkGroupInfo) (cl_kernel kernel, cl_device_id device,
+                                     cl_kernel_work_group_info param_name,
+                                     size_t param_value_size,
+                                     void *param_value,
+                                     size_t *param_value_size_ret)
+{
+  f_clGetKernelWorkGroupInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetKernelWorkGroupInfo)dlsym (so_handle,
+                                            "clGetKernelWorkGroupInfo");
+  if (func)
+    {
+      return func (kernel, device, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clWaitForEvents) (cl_uint num_events, const cl_event *event_list)
+{
+  f_clWaitForEvents func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clWaitForEvents)dlsym (so_handle, "clWaitForEvents");
+  if (func)
+    {
+      return func (num_events, event_list);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetEventInfo) (cl_event event, cl_event_info param_name,
+                           size_t param_value_size, void *param_value,
+                           size_t *param_value_size_ret)
+{
+  f_clGetEventInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetEventInfo)dlsym (so_handle, "clGetEventInfo");
+  if (func)
+    {
+      return func (event, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_event
+stubname (clCreateUserEvent) (cl_context context, cl_int *errcode_ret)
+{
+  f_clCreateUserEvent func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateUserEvent)dlsym (so_handle, "clCreateUserEvent");
+  if (func)
+    {
+      return func (context, errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_int
+stubname (clRetainEvent) (cl_event event)
+{
+  f_clRetainEvent func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clRetainEvent)dlsym (so_handle, "clRetainEvent");
+  if (func)
+    {
+      return func (event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clReleaseEvent) (cl_event event)
+{
+  f_clReleaseEvent func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clReleaseEvent)dlsym (so_handle, "clReleaseEvent");
+  if (func)
+    {
+      return func (event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clSetUserEventStatus) (cl_event event, cl_int execution_status)
+{
+  f_clSetUserEventStatus func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clSetUserEventStatus)dlsym (so_handle, "clSetUserEventStatus");
+  if (func)
+    {
+      return func (event, execution_status);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clSetEventCallback) (cl_event event,
+                               cl_int command_exec_callback_type,
+                               void (*pfn_notify) (cl_event, cl_int, void *),
+                               void *user_data)
+{
+  f_clSetEventCallback func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clSetEventCallback)dlsym (so_handle, "clSetEventCallback");
+  if (func)
+    {
+      return func (event, command_exec_callback_type, pfn_notify, user_data);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetEventProfilingInfo) (cl_event event,
+                                    cl_profiling_info param_name,
+                                    size_t param_value_size, void *param_value,
+                                    size_t *param_value_size_ret)
+{
+  f_clGetEventProfilingInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetEventProfilingInfo)dlsym (so_handle,
+                                           "clGetEventProfilingInfo");
+  if (func)
+    {
+      return func (event, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clFlush) (cl_command_queue command_queue)
+{
+  f_clFlush func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clFlush)dlsym (so_handle, "clFlush");
+  if (func)
+    {
+      return func (command_queue);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clFinish) (cl_command_queue command_queue)
+{
+  f_clFinish func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clFinish)dlsym (so_handle, "clFinish");
+  if (func)
+    {
+      return func (command_queue);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueReadBuffer) (cl_command_queue command_queue, cl_mem buffer,
+                                cl_bool blocking_read, size_t offset,
+                                size_t size, void *ptr,
+                                cl_uint num_events_in_wait_list,
+                                const cl_event *event_wait_list,
+                                cl_event *event)
+{
+  f_clEnqueueReadBuffer func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueReadBuffer)dlsym (so_handle, "clEnqueueReadBuffer");
+  if (func)
+    {
+      return func (command_queue, buffer, blocking_read, offset, size, ptr,
+                   num_events_in_wait_list, event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueReadBufferRect) (
+    cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_read,
+    const size_t *buffer_offset, const size_t *host_offset,
+    const size_t *region, size_t buffer_row_pitch, size_t buffer_slice_pitch,
+    size_t host_row_pitch, size_t host_slice_pitch, void *ptr,
+    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
+    cl_event *event)
+{
+  f_clEnqueueReadBufferRect func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueReadBufferRect)dlsym (so_handle,
+                                           "clEnqueueReadBufferRect");
+  if (func)
+    {
+      return func (command_queue, buffer, blocking_read, buffer_offset,
+                   host_offset, region, buffer_row_pitch, buffer_slice_pitch,
+                   host_row_pitch, host_slice_pitch, ptr,
+                   num_events_in_wait_list, event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueWriteBuffer) (cl_command_queue command_queue, cl_mem buffer,
+                                 cl_bool blocking_write, size_t offset,
+                                 size_t size, const void *ptr,
+                                 cl_uint num_events_in_wait_list,
+                                 const cl_event *event_wait_list,
+                                 cl_event *event)
+{
+  f_clEnqueueWriteBuffer func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueWriteBuffer)dlsym (so_handle, "clEnqueueWriteBuffer");
+  if (func)
+    {
+      return func (command_queue, buffer, blocking_write, offset, size, ptr,
+                   num_events_in_wait_list, event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueWriteBufferRect) (
+    cl_command_queue command_queue, cl_mem buffer, cl_bool blocking_write,
+    const size_t *buffer_offset, const size_t *host_offset,
+    const size_t *region, size_t buffer_row_pitch, size_t buffer_slice_pitch,
+    size_t host_row_pitch, size_t host_slice_pitch, const void *ptr,
+    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
+    cl_event *event)
+{
+  f_clEnqueueWriteBufferRect func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueWriteBufferRect)dlsym (so_handle,
+                                            "clEnqueueWriteBufferRect");
+  if (func)
+    {
+      return func (command_queue, buffer, blocking_write, buffer_offset,
+                   host_offset, region, buffer_row_pitch, buffer_slice_pitch,
+                   host_row_pitch, host_slice_pitch, ptr,
+                   num_events_in_wait_list, event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueFillBuffer) (cl_command_queue command_queue, cl_mem buffer,
+                                const void *pattern, size_t pattern_size,
+                                size_t offset, size_t size,
+                                cl_uint num_events_in_wait_list,
+                                const cl_event *event_wait_list,
+                                cl_event *event)
+{
+  f_clEnqueueFillBuffer func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueFillBuffer)dlsym (so_handle, "clEnqueueFillBuffer");
+  if (func)
+    {
+      return func (command_queue, buffer, pattern, pattern_size, offset, size,
+                   num_events_in_wait_list, event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueCopyBuffer) (cl_command_queue command_queue,
+                                cl_mem src_buffer, cl_mem dst_buffer,
+                                size_t src_offset, size_t dst_offset,
+                                size_t size, cl_uint num_events_in_wait_list,
+                                const cl_event *event_wait_list,
+                                cl_event *event)
+{
+  f_clEnqueueCopyBuffer func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueCopyBuffer)dlsym (so_handle, "clEnqueueCopyBuffer");
+  if (func)
+    {
+      return func (command_queue, src_buffer, dst_buffer, src_offset,
+                   dst_offset, size, num_events_in_wait_list, event_wait_list,
+                   event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueCopyBufferRect) (
+    cl_command_queue command_queue, cl_mem src_buffer, cl_mem dst_buffer,
+    const size_t *src_origin, const size_t *dst_origin, const size_t *region,
+    size_t src_row_pitch, size_t src_slice_pitch, size_t dst_row_pitch,
+    size_t dst_slice_pitch, cl_uint num_events_in_wait_list,
+    const cl_event *event_wait_list, cl_event *event)
+{
+  f_clEnqueueCopyBufferRect func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueCopyBufferRect)dlsym (so_handle,
+                                           "clEnqueueCopyBufferRect");
+  if (func)
+    {
+      return func (command_queue, src_buffer, dst_buffer, src_origin,
+                   dst_origin, region, src_row_pitch, src_slice_pitch,
+                   dst_row_pitch, dst_slice_pitch, num_events_in_wait_list,
+                   event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueReadImage) (cl_command_queue command_queue, cl_mem image,
+                               cl_bool blocking_read, const size_t *origin,
+                               const size_t *region, size_t row_pitch,
+                               size_t slice_pitch, void *ptr,
+                               cl_uint num_events_in_wait_list,
+                               const cl_event *event_wait_list,
+                               cl_event *event)
+{
+  f_clEnqueueReadImage func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueReadImage)dlsym (so_handle, "clEnqueueReadImage");
+  if (func)
+    {
+      return func (command_queue, image, blocking_read, origin, region,
+                   row_pitch, slice_pitch, ptr, num_events_in_wait_list,
+                   event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueWriteImage) (cl_command_queue command_queue, cl_mem image,
+                                cl_bool blocking_write, const size_t *origin,
+                                const size_t *region, size_t input_row_pitch,
+                                size_t input_slice_pitch, const void *ptr,
+                                cl_uint num_events_in_wait_list,
+                                const cl_event *event_wait_list,
+                                cl_event *event)
+{
+  f_clEnqueueWriteImage func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueWriteImage)dlsym (so_handle, "clEnqueueWriteImage");
+  if (func)
+    {
+      return func (command_queue, image, blocking_write, origin, region,
+                   input_row_pitch, input_slice_pitch, ptr,
+                   num_events_in_wait_list, event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueFillImage) (cl_command_queue command_queue, cl_mem image,
+                               const void *fill_color, const size_t *origin,
+                               const size_t *region,
+                               cl_uint num_events_in_wait_list,
+                               const cl_event *event_wait_list,
+                               cl_event *event)
+{
+  f_clEnqueueFillImage func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueFillImage)dlsym (so_handle, "clEnqueueFillImage");
+  if (func)
+    {
+      return func (command_queue, image, fill_color, origin, region,
+                   num_events_in_wait_list, event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueCopyImage) (cl_command_queue command_queue,
+                               cl_mem src_image, cl_mem dst_image,
+                               const size_t *src_origin,
+                               const size_t *dst_origin, const size_t *region,
+                               cl_uint num_events_in_wait_list,
+                               const cl_event *event_wait_list,
+                               cl_event *event)
+{
+  f_clEnqueueCopyImage func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueCopyImage)dlsym (so_handle, "clEnqueueCopyImage");
+  if (func)
+    {
+      return func (command_queue, src_image, dst_image, src_origin, dst_origin,
+                   region, num_events_in_wait_list, event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueCopyImageToBuffer) (cl_command_queue command_queue,
+                                       cl_mem src_image, cl_mem dst_buffer,
+                                       const size_t *src_origin,
+                                       const size_t *region, size_t dst_offset,
+                                       cl_uint num_events_in_wait_list,
+                                       const cl_event *event_wait_list,
+                                       cl_event *event)
+{
+  f_clEnqueueCopyImageToBuffer func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueCopyImageToBuffer)dlsym (so_handle,
+                                              "clEnqueueCopyImageToBuffer");
+  if (func)
+    {
+      return func (command_queue, src_image, dst_buffer, src_origin, region,
+                   dst_offset, num_events_in_wait_list, event_wait_list,
+                   event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueCopyBufferToImage) (
+    cl_command_queue command_queue, cl_mem src_buffer, cl_mem dst_image,
+    size_t src_offset, const size_t *dst_origin, const size_t *region,
+    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
+    cl_event *event)
+{
+  f_clEnqueueCopyBufferToImage func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueCopyBufferToImage)dlsym (so_handle,
+                                              "clEnqueueCopyBufferToImage");
+  if (func)
+    {
+      return func (command_queue, src_buffer, dst_image, src_offset,
+                   dst_origin, region, num_events_in_wait_list,
+                   event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+void *
+stubname (clEnqueueMapBuffer) (cl_command_queue command_queue, cl_mem buffer,
+                               cl_bool blocking_map, cl_map_flags map_flags,
+                               size_t offset, size_t size,
+                               cl_uint num_events_in_wait_list,
+                               const cl_event *event_wait_list,
+                               cl_event *event, cl_int *errcode_ret)
+{
+  f_clEnqueueMapBuffer func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueMapBuffer)dlsym (so_handle, "clEnqueueMapBuffer");
+  if (func)
+    {
+      return func (command_queue, buffer, blocking_map, map_flags, offset,
+                   size, num_events_in_wait_list, event_wait_list, event,
+                   errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+void *
+stubname (clEnqueueMapImage) (cl_command_queue command_queue, cl_mem image,
+                              cl_bool blocking_map, cl_map_flags map_flags,
+                              const size_t *origin, const size_t *region,
+                              size_t *image_row_pitch,
+                              size_t *image_slice_pitch,
+                              cl_uint num_events_in_wait_list,
+                              const cl_event *event_wait_list, cl_event *event,
+                              cl_int *errcode_ret)
+{
+  f_clEnqueueMapImage func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueMapImage)dlsym (so_handle, "clEnqueueMapImage");
+  if (func)
+    {
+      return func (command_queue, image, blocking_map, map_flags, origin,
+                   region, image_row_pitch, image_slice_pitch,
+                   num_events_in_wait_list, event_wait_list, event,
+                   errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_int
+stubname (clEnqueueUnmapMemObject) (cl_command_queue command_queue,
+                                    cl_mem memobj, void *mapped_ptr,
+                                    cl_uint num_events_in_wait_list,
+                                    const cl_event *event_wait_list,
+                                    cl_event *event)
+{
+  f_clEnqueueUnmapMemObject func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueUnmapMemObject)dlsym (so_handle,
+                                           "clEnqueueUnmapMemObject");
+  if (func)
+    {
+      return func (command_queue, memobj, mapped_ptr, num_events_in_wait_list,
+                   event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueMigrateMemObjects) (cl_command_queue command_queue,
+                                       cl_uint num_mem_objects,
+                                       const cl_mem *mem_objects,
+                                       cl_mem_migration_flags flags,
+                                       cl_uint num_events_in_wait_list,
+                                       const cl_event *event_wait_list,
+                                       cl_event *event)
+{
+  f_clEnqueueMigrateMemObjects func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueMigrateMemObjects)dlsym (so_handle,
+                                              "clEnqueueMigrateMemObjects");
+  if (func)
+    {
+      return func (command_queue, num_mem_objects, mem_objects, flags,
+                   num_events_in_wait_list, event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueNDRangeKernel) (
+    cl_command_queue command_queue, cl_kernel kernel, cl_uint work_dim,
+    const size_t *global_work_offset, const size_t *global_work_size,
+    const size_t *local_work_size, cl_uint num_events_in_wait_list,
+    const cl_event *event_wait_list, cl_event *event)
+{
+  f_clEnqueueNDRangeKernel func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueNDRangeKernel)dlsym (so_handle, "clEnqueueNDRangeKernel");
+  if (func)
+    {
+      return func (command_queue, kernel, work_dim, global_work_offset,
+                   global_work_size, local_work_size, num_events_in_wait_list,
+                   event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueTask) (cl_command_queue command_queue, cl_kernel kernel,
+                          cl_uint num_events_in_wait_list,
+                          const cl_event *event_wait_list, cl_event *event)
+{
+  f_clEnqueueTask func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueTask)dlsym (so_handle, "clEnqueueTask");
+  if (func)
+    {
+      return func (command_queue, kernel, num_events_in_wait_list,
+                   event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueNativeKernel) (
+    cl_command_queue command_queue, void (*user_func) (void *), void *args,
+    size_t cb_args, cl_uint num_mem_objects, const cl_mem *mem_list,
+    const void **args_mem_loc, cl_uint num_events_in_wait_list,
+    const cl_event *event_wait_list, cl_event *event)
+{
+  f_clEnqueueNativeKernel func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueNativeKernel)dlsym (so_handle, "clEnqueueNativeKernel");
+  if (func)
+    {
+      return func (command_queue, user_func, args, cb_args, num_mem_objects,
+                   mem_list, args_mem_loc, num_events_in_wait_list,
+                   event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueMarkerWithWaitList) (cl_command_queue command_queue,
+                                        cl_uint num_events_in_wait_list,
+                                        const cl_event *event_wait_list,
+                                        cl_event *event)
+{
+  f_clEnqueueMarkerWithWaitList func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueMarkerWithWaitList)dlsym (so_handle,
+                                               "clEnqueueMarkerWithWaitList");
+  if (func)
+    {
+      return func (command_queue, num_events_in_wait_list, event_wait_list,
+                   event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueBarrierWithWaitList) (cl_command_queue command_queue,
+                                         cl_uint num_events_in_wait_list,
+                                         const cl_event *event_wait_list,
+                                         cl_event *event)
+{
+  f_clEnqueueBarrierWithWaitList func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueBarrierWithWaitList)dlsym (
+      so_handle, "clEnqueueBarrierWithWaitList");
+  if (func)
+    {
+      return func (command_queue, num_events_in_wait_list, event_wait_list,
+                   event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+void *
+stubname (clGetExtensionFunctionAddressForPlatform) (cl_platform_id platform,
+                                                     const char *func_name)
+{
+  f_clGetExtensionFunctionAddressForPlatform func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetExtensionFunctionAddressForPlatform)dlsym (
+      so_handle, "clGetExtensionFunctionAddressForPlatform");
+  if (func)
+    {
+      return func (platform, func_name);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_mem
+stubname (clCreateImage2D) (cl_context context, cl_mem_flags flags,
+                            const cl_image_format *image_format,
+                            size_t image_width, size_t image_height,
+                            size_t image_row_pitch, void *host_ptr,
+                            cl_int *errcode_ret)
+{
+  f_clCreateImage2D func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateImage2D)dlsym (so_handle, "clCreateImage2D");
+  if (func)
+    {
+      return func (context, flags, image_format, image_width, image_height,
+                   image_row_pitch, host_ptr, errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_mem
+stubname (clCreateImage3D) (cl_context context, cl_mem_flags flags,
+                            const cl_image_format *image_format,
+                            size_t image_width, size_t image_height,
+                            size_t image_depth, size_t image_row_pitch,
+                            size_t image_slice_pitch, void *host_ptr,
+                            cl_int *errcode_ret)
+{
+  f_clCreateImage3D func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateImage3D)dlsym (so_handle, "clCreateImage3D");
+  if (func)
+    {
+      return func (context, flags, image_format, image_width, image_height,
+                   image_depth, image_row_pitch, image_slice_pitch, host_ptr,
+                   errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_int
+stubname (clEnqueueMarker) (cl_command_queue command_queue, cl_event *event)
+{
+  f_clEnqueueMarker func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueMarker)dlsym (so_handle, "clEnqueueMarker");
+  if (func)
+    {
+      return func (command_queue, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueWaitForEvents) (cl_command_queue command_queue,
+                                   cl_uint num_events,
+                                   const cl_event *event_list)
+{
+  f_clEnqueueWaitForEvents func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueWaitForEvents)dlsym (so_handle, "clEnqueueWaitForEvents");
+  if (func)
+    {
+      return func (command_queue, num_events, event_list);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueBarrier) (cl_command_queue command_queue)
+{
+  f_clEnqueueBarrier func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueBarrier)dlsym (so_handle, "clEnqueueBarrier");
+  if (func)
+    {
+      return func (command_queue);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clUnloadCompiler) (void)
+{
+  f_clUnloadCompiler func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clUnloadCompiler)dlsym (so_handle, "clUnloadCompiler");
+  if (func)
+    {
+      return func ();
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+void *
+stubname (clGetExtensionFunctionAddress) (const char *func_name)
+{
+  f_clGetExtensionFunctionAddress func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetExtensionFunctionAddress)dlsym (
+      so_handle, "clGetExtensionFunctionAddress");
+  if (func)
+    {
+      return func (func_name);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_mem
+stubname (clCreateFromGLBuffer) (cl_context context, cl_mem_flags flags,
+                                 cl_GLuint bufobj, int *errcode_ret)
+{
+  f_clCreateFromGLBuffer func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateFromGLBuffer)dlsym (so_handle, "clCreateFromGLBuffer");
+  if (func)
+    {
+      return func (context, flags, bufobj, errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_mem
+stubname (clCreateFromGLTexture) (cl_context context, cl_mem_flags flags,
+                                  cl_GLenum target, cl_GLint miplevel,
+                                  cl_GLuint texture, cl_int *errcode_ret)
+{
+  f_clCreateFromGLTexture func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateFromGLTexture)dlsym (so_handle, "clCreateFromGLTexture");
+  if (func)
+    {
+      return func (context, flags, target, miplevel, texture, errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_mem
+stubname (clCreateFromGLRenderbuffer) (cl_context context, cl_mem_flags flags,
+                                       cl_GLuint renderbuffer,
+                                       cl_int *errcode_ret)
+{
+  f_clCreateFromGLRenderbuffer func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateFromGLRenderbuffer)dlsym (so_handle,
+                                              "clCreateFromGLRenderbuffer");
+  if (func)
+    {
+      return func (context, flags, renderbuffer, errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_int
+stubname (clGetGLObjectInfo) (cl_mem memobj, cl_gl_object_type *gl_object_type,
+                              cl_GLuint *gl_object_name)
+{
+  f_clGetGLObjectInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetGLObjectInfo)dlsym (so_handle, "clGetGLObjectInfo");
+  if (func)
+    {
+      return func (memobj, gl_object_type, gl_object_name);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clGetGLTextureInfo) (cl_mem memobj, cl_gl_texture_info param_name,
+                               size_t param_value_size, void *param_value,
+                               size_t *param_value_size_ret)
+{
+  f_clGetGLTextureInfo func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetGLTextureInfo)dlsym (so_handle, "clGetGLTextureInfo");
+  if (func)
+    {
+      return func (memobj, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueAcquireGLObjects) (cl_command_queue command_queue,
+                                      cl_uint num_objects,
+                                      const cl_mem *mem_objects,
+                                      cl_uint num_events_in_wait_list,
+                                      const cl_event *event_wait_list,
+                                      cl_event *event)
+{
+  f_clEnqueueAcquireGLObjects func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueAcquireGLObjects)dlsym (so_handle,
+                                             "clEnqueueAcquireGLObjects");
+  if (func)
+    {
+      return func (command_queue, num_objects, mem_objects,
+                   num_events_in_wait_list, event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_int
+stubname (clEnqueueReleaseGLObjects) (cl_command_queue command_queue,
+                                      cl_uint num_objects,
+                                      const cl_mem *mem_objects,
+                                      cl_uint num_events_in_wait_list,
+                                      const cl_event *event_wait_list,
+                                      cl_event *event)
+{
+  f_clEnqueueReleaseGLObjects func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clEnqueueReleaseGLObjects)dlsym (so_handle,
+                                             "clEnqueueReleaseGLObjects");
+  if (func)
+    {
+      return func (command_queue, num_objects, mem_objects,
+                   num_events_in_wait_list, event_wait_list, event);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}
+
+cl_mem
+stubname (clCreateFromGLTexture2D) (cl_context context, cl_mem_flags flags,
+                                    cl_GLenum target, cl_GLint miplevel,
+                                    cl_GLuint texture, cl_int *errcode_ret)
+{
+  f_clCreateFromGLTexture2D func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateFromGLTexture2D)dlsym (so_handle,
+                                           "clCreateFromGLTexture2D");
+  if (func)
+    {
+      return func (context, flags, target, miplevel, texture, errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_mem
+stubname (clCreateFromGLTexture3D) (cl_context context, cl_mem_flags flags,
+                                    cl_GLenum target, cl_GLint miplevel,
+                                    cl_GLuint texture, cl_int *errcode_ret)
+{
+  f_clCreateFromGLTexture3D func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clCreateFromGLTexture3D)dlsym (so_handle,
+                                           "clCreateFromGLTexture3D");
+  if (func)
+    {
+      return func (context, flags, target, miplevel, texture, errcode_ret);
+    }
+  else
+    {
+      return NULL;
+    }
+}
+
+cl_int
+stubname (clGetGLContextInfoKHR) (const cl_context_properties *properties,
+                                  cl_gl_context_info param_name,
+                                  size_t param_value_size, void *param_value,
+                                  size_t *param_value_size_ret)
+{
+  f_clGetGLContextInfoKHR func;
+
+  if (!so_handle)
+    open_libopencl_so ();
+
+  func = (f_clGetGLContextInfoKHR)dlsym (so_handle, "clGetGLContextInfoKHR");
+  if (func)
+    {
+      return func (properties, param_name, param_value_size, param_value,
+                   param_value_size_ret);
+    }
+  else
+    {
+      return CL_INVALID_PLATFORM;
+    }
+}

--- a/lib/CL/devices/proxy/libopencl_stub/libopencl.h
+++ b/lib/CL/devices/proxy/libopencl_stub/libopencl.h
@@ -1,0 +1,378 @@
+/* libopencl.h - function pointers to ocl functions
+
+   Copyright (c) 2023 PoCL Developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#ifndef LIBOPENCL_STUB_H
+#define LIBOPENCL_STUB_H
+
+#define CL_TARGET_OPENCL_VERSION 120
+#include <CL/cl.h>
+#include <CL/cl_gl.h>
+
+typedef void (*f_pfn_notify) (const char *, const void *, size_t, void *);
+
+typedef cl_int (*f_clGetPlatformIDs) (cl_uint, cl_platform_id *, cl_uint *);
+
+typedef cl_int (*f_clGetPlatformInfo) (cl_platform_id, cl_platform_info,
+                                       size_t, void *, size_t *);
+
+typedef cl_int (*f_clGetDeviceIDs) (cl_platform_id, cl_device_type, cl_uint,
+                                    cl_device_id *, cl_uint *);
+
+typedef cl_int (*f_clGetDeviceInfo) (cl_device_id, cl_device_info, size_t,
+                                     void *, size_t *);
+
+typedef cl_int (*f_clCreateSubDevices) (cl_device_id,
+                                        const cl_device_partition_property *,
+                                        cl_uint, cl_device_id *, cl_uint *);
+
+typedef cl_int (*f_clRetainDevice) (cl_device_id);
+
+typedef cl_int (*f_clReleaseDevice) (cl_device_id);
+
+typedef cl_context (*f_clCreateContext) (const cl_context_properties *,
+                                         cl_uint, const cl_device_id *,
+                                         f_pfn_notify, void *, cl_int *);
+
+typedef cl_context (*f_clCreateContextFromType) (const cl_context_properties *,
+                                                 cl_device_type, f_pfn_notify,
+                                                 void *, cl_int *);
+
+typedef cl_int (*f_clRetainContext) (cl_context);
+
+typedef cl_int (*f_clReleaseContext) (cl_context);
+
+typedef cl_int (*f_clGetContextInfo) (cl_context, cl_context_info, size_t,
+                                      void *, size_t *);
+
+typedef cl_command_queue (*f_clCreateCommandQueue) (
+    cl_context, cl_device_id, cl_command_queue_properties, cl_int *);
+
+#ifdef CL_VERSION_2_0
+typedef cl_command_queue (*f_clCreateCommandQueueWithProperties) (
+    cl_context, cl_device_id, const cl_queue_properties *, cl_int *);
+#endif
+
+typedef cl_int (*f_clRetainCommandQueue) (cl_command_queue);
+
+typedef cl_int (*f_clReleaseCommandQueue) (cl_command_queue);
+
+typedef cl_int (*f_clGetCommandQueueInfo) (cl_command_queue,
+                                           cl_command_queue_info, size_t,
+                                           void *, size_t *);
+
+typedef cl_mem (*f_clCreateBuffer) (cl_context, cl_mem_flags, size_t, void *,
+                                    cl_int *);
+
+typedef cl_mem (*f_clCreateSubBuffer) (cl_mem, cl_mem_flags,
+                                       cl_buffer_create_type, const void *,
+                                       cl_int *);
+
+typedef cl_mem (*f_clCreateImage) (cl_context, cl_mem_flags,
+                                   const cl_image_format *,
+                                   const cl_image_desc *, void *, cl_int *);
+
+typedef cl_int (*f_clRetainMemObject) (cl_mem);
+
+typedef cl_int (*f_clReleaseMemObject) (cl_mem);
+
+typedef cl_int (*f_clGetMemObjectInfo) (cl_mem, cl_mem_info, size_t, void *,
+                                        size_t *);
+
+typedef cl_int (*f_clGetImageInfo) (cl_mem, cl_image_info, size_t, void *,
+                                    size_t *);
+
+typedef cl_int (*f_clSetMemObjectDestructorCallback) (
+    cl_mem, void (*pfn_notify) (cl_mem memobj, void *user_data), void *);
+
+typedef cl_int (*f_clGetSupportedImageFormats) (cl_context, cl_mem_flags,
+                                                cl_mem_object_type, cl_uint,
+                                                cl_image_format *, cl_uint *);
+
+typedef cl_sampler (*f_clCreateSampler) (cl_context, cl_bool,
+                                         cl_addressing_mode, cl_filter_mode,
+                                         cl_int *);
+
+typedef cl_int (*f_clRetainSampler) (cl_sampler);
+
+typedef cl_int (*f_clReleaseSampler) (cl_sampler);
+
+typedef cl_int (*f_clGetSamplerInfo) (cl_sampler, cl_sampler_info, size_t,
+                                      void *, size_t *);
+
+typedef cl_program (*f_clCreateProgramWithSource) (cl_context, cl_uint,
+                                                   const char **,
+                                                   const size_t *, cl_int *);
+
+typedef cl_program (*f_clCreateProgramWithBinary) (cl_context, cl_uint,
+                                                   const cl_device_id *,
+                                                   const size_t *,
+                                                   const unsigned char **,
+                                                   cl_int *, cl_int *);
+
+typedef cl_program (*f_clCreateProgramWithBuiltInKernels) (
+    cl_context, cl_uint, const cl_device_id *, const char *, cl_int *);
+
+typedef cl_int (*f_clRetainProgram) (cl_program);
+
+typedef cl_int (*f_clReleaseProgram) (cl_program);
+
+typedef cl_int (*f_clBuildProgram) (
+    cl_program, cl_uint, const cl_device_id *, const char *,
+    void (*pfn_notify) (cl_program program, void *user_data), void *);
+
+typedef cl_int (*f_clCompileProgram) (
+    cl_program, cl_uint, const cl_device_id *, const char *, cl_uint,
+    const cl_program *, const char **,
+    void (*pfn_notify) (cl_program program, void *user_data), void *);
+
+typedef cl_program (*f_clLinkProgram) (cl_context, cl_uint,
+                                       const cl_device_id *, const char *,
+                                       cl_uint, const cl_program *,
+                                       void (*pfn_notify) (cl_program program,
+                                                           void *user_data),
+                                       void *, cl_int *);
+
+typedef cl_int (*f_clUnloadPlatformCompiler) (cl_platform_id);
+
+typedef cl_int (*f_clGetProgramInfo) (cl_program, cl_program_info, size_t,
+                                      void *, size_t *);
+
+typedef cl_int (*f_clGetProgramBuildInfo) (cl_program, cl_device_id,
+                                           cl_program_build_info, size_t,
+                                           void *, size_t *);
+
+typedef cl_kernel (*f_clCreateKernel) (cl_program, const char *, cl_int *);
+
+typedef cl_int (*f_clCreateKernelsInProgram) (cl_program, cl_uint, cl_kernel *,
+                                              cl_uint *);
+
+typedef cl_int (*f_clRetainKernel) (cl_kernel);
+
+typedef cl_int (*f_clReleaseKernel) (cl_kernel);
+
+typedef cl_int (*f_clSetKernelArg) (cl_kernel, cl_uint, size_t, const void *);
+
+typedef cl_int (*f_clGetKernelInfo) (cl_kernel, cl_kernel_info, size_t, void *,
+                                     size_t *);
+
+typedef cl_int (*f_clGetKernelArgInfo) (cl_kernel, cl_uint, cl_kernel_arg_info,
+                                        size_t, void *, size_t *);
+
+typedef cl_int (*f_clGetKernelWorkGroupInfo) (cl_kernel, cl_device_id,
+                                              cl_kernel_work_group_info,
+                                              size_t, void *, size_t *);
+
+typedef cl_int (*f_clWaitForEvents) (cl_uint, const cl_event *);
+
+typedef cl_int (*f_clGetEventInfo) (cl_event, cl_event_info, size_t, void *,
+                                    size_t *);
+
+typedef cl_event (*f_clCreateUserEvent) (cl_context, cl_int *);
+
+typedef cl_int (*f_clRetainEvent) (cl_event);
+
+typedef cl_int (*f_clReleaseEvent) (cl_event);
+
+typedef cl_int (*f_clSetUserEventStatus) (cl_event, cl_int);
+
+typedef cl_int (*f_clSetEventCallback) (
+    cl_event, cl_int, void (*pfn_notify) (cl_event, cl_int, void *), void *);
+
+typedef cl_int (*f_clGetEventProfilingInfo) (cl_event, cl_profiling_info,
+                                             size_t, void *, size_t *);
+
+typedef cl_int (*f_clFlush) (cl_command_queue);
+
+typedef cl_int (*f_clFinish) (cl_command_queue);
+
+typedef cl_int (*f_clEnqueueReadBuffer) (cl_command_queue, cl_mem, cl_bool,
+                                         size_t, size_t, void *, cl_uint,
+                                         const cl_event *, cl_event *);
+
+typedef cl_int (*f_clEnqueueReadBufferRect) (cl_command_queue, cl_mem, cl_bool,
+                                             const size_t *, const size_t *,
+                                             const size_t *, size_t, size_t,
+                                             size_t, size_t, void *, cl_uint,
+                                             const cl_event *, cl_event *);
+
+typedef cl_int (*f_clEnqueueWriteBuffer) (cl_command_queue, cl_mem, cl_bool,
+                                          size_t, size_t, const void *,
+                                          cl_uint, const cl_event *,
+                                          cl_event *);
+
+typedef cl_int (*f_clEnqueueWriteBufferRect) (cl_command_queue, cl_mem,
+                                              cl_bool, const size_t *,
+                                              const size_t *, const size_t *,
+                                              size_t, size_t, size_t, size_t,
+                                              const void *, cl_uint,
+                                              const cl_event *, cl_event *);
+
+typedef cl_int (*f_clEnqueueFillBuffer) (cl_command_queue, cl_mem,
+                                         const void *, size_t, size_t, size_t,
+                                         cl_uint, const cl_event *,
+                                         cl_event *);
+
+typedef cl_int (*f_clEnqueueCopyBuffer) (cl_command_queue, cl_mem, cl_mem,
+                                         size_t, size_t, size_t, cl_uint,
+                                         const cl_event *, cl_event *);
+
+typedef cl_int (*f_clEnqueueCopyBufferRect) (cl_command_queue, cl_mem, cl_mem,
+                                             const size_t *, const size_t *,
+                                             const size_t *, size_t, size_t,
+                                             size_t, size_t, cl_uint,
+                                             const cl_event *, cl_event *);
+
+typedef cl_int (*f_clEnqueueReadImage) (cl_command_queue, cl_mem, cl_bool,
+                                        const size_t *, const size_t *, size_t,
+                                        size_t, void *, cl_uint,
+                                        const cl_event *, cl_event *);
+
+typedef cl_int (*f_clEnqueueWriteImage) (cl_command_queue, cl_mem, cl_bool,
+                                         const size_t *, const size_t *,
+                                         size_t, size_t, const void *, cl_uint,
+                                         const cl_event *, cl_event *);
+
+typedef cl_int (*f_clEnqueueFillImage) (cl_command_queue, cl_mem, const void *,
+                                        const size_t *, const size_t *,
+                                        cl_uint, const cl_event *, cl_event *);
+
+typedef cl_int (*f_clEnqueueCopyImage) (cl_command_queue, cl_mem, cl_mem,
+                                        const size_t *, const size_t *,
+                                        const size_t *, cl_uint,
+                                        const cl_event *, cl_event *);
+
+typedef cl_int (*f_clEnqueueCopyImageToBuffer) (cl_command_queue, cl_mem,
+                                                cl_mem, const size_t *,
+                                                const size_t *, size_t,
+                                                cl_uint, const cl_event *,
+                                                cl_event *);
+
+typedef cl_int (*f_clEnqueueCopyBufferToImage) (cl_command_queue, cl_mem,
+                                                cl_mem, size_t, const size_t *,
+                                                const size_t *, cl_uint,
+                                                const cl_event *, cl_event *);
+
+typedef void *(*f_clEnqueueMapBuffer) (cl_command_queue, cl_mem, cl_bool,
+                                       cl_map_flags, size_t, size_t, cl_uint,
+                                       const cl_event *, cl_event *, cl_int *);
+
+typedef void *(*f_clEnqueueMapImage) (cl_command_queue, cl_mem, cl_bool,
+                                      cl_map_flags, const size_t *,
+                                      const size_t *, size_t *, size_t *,
+                                      cl_uint, const cl_event *, cl_event *,
+                                      cl_int *);
+
+typedef cl_int (*f_clEnqueueUnmapMemObject) (cl_command_queue, cl_mem, void *,
+                                             cl_uint, const cl_event *,
+                                             cl_event *);
+
+typedef cl_int (*f_clEnqueueMigrateMemObjects) (cl_command_queue, cl_uint,
+                                                const cl_mem *,
+                                                cl_mem_migration_flags,
+                                                cl_uint, const cl_event *,
+                                                cl_event *);
+
+typedef cl_int (*f_clEnqueueNDRangeKernel) (cl_command_queue, cl_kernel,
+                                            cl_uint, const size_t *,
+                                            const size_t *, const size_t *,
+                                            cl_uint, const cl_event *,
+                                            cl_event *);
+
+typedef cl_int (*f_clEnqueueTask) (cl_command_queue, cl_kernel, cl_uint,
+                                   const cl_event *, cl_event *);
+
+typedef cl_int (*f_clEnqueueNativeKernel) (cl_command_queue,
+                                           void (*user_func) (void *), void *,
+                                           size_t, cl_uint, const cl_mem *,
+                                           const void **, cl_uint,
+                                           const cl_event *, cl_event *);
+
+typedef cl_int (*f_clEnqueueMarkerWithWaitList) (cl_command_queue, cl_uint,
+                                                 const cl_event *, cl_event *);
+
+typedef cl_int (*f_clEnqueueBarrierWithWaitList) (cl_command_queue, cl_uint,
+                                                  const cl_event *,
+                                                  cl_event *);
+
+typedef void *(*f_clGetExtensionFunctionAddressForPlatform) (cl_platform_id,
+                                                             const char *);
+
+typedef cl_mem (*f_clCreateImage2D) (cl_context, cl_mem_flags,
+                                     const cl_image_format *, size_t, size_t,
+                                     size_t, void *, cl_int *);
+
+typedef cl_mem (*f_clCreateImage3D) (cl_context, cl_mem_flags,
+                                     const cl_image_format *, size_t, size_t,
+                                     size_t, size_t, size_t, void *, cl_int *);
+
+typedef cl_int (*f_clEnqueueMarker) (cl_command_queue, cl_event *);
+
+typedef cl_int (*f_clEnqueueWaitForEvents) (cl_command_queue, cl_uint,
+                                            const cl_event *);
+
+typedef cl_int (*f_clEnqueueBarrier) (cl_command_queue);
+
+typedef cl_int (*f_clUnloadCompiler) (void);
+
+typedef void *(*f_clGetExtensionFunctionAddress) (const char *);
+
+typedef cl_mem (*f_clCreateFromGLBuffer) (cl_context, cl_mem_flags, cl_GLuint,
+                                          int *);
+
+typedef cl_mem (*f_clCreateFromGLTexture) (cl_context, cl_mem_flags, cl_GLenum,
+                                           cl_GLint, cl_GLuint, cl_int *);
+
+typedef cl_mem (*f_clCreateFromGLRenderbuffer) (cl_context, cl_mem_flags,
+                                                cl_GLuint, cl_int *);
+
+typedef cl_int (*f_clGetGLObjectInfo) (cl_mem memobj, cl_gl_object_type *,
+                                       cl_GLuint *);
+
+typedef cl_int (*f_clGetGLTextureInfo) (cl_mem, cl_gl_texture_info, size_t,
+                                        void *, size_t *);
+
+typedef cl_int (*f_clEnqueueAcquireGLObjects) (cl_command_queue, cl_uint,
+                                               const cl_mem *, cl_uint,
+                                               const cl_event *, cl_event *);
+
+typedef cl_int (*f_clEnqueueReleaseGLObjects) (cl_command_queue, cl_uint,
+                                               const cl_mem *, cl_uint,
+                                               const cl_event *, cl_event *);
+
+typedef cl_mem (*f_clCreateFromGLTexture2D) (cl_context, cl_mem_flags,
+                                             cl_GLenum, cl_GLint, cl_GLuint,
+                                             cl_int *);
+
+typedef cl_mem (*f_clCreateFromGLTexture3D) (cl_context, cl_mem_flags,
+                                             cl_GLenum, cl_GLint, cl_GLuint,
+                                             cl_int *);
+
+typedef cl_int (*f_clGetGLContextInfoKHR) (const cl_context_properties *,
+                                           cl_gl_context_info, size_t, void *,
+                                           size_t *);
+
+// Additional api to reset currently opened opencl shared-object
+// Subsequent calls will use newly set environment variables
+void stubOpenclReset ();
+
+#endif // LIBOPENCL_STUB_H

--- a/lib/CL/devices/proxy/libopencl_stub/rename_stub.h
+++ b/lib/CL/devices/proxy/libopencl_stub/rename_stub.h
@@ -1,0 +1,155 @@
+/* rename_stub.h - renames ocl functions to the libopencl-stub prefix
+
+   Copyright (c) 2023 PoCL Developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#ifndef _RENAME_STUB_H_
+#define _RENAME_STUB_H_
+
+#define clGetPlatformIDs stubclGetPlatformIDs
+#define clGetPlatformInfo stubclGetPlatformInfo
+#define clGetDeviceIDs stubclGetDeviceIDs
+#define clGetDeviceInfo stubclGetDeviceInfo
+#define clCreateSubDevices stubclCreateSubDevices
+#define clRetainDevice stubclRetainDevice
+#define clReleaseDevice stubclReleaseDevice
+#define clCreateContext stubclCreateContext
+#define clCreateContextFromType stubclCreateContextFromType
+#define clRetainContext stubclRetainContext
+#define clReleaseContext stubclReleaseContext
+#define clGetContextInfo stubclGetContextInfo
+#define clCreateCommandQueueWithProperties                                    \
+  stubclCreateCommandQueueWithProperties
+#define clRetainCommandQueue stubclRetainCommandQueue
+#define clReleaseCommandQueue stubclReleaseCommandQueue
+#define clGetCommandQueueInfo stubclGetCommandQueueInfo
+#define clCreateBuffer stubclCreateBuffer
+#define clCreateSubBuffer stubclCreateSubBuffer
+#define clCreateImage stubclCreateImage
+#define clCreatePipe stubclCreatePipe
+#define clRetainMemObject stubclRetainMemObject
+#define clReleaseMemObject stubclReleaseMemObject
+#define clGetSupportedImageFormats stubclGetSupportedImageFormats
+#define clGetMemObjectInfo stubclGetMemObjectInfo
+#define clGetImageInfo stubclGetImageInfo
+#define clGetPipeInfo stubclGetPipeInfo
+#define clSetMemObjectDestructorCallback stubclSetMemObjectDestructorCallback
+#define clSVMAlloc stubclSVMAlloc
+#define clSVMFree stubclSVMFree
+#define clCreateSamplerWithProperties stubclCreateSamplerWithProperties
+#define clRetainSampler stubclRetainSampler
+#define clReleaseSampler stubclReleaseSampler
+#define clGetSamplerInfo stubclGetSamplerInfo
+#define clCreateProgramWithSource stubclCreateProgramWithSource
+#define clCreateProgramWithBinary stubclCreateProgramWithBinary
+#define clCreateProgramWithIL stubclCreateProgramWithIL
+#define clCreateProgramWithBuiltInKernels stubclCreateProgramWithBuiltInKernels
+#define clRetainProgram stubclRetainProgram
+#define clReleaseProgram stubclReleaseProgram
+#define clBuildProgram stubclBuildProgram
+#define clCompileProgram stubclCompileProgram
+#define clLinkProgram stubclLinkProgram
+#define clUnloadPlatformCompiler stubclUnloadPlatformCompiler
+#define clGetProgramInfo stubclGetProgramInfo
+#define clGetProgramBuildInfo stubclGetProgramBuildInfo
+#define clCreateKernel stubclCreateKernel
+#define clCreateKernelsInProgram stubclCreateKernelsInProgram
+#define clRetainKernel stubclRetainKernel
+#define clReleaseKernel stubclReleaseKernel
+#define clSetKernelArg stubclSetKernelArg
+#define clSetKernelArgSVMPointer stubclSetKernelArgSVMPointer
+#define clSetKernelExecInfo stubclSetKernelExecInfo
+#define clGetKernelInfo stubclGetKernelInfo
+#define clGetKernelArgInfo stubclGetKernelArgInfo
+#define clGetKernelWorkGroupInfo stubclGetKernelWorkGroupInfo
+#define clWaitForEvents stubclWaitForEvents
+#define clGetEventInfo stubclGetEventInfo
+#define clCreateUserEvent stubclCreateUserEvent
+#define clRetainEvent stubclRetainEvent
+#define clReleaseEvent stubclReleaseEvent
+#define clSetUserEventStatus stubclSetUserEventStatus
+#define clSetEventCallback stubclSetEventCallback
+#define clGetEventProfilingInfo stubclGetEventProfilingInfo
+#define clFlush stubclFlush
+#define clFinish stubclFinish
+#define clEnqueueReadBuffer stubclEnqueueReadBuffer
+#define clEnqueueReadBufferRect stubclEnqueueReadBufferRect
+#define clEnqueueWriteBuffer stubclEnqueueWriteBuffer
+#define clEnqueueWriteBufferRect stubclEnqueueWriteBufferRect
+#define clEnqueueFillBuffer stubclEnqueueFillBuffer
+#define clEnqueueCopyBuffer stubclEnqueueCopyBuffer
+#define clEnqueueCopyBufferRect stubclEnqueueCopyBufferRect
+#define clEnqueueReadImage stubclEnqueueReadImage
+#define clEnqueueWriteImage stubclEnqueueWriteImage
+#define clEnqueueFillImage stubclEnqueueFillImage
+#define clEnqueueCopyImage stubclEnqueueCopyImage
+#define clEnqueueCopyImageToBuffer stubclEnqueueCopyImageToBuffer
+#define clEnqueueCopyBufferToImage stubclEnqueueCopyBufferToImage
+#define clEnqueueMapBuffer stubclEnqueueMapBuffer
+#define clEnqueueMapImage stubclEnqueueMapImage
+#define clEnqueueUnmapMemObject stubclEnqueueUnmapMemObject
+#define clEnqueueMigrateMemObjects stubclEnqueueMigrateMemObjects
+#define clEnqueueNDRangeKernel stubclEnqueueNDRangeKernel
+#define clEnqueueNativeKernel stubclEnqueueNativeKernel
+#define clEnqueueMarkerWithWaitList stubclEnqueueMarkerWithWaitList
+#define clEnqueueBarrierWithWaitList stubclEnqueueBarrierWithWaitList
+#define clEnqueueSVMFree stubclEnqueueSVMFree
+#define clEnqueueSVMMemcpy stubclEnqueueSVMMemcpy
+#define clEnqueueSVMMemFill stubclEnqueueSVMMemFill
+#define clEnqueueSVMMap stubclEnqueueSVMMap
+#define clEnqueueSVMUnmap stubclEnqueueSVMUnmap
+#define clGetExtensionFunctionAddressForPlatform                              \
+  stubclGetExtensionFunctionAddressForPlatform
+#define clCreateImage2D stubclCreateImage2D
+#define clCreateImage3D stubclCreateImage3D
+#define clEnqueueMarker stubclEnqueueMarker
+#define clEnqueueWaitForEvents stubclEnqueueWaitForEvents
+#define clEnqueueBarrier stubclEnqueueBarrier
+#define clUnloadCompiler stubclUnloadCompiler
+#define clGetExtensionFunctionAddress stubclGetExtensionFunctionAddress
+#define clCreateCommandQueue stubclCreateCommandQueue
+#define clCreateSampler stubclCreateSampler
+#define clEnqueueTask stubclEnqueueTask
+
+#define clCreateFromGLTexture stubclCreateFromGLTexture
+#define clCreateFromGLTexture2D stubclCreateFromGLTexture2D
+#define clCreateFromGLTexture3D stubclCreateFromGLTexture3D
+#define clEnqueueAcquireGLObjects stubclEnqueueAcquireGLObjects
+#define clEnqueueReleaseGLObjects stubclEnqueueReleaseGLObjects
+#define clGetGLContextInfoKHR stubclGetGLContextInfoKHR
+
+/* cl_khr_command_buffer */
+#define clCreateCommandBufferKHR stubclCreateCommandBufferKHR
+#define clRetainCommandBufferKHR stubclRetainCommandBufferKHR
+#define clReleaseCommandBufferKHR stubclReleaseCommandBufferKHR
+#define clGetCommandBufferInfoKHR stubclGetCommandBufferInfoKHR
+#define clEnqueueCommandBufferKHR stubclEnqueueCommandBufferKHR
+#define clCommandBarrierWithWaitListKHR stubclCommandBarrierWithWaitListKHR
+#define clCommandNDRangeKernelKHR stubclCommandNDRangeKernelKHR
+#define clCommandCopyBufferKHR stubclCommandCopyBufferKHR
+#define clCommandCopyBufferRectKHR stubclCommandCopyBufferRectKHR
+#define clCommandCopyBufferToImageKHR stubclCommandCopyBufferToImageKHR
+#define clCommandCopyImageKHR stubclCommandCopyImageKHR
+#define clCommandCopyImageToBufferKHR stubclCommandCopyImageToBufferKHR
+#define clCommandFillBufferKHR stubclCommandFillBufferKHR
+#define clCommandFillImageKHR stubclCommandFillImageKHR
+
+#endif //_RENAME_STUB_H_

--- a/lib/CL/devices/proxy/pocl_proxy.c
+++ b/lib/CL/devices/proxy/pocl_proxy.c
@@ -20,8 +20,12 @@
    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
    IN THE SOFTWARE.
 */
-
 #include "config.h"
+
+#if !defined(RENAME_POCL)
+#include "libopencl_stub/rename_stub.h"
+#endif
+
 #include "pocl_proxy.h"
 #include "common.h"
 #include "devices.h"

--- a/lib/CL/devices/proxy/pocl_proxy.c
+++ b/lib/CL/devices/proxy/pocl_proxy.c
@@ -650,7 +650,7 @@ pocl_proxy_uninit (unsigned j, cl_device_id device)
 }
 
 cl_int
-pocl_proxy_reinit (unsigned j, cl_device_id device)
+pocl_proxy_reinit (unsigned j, cl_device_id device, const char *parameters)
 {
   return CL_SUCCESS;
 }

--- a/lib/CL/devices/proxy/pocl_proxy.c
+++ b/lib/CL/devices/proxy/pocl_proxy.c
@@ -510,7 +510,7 @@ pocl_proxy_get_device_info (cl_device_id device, proxy_device_data_t *d)
 
   // TODO queue properties
   device->queue_properties = CL_QUEUE_PROFILING_ENABLE;
-  DIboolptr (available, CL_DEVICE_AVAILABLE);
+  DIbool (available[0], CL_DEVICE_AVAILABLE);
   DIbool (compiler_available, CL_DEVICE_COMPILER_AVAILABLE);
   DIbool (linker_available, CL_DEVICE_LINKER_AVAILABLE);
 

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -565,7 +565,7 @@ pocl_pthread_driver_thread (void *p)
   assert (scheduler.local_mem_size > 0);
   td->local_mem = pocl_aligned_malloc (MAX_EXTENDED_ALIGNMENT,
                                        scheduler.local_mem_size);
-#ifdef __linux__
+#if defined(__linux__) && !defined(__ANDROID__)
   if (pocl_get_bool_option ("POCL_AFFINITY", 0))
     {
       cpu_set_t set;

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -269,13 +269,13 @@ extern uint64_t last_object_id;
 #  define POCL_ALIAS_OPENCL_SYMBOL(name)                                \
   __typeof__(name) name __attribute__((alias ("PO" #name), visibility("default")));
 
-#  if !defined(BUILD_ICD) && !defined(BUILD_PROXY)
+#if !defined(BUILD_ICD) && !defined(RENAME_POCL)
 #    define POsym(name) POCL_ALIAS_OPENCL_SYMBOL(name)
 #  else
 #    define POsym(name)
 #  endif
 
-#  if !defined(BUILD_PROXY)
+#if !defined(RENAME_POCL)
 #    define POsymAlways(name) POCL_ALIAS_OPENCL_SYMBOL(name)
 #  else
 #    define POsymAlways(name)

--- a/lib/CL/pocl_networking.c
+++ b/lib/CL/pocl_networking.c
@@ -26,8 +26,11 @@
 #include <errno.h>
 #include <netdb.h>
 #include <netinet/tcp.h>
+#include <netinet/in.h>
 #include <stdio.h>
 #include <string.h>
+#include <ctype.h>
+#include <sys/time.h>
 
 #include "pocl_debug.h"
 #include "pocl_networking.h"

--- a/pocl_opencl.h.in.cmake
+++ b/pocl_opencl.h.in.cmake
@@ -1,6 +1,6 @@
-#cmakedefine ENABLE_PROXY_DEVICE
+#cmakedefine RENAME_POCL
 
-#ifdef ENABLE_PROXY_DEVICE
+#ifdef RENAME_POCL
 #include "rename_opencl.h"
 #endif
 

--- a/tests/runtime/test_pinned_buffers.cpp
+++ b/tests/runtime/test_pinned_buffers.cpp
@@ -24,6 +24,8 @@
 // Enable OpenCL C++ exceptions
 #define CL_HPP_ENABLE_EXCEPTIONS
 
+#include "pocl_opencl.h"
+
 #include "../../include/CL/cl_ext_pocl.h"
 #include <CL/opencl.hpp>
 
@@ -31,8 +33,6 @@
 #include <cstdlib>
 #include <iostream>
 #include <random>
-
-#include "pocl_opencl.h"
 
 #define BUF_SIZE 16
 

--- a/tests/runtime/test_svm.cpp
+++ b/tests/runtime/test_svm.cpp
@@ -24,6 +24,8 @@
 // Enable OpenCL C++ exceptions
 #define CL_HPP_ENABLE_EXCEPTIONS
 
+#include "pocl_opencl.h"
+
 #include "../../include/CL/cl_ext_pocl.h"
 #include <CL/opencl.hpp>
 
@@ -32,8 +34,6 @@
 #include <iostream>
 #include <map>
 #include <random>
-
-#include "pocl_opencl.h"
 
 #define BUF_SIZE 16
 


### PR DESCRIPTION
This pr does the following things:
* disables a couple of things not available on android
* renames the shared lib to libpocl.so when on android
* finds and adds logging library for android
* adds some explicit imports of libraries to pocl_networking.c that were not found otherwise
* updates some function declarations in the proxy driver
* adds a new cmake option called `PROXY_USE_LIBOPENCL_STUB` which allows the proxy device to link that instead of the system libopencl library.
* add a new cmake option called `RENAME_POCL` which does many things similar to what `ENABLE_PROXY_DEVICE` used to do.
* the proxy driver can now be used without renaming all of pocl's ocl functions by using `PROXY_USE_LIBOPENCL_STUB`
* fixes the ordering of a couple of includes on test files that would fail during the build phase if the proxy device was enabled.
