### PR TITLE
doc: add info on building PoCL on Android

### DIFF
--- a/doc/sphinx/source/android.rst
+++ b/doc/sphinx/source/android.rst
@@ -1,0 +1,82 @@
+.. _android-label:
+
+Using PoCL on Android
+=====================
+
+It is possible to build and use PoCL on Android. However, the setup requires a number of options to be set.
+To see an example project, have a look at the `PoCL-R Reference Android Java Client <https://github.com/cpc/PoCL-R-Reference-Android-Java-Client>`_ .
+This Reference app uses both the :ref:`proxy<proxy-label>` and :ref:`remote<remote-label>` device in its example apps. It also builds a custom version of `JOCL <http://jocl.org/>`_ so
+that PoCL can be used in Java instead of calling C code using the Java Native Interface (jni). These guidelines assume
+that Android studio is used as an IDE, but it should be possible to do something similar with a different IDE. It is also
+assumed that a recent enough version of the NDK and CMake (the one found in the SDK tools of Android Studio) have been
+installed via Android Studio. Versions that have been used before include: NDK 25.1.8937393 and 26.0.10792818 and CMake
+3.22.1.
+
+CMake Arguments
+---------------
+
+A number of features in PoCL such as CPU devices and the icd loader are not available on Android. Below is a list of
+recommended CMake options::
+
+    -DENABLE_LLVM=0 -DHOST_DEVICE_BUILD_HASH=00000000 -DENABLE_ICD=0 -DENABLE_LOADABLE_DRIVERS=0 -DENABLE_HOST_CPU_DEVICES=0 -DENABLE_HWLOC=0 -DENABLE_POCLCC=0 -DENABLE_TESTS=0 -DENABLE_EXAMPLES=0 -DBUILD_SHARED_LIBS=0 -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake -DANDROID_NDK=${ANDROID_NDK} -DANDROID_PLATFORM=${ANDROID_PLATFORM_LEVEL} -DANDROID_ABI=${ANDROID_ABI} -DANDROID_NATIVE_API_LEVEL=${ANDROID_PLATFORM_LEVEL}
+
+It is recommended to Build PoCL as an external project in the CMakeLists.txt that belongs to the native code of the
+Android project. This will set the ``ANDROID_NDK, ANDROID_PLATFORM_LEVEL`` and ``ANDROID_ABI`` to what you are building the
+project for. By default, Android Studio will build native code for multiple architectures (ARM 32/64 and x86), so the
+``ANDROID_ABI`` will change for each architecture. Adding pocl as a library dependency to your native code will ensure that
+it is packed into the APK. It is recommended to set ``-DBUILD_SHARED_LIBS=0`` so that PoCL gets built as a static library
+(libpocl.a) as this is easier to use.
+
+Building Remote Client
+----------------------
+
+If you want to make use of PoCL-R, you can add ``-DENABLE_REMOTE_CLIENT=YES`` to the cmake options
+and make sure that network access is allowed in the `AndroidManifest.xml`.
+
+
+Building Proxy Device
+---------------------
+
+The proxy device allow you make use of any system provided OpenCL implementation as well as any devices provided by PoCL
+at the same time. Combined with the remote device, this allows you for example to easily switch between executing kernels
+locally or remotely or create a pipeline where work is done on both devices at the same time. To make use of the Proxy
+device on Android, You first need to make sure that the phone comes with an OpenCL library and that is whitelisted by
+the vendor. Starting with API level 24, vendors need whitelist libraries that are allowed to be dlopened. To check that
+OpenCL is whitelisted do this:
+
+    1. adb into the phone
+    2. run::
+
+        cat /vendor/etc/public.libraries.txt
+
+    3. check that `libOpenCL.so` is there
+
+For newer Android versions (Android 12 and up), you also need to add::
+
+        <uses-native-library
+            android:name="libOpenCL.so"
+            android:required="false" />
+
+to the ``<applications>`` element of the `AndroidManifest.xml`
+
+Once you know that your phone comes with an OpenCL library, it possible to use the proxy device. To build the proxy device add the
+following CMake options to the ones mentioned before: ``-DENABLE_PROXY_DEVICE=YES -DVISIBILITY_HIDDEN=NO``. This will build
+the proxy device and pocl as a static library. If you want to use JOCL, you need to also add ``-DPROXY_USE_LIBOPENCL_STUB=YES``
+and set ``-DBUILD_SHARED_LIBS=YES``. This will build a dynamic library of pocl.
+
+*NOTE:* The proxy driver suffers from the same issues the remote driver has with :ref:`Mali GPUs<remote-issues-label>`.
+See that section for a workaround.
+
+
+Setting PoCL Environment Variables
+----------------------------------
+
+The easiest way to set PoCL environment variables is to create a native function that calls stdlib.h's setenv function.
+
+Using JOCL
+----------
+
+It is possible to use JOCL on Android. However, by default JOCL does not get built for Android. It also doesn't look for libpocl.
+See the android reference client readme on how to build JOCL for android and a submodule to our JOCL repo that looks for
+`libpocl.so` on Android.
+

