### PR TITLE
pocld: Fix pocld crash when running without listenning address

### DIFF
--- a/pocld/pocld.cc
+++ b/pocld/pocld.cc
@@ -110,7 +110,7 @@ in_addr_t find_default_ip_address() {
         continue;
 
       struct sockaddr *saddr = p->ifa_addr;
-      if (saddr->sa_family != AF_INET)
+      if (saddr == NULL || saddr->sa_family != AF_INET)
         continue;
 
       struct sockaddr_in *saddr_in = (struct sockaddr_in *)saddr;


### PR DESCRIPTION
The original code uses the ifa_addr member to get the address of an interface in the find_default_ip_address() function. However, for some interfaces, such as WireGuard, ifa_addr may be NULL. Therefore, it is necessary to check if ifa_addr is NULL, and if it is, skip the interface.

getifaddrs() man page: [https://man7.org/linux/man-pages/man3/getifaddrs.3.html]