### PR TITLE
PoCL-R: Somewhat usable Coarse Grain SVM trial 2 + misc fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1265,7 +1265,7 @@ endif()
 set(HOST_DEVICE_EXTENSIONS "cl_khr_byte_addressable_store cl_khr_global_int32_base_atomics \
 cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics \
 cl_khr_local_int32_extended_atomics cl_khr_3d_image_writes cl_khr_command_buffer \
-cl_pocl_pinned_buffers")
+cl_exp_pinned_buffers")
 
 # Host CPU device: list of OpenCL 3.0 features that are always enabled
 set(HOST_DEVICE_FEATURES_30 "__opencl_c_3d_image_writes  __opencl_c_images \

--- a/doc/sphinx/source/notes_5_1.rst
+++ b/doc/sphinx/source/notes_5_1.rst
@@ -1,0 +1,22 @@
+
+**************************
+Release Notes for PoCL 5.1
+**************************
+
+========================
+Driver-specific features
+========================
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Remote: Basis for the coarse-grain SVM support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The CG SVM support works only if the client manages to mmap() the
+device-side allocated SVM pool to the same address as in the
+server-side. This is a work-in-progress, but is usable for testing
+client apps and libraries that require CG SVM as it seems to work
+often enough.
+
+===================================
+Deprecation/feature removal notices
+===================================

--- a/doc/sphinx/source/remote.rst
+++ b/doc/sphinx/source/remote.rst
@@ -59,7 +59,7 @@ There is also a full length journal article under review which describes the
 published version (for example its RDMA support). A preprint of the article is
 available in `arXiv <https://doi.org/10.48550/arXiv.2309.00407>`__.
 
-If you use PoCL-R in a research paper, please cite the introductory paper with the following format::
+In publications, when referring to PoCL-R, please cite the introductory paper with the following format::
 
   @InProceedings{10.1007/978-3-031-04580-6_6,
   author="Solanti, Jan and Babej, Michal and Ikkala, Julius and Malamal Vadakital, Vinod Kumar and J{\"a}{\"a}skel{\"a}inen, Pekka",

--- a/include/messages.h
+++ b/include/messages.h
@@ -344,7 +344,8 @@ extern "C"
     uint32_t flags;
     /* If non-zero, a previously allocated SVM pointer to be wrapped as
        the backing store for the buffer OR a pointer to a host-side
-       backing store. Should set to CL_MEM_USES_SVM_POINTER to flags.*/
+       backing store. Should set to CL_MEM_USES_SVM_POINTER to flags,
+       if the former. */
     uint64_t host_ptr;
   } CreateBufferMsg_t;
 

--- a/include/messages.h
+++ b/include/messages.h
@@ -342,6 +342,10 @@ extern "C"
   {
     uint64_t size;
     uint32_t flags;
+    /* If non-zero, a previously allocated SVM pointer to be wrapped as
+       the backing store for the buffer OR a pointer to a host-side
+       backing store. Should set to CL_MEM_USES_SVM_POINTER to flags.*/
+    uint64_t host_ptr;
   } CreateBufferMsg_t;
 
   typedef struct __attribute__ ((packed, aligned (8))) CreateBufferReply_s

--- a/include/pocl.h
+++ b/include/pocl.h
@@ -96,7 +96,7 @@ typedef struct pocl_mem_identifier
   int is_pinned;
 
   /* The device-side memory address (if known). If is_pinned is true, this
-     must be a valid value (note: 0 can be a valid address!). */
+     must be a valid value (note: 0 means invalid address). */
   void *device_addr;
 
   /* Content version tracking. Every write use (clEnqWriteBuffer,

--- a/lib/CL/clEnqueueMemcpyINTEL.c
+++ b/lib/CL/clEnqueueMemcpyINTEL.c
@@ -1,6 +1,7 @@
 /* OpenCL runtime library: clEnqueueMemcpyINTEL()
 
    Copyright (c) 2023 Michal Babej / Intel Finland Oy
+                 2024 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to
@@ -42,7 +43,8 @@ POname (clEnqueueMemcpyINTEL) (cl_command_queue command_queue,
   if (errcode != CL_SUCCESS)
     return errcode;
 
-  pocl_command_enqueue (command_queue, cmd);
+  if (cmd != NULL)
+    pocl_command_enqueue (command_queue, cmd);
 
   if (blocking)
     POname (clFinish) (command_queue);

--- a/lib/CL/clEnqueueNativeKernel.c
+++ b/lib/CL/clEnqueueNativeKernel.c
@@ -1,3 +1,26 @@
+/* OpenCL runtime library: clEnqueueNativeKernel()
+
+   Copyright (c) 2010-2023 PoCL developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
 #include "config.h"
 #include "pocl_cl.h"
 #include "pocl_util.h"

--- a/lib/CL/clEnqueueReadBuffer.c
+++ b/lib/CL/clEnqueueReadBuffer.c
@@ -93,7 +93,7 @@ POname(clEnqueueReadBuffer)(cl_command_queue command_queue,
   cmd->command.read.offset = offset;
   cmd->command.read.size = size;
 
-  pocl_command_enqueue(command_queue, cmd);
+  pocl_command_enqueue (command_queue, cmd);
 
   if (blocking_read)
     POname(clFinish) (command_queue);

--- a/lib/CL/clEnqueueSVMMemcpy.c
+++ b/lib/CL/clEnqueueSVMMemcpy.c
@@ -1,12 +1,13 @@
 /* OpenCL runtime library: clEnqueueSVMMemcpy()
 
    Copyright (c) 2015 Michal Babej / Tampere University of Technology
+                 2023 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -16,9 +17,9 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #include "pocl_cl.h"
@@ -66,32 +67,67 @@ pocl_svm_memcpy_common (cl_command_buffer_khr command_buffer,
   if (((s <= d) && (s + size > d)) || ((d <= s) && (d + size > s)))
     POCL_RETURN_ERROR_ON (1, CL_MEM_COPY_OVERLAP, "overlapping copy \n");
 
-  if (command_buffer == NULL)
+  /* Utilize shadow buffers internally to share code with cl_mem buffer
+     copies. */
+
+  pocl_svm_ptr *src_svm_ptr = pocl_find_svm_ptr_in_context (context, src_ptr);
+  pocl_svm_ptr *dst_svm_ptr = pocl_find_svm_ptr_in_context (context, dst_ptr);
+
+  /* TODO: Command buffering. */
+  if (src_svm_ptr != NULL && dst_svm_ptr != NULL)
     {
+      /* A copy between SVM regions. Use the basic buffer copy using the shadow
+         buffers. */
+      errcode = pocl_copy_buffer_common (
+          NULL, command_queue, src_svm_ptr->shadow_cl_mem,
+          dst_svm_ptr->shadow_cl_mem, src_ptr - src_svm_ptr->svm_ptr,
+          dst_ptr - dst_svm_ptr->svm_ptr, size, num_items_in_wait_list,
+          event_wait_list, event, NULL, NULL, cmd);
+    }
+  else if (dst_svm_ptr != NULL && src_svm_ptr == NULL)
+    {
+      /* Read from a host address to the SVM region. */
+      /* TODO: Command buffering. clEnqueueWriteBuffer is not supported by
+         the command buffer specs. We should extend the spec to include it. */
+      errcode = POname (clEnqueueWriteBuffer) (
+          command_queue, dst_svm_ptr->shadow_cl_mem, CL_FALSE,
+          dst_ptr - dst_svm_ptr->svm_ptr, size, src_ptr,
+          num_items_in_wait_list, event_wait_list, event);
+    }
+  else if (src_svm_ptr != NULL && dst_svm_ptr == NULL)
+    {
+      /* Read from the SVM region to a host address. */
+      /* TODO: Command buffering. clEnqueueReadBuffer is not supported by
+         the command buffer specs. We should extend the spec to include it. */
+      errcode = POname (clEnqueueReadBuffer) (
+          command_queue, src_svm_ptr->shadow_cl_mem, CL_FALSE,
+          src_ptr - src_svm_ptr->svm_ptr, size, dst_ptr,
+          num_items_in_wait_list, event_wait_list, event);
+    }
+  else
+    {
+      /* Copy between non-SVM allocated host pointers. Can be a system SVM
+         or any region of memory (even if the device wouldn't support system
+         SVM?). */
       errcode = pocl_check_event_wait_list (
           command_queue, num_items_in_wait_list, event_wait_list);
       if (errcode != CL_SUCCESS)
         return errcode;
-      errcode = pocl_create_command (cmd, command_queue, command_type, event,
-                                     num_items_in_wait_list, event_wait_list,
-                                     0, NULL, NULL);
+
+      errcode = pocl_create_command (cmd, command_queue, CL_COMMAND_SVM_MEMCPY,
+                                     event, num_items_in_wait_list,
+                                     event_wait_list, 0, NULL, NULL);
+
+      if (errcode != CL_SUCCESS)
+        return errcode;
+
+      _cl_command_node *c = *cmd;
+
+      c->command.svm_memcpy.src = src_ptr;
+      c->command.svm_memcpy.dst = dst_ptr;
+      c->command.svm_memcpy.size = size;
     }
-  else
-    {
-      errcode = pocl_create_recorded_command (
-          cmd, command_buffer, command_queue, command_type,
-          num_items_in_wait_list, sync_point_wait_list, 0, NULL, NULL);
-    }
-  if (errcode != CL_SUCCESS)
-    return errcode;
-
-  _cl_command_node *c = *cmd;
-
-  c->command.svm_memcpy.src = src_ptr;
-  c->command.svm_memcpy.dst = dst_ptr;
-  c->command.svm_memcpy.size = size;
-
-  return CL_SUCCESS;
+  return errcode;
 }
 
 CL_API_ENTRY cl_int CL_API_CALL
@@ -110,7 +146,11 @@ POname (clEnqueueSVMMemcpy) (cl_command_queue command_queue, cl_bool blocking,
   if (errcode != CL_SUCCESS)
     return errcode;
 
-  pocl_command_enqueue (command_queue, cmd);
+  if (event != NULL)
+    (*event)->command_type = CL_COMMAND_SVM_MEMCPY;
+
+  if (cmd != NULL)
+    pocl_command_enqueue (command_queue, cmd);
 
   if (blocking)
     POname (clFinish) (command_queue);

--- a/lib/CL/clEnqueueSVMMemcpy.c
+++ b/lib/CL/clEnqueueSVMMemcpy.c
@@ -127,6 +127,10 @@ pocl_svm_memcpy_common (cl_command_buffer_khr command_buffer,
       c->command.svm_memcpy.dst = dst_ptr;
       c->command.svm_memcpy.size = size;
     }
+
+  if (event != NULL)
+    (*event)->command_type = command_type;
+
   return errcode;
 }
 
@@ -145,9 +149,6 @@ POname (clEnqueueSVMMemcpy) (cl_command_queue command_queue, cl_bool blocking,
       num_events_in_wait_list, event_wait_list, event, NULL, NULL, &cmd);
   if (errcode != CL_SUCCESS)
     return errcode;
-
-  if (event != NULL)
-    (*event)->command_type = CL_COMMAND_SVM_MEMCPY;
 
   if (cmd != NULL)
     pocl_command_enqueue (command_queue, cmd);