--- a/doc/sphinx/source/android.rst
+++ b/doc/sphinx/source/android.rst
@@ -59,7 +59,7 @@ For newer Android versions (Android 12 and up), you also need to add::
 
 to the ``<applications>`` element of the `AndroidManifest.xml`
 
-Once you know that your phone comes with an OpenCL library, it possible to use the proxy device. To build the proxy device add the
+Once you know that your phone comes with an OpenCL library, it's possible to use the proxy device. To build the proxy device add the
 following CMake options to the ones mentioned before: ``-DENABLE_PROXY_DEVICE=YES -DVISIBILITY_HIDDEN=NO``. This will build
 the proxy device and pocl as a static library. If you want to use JOCL, you need to also add ``-DPROXY_USE_LIBOPENCL_STUB=YES``
 and set ``-DBUILD_SHARED_LIBS=YES``. This will build a dynamic library of pocl.

--- a/doc/sphinx/source/features.rst
+++ b/doc/sphinx/source/features.rst
@@ -18,3 +18,4 @@ TCE devices and fixed-function accelerators.
    vulkan
    level0
    remote
+   android

--- a/doc/sphinx/source/proxy.rst
+++ b/doc/sphinx/source/proxy.rst
@@ -1,3 +1,5 @@
+.. _proxy-label:
+
 Proxy driver
 =================
 
@@ -5,8 +7,9 @@ This is a driver that is used as proxy to another OpenCL implementation installe
 
 To build just the proxy driver::
 
-    cmake -DENABLE_HOST_CPU_DEVICES=0 -DENABLE_LLVM=0 -DENABLE_PROXY_DEVICE=1 -DENABLE_ICD=0 <path-to-pocl-source-dir>
+    cmake -DENABLE_HOST_CPU_DEVICES=0 -DENABLE_LLVM=0 -DHOST_DEVICE_BUILD_HASH=<a hash of your choosing> -DENABLE_PROXY_DEVICE=1 -DENABLE_ICD=0 <path-to-pocl-source-dir>
 
+The ``-DHOST_DEVICE_BUILD_HASH`` is required if not using llvm and can be anything, for example ``00000000`` is fine.
 ``-DENABLE_PROXY_DEVICE_INTEROP=1`` CMake option enables EGL interop on Android, and OpenGL interop otherwise
 (requires support from the proxyed implementation).
 
