### PR TITLE
cl: Add no-op support for cl_khr_priority_hints and cl_khr_throttle_hints

### DIFF
--- a/doc/sphinx/source/notes_6_0.rst
+++ b/doc/sphinx/source/notes_6_0.rst
@@ -8,6 +8,12 @@ LLVM 14 to 17 are supported.
 Support for  `cl_khr_spir` (SPIR 1.x/2.0) has been removed.
 SPIR-V remains supported.
 
+Support for `cl_khr_priority_hints` and `cl_khr_throttle_hints` has been added.
+As the extension specification states that these hints provide no guarantees of
+any particular behavior (or lack thereof) they are treated as a no-op. However
+specifying them no longer causes `clCreateCommandQueueWithProperties` to return
+an error.
+
 ============================
 New device driver: cpu-tbb
 ============================

--- a/doc/sphinx/source/notes_6_0.rst
+++ b/doc/sphinx/source/notes_6_0.rst
@@ -8,7 +8,7 @@ LLVM 14 to 17 are supported.
 Support for  `cl_khr_spir` (SPIR 1.x/2.0) has been removed.
 SPIR-V remains supported.
 
-Support for `cl_khr_priority_hints` and `cl_khr_throttle_hints` has been added.
+Minimal support for `cl_khr_priority_hints` and `cl_khr_throttle_hints` has been added.
 As the extension specification states that these hints provide no guarantees of
 any particular behavior (or lack thereof) they are treated as a no-op. However
 specifying them no longer causes `clCreateCommandQueueWithProperties` to return

--- a/lib/CL/clCreateCommandQueueWithProperties.c
+++ b/lib/CL/clCreateCommandQueueWithProperties.c
@@ -34,6 +34,7 @@ POname(clCreateCommandQueueWithProperties)(cl_context context,
   cl_bool found = CL_FALSE;
   cl_command_queue_properties queue_props = 0;
   int queue_props_set = 0, queue_size_set = 0;
+  int queue_priority_set = 0, queue_throttle_set = 0;
   cl_uint queue_size = 0;
   const cl_command_queue_properties valid_prop_flags =
       (CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE
@@ -77,6 +78,34 @@ POname(clCreateCommandQueueWithProperties)(cl_context context,
             i += 2;
             break;
           }
+        case CL_QUEUE_PRIORITY_KHR:
+          {
+            cl_queue_properties value = properties[i + 1];
+            POCL_GOTO_ERROR_ON ((value != CL_QUEUE_PRIORITY_HIGH_KHR
+                                 && value != CL_QUEUE_PRIORITY_MED_KHR
+                                 && value != CL_QUEUE_PRIORITY_LOW_KHR),
+                                CL_INVALID_VALUE,
+                                "Invalid CL_QUEUE_PRIORITY_KHR value");
+            queue_priority_set = 1;
+            /* This is a hint that provides no behavior or minimum guarantees
+             * so it is always safe to bring it along (no action required) */
+            i += 2;
+            break;
+          }
+        case CL_QUEUE_THROTTLE_KHR:
+          {
+            cl_queue_properties value = properties[i + 1];
+            POCL_GOTO_ERROR_ON ((value != CL_QUEUE_THROTTLE_HIGH_KHR
+                                 && value != CL_QUEUE_THROTTLE_MED_KHR
+                                 && value != CL_QUEUE_THROTTLE_LOW_KHR),
+                                CL_INVALID_VALUE,
+                                "Invalid CL_QUEUE_THROTTLE_KHR value");
+            queue_throttle_set = 1;
+            /* This is a hint that provides no behavior or minimum guarantees
+             * so it is always safe to bring it along (no action required) */
+            i += 2;
+            break;
+          }
         default:
           POCL_GOTO_ERROR_ON (1, CL_INVALID_VALUE,
                               "Invalid values in properties: %lu\n",
@@ -92,6 +121,8 @@ POname(clCreateCommandQueueWithProperties)(cl_context context,
 
           POCL_GOTO_ERROR_COND((queue_size > device->dev_queue_max_size),
                                CL_INVALID_QUEUE_PROPERTIES);
+          POCL_GOTO_ERROR_COND((queue_priority_set), CL_INVALID_QUEUE_PROPERTIES);
+          POCL_GOTO_ERROR_COND((queue_throttle_set), CL_INVALID_QUEUE_PROPERTIES);
 
          // create a device side queue
          POCL_ABORT_UNIMPLEMENTED("Device side queue");

--- a/lib/CL/clGetPlatformInfo.c
+++ b/lib/CL/clGetPlatformInfo.c
@@ -141,6 +141,8 @@ static const cl_name_version pocl_platform_extensions[] = {
 #ifdef BUILD_ICD
   { CL_MAKE_VERSION (1, 0, 0), "cl_khr_icd" },
 #endif
+  { CL_MAKE_VERSION (1, 0, 0), "cl_khr_priority_hints" },
+  { CL_MAKE_VERSION (1, 0, 0), "cl_khr_throttle_hints" },
   { CL_MAKE_VERSION (1, 0, 0), "cl_pocl_content_size" }
 };
 static const size_t pocl_platform_extensions_num


### PR DESCRIPTION
Both extensions explicitly say that the hints provide no guarantee of anything, so a no-op implementation like this is fine. This simply makes PoCL not error out if an application actually tries to specify these hints.