--- a/lib/CL/clEnqueueSVMUnmap.c
+++ b/lib/CL/clEnqueueSVMUnmap.c
@@ -1,12 +1,13 @@
 /* OpenCL runtime library: clEnqueueSVMUnmap()
 
    Copyright (c) 2015 Michal Babej / Tampere University of Technology
+                 2023 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -16,9 +17,9 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #include "pocl_cl.h"
@@ -61,22 +62,20 @@ POname(clEnqueueSVMUnmap) (cl_command_queue command_queue,
       && (num_events_in_wait_list == 0) && (event == NULL))
     return CL_SUCCESS;
 
-  _cl_command_node *cmd = NULL;
+  pocl_svm_ptr *svm_ptr_pocl = pocl_find_svm_ptr_in_context (context, svm_ptr);
 
-  errcode = pocl_create_command (&cmd, command_queue, CL_COMMAND_SVM_UNMAP,
-                                 event, num_events_in_wait_list,
-                                 event_wait_list, 0, NULL, NULL);
-
-  if (errcode != CL_SUCCESS)
+  /* If it's nullptr, it must be a system allocation. */
+  if (svm_ptr_pocl != NULL)
     {
-      POCL_MEM_FREE(cmd);
-      return errcode;
+      assert (svm_ptr_pocl->shadow_cl_mem != NULL);
+      POname (clEnqueueUnmapMemObject (
+          command_queue, svm_ptr_pocl->shadow_cl_mem, svm_ptr,
+          num_events_in_wait_list, event_wait_list, event));
+      if (errcode != CL_SUCCESS)
+        return errcode;
+      if (event != NULL)
+        (*event)->command_type = CL_COMMAND_SVM_UNMAP;
     }
-
-  cmd->command.svm_unmap.svm_ptr = svm_ptr;
-  cmd->command.svm_unmap.size = svm_buf_size;
-  pocl_command_enqueue(command_queue, cmd);
-
   return CL_SUCCESS;
 }
 POsym(clEnqueueSVMUnmap)

--- a/lib/CL/clReleaseKernel.c
+++ b/lib/CL/clReleaseKernel.c
@@ -1,24 +1,25 @@
 /* OpenCL runtime library: clReleaseKernel()
 
    Copyright (c) 2011 Universidad Rey Juan Carlos
-   
+                 2023 Pekka Jääskeläinen / Intel Finland Oy
+
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
-   
+
    The above copyright notice and this permission notice shall be included in
    all copies or substantial portions of the Software.
-   
+
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #include "pocl_cl.h"
@@ -77,6 +78,11 @@ POname(clReleaseKernel)(cl_kernel kernel) CL_API_SUFFIX__VERSION_1_0
         }
       kernel->name = NULL;
       kernel->meta = NULL;
+
+      struct _pocl_ptr_list_node *n, *tmp;
+      DL_FOREACH_SAFE (kernel->svm_ptrs, n, tmp) { free (n); }
+      kernel->svm_ptrs = NULL;
+
       POCL_MEM_FREE (kernel->data);
       POCL_MEM_FREE (kernel->dyn_arguments);
       POCL_DESTROY_OBJECT (kernel);

--- a/lib/CL/clSVMAlloc.c
+++ b/lib/CL/clSVMAlloc.c
@@ -1,12 +1,13 @@
 /* OpenCL runtime library: clSVMAlloc()
 
    Copyright (c) 2015 Michal Babej / Tampere University of Technology
+                 2023 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -16,12 +17,13 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #include "devices.h"
+#include "pocl_cl.h"
 #include "pocl_shared.h"
 #include "pocl_util.h"
 
@@ -105,11 +107,30 @@ POname(clSVMAlloc)(cl_context context,
       return NULL;
     }
 
+  /* Create a shadow cl_mem object for keeping track of the SVM
+     allocation and to implement automated migrations, cl_pocl_content_size,
+     etc. for CG SVM using the same code paths as with cl_mems. */
+
+  /* TODO: FOR REMOTE: This bounces down to the server again although we should
+     just return quickly with the ptr set. */
+  cl_int errcode = CL_SUCCESS;
+  cl_mem clmem_shadow = POname (clCreateBuffer) (
+      context, CL_MEM_PINNED | CL_MEM_USE_HOST_PTR | CL_MEM_READ_WRITE, size,
+      ptr, &errcode);
+
+  if (errcode != CL_SUCCESS)
+    {
+      POCL_MSG_ERR ("Failed to allocate memory a shadow cl_mem.");
+      return NULL;
+    }
+
   POCL_LOCK_OBJ (context);
   item->svm_ptr = ptr;
   item->size = size;
+  item->shadow_cl_mem = clmem_shadow;
   DL_APPEND (context->svm_ptrs, item);
   POCL_UNLOCK_OBJ (context);