@@ -21,3 +24,22 @@ all OpenCL API calls to direct pocl calls (clCreateBuffer -> POclCreateBuffer et
 This is required because the application will have both pocl and libOpenCL linked into it,
 but all calls must go through pocl, otherwise crashes are certain. For this reason also,
 the proxy driver cannot be built with -DENABLE_ICD=1.
+
+Using LIBOPENCL_STUB
+--------------------
+Optionally, the proxy driver can also be built with the ``-DPROXY_USE_LIBOPENCL_STUB=1`` option. This will build the proxy driver with the ``libopencl-stub`` library (original code can be found `here <https://github.com/krrishnarraj/libopencl-stub>`_). This has a number of benefits:
+
+    * PoCL does not need to be built as a static library, however you should still link to libpocl and not use the icd loader.
+    * You do not need to include ``"rename_opencl.h"`` in your files. In fact, you shouldn't at all.
+    * When building PoCL, you do not need to link to an existing OpenCL implementation. This is useful when crosscompiling for Android.
+    * During runtime, the Proxy driver will try to dlopen libOpenCL from a number of common locations. These are common locations for MacOS, Windows, Android and Linux. It is also possible to pass a custom location by setting one of the following environment variables during runtime:
+
+        * LIBOPENCL_SO_PATH
+        * LIBOPENCL_SO_PATH_2
+        * LIBOPENCL_SO_PATH_3
+        * LIBOPENCL_SO_PATH_4
+
+Known Issues
+------------
+
+    * The proxy driver suffers from the same issues the remote driver has with :ref:`Mali GPUs<remote-issues-label>`. See that section for a workaround.

--- a/doc/sphinx/source/remote.rst
+++ b/doc/sphinx/source/remote.rst
@@ -1,3 +1,5 @@
+.. _remote-label:
+
 =============
 Remote Driver
 =============
@@ -112,6 +114,8 @@ Known Bugs/Issues/WiP
   information cannot be retrieved from OpenCL API runtime calls.
 * There are some hardcoded limits (max devices per server)
 
+.. _remote-issues-label:
+
 Known Bugs/Issues in OpenCL Implementations
 --------------------------------------------
 
@@ -216,50 +220,7 @@ Then you can run the simple dot product in example1::
 Android Build (Client Only)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Download Android NDK (or install via package management). Note that older
-versions of NDK may not work (r18 works; r10 does not).
-
-Git checkout pocl remote branch.
-
-Replace variables with actual paths::
-
-    export ANDROID_NDK=<path to extracted android NDK zip>
-    export POCL_REPO=<path to git checkout of pocl>
-    export ABI=arm64-v8a
-    export API=23
-
-You may also change the Android API level and the ABI (cpu architecture),
-but older Android API may not work (only tested with 23). Then run CMake::
-
-    cmake -DENABLE_LLVM=0 -DENABLE_ICD=0 -DENABLE_REMOTE_CLIENT=1 -DENABLE_REMOTE_SERVER=0 -DENABLE_HOST_CPU_DEVICES=0 -DCMAKE_MAKE_PROGRAM=$ANDROID_NDK/prebuilt/linux-x86_64/bin/make -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DANDROID_NDK=$ANDROID_NDK -DCMAKE_BUILD_TYPE=Release -DANDROID_ABI=$ABI -DANDROID_NATIVE_API_LEVEL=$API $POCL_REPO
-    make -j$(nproc)
-
-Now there is a static library lib/CL/libOpenCL.a (or libpocl.a), you need to
-import this as an external prebuilt library, and build your native OpenCL code
-in your Android project against it.
-The way to do this seems to be::
-
-    LOCAL_PATH := $(call my-dir)
-
-    include $(CLEAR_VARS)
-    LOCAL_MODULE    := libOpenCL
-    LOCAL_SRC_FILES := libOpenCL.a
-
-    include $(PREBUILT_STATIC_LIBRARY)
-    include $(CLEAR_VARS)
-
-    LOCAL_MODULE := your-app-name
-    LOCAL_SRC_FILES := your-native-sources
-    LOCAL_C_INCLUDES := native-includes
-
-    LOCAL_STATIC_LIBRARIES := libOpenCL
-    include $(BUILD_SHARED_LIBRARY)
-
-The reason for having a static library is that if you use a dynamic one,
-it will quite possibly not load at all (because the lib<GPU-driver>.so will
-load before libOpenCL.so, and this library on Android usually provides all
-OpenCL symbols, so the dynamic linker will resolve all symbols from the GPU
-driver and not bother loading pocl's libOpenCL at all).
+See :ref:`android-label` on how to do this.
 
 Windows build (server only)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
additions:
* android topic
* update proxy docs with new features
* remove old remote build instructions for Android and point towards android page.
* also includes reference to original libopencl-stub project