### PR TITLE
Updates to cl_ext_buffer_device_address

### DIFF
--- a/include/CL/cl_ext_pocl.h
+++ b/include/CL/cl_ext_pocl.h
@@ -109,24 +109,24 @@ typedef CL_API_ENTRY cl_int
 
 /* clGetMemObjectInfo(): A new cl_mem_info type CL_MEM_DEVICE_PTR_EXT:
 
-   Returns the device address (as a void*) for a buffer allocated with
+   Returns the device address for a buffer allocated with
    CL_MEM_DEVICE_ADDRESS_EXT. If the buffer was not created with the flag,
    returns CL_INVALID_MEM_OBJECT.
 */
 #define CL_MEM_DEVICE_PTR_EXT 0xff01
 
-typedef void *cl_mem_device_address_EXT;
+typedef cl_ulong cl_mem_device_address_EXT;
 
 /* Returns the device-address pairs for a buffer allocated with
    CL_MEM_DEVICE_ADDRESS_EXT | CL_MEM_DEVICE_PRIVATE_EXT.
 */
 #define CL_MEM_DEVICE_PTRS_EXT 0xff02
 
-  typedef struct _cl_mem_device_address_pair_EXT
-  {
-    cl_device_id device;
-    cl_mem_device_address_EXT *address;
-  } cl_mem_device_address_pair_EXT;
+typedef struct _cl_mem_device_address_pair_EXT
+{
+  cl_device_id device;
+  cl_mem_device_address_EXT address;
+} cl_mem_device_address_pair_EXT;
 
 /* clSetKernelExecInfo(): CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT:
 
@@ -136,11 +136,11 @@ typedef void *cl_mem_device_address_EXT;
 */
 #define CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT 0x11B8
 
-  /* A new function clSetKernelArgDevicePointerEXT() for setting raw device
-     pointers as kernel arguments. */
+/* A new function clSetKernelArgDevicePointerEXT() for setting raw device
+   pointers as kernel arguments. */
 
-  typedef cl_int (CL_API_CALL *clSetKernelArgDevicePointerEXT_fn) (
-      cl_kernel kernel, cl_uint arg_index, const void *arg_value);
+typedef cl_int (CL_API_CALL *clSetKernelArgDevicePointerEXT_fn) (
+    cl_kernel kernel, cl_uint arg_index, cl_mem_device_address_EXT dev_addr);
 
 /* cl_ext_buffer_device_address (experimental stage) */
 #endif
@@ -545,7 +545,7 @@ clEnqueueSVMMemFillRectPOCL (cl_command_queue  command_queue,
                              cl_event *        event);
 
 extern CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgDevicePointerEXT (
-    cl_kernel kernel, cl_uint arg_index, const void *arg_value);
+    cl_kernel kernel, cl_uint arg_index, cl_mem_device_address_EXT dev_addr);
 
 #endif // CL_NO_PROTOTYPES
 

--- a/lib/CL/clGetMemObjectInfo.c
+++ b/lib/CL/clGetMemObjectInfo.c
@@ -85,7 +85,7 @@ POname (clGetMemObjectInfo) (
           cl_device_id dev = context->devices[i];
           pocl_mem_identifier *p = &memobj->device_ptrs[dev->global_mem_id];
           addresses[i].device = dev;
-          addresses[i].address = p->device_addr;
+          addresses[i].address = (cl_mem_device_address_EXT)p->device_addr;
         }
       return CL_SUCCESS;
     }
@@ -95,20 +95,21 @@ POname (clGetMemObjectInfo) (
                               CL_INVALID_MEM_OBJECT);
 
       POCL_RETURN_GETINFO_SIZE_CHECK (memobj->context->num_devices
-                                      * sizeof (void *));
-      void **addr = (void **)param_value;
-      *addr = NULL;
+                                      * sizeof (cl_mem_device_address_EXT));
+      cl_mem_device_address_EXT *addr
+          = (cl_mem_device_address_EXT *)param_value;
+      *addr = 0;
       cl_context context = memobj->context;
       for (size_t i = 0; i < context->num_devices; ++i)
         {
           cl_device_id dev = context->devices[i];
           pocl_mem_identifier *p = &memobj->device_ptrs[dev->global_mem_id];
           POCL_MSG_PRINT_MEMORY (
-              "Got dev ptr %p for device %d (gmem id %d).\n", p->device_addr,
+              "Got dev ptr %p for device %zu (gmem id %d).\n", p->device_addr,
               i, dev->global_mem_id);
-          if (*addr != NULL && p->device_addr != *addr)
+          if (*addr != 0 && (cl_mem_device_address_EXT)p->device_addr != *addr)
             POCL_ABORT ("All devices do not have the same cl_mem address!");
-          *addr = p->device_addr;
+          *addr = (cl_mem_device_address_EXT)p->device_addr;
         }
       return CL_SUCCESS;
     }

--- a/lib/CL/clSetKernelArgDevicePointer.c
+++ b/lib/CL/clSetKernelArgDevicePointer.c
@@ -33,7 +33,7 @@
  */
 CL_API_ENTRY cl_int CL_API_CALL
 POname (clSetKernelArgDevicePointerEXT) (cl_kernel kernel, cl_uint arg_index,
-                                         const void *arg_value)
+                                         cl_mem_device_address_EXT dev_addr)
     CL_API_SUFFIX__VERSION_1_2
 {
   POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (kernel)), CL_INVALID_KERNEL);
@@ -53,6 +53,7 @@ POname (clSetKernelArgDevicePointerEXT) (cl_kernel kernel, cl_uint arg_index,
       (!found_supported_dev), CL_INVALID_OPERATION,
       "None of the devices in this context supports 'cl_ext_buffer_device_address'\n");
 
-  return pocl_set_kernel_arg_pointer (kernel, arg_index, arg_value);
+  assert (sizeof (void *) == sizeof (dev_addr));
+  return pocl_set_kernel_arg_pointer (kernel, arg_index, (void *)dev_addr);
 }
 POsym(clSetKernelArgDevicePointerEXT)

--- a/tests/runtime/test_device_address.cpp
+++ b/tests/runtime/test_device_address.cpp
@@ -68,7 +68,7 @@ static char PtrArith[] = R"raw(
 )raw";
 
 void *getDeviceAddressFromHost(cl::Buffer &Buf) {
-  void *Addr;
+  cl_mem_device_address_EXT Addr;
   cl_int Err = Buf.getInfo(CL_MEM_DEVICE_PTR_EXT, &Addr);
 
   if (Err != CL_SUCCESS) {
@@ -77,7 +77,7 @@ void *getDeviceAddressFromHost(cl::Buffer &Buf) {
     return nullptr;
   }
 
-  return Addr;
+  return (void *)Addr;
 }
 
 int main(void) {
@@ -303,7 +303,9 @@ int main(void) {
 
     clSetKernelArgDevicePointer(
         PtrArithKernel.get(), 0,
-        (cl_uint *)getDeviceAddressFromHost(PinnedCLBuffer) + 2);
+        (cl_mem_device_address_EXT)((cl_uint *)getDeviceAddressFromHost(
+                                        PinnedCLBuffer) +
+                                    2));
     PtrArithKernel.setArg(1, NormalCLBufferOut);
 
     DataOut = -1;


### PR DESCRIPTION
According to feedback from Karol in PR #1441:

- The address is now cl_ulong to avoid ambiguity and problems with the 32/64 bitness combination (this actually can be a realistic case with PoCL-R clients on very light weight devices).
- Dropped extra * from the address member.