+
   POname (clRetainContext) (context);
 
   POCL_MSG_PRINT_MEMORY ("Allocated SVM: PTR %p, SIZE %zu, FLAGS %" PRIu64

--- a/lib/CL/clSVMAlloc.c
+++ b/lib/CL/clSVMAlloc.c
@@ -1,7 +1,7 @@
 /* OpenCL runtime library: clSVMAlloc()
 
    Copyright (c) 2015 Michal Babej / Tampere University of Technology
-                 2023 Pekka Jääskeläinen / Intel Finland Oy
+                 2023-2024 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to

--- a/lib/CL/clSVMFree.c
+++ b/lib/CL/clSVMFree.c
@@ -66,6 +66,7 @@ POname(clSVMFree)(cl_context context,
       return;
     }
 
+  POname (clReleaseMemObject) (item->shadow_cl_mem);
   POCL_MEM_FREE (item);
 
   POname (clReleaseContext) (context);

--- a/lib/CL/clSetKernelArg.c
+++ b/lib/CL/clSetKernelArg.c
@@ -1,25 +1,26 @@
 /* OpenCL runtime library: clSetKernelArg()
 
    Copyright (c) 2011 Universidad Rey Juan Carlos
-                 2013 Pekka Jääskeläinen / Tampere University of Technology
-   
+                 2013 Pekka Jääskeläinen / Tampere University
+                 2023 Pekka Jääskeläinen / Intel Finland Oy
+
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
-   
+
    The above copyright notice and this permission notice shall be included in
    all copies or substantial portions of the Software.
-   
+
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #include "config.h"
@@ -139,11 +140,11 @@ POname(clSetKernelArg)(cl_kernel kernel,
   if (pi->type == POCL_ARG_TYPE_POINTER || pi->type == POCL_ARG_TYPE_IMAGE
       || pi->type == POCL_ARG_TYPE_SAMPLER)
     {
-      POCL_RETURN_ERROR_ON (((!is_local) && (arg_size != sizeof (cl_mem))),
-                            CL_INVALID_ARG_SIZE,
-                            "Arg %u is pointer/buffer/image, but arg_size is "
-                            "not sizeof(cl_mem)\n",
-                            arg_index);
+      POCL_RETURN_ERROR_ON (
+          ((!is_local) && (arg_size != sizeof (cl_mem))), CL_INVALID_ARG_SIZE,
+          "Arg %u is pointer/buffer/image, but arg_size (%zu) is "
+          "not sizeof(cl_mem) == %zu\n",
+          arg_index, arg_size, sizeof (cl_mem));
       if (ptr_value)
         {
           POCL_RETURN_ERROR_ON (

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1835,7 +1835,8 @@ static const cl_name_version OPENCL_EXTENSIONS[]
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_subgroup_extended_types" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_subgroup_non_uniform_vote" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_subgroup_ballot" },
-        { CL_MAKE_VERSION (1, 0, 0), "cl_khr_subgroup_non_uniform_arithmetic" },
+        { CL_MAKE_VERSION (1, 0, 0),
+          "cl_khr_subgroup_non_uniform_arithmetic" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_subgroup_shuffle" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_subgroup_shuffle_relative" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_khr_subgroup_clustered_reduce" },
@@ -1849,7 +1850,7 @@ static const cl_name_version OPENCL_EXTENSIONS[]
         { CL_MAKE_VERSION (2, 1, 0), "cl_khr_il_program" },
         { CL_MAKE_VERSION (0, 9, 4), "cl_khr_command_buffer" },
         { CL_MAKE_VERSION (1, 0, 0), "cl_ext_float_atomics" },
-        { CL_MAKE_VERSION (0, 1, 0), "cl_pocl_pinned_buffers" }};
+        { CL_MAKE_VERSION (0, 1, 0), CL_POCL_PINNED_BUFFERS_EXTENSION_NAME } };
 
 const size_t OPENCL_EXTENSIONS_NUM
     = sizeof (OPENCL_EXTENSIONS) / sizeof (OPENCL_EXTENSIONS[0]);

--- a/lib/CL/devices/common_driver.c
+++ b/lib/CL/devices/common_driver.c
@@ -1216,4 +1216,3 @@ pocl_cpu_gvar_init_callback(cl_program program, cl_uint dev_i,
                 0, 0, 0);
 #endif
 }
-

--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -212,7 +212,6 @@ char pocl_device_types[POCL_NUM_DEVICE_TYPES][30] = {
 
 static struct pocl_device_ops pocl_device_ops[POCL_NUM_DEVICE_TYPES];
 
-extern pocl_lock_t pocl_runtime_config_lock;
 extern pocl_lock_t pocl_context_handling_lock;
 
 POCL_EXPORT int pocl_offline_compile = 0;
@@ -506,7 +505,6 @@ pocl_init_devices ()
     }
   else
     {
-      POCL_INIT_LOCK (pocl_runtime_config_lock);
       POCL_INIT_LOCK (pocl_context_handling_lock);
     }
 

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -205,7 +205,7 @@ pocl_pthread_init (unsigned j, cl_device_id device, const char* parameters)
   /* OpenCL 2.0 properties */
   device->svm_caps = CL_DEVICE_SVM_COARSE_GRAIN_BUFFER
                      | CL_DEVICE_SVM_FINE_GRAIN_BUFFER
-                     | CL_DEVICE_SVM_ATOMICS;
+                     | CL_DEVICE_SVM_FINE_GRAIN_SYSTEM | CL_DEVICE_SVM_ATOMICS;
 
   if (strstr (HOST_DEVICE_EXTENSIONS, "cl_ext_float_atomics")
       != NULL) {

--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -1111,7 +1111,8 @@ pocl_remote_writer_pthread (void *aa)
           uint32_t msg_size = request_size (cmd->request.message_type);
 
           POCL_MSG_PRINT_REMOTE ("WRITER THR: WRITING MSG, TYPE: %u  ID: %zu  "
-                                 "EVENT: %zu  SIZE: %u + %zu + %zu + %zu\n",
+                                 "EVENT: %zu  SIZE: msg_size: %u + waitlist: "
+                                 "%zu + extra: %zu + extra2: %zu\n",
                                  cmd->request.message_type,
                                  cmd->request.msg_id, cmd->event_id, msg_size,
                                  cmd->req_waitlist_size * sizeof (uint64_t),
@@ -2034,22 +2035,23 @@ pocl_network_free_device (cl_device_id device)
 // SYNCHRONOUS
 
 cl_int
-pocl_network_create_buffer (remote_device_data_t *ddata, uint32_t mem_id,
-                            uint32_t mem_flags, uint64_t mem_size,
+pocl_network_create_buffer (remote_device_data_t *ddata, cl_mem mem,
                             void **device_addr)
 {
   // = (remote_device_data_t *)device->data;
   REMOTE_SERV_DATA2;
 
-  RETURN_IF_REMOTE_ID (buffer, mem_id);
+  RETURN_IF_REMOTE_ID (buffer, mem->id);
 
   CREATE_SYNC_NETCMD;
 
   POCL_MEASURE_START (REMOTE_ALLOC);
 
-  ID_REQUEST (CreateBuffer, mem_id);
-  nc.request.m.create_buffer.flags = mem_flags;
-  nc.request.m.create_buffer.size = mem_size;
+  ID_REQUEST (CreateBuffer, mem->id);
+  nc.request.m.create_buffer.flags = mem->flags;
+  nc.request.m.create_buffer.size = mem->size;
+  nc.request.m.create_buffer.host_ptr = mem->mem_host_ptr;
+
 #ifdef ENABLE_RDMA
   CreateRdmaBufferReply_t info;
   nc.rep_extra_data = (char *)&info;
@@ -2064,9 +2066,9 @@ pocl_network_create_buffer (remote_device_data_t *ddata, uint32_t mem_id,
 
   CHECK_REPLY (CreateBuffer);
 
-  SET_REMOTE_ID (buffer, mem_id);
+  SET_REMOTE_ID (buffer, mem->id);
 
-  if (mem_flags & CL_MEM_PINNED)
+  if (mem->flags & CL_MEM_PINNED)
     {
       assert (device_addr != NULL);
       *device_addr = (void *)netcmd->reply.m.create_buffer.device_addr;
@@ -2074,12 +2076,12 @@ pocl_network_create_buffer (remote_device_data_t *ddata, uint32_t mem_id,
 
 #ifdef ENABLE_RDMA
   rdma_buffer_info_t *s = malloc (sizeof (rdma_buffer_info_t));
-  s->mem_id = mem_id;
+  s->mem_id = mem->id;
   s->remote_vaddr = info.server_vaddr;
   s->remote_rkey = info.server_rkey;
   // NOTE: mem_id here is the name of the struct field holding the hashmap key,
   // not the local variable
-  HASH_ADD (hh, data->rdma_keys, mem_id, sizeof (uint32_t), s);
+  HASH_ADD (hh, data->rdma_keys, mem->id, sizeof (uint32_t), s);
 #endif
 
   return CL_SUCCESS;

--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -2048,6 +2048,17 @@ pocl_network_create_buffer (remote_device_data_t *ddata, cl_mem mem,
   POCL_MEASURE_START (REMOTE_ALLOC);
 
   ID_REQUEST (CreateBuffer, mem->id);
+
+  assert (mem->size > 0);
+  assert (mem->flags != 0);
+
+  assert (mem->mem_host_ptr == 0 || (mem->flags & CL_MEM_USES_SVM_POINTER != 0)
+          || (size_t)mem->mem_host_ptr < ddata->device_svm_region_start_addr
+          || (size_t)mem->mem_host_ptr
+                 > ddata->device_svm_region_start_addr
+                       + ddata->device_svm_region_start_addr
+                       + ddata->device_svm_region_size);
+
   nc.request.m.create_buffer.flags = mem->flags;
   nc.request.m.create_buffer.size = mem->size;
   nc.request.m.create_buffer.host_ptr = mem->mem_host_ptr;
@@ -2081,7 +2092,7 @@ pocl_network_create_buffer (remote_device_data_t *ddata, cl_mem mem,
   s->remote_rkey = info.server_rkey;
   // NOTE: mem_id here is the name of the struct field holding the hashmap key,
   // not the local variable
-  HASH_ADD (hh, data->rdma_keys, mem->id, sizeof (uint32_t), s);
+  HASH_ADD (hh, data->rdma_keys, mem_id, sizeof (uint32_t), s);
 #endif
 
   return CL_SUCCESS;

--- a/lib/CL/devices/remote/communication.h
+++ b/lib/CL/devices/remote/communication.h
@@ -351,8 +351,7 @@ cl_int pocl_network_setup_devinfo (cl_device_id device,
                                    remote_server_data_t *data, uint32_t pid,
                                    uint32_t did);
 
-cl_int pocl_network_create_buffer (remote_device_data_t *d, uint32_t mem_id,
-                                   uint32_t mem_flags, uint64_t mem_size,
+cl_int pocl_network_create_buffer (remote_device_data_t *d, cl_mem mem,
                                    void **device_addr);
 
 cl_int pocl_network_free_buffer (remote_device_data_t *d, uint64_t mem_id,

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -1144,6 +1144,9 @@ struct _pocl_svm_ptr
 {
   void *svm_ptr;
   size_t size;
+  /* A CL_MEM_PINNED cl_mem with device and host ptr the same. This is for
+     internal book keeping and automated migration purposes. */
+  cl_mem shadow_cl_mem;
   struct _pocl_svm_ptr *prev, *next;
 };
 
@@ -1602,6 +1605,13 @@ struct _cl_program {
   char *spec_const_is_set;
 };
 
+typedef struct _pocl_ptr_list_node pocl_ptr_list;
+struct _pocl_ptr_list_node
+{
+  void *ptr;
+  struct _pocl_ptr_list_node *prev, *next;
+};
+
 struct _cl_kernel {
   POCL_ICD_OBJECT
   POCL_OBJECT;
@@ -1636,6 +1646,10 @@ struct _cl_kernel {
    */
   char *dyn_argument_storage;
   void **dyn_argument_offsets;
+
+  /* The SVM allocations accessed by the kernel which were set explicitly
+     using clSetKernelExecInfo(). */
+  pocl_ptr_list *svm_ptrs;
 
   /* for program's linked list of kernels */
   struct _cl_kernel *next;

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -1446,7 +1446,7 @@ struct _cl_mem {
 
   /* If the allocation was requested to be permanent on the device
      global memory (until freed). This is set via CL_MEM_PINNED
-     flag of cl_pocl_pinned_buffers extension. */
+     flag of the cl_ext_pinned_buffers extension. */
   cl_bool is_device_pinned;
 
   /* Image flags */

--- a/lib/CL/pocl_runtime_config.c
+++ b/lib/CL/pocl_runtime_config.c
@@ -1,97 +1,59 @@
-/* pocl_runtime_config.c: functions to query pocl runtime configuration settings
+/* pocl_runtime_config.c: functions to query pocl runtime configuration
+   settings
 
-   Copyright (c) 2013 Pekka Jääskeläinen
-   
+   Copyright (c) 2013 Pekka Jääskeläinen / Tampere University (of Technology)
+                 2023 Pekka Jääskeläinen / Intel Finland Oy
+
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
-   
+
    The above copyright notice and this permission notice shall be included in
    all copies or substantial portions of the Software.
-   
+
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #include "pocl_runtime_config.h"
-#include "pocl_cl.h"
-#include "utlist.h"
 
 #include <stdlib.h>
 #include <string.h>
 
-typedef struct env_data env_data;
-struct env_data
-{
-  char *env;
-  char *value;
-  env_data *next;
-};
-
-static env_data *volatile env_cache = 0;
-pocl_lock_t pocl_runtime_config_lock;
-
-static env_data* find_env (env_data* cache, const char* key)
-{
-  env_data* ed;
-  char *value;
-
-  POCL_LOCK (pocl_runtime_config_lock);
-  LL_FOREACH(cache, ed)
-    {
-      if (strcmp(ed->env, key) == 0)
-        {
-          POCL_UNLOCK (pocl_runtime_config_lock);
-          return ed;
-        }
-    }
-  if ((value = getenv(key)))
-    {
-      ed = (env_data*) malloc (sizeof (env_data));
-      ed->env = strdup (key);
-      ed->value = strdup (value);
-      ed->next = NULL;
-      LL_APPEND(env_cache, ed);
-      POCL_UNLOCK (pocl_runtime_config_lock);
-      return ed;
-    }
-
-  POCL_UNLOCK (pocl_runtime_config_lock);
-  return NULL;
-}
 /* Can be used to query if the given option has been set by the user. */
 int pocl_is_option_set(const char *key)
 {
-  env_data* ed = NULL;
-  return (ed = find_env (env_cache, key)) ? 1 : 0;
+  return getenv (key) != NULL ? 1 : 0;
 }
 
 /* Returns an integer value for the option with the given key string. */
 int pocl_get_int_option(const char *key, int default_value)
 {
-  env_data *ed;
-  return (ed = find_env (env_cache, key)) ? atoi(ed->value) : default_value;
+  const char *val = getenv (key);
+  return val ? atoi (val) : default_value;
 }
 
 /* Returns a boolean value for the option with the given key string. */
-int pocl_get_bool_option(const char *key, int default_value) 
+int
+pocl_get_bool_option (const char *key, int default_value)
 {
-  env_data *ed;
-  if ((ed = find_env(env_cache, key)))
-    return (strncmp(ed->value, "1", 1) == 0);
+  const char *val = getenv (key);
+  if (val != NULL)
+    return (strncmp (val, "1", 1) == 0);
   return default_value;
 }
- 
-const char* pocl_get_string_option(const char *key, const char *default_value) 
+
+const char *
+pocl_get_string_option (const char *key, const char *default_value)
 {
-  env_data *ed;
-  return (ed = find_env (env_cache, key)) ? ed->value : default_value;
+  const char *val = getenv (key);
+  return val != NULL ? val : default_value;
 }

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -1874,7 +1874,7 @@ pocl_find_svm_ptr_in_context (cl_context context, const void *host_ptr)
   pocl_svm_ptr *item = NULL;
   DL_FOREACH (context->svm_ptrs, item)
   {
-    if (item->svm_ptr == host_ptr)
+    if (item->svm_ptr <= host_ptr && item->svm_ptr + item->size > host_ptr)
       {
         break;
       }

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -156,6 +156,11 @@ int pocl_buffer_boundcheck_3d(const size_t buffer_size, const size_t *origin,
                               const size_t *region, size_t *row_pitch,
                               size_t *slice_pitch, const char* prefix);
 
+/**
+ * Finds an SVM allocation where the host_ptr is mapped.
+ *
+ * @return an allocation where host_ptr is in, NULL if not found.
+ */
 pocl_svm_ptr *pocl_find_svm_ptr_in_context (cl_context context,
                                             const void *host_ptr);
 

--- a/pocld/CMakeLists.txt
+++ b/pocld/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SOURCES pocld.cc cmdline.h cmdline.c
             ../lib/CL/devices/spirv_parser.hh ../lib/CL/devices/spirv_parser.cc
             ../lib/CL/devices/bufalloc.h ../lib/CL/devices/bufalloc.c
             ../lib/CL/pocl_networking.c ../lib/CL/pocl_networking.h
+            ../lib/CL/pocl_runtime_config.c
             shared_cl_context.cc shared_cl_context.hh
             virtual_cl_context.cc virtual_cl_context.hh
             cmd_queue.cc  cmd_queue.hh  common.cc  common.hh

--- a/pocld/common.hh
+++ b/pocld/common.hh
@@ -400,8 +400,11 @@ struct EventPair {
 
 std::string hexstr(const std::string &);
 
-// Type for the buffer allocation identifier.
-typedef uint32_t BufferId_t;
+// Type for the buffer allocation identifier, a running number starting from
+// 0. Note: In some parts functions, the input can be declared as a buffer
+// id which might be treated as a raw 64b SVM pointer instead of a cl_mem
+// buffer identifier, in case referring to SVM buffers.
+typedef uint64_t BufferId_t;
 
 #ifdef __GNUC__
 #pragma GCC visibility pop

--- a/pocld/peer_handler.hh
+++ b/pocld/peer_handler.hh
@@ -79,7 +79,12 @@ public:
 #endif
 };
 
+#if 0
+// TOFIX: peers cannot be freed without crashing, let them leak for now.
 typedef std::unique_ptr<PeerHandler> PeerHandlerUPtr;
+#else
+typedef PeerHandler *PeerHandlerUPtr;
+#endif
 
 #ifdef __GNUC__
 #pragma GCC visibility pop

--- a/pocld/pocld.cc
+++ b/pocld/pocld.cc
@@ -789,11 +789,13 @@ void PoclDaemon::readAllClientSocketsThread() {
         if (d == fd) {
           close(fd);
           std::swap(open_client_fds[i], open_client_fds.back());
+
+          // Contexts can outlive their client connection (client may reconnect
+          // later) so don't destroy them here, only remove them from the socket
+          // bookkeeping list.
+
           open_client_fds.pop_back();
           std::swap(socket_contexts[i], socket_contexts.back());
-          /* Contexts can outlive their client connection (client may reconnect
-           * later) so don't destroy them here, only remove them from the socket
-           * bookkeeping list. */
           VirtualContextBase *vctx = socket_contexts.back();
           DroppedVCtxs.insert(vctx);
           socket_contexts.pop_back();

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -135,7 +135,7 @@ public:
   SharedCLContext(cl::Platform *p, unsigned plat_id, VirtualContextBase *v,
                   ReplyQueueThread *s, ReplyQueueThread *f);
 
-  ~SharedCLContext() = default;
+  virtual ~SharedCLContext();
 
   virtual cl::Context getHandle() const override {
     return ContextWithAllDevices;
@@ -624,6 +624,14 @@ SharedCLContext::SharedCLContext(cl::Platform *p, unsigned pid,
       POCL_MSG_PRINT_REMOTE(
           "Unable to allocate an SVM pool over the remote devices.\n");
     }
+  }
+}
+
+SharedCLContext::~SharedCLContext() {
+  if (SVMPool != nullptr) {
+    POCL_MSG_PRINT_MEMORY("Freeing the SVMPool.\n");
+    clSVMFree(ContextWithAllDevices.get(), SVMPool);
+    clReleaseMemObject(SVMRegionBuffer);
   }
 }
 

--- a/pocld/shared_cl_context.hh
+++ b/pocld/shared_cl_context.hh
@@ -68,10 +68,10 @@ public:
 
   /************************************************************************/
 
-  virtual int createBuffer(uint32_t buffer_id, size_t size, uint64_t flags,
+  virtual int createBuffer(BufferId_t BufferID, size_t size, uint64_t flags,
                            void *host_ptr, void **device_addr) = 0;
 
-  virtual int freeBuffer(uint64_t buffer_id, bool is_svm) = 0;
+  virtual int freeBuffer(BufferId_t BufferID, bool is_svm) = 0;
 
   virtual int buildProgram(
       uint32_t program_id, std::vector<uint32_t> &DeviceList, char *source,

--- a/pocld/virtual_cl_context.cc
+++ b/pocld/virtual_cl_context.cc
@@ -368,8 +368,8 @@ void VirtualCLContext::queuedPush(Request *req) {
 }
 
 void VirtualCLContext::notifyEvent(uint64_t event_id, cl_int status) {
-  POCL_MSG_PRINT_GENERAL("Updating event %" PRIu64 " status to %d\n", event_id,
-                         status);
+  POCL_MSG_PRINT_EVENTS("Updating event %" PRIu64 " status to %d\n", event_id,
+                        status);
   for (auto ctx : SharedContextList) {
     ctx->notifyEvent(event_id, status);
   }
@@ -664,7 +664,7 @@ void VirtualCLContext::CreateBuffer(Request *req, Reply *rep) {
 
   uint64_t devaddr;
   FOR_EACH_CONTEXT_DO(
-      createBuffer(id, m.size, m.flags, nullptr, (void **)&devaddr));
+      createBuffer(id, m.size, m.flags, (void *)m.host_ptr, (void **)&devaddr));
   // Do not pass pointer to device_addr directly above since
   // it's a packed struct and the address might be unaligned.
   rep->rep.m.create_buffer.device_addr = devaddr;
@@ -863,8 +863,6 @@ void VirtualCLContext::FreeProgram(Request *req, Reply *rep) {
   RETURN_IF_ERR;
   replyOK(rep, MessageType_FreeProgramReply);
 }
-
-/****************************************************************************************************************/
 
 void VirtualCLContext::CreateKernel(Request *req, Reply *rep) {
   INIT_VARS;

--- a/pocld/virtual_cl_context.cc
+++ b/pocld/virtual_cl_context.cc
@@ -147,7 +147,8 @@ public:
 
     // make sure no shared context tries to broadcast stuff
     std::unique_lock<std::mutex> lock(main_mutex);
-    peers.reset();
+    // TOFIX: peers cannot be freed without crashing, let them leak for now.
+    // peers.reset();
     for (auto i : SharedContextList) {
       delete i;
     }
@@ -267,7 +268,6 @@ size_t VirtualCLContext::init(client_connections_t conns,
   peers = PeerHandlerUPtr(new PeerHandler(peer_id, conns.incoming_peer_mutex,
                                           conns.incoming_peer_queue, this,
                                           &exit_helper, netstat));
-
   initPlatforms();
 
   initialMessage(*command_fd);

--- a/poclu/misc.c
+++ b/poclu/misc.c
@@ -2,13 +2,14 @@
  * \brief poclu_misc - misc generic OpenCL helper functions
 
    Copyright (c) 2013 Pekka Jääskeläinen / Tampere University of Technology
-   Copyright (c) 2014 Kalle Raiskila
+                 2014 Kalle Raiskila
+                 2023-2024 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+ deal in the Software without restriction, including without limitation the
+ rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -18,9 +19,9 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ IN THE SOFTWARE.
 
    \file
 */
@@ -502,7 +503,7 @@ poclu_load_program_multidev (cl_context context, cl_device_id *devices,
 {
   cl_bool little_endian = 0;
   cl_uint address_bits = 0;
-  char extensions[10000];
+  char *extensions;
   char path[1024];
   const char *ext;
   char final_opts[2048];
@@ -556,8 +557,16 @@ poclu_load_program_multidev (cl_context context, cl_device_id *devices,
     {
       TEST_ASSERT (device != NULL);
       strcat (final_opts, " -x spir -spir-std=1.2");
-      err = clGetDeviceInfo (device, CL_DEVICE_EXTENSIONS, 10000, extensions,
-                             NULL);
+      size_t exts_size;
+
+      err = clGetDeviceInfo (device, CL_DEVICE_EXTENSIONS, 0, NULL,
+                             &exts_size);
+
+      extensions = (char *)malloc (exts_size);
+
+      err = clGetDeviceInfo (device, CL_DEVICE_EXTENSIONS, exts_size,
+                             extensions, NULL);
+
       CHECK_OPENCL_ERROR_IN ("clGetDeviceInfo extensions");
 
       if ((spir && strstr (extensions, "cl_khr_spir") == NULL)
@@ -567,6 +576,8 @@ poclu_load_program_multidev (cl_context context, cl_device_id *devices,
                   spirv ? "-V" : "");
           return -1;
         }
+
+      free (extensions);
 
       err = clGetDeviceInfo (device, CL_DEVICE_ENDIAN_LITTLE, sizeof (cl_bool),
                              &little_endian, NULL);

--- a/poclu/misc.c
+++ b/poclu/misc.c
@@ -502,7 +502,7 @@ poclu_load_program_multidev (cl_context context, cl_device_id *devices,
 {
   cl_bool little_endian = 0;
   cl_uint address_bits = 0;
-  char extensions[1024];
+  char extensions[10000];
   char path[1024];
   const char *ext;
   char final_opts[2048];
@@ -556,7 +556,7 @@ poclu_load_program_multidev (cl_context context, cl_device_id *devices,
     {
       TEST_ASSERT (device != NULL);
       strcat (final_opts, " -x spir -spir-std=1.2");
-      err = clGetDeviceInfo (device, CL_DEVICE_EXTENSIONS, 1024, extensions,
+      err = clGetDeviceInfo (device, CL_DEVICE_EXTENSIONS, 10000, extensions,
                              NULL);
       CHECK_OPENCL_ERROR_IN ("clGetDeviceInfo extensions");
 

--- a/tests/runtime/test_clCreateSubDevices.c
+++ b/tests/runtime/test_clCreateSubDevices.c
@@ -140,6 +140,11 @@ int main(int argc, char **argv)
     {
       printf (
           "This test requires a cl device with at least 2 compute units\n");
+      err = clReleaseCommandQueue(q);
+      CHECK_OPENCL_ERROR_IN("clReleaseCommandQueue");
+      err = clReleaseContext(ctx);
+      CHECK_OPENCL_ERROR_IN("clReleaseContext");
+      CHECK_CL_ERROR (clUnloadCompiler ());
       return 77;
     }
 
@@ -151,6 +156,11 @@ int main(int argc, char **argv)
   if (max_subs < 2)
     {
       printf ("This test requires a cl device with at least 2 subdevices\n");
+      err = clReleaseCommandQueue(q);
+      CHECK_OPENCL_ERROR_IN("clReleaseCommandQueue");
+      err = clReleaseContext(ctx);
+      CHECK_OPENCL_ERROR_IN("clReleaseContext");
+      CHECK_CL_ERROR (clUnloadCompiler ());
       return 77;
     }
 

--- a/tests/runtime/test_clEnqueueNativeKernel.c
+++ b/tests/runtime/test_clEnqueueNativeKernel.c
@@ -93,6 +93,12 @@ int main(int argc, char **argv) {
   if ((cap & CL_EXEC_NATIVE_KERNEL) == 0)
     {
       printf ("device doesn't support executing native kernels, exiting\n");
+      free(h_a);
+      free(h_b);
+      free(h_c);
+      CHECK_CL_ERROR (clReleaseCommandQueue (queue));
+      CHECK_CL_ERROR (clReleaseContext (ctx));
+      CHECK_CL_ERROR (clUnloadCompiler ());
       return 77;
     }
 

--- a/tests/runtime/test_clGetDeviceInfo.c
+++ b/tests/runtime/test_clGetDeviceInfo.c
@@ -43,9 +43,11 @@ main(void)
 
       TEST_ASSERT(global_memsize > 0);
 
-      min_max_mem_alloc_size = 128*1024*1024;
-      if (min_max_mem_alloc_size < global_memsize/4)
-        min_max_mem_alloc_size = global_memsize/4;
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+
+      min_max_mem_alloc_size = MAX (
+          MIN (1024 * 1024 * 1024, global_memsize / 4), 32 * 1024 * 1024);
 
       TEST_ASSERT(max_mem_alloc_size >= min_max_mem_alloc_size);
 

--- a/tests/runtime/test_clGetKernelArgInfo.c
+++ b/tests/runtime/test_clGetKernelArgInfo.c
@@ -409,38 +409,6 @@ int main()
 
   CHECK_CL_ERROR(clReleaseProgram(program));
 
-  char extensions[1000];
-  err = clGetDeviceInfo(did, CL_DEVICE_EXTENSIONS, 10000, extensions, NULL);
-  CHECK_OPENCL_ERROR_IN("clGetDeviceInfo");
-  if (strstr(extensions, "cl_khr_spir") == NULL)
-    {
-      printf ("SPIR not supported, skipping SPIR arg info tests\n");
-      goto FINISH;
-    }
-
-  /* SPIR program */
-
-  printf ("\nSPIR with metadata\n");
-
-  const char *filename = (address_bits == 32 ? meta_files[0] : meta_files[1]);
-  TEST_ASSERT (spir_program (filename, ctx, did, &program) == EXIT_SUCCESS);
-
-  TEST_ASSERT (test_program (program, 1) == EXIT_SUCCESS);
-
-  CHECK_CL_ERROR(clReleaseProgram(program));
-
-  /* SPIR program without metadata - currently disabled since Clang seems to
-   * always generate metadata. */
-  /*
-    printf("\nSPIR WITHOUT metadata\n");
-    filename = (address_bits == 32 ? nometa_files[0] : nometa_files[1]);
-    TEST_ASSERT(spir_program(filename, ctx, did, &program) == EXIT_SUCCESS);
-
-    TEST_ASSERT(test_program_nometa(program) == EXIT_SUCCESS);
-
-    CHECK_CL_ERROR(clReleaseProgram(program));
-  */
-
 FINISH:
   CHECK_CL_ERROR (clReleaseCommandQueue (queue));
   CHECK_CL_ERROR (clReleaseContext (ctx));

--- a/tests/runtime/test_clGetKernelArgInfo.c
+++ b/tests/runtime/test_clGetKernelArgInfo.c
@@ -409,8 +409,8 @@ int main()
 
   CHECK_CL_ERROR(clReleaseProgram(program));
 
-  char extensions[1024];
-  err = clGetDeviceInfo(did, CL_DEVICE_EXTENSIONS, 1024, extensions, NULL);
+  char extensions[1000];
+  err = clGetDeviceInfo(did, CL_DEVICE_EXTENSIONS, 10000, extensions, NULL);
   CHECK_OPENCL_ERROR_IN("clGetDeviceInfo");
   if (strstr(extensions, "cl_khr_spir") == NULL)
     {

--- a/tests/runtime/test_pinned_buffers.cpp
+++ b/tests/runtime/test_pinned_buffers.cpp
@@ -73,14 +73,21 @@ int main(void) {
 
     for (cl::Device &Dev : Devices) {
       std::string Exts = Dev.getInfo<CL_DEVICE_EXTENSIONS>();
-      if (Exts.find("cl_pocl_pinned_buffers") != std::string::npos) {
+      std::cout << Dev.getInfo<CL_DEVICE_NAME>() << " "
+                << Dev.getInfo<CL_DEVICE_VERSION>() << ": ";
+      if (Exts.find(CL_POCL_PINNED_BUFFERS_EXTENSION_NAME) !=
+          std::string::npos) {
+        std::cout << "suitable" << std::endl;
         SuitableDevices.push_back(Dev);
         break;
+      } else {
+        std::cout << CL_POCL_PINNED_BUFFERS_EXTENSION_NAME << " not supported"
+                  << std::endl;
       }
     }
 
     if (SuitableDevices.empty()) {
-      std::cout << "No devices with cl_pocl_pinned_buffers found.";
+      std::cout << "No suitable devices found.";
       return 77;
     }
     int PinnedBufferHost[BUF_SIZE];

--- a/tests/runtime/test_svm.cpp
+++ b/tests/runtime/test_svm.cpp
@@ -233,8 +233,6 @@ int TestCGSVM() {
     AllOK = false;
   }
 
-  CHECK_CL_ERROR(clUnloadCompiler());
-
   if (AllOK) {
     printf("PASSED\n");
     return EXIT_SUCCESS;
@@ -330,8 +328,6 @@ int TestSimpleKernel_CGSVM() {
               << std::endl;
     AllOK = false;
   }
-
-  CHECK_CL_ERROR(clUnloadCompiler());
 
   if (AllOK)
     return EXIT_SUCCESS;
@@ -438,8 +434,6 @@ int TestCLMem_SVM() {
               << std::endl;
     AllOK = false;
   }
-
-  CHECK_CL_ERROR(clUnloadCompiler());
 
   if (AllOK)
     return EXIT_SUCCESS;
@@ -625,8 +619,6 @@ int TestFGSVM() {
     AllOK = false;
   }
 
-  CHECK_CL_ERROR (clUnloadCompiler ());
-
   if (!AllOK)
     return EXIT_FAILURE;
   else
@@ -764,8 +756,6 @@ int TestSSVM() {
     AllOK = false;
   }
 
-  CHECK_CL_ERROR(clUnloadCompiler());
-
   if (!AllOK)
     return EXIT_FAILURE;
   else
@@ -795,5 +785,7 @@ int main() {
     return EXIT_FAILURE;
 
   std::cout << "OK" << std::endl;
+  CHECK_CL_ERROR(clUnloadCompiler());
+ 
   return EXIT_SUCCESS;
 }

--- a/tests/runtime/test_svm.cpp
+++ b/tests/runtime/test_svm.cpp
@@ -1,6 +1,6 @@
-/* Test the pinned buffers extension.
+/* Tests for SVM.
 
-   Copyright (c) 2023 Pekka Jääskeläinen / Intel Finland Oy
+   Copyright (c) 2023-2024 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -35,22 +35,25 @@
 #include <map>
 #include <random>
 
-#define BUF_SIZE 16
+#include "pocl_opencl.h"
+
+#define N_ELEMENTS 16
 
 static char GetAddrSourceCode[] = R"raw(
 
   __kernel void get_addr (__global int *svm_buffer,
                           __global ulong* addr) {
-    for (int i = 0; i < BUF_SIZE; ++i) {
+    for (int i = 0; i < N_ELEMENTS; ++i) {
       svm_buffer[i] += 1;
-      printf("kern-side svm_buffer[%d] == %d\n", i, svm_buffer[i]);
     }
     *addr = (ulong)svm_buffer;
-    printf("kern-side addr %p\n", svm_buffer);
   }
 )raw";
 
-int main(void) {
+#define STRINGIFY(X, Y) X #Y
+#define SET_N_ELEMENTS(NUM) STRINGIFY("-DN_ELEMENTS=", NUM)
+
+int TestCGSVM() {
 
   unsigned Errors = 0;
   bool AllOK = true;
@@ -80,7 +83,8 @@ int main(void) {
     }
 
     if (SuitableDevices.empty()) {
-      std::cout << "No devices with SVM coarse grain buffer capabilities found.";
+      std::cout << "No devices with SVM coarse grain buffer capabilities found."
+                << std::endl;
       return 77;
     }
 
@@ -101,8 +105,7 @@ int main(void) {
 
       // If we exhaust the SVM space space, it's fine.
       // Freeing the allocations should make the remainder of the test
-      // work still, unless there's a mem leak in the implementation
-      // side.
+      // work still, unless there's a mem leak in the implementation.
       if (Buf == nullptr)
         break;
 
@@ -113,7 +116,7 @@ int main(void) {
                     << " with size " << std::dec << AllocSize
                     << " overlaps with a previous one at " << std::hex
                     << (size_t)m.first << " with size " << m.second << std::endl;
-          return EXIT_FAILURE;
+          return false;
         }
       }
       Allocs[Buf] = AllocSize;
@@ -133,14 +136,11 @@ int main(void) {
     cl::Program::Sources Sources({GetAddrSourceCode});
     cl::Program Program(Context, Sources);
 
-#define STRINGIFY(X, Y) X #Y
-#define SET_BUF_SIZE(NUM) STRINGIFY("-DBUF_SIZE=", NUM)
-
-    Program.build(SuitableDevices, SET_BUF_SIZE(BUF_SIZE));
+    Program.build(SuitableDevices, SET_N_ELEMENTS(N_ELEMENTS));
 
     cl::Kernel GetAddrKernel(Program, "get_addr");
 
-    constexpr size_t BufSize = BUF_SIZE * sizeof(int);
+    constexpr size_t BufSize = N_ELEMENTS * sizeof(int);
     int *CGSVMBuf = (int*)::clSVMAlloc(Context.get(), CL_MEM_READ_WRITE,
                                        BufSize, 0);
 
@@ -157,17 +157,46 @@ int main(void) {
     ::clSetKernelArgSVMPointer(GetAddrKernel.get(), 0, CGSVMBuf);
     GetAddrKernel.setArg(1, AddrCLBuffer);
 
-    Queue.enqueueMapSVM(CGSVMBuf, true, CL_MAP_WRITE, BufSize);
+    int HostBuf[] = {0, 1, 2, 3};
+    // Initialize the first inputs via an SVM memcpy command.
 
-    for (int i = 0; i < BUF_SIZE; ++i) {
+    // Without the destination being host-mapped...
+    CHECK_CL_ERROR(::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &CGSVMBuf[0],
+                                        &HostBuf[0], 2 * sizeof(int), 0,
+                                        nullptr, nullptr));
+
+    Queue.enqueueMapSVM(&CGSVMBuf[0], true, CL_MAP_READ, 2 * sizeof(int));
+
+    for (int i = 0; i < 2; ++i) {
+      if (CGSVMBuf[i] != i) {
+        AllOK = false;
+        std::cerr << "CGSVMBuf[" << i << "] " << std::hex << &CGSVMBuf[i]
+                  << " expected to be " << i << " but got " << (int)CGSVMBuf[i]
+                  << std::endl;
+      }
+      if (HostBuf[i] != i) {
+        AllOK = false;
+        std::cerr << "HostBuf[" << i << "] expected to be " << i << " but got "
+                  << (int)HostBuf[i] << std::endl;
+      }
+    }
+
+    Queue.enqueueUnmapSVM(CGSVMBuf);
+
+    // ...and while it has been host-mapped.
+    ::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &CGSVMBuf[2], &HostBuf[2],
+                         2 * sizeof(int), 0, nullptr, nullptr);
+
+    Queue.enqueueMapSVM(CGSVMBuf, true, CL_MAP_WRITE, BufSize);
+    // Write the rest of the inputs directly.
+    for (int i = 4; i < N_ELEMENTS; ++i) {
       CGSVMBuf[i] = i;
     }
 
-    // Is this actually unneccessary because the kernel execution and finishing are
-    // syncpoints?
     Queue.enqueueUnmapSVM(CGSVMBuf);
     Queue.enqueueNDRangeKernel(GetAddrKernel, cl::NullRange, cl::NDRange(1),
                                cl::NullRange);
+    Queue.enqueueMapSVM(CGSVMBuf, true, CL_MAP_READ, BufSize);
 
     Queue.enqueueReadBuffer(AddrCLBuffer,
                             CL_TRUE, // block
@@ -180,19 +209,416 @@ int main(void) {
       AllOK = false;
     }
 
-    // Is not needed because the kernel execution and finishing are
-    // syncpoints.
-    Queue.enqueueMapSVM(CGSVMBuf, CL_TRUE, CL_MAP_READ, BufSize);
+    // Read some of the data with SVMMemcpy().
+    ::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &HostBuf[0], &CGSVMBuf[0],
+                         4 * sizeof(int), 0, nullptr, nullptr);
 
-    for (int i = 0; i < BUF_SIZE; ++i) {
+    std::cerr << std::dec;
+    for (int i = 0; i < N_ELEMENTS; ++i) {
       if (CGSVMBuf[i] != i + 1) {
         AllOK = false;
         std::cerr << "CGSVMBuf[" << i << "] expected to be " << i + 1
                   << " but got " << (int)CGSVMBuf[i] << std::endl;
       }
+      if (i < 4 && i + 1 != HostBuf[i]) {
+        AllOK = false;
+        std::cerr << "Wrong data in the memcopied buf at " << i << " expected "
+                  << i + 1 << " got " << HostBuf[i] << std::endl;
+      }
     }
     clSVMFree(Context.get(), CGSVMBuf);
+  } catch (cl::Error &err) {
+    std::cerr << "ERROR: " << err.what() << "(" << err.err() << ")"
+              << std::endl;
+    AllOK = false;
+  }
 
+  CHECK_CL_ERROR(clUnloadCompiler());
+
+  if (AllOK) {
+    printf("PASSED\n");
+    return EXIT_SUCCESS;
+  } else
+    return EXIT_FAILURE;
+}
+
+static char SimpleKernelSourceCode[] = R"raw(
+
+  __kernel void simple_kernel(__global int *Out,
+                              __global int *In) {
+    *Out = *In;
+  }
+)raw";
+
+// OpenCL version of simple_kernel.hip in the chipStar samples.
+int TestSimpleKernel_CGSVM() {
+  unsigned Errors = 0;
+  bool AllOK = true;
+
+  try {
+    std::vector<cl::Platform> PlatformList;
+
+    cl::Platform::get(&PlatformList);
+
+    cl_context_properties cprops[] = {
+        CL_CONTEXT_PLATFORM, (cl_context_properties)(PlatformList[0])(), 0};
+    cl::Context Context(CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU, cprops);
+
+    std::vector<cl::Device> Devices = Context.getInfo<CL_CONTEXT_DEVICES>();
+
+    std::vector<cl::Device> SuitableDevices;
+
+    for (cl::Device &Dev : Devices) {
+      if (Dev.getInfo<CL_DEVICE_SVM_CAPABILITIES>() &
+          CL_DEVICE_SVM_COARSE_GRAIN_BUFFER) {
+        SuitableDevices.push_back(Dev);
+        break;
+      } else {
+        std::cout << "Device '" << Dev.getInfo<CL_DEVICE_NAME>()
+                  << "' doesn't support CG SVM." << std::endl;
+      }
+    }
+
+    if (SuitableDevices.empty()) {
+      std::cout << "No devices with SVM coarse grain buffer capabilities found."
+                << std::endl;
+      return 77;
+    }
+
+    cl::CommandQueue Queue(Context, SuitableDevices[0], 0);
+
+    cl::Program::Sources Sources({SimpleKernelSourceCode});
+    cl::Program Program(Context, Sources);
+
+    Program.build(SuitableDevices);
+
+    cl::Kernel SimpleKernel(Program, "simple_kernel");
+
+    int InH = 123, OutH = 0, *InD, *OutD;
+    OutD =
+        (int *)::clSVMAlloc(Context.get(), CL_MEM_READ_WRITE, sizeof(int), 0);
+    InD = (int *)::clSVMAlloc(Context.get(), CL_MEM_READ_WRITE, sizeof(int), 0);
+
+    if (OutD == nullptr || InD == nullptr) {
+      std::cerr << "Unable to allocate SVM buffers.\n";
+      return EXIT_FAILURE;
+    }
+
+    CHECK_CL_ERROR(::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, InD, &InH,
+                                        sizeof(int), 0, nullptr, nullptr));
+
+    ::clSetKernelArgSVMPointer(SimpleKernel.get(), 0, OutD);
+    ::clSetKernelArgSVMPointer(SimpleKernel.get(), 1, InD);
+
+    Queue.enqueueNDRangeKernel(SimpleKernel, cl::NullRange, cl::NDRange(1),
+                               cl::NullRange);
+
+    CHECK_CL_ERROR(::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &OutH, OutD,
+                                        sizeof(int), 0, nullptr, nullptr));
+
+    clSVMFree(Context.get(), OutD);
+    clSVMFree(Context.get(), InD);
+
+    if (OutH == 123) {
+      printf("PASSED\n");
+    } else {
+      AllOK = false;
+      printf("OutH=%d\n", OutH);
+    }
+  } catch (cl::Error &err) {
+    std::cerr << "ERROR: " << err.what() << "(" << err.err() << ")"
+              << std::endl;
+    AllOK = false;
+  }
+
+  CHECK_CL_ERROR(clUnloadCompiler());
+
+  if (AllOK)
+    return EXIT_SUCCESS;
+  else
+    return EXIT_FAILURE;
+}
+
+// Test for cl_mem-wrapped SVM pointers.
+int TestCLMem_SVM() {
+  cl_int Err = 0;
+  bool AllOK = true;
+
+  try {
+    std::vector<cl::Platform> PlatformList;
+
+    cl::Platform::get(&PlatformList);
+
+    cl_context_properties cprops[] = {
+        CL_CONTEXT_PLATFORM, (cl_context_properties)(PlatformList[0])(), 0};
+    cl::Context Context(CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU, cprops);
+
+    std::vector<cl::Device> Devices = Context.getInfo<CL_CONTEXT_DEVICES>();
+
+    std::vector<cl::Device> SuitableDevices;
+
+    for (cl::Device &Dev : Devices) {
+      if (Dev.getInfo<CL_DEVICE_SVM_CAPABILITIES>() &
+          CL_DEVICE_SVM_COARSE_GRAIN_BUFFER) {
+        SuitableDevices.push_back(Dev);
+        break;
+      } else {
+        std::cout << "Device '" << Dev.getInfo<CL_DEVICE_NAME>()
+                  << "' doesn't support CG SVM." << std::endl;
+      }
+    }
+
+    if (SuitableDevices.empty()) {
+      std::cout << "No devices with SVM coarse grain buffer capabilities found."
+                << std::endl;
+      return 77;
+    }
+
+    cl::CommandQueue Q(Context, SuitableDevices[0], 0);
+
+    cl::Program::Sources Sources({SimpleKernelSourceCode});
+    cl::Program Program(Context, Sources);
+
+    Program.build(SuitableDevices);
+
+    cl::Kernel SimpleKernel(Program, "simple_kernel");
+
+    int InH = 123, OutH = 0, *InD, *OutD;
+    InD = (int *)::clSVMAlloc(Context.get(), CL_MEM_READ_WRITE, sizeof(int), 0);
+    OutD =
+        (int *)::clSVMAlloc(Context.get(), CL_MEM_READ_WRITE, sizeof(int), 0);
+    if (OutD == nullptr || InD == nullptr) {
+      std::cerr << "Unable to allocate SVM buffers.\n";
+      return EXIT_FAILURE;
+    }
+
+    cl::Buffer clBufInD(Context, CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
+                        sizeof(int), InD, &Err);
+
+    CHECK_CL_ERROR(Err);
+
+    cl::Buffer clBufOutD(Context, CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR,
+                         sizeof(int), OutD, &Err);
+    CHECK_CL_ERROR(Err);
+
+    if (!clBufInD.getInfo<CL_MEM_USES_SVM_POINTER>() ||
+        !clBufOutD.getInfo<CL_MEM_USES_SVM_POINTER>()) {
+      std::cerr << "cl_mem wrappers for the SVM pointers do not have "
+                   "CL_MEM_USES_SVM_POINTER set.\n";
+      return EXIT_FAILURE;
+    }
+
+    // Now clWriteBuffer() should allow us to update the SVM
+    // region as an alternative to clEnqueueSVMMemcpy().
+    CHECK_CL_ERROR(
+        Q.enqueueWriteBuffer(clBufInD, CL_FALSE, 0, sizeof(int), &InH));
+
+    // We still should be able to use clSetKernelArgSVMPointer
+    // ::clSetKernelArgSVMPointer(SimpleKernel.get(), 0, OutD);
+    // ...or clSetKernelArg()
+    CHECK_CL_ERROR(SimpleKernel.setArg(0, clBufOutD));
+    CHECK_CL_ERROR(SimpleKernel.setArg(1, clBufInD));
+
+    CHECK_CL_ERROR(Q.enqueueNDRangeKernel(SimpleKernel, cl::NullRange,
+                                          cl::NDRange(1), cl::NullRange));
+
+    CHECK_CL_ERROR(
+        Q.enqueueReadBuffer(clBufOutD, CL_TRUE, 0, sizeof(int), &OutH));
+    clSVMFree(Context.get(), OutD);
+    clSVMFree(Context.get(), InD);
+
+    if (OutH == 123) {
+      printf("PASSED\n");
+    } else {
+      AllOK = false;
+      printf("FAILED OutH=%d\n", OutH);
+    }
+  } catch (cl::Error &err) {
+    std::cerr << "ERROR: " << err.what() << "(" << err.err() << ")"
+              << std::endl;
+    AllOK = false;
+  }
+
+  CHECK_CL_ERROR(clUnloadCompiler());
+
+  if (AllOK)
+    return EXIT_SUCCESS;
+  else
+    return EXIT_FAILURE;
+}
+
+int TestFGSVM() {
+
+  unsigned Errors = 0;
+  bool AllOK = true;
+
+  try {
+    std::vector<cl::Platform> PlatformList;
+
+    cl::Platform::get(&PlatformList);
+
+    cl_context_properties cprops[] = {
+        CL_CONTEXT_PLATFORM, (cl_context_properties)(PlatformList[0])(), 0};
+    cl::Context Context(CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU, cprops);
+
+    std::vector<cl::Device> Devices = Context.getInfo<CL_CONTEXT_DEVICES>();
+
+    std::vector<cl::Device> SuitableDevices;
+
+    for (cl::Device &Dev : Devices) {
+      if (Dev.getInfo<CL_DEVICE_SVM_CAPABILITIES>() &
+          CL_DEVICE_SVM_FINE_GRAIN_BUFFER) {
+        SuitableDevices.push_back(Dev);
+        break;
+      } else {
+        std::cout << "Device '" << Dev.getInfo<CL_DEVICE_NAME>()
+                  << "' doesn't support FG SVM." << std::endl;
+      }
+    }
+
+    if (SuitableDevices.empty()) {
+      std::cout << "No devices with SVM fine grain buffer capabilities found."
+                << std::endl;
+      return 77;
+    }
+
+    // Basics: Create a bunch of random-sized allocations and ensure their
+    // address ranges do not overlap.
+    constexpr size_t NumAllocs = 1000;
+    constexpr size_t MaxSize = 1024 * 1024;
+
+    std::mt19937 Gen(1234);
+    std::uniform_int_distribution<> Distrib(1, MaxSize);
+
+    std::map<char *, size_t> Allocs;
+    for (int i = 0; i < NumAllocs; ++i) {
+      size_t AllocSize = Distrib(Gen);
+
+      char *Buf = (char *)::clSVMAlloc(
+          Context.get(), CL_MEM_READ_WRITE | CL_MEM_SVM_FINE_GRAIN_BUFFER,
+          AllocSize, 0);
+
+      // If we exhaust the SVM space space, it's fine.
+      // Freeing the allocations should make the remainder of the test
+      // work still, unless there's a mem leak in the implementation
+      // side.
+      if (Buf == nullptr)
+        break;
+
+      // Check for overlap.
+      for (auto &m : Allocs) {
+        if (m.first <= Buf && m.first + m.second > Buf) {
+          std::cerr << "An SVM allocation at " << std::hex << (size_t)Buf
+                    << " with size " << std::dec << AllocSize
+                    << " overlaps with a previous one at " << std::hex
+                    << (size_t)m.first << " with size " << m.second
+                    << std::endl;
+          return false;
+        }
+      }
+      Allocs[Buf] = AllocSize;
+    }
+
+    if (Allocs.size() == 0) {
+      std::cerr << "Unable to allocate any SVM chunks." << std::endl;
+      return EXIT_FAILURE;
+    }
+    for (auto &m : Allocs) {
+      // std::cout << "Freeing " << std::hex << (size_t)m.first << std::endl;
+      clSVMFree(Context.get(), m.first);
+    }
+
+    cl::CommandQueue Queue(Context, SuitableDevices[0], 0);
+
+    cl::Program::Sources Sources({GetAddrSourceCode});
+    cl::Program Program(Context, Sources);
+
+    Program.build(SuitableDevices, SET_N_ELEMENTS(N_ELEMENTS));
+
+    cl::Kernel GetAddrKernel(Program, "get_addr");
+
+    constexpr size_t BufSize = N_ELEMENTS * sizeof(int);
+    int *FGSVMBuf = (int *)::clSVMAlloc(
+        Context.get(), CL_MEM_READ_WRITE | CL_MEM_SVM_FINE_GRAIN_BUFFER,
+        BufSize, 0);
+
+    if (FGSVMBuf == nullptr) {
+      std::cerr << "FG SVM allocation returned a nullptr." << std::endl;
+      return false;
+    }
+
+    cl_ulong AddrFromKernel = 1;
+
+    cl::Buffer AddrCLBuffer =
+        cl::Buffer(Context, CL_MEM_WRITE_ONLY, sizeof(cl_ulong), nullptr);
+
+    ::clSetKernelArgSVMPointer(GetAddrKernel.get(), 0, FGSVMBuf);
+    GetAddrKernel.setArg(1, AddrCLBuffer);
+
+    int HostBuf[] = {0, 1, 2, 3};
+    // Initialize the first inputs via an SVM memcpy command.
+
+    // Without the destination being host-mapped...
+    CHECK_CL_ERROR(::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &FGSVMBuf[0],
+                                        &HostBuf[0], 2 * sizeof(int), 0,
+                                        nullptr, nullptr));
+
+    for (int i = 0; i < 2; ++i) {
+      if (FGSVMBuf[i] != i) {
+        AllOK = false;
+        std::cerr << "FGSVMBuf[" << i << "] " << std::hex << &FGSVMBuf[i]
+                  << " expected to be " << i << " but got " << (int)FGSVMBuf[i]
+                  << std::endl;
+      }
+      if (HostBuf[i] != i) {
+        AllOK = false;
+        std::cerr << "HostBuf[" << i << "] expected to be " << i << " but got "
+                  << (int)HostBuf[i] << std::endl;
+      }
+    }
+
+    ::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &FGSVMBuf[2], &HostBuf[2],
+                         2 * sizeof(int), 0, nullptr, nullptr);
+
+    // Write the rest of the inputs directly.
+    for (int i = 4; i < N_ELEMENTS; ++i) {
+      FGSVMBuf[i] = i;
+    }
+
+    Queue.enqueueNDRangeKernel(GetAddrKernel, cl::NullRange, cl::NDRange(1),
+                               cl::NullRange);
+    Queue.enqueueReadBuffer(AddrCLBuffer,
+                            CL_TRUE, // block
+                            0, sizeof(cl_ulong), (void *)&AddrFromKernel);
+
+    if (FGSVMBuf != (void *)AddrFromKernel) {
+      std::cerr << "FG buffer's device address on kernel side and host "
+                   "side do not match. Host sees "
+                << std::hex << FGSVMBuf
+                << " while "
+                   "the device sees "
+                << AddrFromKernel << std::endl;
+      AllOK = false;
+    }
+
+    // Read some of the data with SVMMemcpy().
+    ::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &HostBuf[0], &FGSVMBuf[0],
+                         4 * sizeof(int), 0, nullptr, nullptr);
+
+    std::cerr << std::dec;
+    for (int i = 0; i < N_ELEMENTS; ++i) {
+      if (FGSVMBuf[i] != i + 1) {
+        AllOK = false;
+        std::cerr << "FGSVMBuf[" << i << "] expected to be " << i + 1
+                  << " but got " << (int)FGSVMBuf[i] << std::endl;
+      }
+      if (i < 4 && i + 1 != HostBuf[i]) {
+        AllOK = false;
+        std::cerr << "Wrong data in the memcopied buf at " << i << " expected "
+                  << i + 1 << " got " << HostBuf[i] << std::endl;
+      }
+    }
+    clSVMFree(Context.get(), FGSVMBuf);
   } catch (cl::Error &err) {
     std::cerr << "ERROR: " << err.what() << "(" << err.err() << ")"
               << std::endl;
@@ -201,9 +627,173 @@ int main(void) {
 
   CHECK_CL_ERROR (clUnloadCompiler ());
 
-  if (AllOK) {
-    std::cout << "OK" << std::endl;
-    return EXIT_SUCCESS;
-  } else
+  if (!AllOK)
     return EXIT_FAILURE;
+  else
+    return EXIT_SUCCESS;
+}
+
+int TestSSVM() {
+
+  unsigned Errors = 0;
+  bool AllOK = true;
+
+  try {
+    std::vector<cl::Platform> PlatformList;
+
+    cl::Platform::get(&PlatformList);
+
+    cl_context_properties cprops[] = {
+        CL_CONTEXT_PLATFORM, (cl_context_properties)(PlatformList[0])(), 0};
+    cl::Context Context(CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU, cprops);
+
+    std::vector<cl::Device> Devices = Context.getInfo<CL_CONTEXT_DEVICES>();
+
+    std::vector<cl::Device> SuitableDevices;
+
+    for (cl::Device &Dev : Devices) {
+      if (Dev.getInfo<CL_DEVICE_SVM_CAPABILITIES>() &
+          CL_DEVICE_SVM_FINE_GRAIN_SYSTEM) {
+        SuitableDevices.push_back(Dev);
+        break;
+      } else {
+        std::cout << "Device '" << Dev.getInfo<CL_DEVICE_NAME>()
+                  << "' doesn't support FG System SVM." << std::endl;
+      }
+    }
+
+    if (SuitableDevices.empty()) {
+      std::cout << "No devices with fine grain system SVM capabilities found."
+                << std::endl;
+      return 77;
+    }
+
+    cl::CommandQueue Queue(Context, SuitableDevices[0], 0);
+
+    cl::Program::Sources Sources({GetAddrSourceCode});
+    cl::Program Program(Context, Sources);
+
+    Program.build(SuitableDevices, SET_N_ELEMENTS(N_ELEMENTS));
+
+    cl::Kernel GetAddrKernel(Program, "get_addr");
+
+    constexpr size_t BufSize = N_ELEMENTS * sizeof(int);
+    int *SSVMBuf = (int *)::malloc(BufSize);
+
+    if (SSVMBuf == nullptr) {
+      std::cerr << "malloc() returned a nullptr." << std::endl;
+      return false;
+    }
+
+    cl_ulong AddrFromKernel = 1;
+
+    cl::Buffer AddrCLBuffer =
+        cl::Buffer(Context, CL_MEM_WRITE_ONLY, sizeof(cl_ulong), nullptr);
+
+    ::clSetKernelArgSVMPointer(GetAddrKernel.get(), 0, SSVMBuf);
+    GetAddrKernel.setArg(1, AddrCLBuffer);
+
+    int HostBuf[] = {0, 1, 2, 3};
+    // Initialize the first inputs via an SVM memcpy command.
+
+    // Without the destination being host-mapped...
+    CHECK_CL_ERROR(::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &SSVMBuf[0],
+                                        &HostBuf[0], 2 * sizeof(int), 0,
+                                        nullptr, nullptr));
+
+    for (int i = 0; i < 2; ++i) {
+      if (SSVMBuf[i] != i) {
+        AllOK = false;
+        std::cerr << "SSVMBuf[" << i << "] " << std::hex << &SSVMBuf[i]
+                  << " expected to be " << i << " but got " << (int)SSVMBuf[i]
+                  << std::endl;
+      }
+      if (HostBuf[i] != i) {
+        AllOK = false;
+        std::cerr << "HostBuf[" << i << "] expected to be " << i << " but got "
+                  << (int)HostBuf[i] << std::endl;
+      }
+    }
+
+    ::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &SSVMBuf[2], &HostBuf[2],
+                         2 * sizeof(int), 0, nullptr, nullptr);
+
+    // Write the rest of the inputs directly.
+    for (int i = 4; i < N_ELEMENTS; ++i) {
+      SSVMBuf[i] = i;
+    }
+
+    Queue.enqueueNDRangeKernel(GetAddrKernel, cl::NullRange, cl::NDRange(1),
+                               cl::NullRange);
+    Queue.enqueueReadBuffer(AddrCLBuffer,
+                            CL_TRUE, // block
+                            0, sizeof(cl_ulong), (void *)&AddrFromKernel);
+
+    if (SSVMBuf != (void *)AddrFromKernel) {
+      std::cerr << "FG system buffer's device address on kernel side and host "
+                   "side do not match. Host sees "
+                << std::hex << SSVMBuf
+                << " while "
+                   "the device sees "
+                << AddrFromKernel << std::endl;
+      AllOK = false;
+    }
+
+    // Read some of the data with SVMMemcpy().
+    ::clEnqueueSVMMemcpy(Queue.get(), CL_TRUE, &HostBuf[0], &SSVMBuf[0],
+                         4 * sizeof(int), 0, nullptr, nullptr);
+
+    std::cerr << std::dec;
+    for (int i = 0; i < N_ELEMENTS; ++i) {
+      if (SSVMBuf[i] != i + 1) {
+        AllOK = false;
+        std::cerr << "SSVMBuf[" << i << "] expected to be " << i + 1
+                  << " but got " << (int)SSVMBuf[i] << std::endl;
+      }
+      if (i < 4 && i + 1 != HostBuf[i]) {
+        AllOK = false;
+        std::cerr << "Wrong data in the memcopied buf at " << i << " expected "
+                  << i + 1 << " got " << HostBuf[i] << std::endl;
+      }
+    }
+
+    free(SSVMBuf);
+  } catch (cl::Error &err) {
+    std::cerr << "ERROR: " << err.what() << "(" << err.err() << ")"
+              << std::endl;
+    AllOK = false;
+  }
+
+  CHECK_CL_ERROR(clUnloadCompiler());
+
+  if (!AllOK)
+    return EXIT_FAILURE;
+  else
+    return EXIT_SUCCESS;
+}
+
+int main() {
+
+  std::cout << "TestSimpleKernel_CGSVM: ";
+  if (TestSimpleKernel_CGSVM() == EXIT_FAILURE)
+    return EXIT_FAILURE;
+
+  std::cout << "TestCLMem_SVM: ";
+  if (TestCLMem_SVM() == EXIT_FAILURE)
+    return EXIT_FAILURE;
+
+  std::cout << "TestCGSVM: ";
+  if (TestCGSVM() == EXIT_FAILURE)
+    return EXIT_FAILURE;
+
+  std::cout << "TestFGSVM: ";
+  if (TestFGSVM() == EXIT_FAILURE)
+    return EXIT_FAILURE;
+
+  std::cout << "TestSSVM: ";
+  if (TestSSVM() == EXIT_FAILURE)
+    return EXIT_FAILURE;
+
+  std::cout << "OK" << std::endl;
+  return EXIT_SUCCESS;
 }

--- a/tools/scripts/test_remote_runner_multi.sh
+++ b/tools/scripts/test_remote_runner_multi.sh
@@ -23,7 +23,7 @@ BUILD_DIR=$1
 TEST_BINARY=$2
 shift 2
 
-PUBLIC_IP=$(ip route get 9.9.9.9 | tr -s ' ' | awk '{ print $(NF - 2) }')
+PUBLIC_IP=$(ip route get 9.9.9.9 | head -1 | tr -s ' ' | awk '{ print $(NF - 2) }')
 
 # If POCLD_PORT is defined, use a prelaunched PoCL-D at that port.
 if [ -z "$POCLD_PORT" ]; then

--- a/tools/scripts/test_remote_runner_multi.sh
+++ b/tools/scripts/test_remote_runner_multi.sh
@@ -23,7 +23,7 @@ BUILD_DIR=$1
 TEST_BINARY=$2
 shift 2
 
-PUBLIC_IP=$(ip route get 9.9.9.9 | tr -s ' ' | cut -d' ' -f7)
+PUBLIC_IP=$(ip route get 9.9.9.9 | tr -s ' ' | awk '{ print $(NF - 2) }')
 
 # If POCLD_PORT is defined, use a prelaunched PoCL-D at that port.
 if [ -z "$POCLD_PORT" ]; then

--- a/tools/scripts/test_remote_runner_multi.sh
+++ b/tools/scripts/test_remote_runner_multi.sh
@@ -24,15 +24,27 @@ TEST_BINARY=$2
 shift 2
 
 PUBLIC_IP=$(ip route get 9.9.9.9 | tr -s ' ' | cut -d' ' -f7)
-PORT1=12000
-PORT2=22000
+
+# If POCLD_PORT is defined, use a prelaunched PoCL-D at that port.
+if [ -z "$POCLD_PORT" ]; then
+    PORT1=12000
+    if [ ! -e "$BUILD_DIR/pocld/pocld" ]; then
+        echo "Can't find server binary at $BUILD_DIR/pocld/pocld"
+        exit 1
+    fi
+
+else
+ PORT1=$POCLD_PORT
+fi
+
+if [ -z "$POCLD_PORT2" ]; then
+ PORT2=22000
+else
+ PORT2=$POCLD_PORT2
+fi
 
 echo "Running in $BUILD_DIR with PORT1: $PORT1 PORT2: $PORT2"
 
-if [ ! -e "$BUILD_DIR/pocld/pocld" ]; then
-  echo "Can't find server binary at $BUILD_DIR/pocld/pocld"
-  exit 1
-fi
 
 if [ ! -e "$BUILD_DIR/$TEST_BINARY" ]; then
   echo "Can't find test binary at $BUILD_DIR/$TEST_BINARY"
@@ -44,15 +56,17 @@ export POCL_BUILDING=1
 export POCL_DEVICES="cpu"
 export POCL_DEBUG=
 
-$BUILD_DIR/pocld/pocld -a $PUBLIC_IP -p $PORT1 -v error,warn,general &
-POCLD_PID1=$!
+if [ -z "$POCLD_PORT" ]; then
+    $BUILD_DIR/pocld/pocld -a $PUBLIC_IP -p $PORT1 -v error,warn,general &
+    POCLD_PID1=$!
+    echo "Pocld running with PID: $POCLD_PID1"
+fi
 
-echo "Pocld running with PID: $POCLD_PID1"
-
-$BUILD_DIR/pocld/pocld -a $PUBLIC_IP -p $PORT2 -v error,warn,general &
-POCLD_PID2=$!
-
-echo "Pocld running with PID: $POCLD_PID2"
+if [ -z "$POCLD_PORT2" ]; then
+    $BUILD_DIR/pocld/pocld -a $PUBLIC_IP -p $PORT2 -v error,warn,general &
+    POCLD_PID2=$!
+    echo "Pocld running with PID: $POCLD_PID2"
+fi
 
 sleep 1
 
@@ -89,19 +103,29 @@ if [ -e "/proc/$EXAMPLE_PID" ]; then
   kill $EXAMPLE_PID
 fi
 
-if [ -e "/proc/$POCLD_PID1" ]; then
-  kill $POCLD_PID1
+if [ -z "$POCLD_PORT" ]; then
+    if [ -e "/proc/$POCLD_PID1" ]; then
+        kill $POCLD_PID1
+    fi
 fi
 
-if [ -e "/proc/$POCLD_PID2" ]; then
-  kill $POCLD_PID2
+if [ -z "$POCLD_PORT2" ]; then
+    if [ -e "/proc/$POCLD_PID2" ]; then
+        kill $POCLD_PID2
+    fi
 fi
 
 sleep 2
 
 kill -9 $EXAMPLE_PID 1>/dev/null 2>&1
-kill -9 $POCLD_PID1 1>/dev/null 2>&1
-kill -9 $POCLD_PID2 1>/dev/null 2>&1
+
+if [ -z "$POCLD_PORT" ]; then
+    kill -9 $POCLD_PID1 1>/dev/null 2>&1
+fi
+
+if [ -z "$POCLD_PORT" ]; then
+    kill -9 $POCLD_PID2 1>/dev/null 2>&1
+fi
 
 wait -f
 

--- a/tools/scripts/test_remote_runner_single.sh
+++ b/tools/scripts/test_remote_runner_single.sh
@@ -23,7 +23,12 @@ BUILD_DIR=$1
 TEST_BINARY=$2
 shift 2
 
-PORT=12000
+# If POCLD_PORT is defined, use a prelaunched PoCL-D at that port.
+if [ -z "$POCLD_PORT" ]; then
+ PORT=12000
+else
+ PORT=$POCLD_PORT
+fi
 
 echo "Running in $BUILD_DIR with PORT: $PORT"
 
@@ -42,10 +47,11 @@ export POCL_BUILDING=1
 export POCL_DEVICES="cpu"
 export POCL_DEBUG=
 
-$BUILD_DIR/pocld/pocld -a 127.0.0.1 -p $PORT -v error,warn,general &
-POCLD_PID=$!
-
-echo "Pocld running with PID: $POCLD_PID"
+if [ -z $POCLD_PORT ]; then
+    $BUILD_DIR/pocld/pocld -a 127.0.0.1 -p $PORT -v error,warn,general &
+    POCLD_PID=$!
+    echo "PoCL-D launched with PID: $POCLD_PID"
+fi
 
 sleep 1
 
@@ -81,14 +87,19 @@ if [ -e "/proc/$EXAMPLE_PID" ]; then
   kill $EXAMPLE_PID
 fi
 
-if [ -e "/proc/$POCLD_PID" ]; then
-  kill $POCLD_PID
+if [ -z $POCLD_PORT ]; then
+  if [ -e "/proc/$POCLD_PID" ]; then
+     kill $POCLD_PID
+  fi
 fi
 
 sleep 2
 
 kill -9 $EXAMPLE_PID 1>/dev/null 2>&1
-kill -9 $POCLD_PID 1>/dev/null 2>&1
+
+if [ -z $POCLD_PORT ]; then
+    kill -9 $POCLD_PID 1>/dev/null 2>&1
+fi
 
 wait -f
 

--- a/tools/scripts/test_remote_runner_single.sh
+++ b/tools/scripts/test_remote_runner_single.sh
@@ -48,7 +48,7 @@ export POCL_DEVICES="cpu"
 export POCL_DEBUG=
 
 if [ -z $POCLD_PORT ]; then
-    $BUILD_DIR/pocld/pocld -a 127.0.0.1 -p $PORT -v error,warn,general &
+    $BUILD_DIR/pocld/pocld -a 127.0.0.1 -p $PORT -v error &
     POCLD_PID=$!
     echo "PoCL-D launched with PID: $POCLD_PID"
 fi
@@ -57,12 +57,10 @@ sleep 1
 
 export POCL_DEVICES="remote"
 export POCL_REMOTE0_PARAMETERS="127.0.0.1:$PORT/0"
-export POCL_DEBUG="warn,err,remote"
+export POCL_DEBUG="err"
 unset POCL_ENABLE_UNINIT
 
 echo "Running $BUILD_DIR/$TEST_BINARY"
-
-sleep 1
 
 $BUILD_DIR/$TEST_BINARY $@ &
 EXAMPLE_PID=$!


### PR DESCRIPTION
Implemented initial CG SVM support for PoCL-R (when mmap start addresses can be made to match):

Rework the internal SVM implementation to use a cl_mem shadow buffer. The shadow buffer will be then passed to standard cl_mem APIs for mapping, unmapping, memcpy, migrate etc.

This unifies all the automated migration, content size buffer, etc. handling code to avoid special casing for SVM buffers.

Converted PoCL-D/SVM to use SubBuffers in the server-side for managing the chunks: Using parent Buffers doesn't work as a wrapper since the cl_mems are expected to point to the beginning of the SVM buffer, which leads to undefined results when wrapping chunks from the large SVM allocation.

With this, chipStar 1.1-RC1 can run at least the simple_kernel and MatrixMultiply correctly (when "the mmoon" happens to land in the right phase). 

chipStar 1.1-RC3 added the runtime linking for enhanced portability feature, which requires cl{Compile,Link}Program support which the remote driver currently lacks.

It also starts to fix memleaks on pocld-side (see [comment](https://github.com/pocl/pocl/pull/1381#issuecomment-1878300371)) since the SVM pool can be a huge chunk of VM to leak. 

This PR requires the fixes I submitted in #1382 and includes its commits.