### PR TITLE
ci: bump 3rd party actions to get rid of deprecated nodejs dependency

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -54,7 +54,7 @@ jobs:
             config: chipstar
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: CMake
         id: cmake
@@ -150,7 +150,7 @@ jobs:
         llvm: [16]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: CMake
         id: cmake
@@ -203,7 +203,7 @@ jobs:
         llvm: [16]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: CMake
         id: cmake
@@ -243,7 +243,7 @@ jobs:
         llvm: [16]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: CMake
         id: cmake
@@ -284,7 +284,7 @@ jobs:
         config: [cuda]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run CMake
         id: cmake
@@ -327,7 +327,7 @@ jobs:
         config: [openasip]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run CMake
         id: cmake
@@ -370,7 +370,7 @@ jobs:
     runs-on: [self-hosted, linux, vulkan]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run CMake
         id: cmake
@@ -412,7 +412,7 @@ jobs:
         config: [basic]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run CMake
         id: cmake
@@ -454,7 +454,7 @@ jobs:
         config: [level_zero]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run CMake
         id: cmake

--- a/.github/workflows/build_cmake_macos.yml
+++ b/.github/workflows/build_cmake_macos.yml
@@ -36,9 +36,9 @@ jobs:
         config: [basic, devel]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
           mamba-version: "*"


### PR DESCRIPTION
Let's try to get this done before it *actually* becomes a problem.

Failing CI runs are caused by those machines having a too old version of github-runner.