### PR TITLE
Fix the SVM memcpy command buffering issues found by the CTS

### DIFF
--- a/lib/CL/clCommandSVMMemcpyKHR.c
+++ b/lib/CL/clCommandSVMMemcpyKHR.c
@@ -36,26 +36,12 @@ POname (clCommandSVMMemcpyKHR) (
     cl_mutable_command_khr *mutable_handle) CL_API_SUFFIX__VERSION_2_0
 {
   cl_int errcode;
-  _cl_command_node *cmd = NULL;
 
   CMDBUF_VALIDATE_COMMON_HANDLES;
 
-  errcode = pocl_svm_memcpy_common (
-      command_buffer, command_queue, CL_COMMAND_SVM_MEMCPY, dst_ptr, src_ptr,
-      size, num_sync_points_in_wait_list, NULL, NULL, sync_point_wait_list,
-      sync_point, &cmd);
-
-  if (errcode != CL_SUCCESS)
-    return errcode;
-
-  errcode = pocl_command_record (command_buffer, cmd, sync_point);
-  if (errcode != CL_SUCCESS)
-    goto ERROR;
-
-  return CL_SUCCESS;
-
-ERROR:
-  pocl_mem_manager_free_command (cmd);
-  return errcode;
+  return pocl_svm_memcpy_common (command_buffer, command_queue,
+                                 CL_COMMAND_SVM_MEMCPY, dst_ptr, src_ptr, size,
+                                 num_sync_points_in_wait_list, NULL, NULL,
+                                 sync_point_wait_list, sync_point, NULL);
 }
 POsym (clCommandSVMMemcpyKHR)

--- a/lib/CL/clEnqueueSVMMemFill.c
+++ b/lib/CL/clEnqueueSVMMemFill.c
@@ -44,11 +44,15 @@ pocl_svm_memfill_common (cl_command_buffer_khr command_buffer,
 
   unsigned i;
   cl_device_id device;
-  POCL_CHECK_DEV_IN_CMDQ;
   cl_int errcode;
 
-  POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (command_queue)),
-                          CL_INVALID_COMMAND_QUEUE);
+  /* command_queue can be NULL when pushing to a command buffer. */
+  if (command_queue != NULL)
+    {
+      POCL_CHECK_DEV_IN_CMDQ;
+      POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (command_queue)),
+                              CL_INVALID_COMMAND_QUEUE);
+    }
 
   cl_context context = command_queue->context;
 
@@ -88,7 +92,7 @@ pocl_svm_memfill_common (cl_command_buffer_khr command_buffer,
   size_t offset = svm_ptr - dst_svm_ptr->svm_ptr;
   if (command_buffer)
     errcode = POname (clCommandFillBufferKHR) (
-        command_buffer, command_queue, dst_svm_ptr->shadow_cl_mem, pattern,
+        command_buffer, NULL, dst_svm_ptr->shadow_cl_mem, pattern,
         pattern_size, offset, size, num_items_in_wait_list,
         sync_point_wait_list, sync_point, NULL);
   else


### PR DESCRIPTION
Note: host2SVM, SVM2host and host2host are still unimplemented.