### PR TITLE
PoCL-R SVM offsetting improvements

### DIFF
--- a/doc/sphinx/source/using.rst
+++ b/doc/sphinx/source/using.rst
@@ -242,6 +242,12 @@ pocl.
  adding debug data all the built kernels to help debugging kernel issues
  with tools such as gdb or valgrind.
 
+- **POCL_IGNORE_CL_STD**
+
+ Ignores any ``--cl-std`` options passed to clBuildProgram(). This is useful
+ to force-run programs that set the version to 2.x although they do not need
+ all of its features which the targeted 3.x driver might not implement.
+
 - **POCL_KERNEL_CACHE**
 
  If this is set to 0 at runtime, kernel compilation files will be deleted at

--- a/examples/oneapi-samples/CMakeLists.txt
+++ b/examples/oneapi-samples/CMakeLists.txt
@@ -80,11 +80,16 @@ add_dependencies(prepare_examples ${TS_NAME})
 #   3: Cannot find symbol _Z21work_group_reduce_addf in kernel library
 
 add_test(NAME oneapi_samples
-         COMMAND "${CMAKE_CTEST_COMMAND}" --output-on-failure -E oneapi_nbody
+         COMMAND "${CMAKE_CTEST_COMMAND}" -V --output-on-failure -E oneapi_nbody
          WORKING_DIRECTORY "${TS_BUILDDIR}")
 
+# We need to use the oneAPI environment's LD_LIBRARY_PATH (need to source
+# the setvars.sh before testing), but still ensure we use the system's libOpenCL.so
+# to use its ICD to direct the OpenCL to libpocl (otherwise setvars.sh overwrites
+# it with its own libOpenCL.so which is not ocl-icd). Also we have to fake the CPU device
+# to look like Intel OpenCL CPU to force the oneAPI DPC++ to target it.
 set_tests_properties(
   oneapi_samples
   PROPERTIES
-    ENVIRONMENT "LD_LIBRARY_PATH=${SYCL_LIBDIR};ONEAPI_DEVICE_SELECTOR=opencl:*"
+    ENVIRONMENT "LD_LIBRARY_PATH=${OPENCL_LIBDIR}:${SYCL_LIBDIR}:$ENV{LD_LIBRARY_PATH};ONEAPI_DEVICE_SELECTOR=opencl:*;POCL_DRIVER_VERSION_OVERRIDE=2023.16.7.0.21_160000;POCL_CPU_VENDOR_ID_OVERRIDE=32902"
     LABELS "${TS_NAME};level0")

--- a/examples/oneapi-samples/src/CMakeLists.txt
+++ b/examples/oneapi-samples/src/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 set(SYCL_LIBRARIES ${OCL_LIB})
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl -fsycl-targets=spir64")
 
@@ -28,3 +28,7 @@ add_subdirectory(bitonic-sort)
 add_subdirectory(Nbody)
 add_subdirectory(simple-add)
 add_subdirectory(vector-add)
+
+# Note this case needs TBB due to C++20 parallel usage.
+add_subdirectory(jacobian-solver)
+

--- a/examples/oneapi-samples/src/jacobian-solver/CMakeLists.txt
+++ b/examples/oneapi-samples/src/jacobian-solver/CMakeLists.txt
@@ -1,0 +1,33 @@
+# set(CMAKE_CXX_FLAGS "")
+
+add_executable(jacobian_solver_multidevice_sycl src/jacobian_gpu_sycl_multidevice.cpp)
+target_link_libraries (jacobian_solver_multidevice_sycl PRIVATE ${SYCL_LIBRARIES} -fsycl)
+
+target_compile_options("jacobian_solver_multidevice_sycl" PUBLIC "-fsycl" "-fsycl-targets=spir64")
+
+add_test (NAME oneapi_jacobian_solver_multidevice_sycl-cpu
+  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/jacobian_solver_multidevice_sycl
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -ltbb")
+
+set_tests_properties("oneapi_jacobian_solver_multidevice_sycl-cpu"
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION "OK"
+  FAIL_REGULAR_EXPRESSION "FAIL"
+  ENVIRONMENT "POCL_DEVICES='cpu cpu cpu cpu cpu cpu cpu cpu';POCLD_COARSE_GRAIN_SVM=1;POCL_CPU_VENDOR_ID_OVERRIDE=32902;POCL_DRIVER_VERSION_OVERRIDE=2023.16.7.0.21_160000;ONEAPI_DEVICE_SELECTOR='opencl:cpu'"
+  )
+
+add_test (NAME oneapi_jacobian_solver_multidevice_sycl-remote
+  COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../../../../tools/scripts/test_remote_runner_single.sh" "${CMAKE_BINARY_DIR}/../../../.." examples/oneapi-samples/src/oneapi-samples-build/jacobian-solver/jacobian_solver_multidevice_sycl
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+set_tests_properties("oneapi_jacobian_solver_multidevice_sycl-remote"
+  PROPERTIES
+  PASS_REGULAR_EXPRESSION "OK"
+  FAIL_REGULAR_EXPRESSION "FAIL"
+  ENVIRONMENT "POCL_DEVICES='remote remote';POCLD_COARSE_GRAIN_SVM=1;POCL_CPU_VENDOR_ID_OVERRIDE=32902;POCL_DRIVER_VERSION_OVERRIDE=2023.16.7.0.21_160000;ONEAPI_DEVICE_SELECTOR='opencl:cpu'"
+)
+
+# We use the barrier etc.
+set(CMAKE_CXX_STANDARD 20)

--- a/examples/oneapi-samples/src/jacobian-solver/CMakeLists.txt
+++ b/examples/oneapi-samples/src/jacobian-solver/CMakeLists.txt
@@ -9,6 +9,16 @@ add_test (NAME oneapi_jacobian_solver_multidevice_sycl-cpu
   COMMAND ${CMAKE_CURRENT_BINARY_DIR}/jacobian_solver_multidevice_sycl
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
+# Disabled until the PoCL-CPU execution issue with the reduction loop is resolved.
+#add_executable(jacobian_solver_multidevice_openmp src/jacobian_gpu_openmp_multidevice.cpp)
+
+#target_compile_options("jacobian_solver_multidevice_openmp" PUBLIC "-qopenmp" "-fopenmp-targets=spir64")
+#target_link_libraries (jacobian_solver_multidevice_openmp PRIVATE -fopenmp -lomptarget)
+
+#add_test (NAME oneapi_jacobian_solver_multidevice_openmp-cpu
+#  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/jacobian_solver_multidevice_openmp
+#  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -ltbb")
 
 set_tests_properties("oneapi_jacobian_solver_multidevice_sycl-cpu"
@@ -17,6 +27,13 @@ set_tests_properties("oneapi_jacobian_solver_multidevice_sycl-cpu"
   FAIL_REGULAR_EXPRESSION "FAIL"
   ENVIRONMENT "POCL_DEVICES='cpu cpu cpu cpu cpu cpu cpu cpu';POCLD_COARSE_GRAIN_SVM=1;POCL_CPU_VENDOR_ID_OVERRIDE=32902;POCL_DRIVER_VERSION_OVERRIDE=2023.16.7.0.21_160000;ONEAPI_DEVICE_SELECTOR='opencl:cpu'"
   )
+
+#set_tests_properties("oneapi_jacobian_solver_multidevice_openmp-cpu"
+#  PROPERTIES
+#  PASS_REGULAR_EXPRESSION "OK"
+#  FAIL_REGULAR_EXPRESSION "FAIL"
+#  ENVIRONMENT "POCL_DEVICES='cpu cpu cpu cpu cpu cpu cpu cpu';POCLD_COARSE_GRAIN_SVM=1;POCL_CPU_VENDOR_ID_OVERRIDE=32902;POCL_DRIVER_VERSION_OVERRIDE=2023.16.7.0.21_160000;ONEAPI_DEVICE_SELECTOR='opencl:cpu'"
+#  )
 
 add_test (NAME oneapi_jacobian_solver_multidevice_sycl-remote
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/../../../../tools/scripts/test_remote_runner_single.sh" "${CMAKE_BINARY_DIR}/../../../.." examples/oneapi-samples/src/oneapi-samples-build/jacobian-solver/jacobian_solver_multidevice_sycl

--- a/examples/oneapi-samples/src/jacobian-solver/README.md
+++ b/examples/oneapi-samples/src/jacobian-solver/README.md
@@ -1,0 +1,3 @@
+Adapted from the MPI3-based implementation from https://github.com/oneapi-src/oneAPI-samples/tree/development/Libraries/MPI/jacobian_solver by changing
+the codes multi-device SYCL to use PoCL-R for distributed execution without
+using MPI.

--- a/examples/oneapi-samples/src/jacobian-solver/src/jacobian_gpu_openmp_multidevice.cpp
+++ b/examples/oneapi-samples/src/jacobian-solver/src/jacobian_gpu_openmp_multidevice.cpp
@@ -1,0 +1,213 @@
+/*==============================================================
+ * Copyright © 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ * ============================================================= */
+
+/* Heterogeneous distributed Jacobian computation sample using OpenMP and PoCL-R.
+ */
+
+#include <omp.h>
+#include <atomic>
+#include <barrier>
+#include <execution>
+#include <iostream>
+#include <sycl.hpp>
+#include <vector>
+
+//const int Nx = 16384; /* Grid size */
+const int Nx = 1024;
+const int Ny = Nx;
+const int Niter = 100; /* Nuber of algorithm iterations */
+const int NormIteration = 10; /* Recaluculate norm after given number of iterations. 0 to disable norm calculation */
+
+size_t device_count = 0;
+
+struct subarray {
+  int device_i;       /* Device's index [0..device_count) */
+  int x_size, y_size; /* Subarray size excluding border rows and columns */
+  int l_nbh_offt;     /* Offset predecessor data to update */
+};
+
+#define ROW_SIZE(S) ((S).x_size + 2)
+#define XY_2_IDX(X,Y,S) (((Y)+1)*ROW_SIZE(S)+((X)+1))
+
+/* Subroutine to create and initialize initial state of input subarrays */
+void InitDeviceArrays(double** bufs, struct subarray *sub)
+{
+  size_t total_size = (sub->x_size + 2) * (sub->y_size + 2);
+
+  int host_id = omp_get_initial_device();
+  double *A = (double*) malloc(total_size * sizeof(double));
+
+  double *A_dev_1 = (double*) omp_target_alloc_device(total_size * sizeof(double), sub->device_i);
+  double *A_dev_2 = (double*) omp_target_alloc_device(total_size * sizeof(double), sub->device_i);
+
+  bufs[sub->device_i * 2] = A_dev_1;
+  bufs[sub->device_i * 2 + 1] = A_dev_2;
+
+  for (int i = 0; i < (sub->y_size + 2); i++)
+    for (int j = 0; j < (sub->x_size + 2); j++)
+      A[i * (sub->x_size + 2) + j] = 0.0;
+
+  if (sub->device_i == 0) /* set top boundary */
+    for (int i = 1; i <= sub->x_size; i++)
+      A[i] = 1.0; /* set bottom boundary */
+  if (sub->device_i == (device_count - 1))
+    for (int i = 1; i <= sub->x_size; i++)
+      A[(sub->x_size + 2) * (sub->y_size + 1) + i] = 10.0;
+
+  for (int i = 1; i <= sub->y_size; i++) {
+    int row_offt = i * (sub->x_size + 2);
+    A[row_offt] = 1.0;      /* set left boundary */
+    A[row_offt + sub->x_size + 1] = 1.0;    /* set right boundary */
+  }
+
+  /* Move input arrays to device */
+  omp_target_memcpy(A_dev_1, A, sizeof(double) * total_size, 0, 0, sub->device_i, host_id);
+  omp_target_memcpy(A_dev_2, A, sizeof(double) * total_size, 0, 0, sub->device_i, host_id);
+  free(A);
+}
+
+int main(int argc, char *argv[])
+{
+  device_count = omp_get_num_devices();
+  if (device_count == 0) {
+    std::cerr << "No OpenMP target devices found.\n";
+    return EXIT_FAILURE;
+  }
+  std::cout << "Running on " << device_count << " device(s)\n";
+  std::cout << "Initial (host) device: " << omp_get_initial_device() << "\n";
+
+  double* A_device[device_count * 2];
+  std::vector<subarray> subarrays(device_count);
+
+  // Compute the work shares and initialize data.
+  for (size_t device_id = 0; device_id < device_count; ++device_id) {
+    std::cout << "Initializing device " << device_id << std::endl;
+
+    // Setup subarray size and layout processed by a device.
+    struct subarray& sub = subarrays.at(device_id);
+
+    sub.device_i = device_id;
+    sub.y_size = Ny / device_count;
+    sub.x_size = Nx;
+    sub.l_nbh_offt = (sub.x_size + 2) * (sub.y_size + 1) + 1;
+
+    int tail = sub.y_size % device_count;
+    if (tail != 0) {
+      if (sub.device_i < tail)
+        sub.y_size++;
+      if ((sub.device_i > 0) && ((sub.device_i - 1) < tail))
+        sub.l_nbh_offt += (sub.x_size + 2);
+    }
+
+    InitDeviceArrays(A_device, &sub);
+  }
+
+  std::atomic<double> norm = 0.0;
+  double final_norm = 0.0;
+
+  // Spawn parallel threads explicitly since we cannot use barriers
+  // inside "omp parallel for" segments (!).
+  omp_set_num_threads(device_count);
+#pragma omp parallel
+    {
+      int device_i = omp_get_thread_num();
+      std::cerr << "Running " << device_i << " device thread\n";
+      auto my_subarray = subarrays.at(device_i);
+
+#pragma omp target data map(to: Niter, my_subarray, A_device, NormIteration) device(device_i)
+      {
+      for (int i = 0; i < Niter; ++i) {
+        double *a = A_device[device_i * 2 + i % 2];
+        double *a_out = A_device[device_i * 2 + (i + 1) % 2];
+#pragma omp target data map(to: a, a_out) device(device_i)
+        {
+          /* Offload compute loop to the device */
+#pragma omp target teams distribute parallel for is_device_ptr(a, a_out) device(device_i)
+          /* Calculate values on borders to initiate communications early */
+          for (int _column = 0; _column < my_subarray.x_size; ++_column) {
+            int idx = XY_2_IDX(_column, 0, my_subarray);
+            a_out[idx] = 0.25 * (a[idx - 1] + a[idx + 1] + a[idx - ROW_SIZE(my_subarray)] +
+                                 a[idx + ROW_SIZE(my_subarray)]);
+
+            idx = XY_2_IDX(_column, my_subarray.y_size - 1, my_subarray);
+            a_out[idx] = 0.25 * (a[idx - 1] + a[idx + 1] + a[idx - ROW_SIZE(my_subarray)] +
+                                 a[idx + ROW_SIZE(my_subarray)]);
+          }
+        }
+#pragma omp barrier
+
+        /* Perform 1D halo-exchange with neighbours */
+        if (device_i != 0) {
+            int idx = XY_2_IDX(0, 0, my_subarray);
+            double *cwin = A_device[(device_i - 1) * 2 + (i + 1) % 2];
+            omp_target_memcpy(&cwin[my_subarray.l_nbh_offt], &a_out[idx],
+                              my_subarray.x_size * sizeof (double), 0, 0,
+                              device_i - 1, device_i);
+        }
+
+#pragma omp barrier
+
+        if (my_subarray.device_i != (device_count - 1)) {
+            int idx = XY_2_IDX(0, my_subarray.y_size - 1, my_subarray);
+            double *cwin = A_device[(device_i + 1) * 2  + (i + 1) % 2];
+            omp_target_memcpy(&cwin[1], &a_out[idx],
+                              my_subarray.x_size * sizeof (double), 0, 0,
+                              device_i + 1, device_i);
+        }
+
+#pragma omp barrier
+
+        /* Offload compute loop to the device */
+#pragma omp target teams distribute parallel for is_device_ptr(a, a_out) collapse(2) device(device_i)
+        /* Recalculate internal points in parallel with communication */
+        for (int row = 1; row < my_subarray.y_size - 1; ++row) {
+          for (int column = 0; column < my_subarray.x_size; ++column) {
+            int idx = XY_2_IDX(column, row, my_subarray);
+            a_out[idx] = 0.25 * (a[idx - 1] + a[idx + 1] + a[idx - ROW_SIZE(my_subarray)]
+                                 + a[idx + ROW_SIZE(my_subarray)]);
+          }
+        }
+
+#pragma omp barrier
+
+        /* Calculate and report norm value after given number of iterations */
+        if ((NormIteration > 0) && ((NormIteration - 1) == i % NormIteration)) {
+            double device_norm = 0.0;
+
+            /* Offload compute loop to the device */
+            /* This fails on PoCL-CPU (race condition on a global value?) */
+#pragma omp target teams distribute parallel for is_device_ptr(a, a_out) reduction(+:device_norm) collapse(2) device(device_i)
+            /* Calculate and report norm value after given number of iterations */
+            for (int row = 0; row < my_subarray.y_size; ++row) {
+              for (int column = 0; column < my_subarray.x_size; ++column) {
+                int idx = XY_2_IDX(column, row, my_subarray);
+                double diff = a_out[idx] - a[idx];
+                device_norm += diff*diff;
+              }
+            }
+
+            /* Update global norm value atomically. TODO: OMP atomic*/
+#pragma omp barrier
+            norm += device_norm;
+#pragma omp barrier
+
+            if (my_subarray.device_i == 0) {
+                final_norm = sqrt(norm);
+                norm = 0.0;
+            }
+        }
+#pragma omp barrier
+      }
+      }
+    }
+  // For Nx 1024 the norm at 100 should be 2.282558.
+  if (fabs(final_norm - 2.282558) < 0.001)
+    printf("OK\n");
+  else
+    printf("FAIL! Delta == %f\n", fabs(final_norm - 2.282558));
+
+  return 0;
+}

--- a/examples/oneapi-samples/src/jacobian-solver/src/jacobian_gpu_sycl_multidevice.cpp
+++ b/examples/oneapi-samples/src/jacobian-solver/src/jacobian_gpu_sycl_multidevice.cpp
@@ -1,0 +1,241 @@
+/*==============================================================
+ * Copyright © 2023 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ * ============================================================= */
+
+/* Heterogeneous distributed Jacobian computation sample using SYCL and PoCL-R.
+ */
+#include <atomic>
+#include <barrier>
+#include <execution>
+#include <iostream>
+#include <sycl.hpp>
+#include <vector>
+
+//const int Nx = 16384; /* Grid size */
+const int Nx = 1024;
+const int Ny = Nx;
+const int Niter = 100; /* Nuber of algorithm iterations */
+const int NormIteration = 10; /* Recaluculate norm after given number of iterations. 0 to disable norm calculation */
+
+struct subarray {
+  int device_i;
+  int x_size, y_size; /* Subarray size excluding border rows and columns */
+  int l_nbh_offt;     /* Offset predecessor data to update */
+};
+
+size_t device_count = 0;
+
+#define ROW_SIZE(S) ((S).x_size + 2)
+#define XY_2_IDX(X,Y,S) (((Y)+1)*ROW_SIZE(S)+((X)+1))
+
+/* Subroutine to create and initialize initial state of input subarrays */
+void InitDeviceArrays(std::vector<double*>& bufs, sycl::queue& q, struct subarray *sub)
+{
+    size_t total_size = (sub->x_size + 2) * (sub->y_size + 2);
+
+    double *A = sycl::malloc_host < double >(total_size, q);
+    assert (A != nullptr);
+
+    double *A_dev_1 = sycl::malloc_device < double >(total_size, q);
+    assert (A_dev_1 != nullptr);
+
+    double *A_dev_2 = sycl::malloc_device < double >(total_size, q);
+    assert (A_dev_2 != nullptr);
+
+    bufs[sub->device_i * 2] = A_dev_1;
+    bufs[sub->device_i * 2 + 1] = A_dev_2;
+
+    for (int i = 0; i < (sub->y_size + 2); i++)
+        for (int j = 0; j < (sub->x_size + 2); j++)
+            A[i * (sub->x_size + 2) + j] = 0.0;
+
+    if (sub->device_i == 0) /* set top boundary */
+        for (int i = 1; i <= sub->x_size; i++)
+            A[i] = 1.0; /* set bottom boundary */
+    if (sub->device_i == (device_count - 1))
+        for (int i = 1; i <= sub->x_size; i++)
+            A[(sub->x_size + 2) * (sub->y_size + 1) + i] = 10.0;
+
+    for (int i = 1; i <= sub->y_size; i++) {
+        int row_offt = i * (sub->x_size + 2);
+        A[row_offt] = 1.0;      /* set left boundary */
+        A[row_offt + sub->x_size + 1] = 1.0;    /* set right boundary */
+    }
+
+    /* Move input arrays to device */
+    q.memcpy(A_dev_1, A, sizeof(double) * total_size);
+    q.memcpy(A_dev_2, A, sizeof(double) * total_size);
+
+    q.wait();
+}
+
+int main(int argc, char *argv[])
+{
+    if (sycl::platform::get_platforms().size() == 0) {
+      std::cerr << "No SYCL platforms found.\n";
+      return EXIT_FAILURE;
+    }
+    auto platform = sycl::platform::get_platforms().at(0);
+    auto devices = platform.get_devices();
+    std::cout << "Running on " << devices.size() << " device(s)\n";
+
+    std::vector<double*> A_device(devices.size() * 2);
+    std::vector<subarray> subarrays(devices.size());
+    std::vector<sycl::queue*> queues(devices.size());
+
+    std::barrier host_sync_point(devices.size());
+
+    device_count = devices.size();
+
+    // Compute the work shares and initialize data.
+    for (size_t device_id = 0; device_id < device_count; ++device_id) {
+      auto device = devices.at(device_id);
+      std::cout << "\tUsing device: "
+                << device.get_info<sycl::info::device::name>()
+                << std::endl;
+
+      // Setup subarray size and layout processed by a device.
+      struct subarray& sub = subarrays.at(device_id);
+
+      sub.device_i = device_id;
+      sub.y_size = Ny / device_count;
+      sub.x_size = Nx;
+      sub.l_nbh_offt = (sub.x_size + 2) * (sub.y_size + 1) + 1;
+
+      int tail = sub.y_size % device_count;
+      if (tail != 0) {
+            if (sub.device_i < tail)
+              sub.y_size++;
+            if ((sub.device_i > 0) && ((sub.device_i - 1) < tail))
+              sub.l_nbh_offt += (sub.x_size + 2);
+      }
+
+      sycl::queue * q = new sycl::queue(device);
+      queues[device_id] = q;
+      InitDeviceArrays(A_device, *q, &sub);
+    }
+
+    std::atomic<double> norm = 0.0;
+    double final_norm = 0.0;
+
+    std::for_each(
+        std::execution::par, std::begin(subarrays), std::end(subarrays),
+        [&](subarray &my_subarray) {
+          auto device = devices.at(my_subarray.device_i);
+
+          /* Initialization of runtime and initial state of data */
+          auto &q = *queues.at(my_subarray.device_i);
+
+          host_sync_point.arrive_and_wait();
+
+          for (int i = 0; i < Niter; ++i) {
+            double *a = A_device[my_subarray.device_i * 2 + i % 2];
+            double *a_out = A_device[my_subarray.device_i * 2 + (i + 1) % 2];
+            {
+              /* Calculate values on borders to initiate communications early */
+              q.submit([&](auto &h) {
+                 sycl::stream out(1024, 256, h);
+                 h.parallel_for(
+                     sycl::range(my_subarray.x_size), [=](auto index) {
+                       int column = index[0];
+                       int idx = XY_2_IDX(column, 0, my_subarray);
+                       a_out[idx] = 0.25 * (a[idx - 1] + a[idx + 1] +
+                                            a[idx - ROW_SIZE(my_subarray)] +
+                                            a[idx + ROW_SIZE(my_subarray)]);
+
+                       idx = XY_2_IDX(column, my_subarray.y_size - 1,
+                                      my_subarray);
+                       a_out[idx] = 0.25 * (a[idx - 1] + a[idx + 1] +
+                                            a[idx - ROW_SIZE(my_subarray)] +
+                                            a[idx + ROW_SIZE(my_subarray)]);
+                     });
+               }).wait();
+            }
+
+            host_sync_point.arrive_and_wait();
+
+            /* Perform 1D halo-exchange with neighbours */
+            if (my_subarray.device_i != 0) {
+              int idx = XY_2_IDX(0, 0, my_subarray);
+              double *cwin =
+                  A_device[(my_subarray.device_i - 1) * 2 + (i + 1) % 2];
+              q.memcpy(&cwin[my_subarray.l_nbh_offt], &a_out[idx],
+                       my_subarray.x_size * sizeof(double));
+              q.wait();
+            }
+
+            host_sync_point.arrive_and_wait();
+
+            if (my_subarray.device_i != (device_count - 1)) {
+              int idx = XY_2_IDX(0, my_subarray.y_size - 1, my_subarray);
+              double *cwin =
+                  A_device[(my_subarray.device_i + 1) * 2 + (i + 1) % 2];
+              q.memcpy(&cwin[1], &a_out[idx],
+                       my_subarray.x_size * sizeof(double));
+              q.wait();
+            }
+
+            host_sync_point.arrive_and_wait();
+
+            {
+              q.submit([&](auto &h) {
+                 h.parallel_for(
+                     sycl::range(my_subarray.x_size, my_subarray.y_size - 2),
+                     [=](auto index) {
+                       int idx = XY_2_IDX(index[0], index[1] + 1, my_subarray);
+                       a_out[idx] = 0.25 * (a[idx - 1] + a[idx + 1] +
+                                            a[idx - ROW_SIZE(my_subarray)] +
+                                            a[idx + ROW_SIZE(my_subarray)]);
+                     });
+               }).wait();
+            }
+
+            host_sync_point.arrive_and_wait();
+
+            /* Calculate and report norm value after given number of iterations
+             */
+            if ((NormIteration > 0) &&
+                ((NormIteration - 1) == i % NormIteration)) {
+              double device_norm = 0.0;
+              {
+                sycl::buffer<double> norm_buf(&device_norm, 1);
+                q.submit([&](auto &h) {
+                   auto sumr = sycl::reduction(norm_buf, h, sycl::plus<>());
+                   h.parallel_for(
+                       sycl::range(my_subarray.x_size, my_subarray.y_size),
+                       sumr, [=](auto index, auto &v) {
+                         int idx = XY_2_IDX(index[0], index[1], my_subarray);
+                         double diff = a_out[idx] - a[idx];
+                         v += (diff * diff);
+                       });
+                 }).wait();
+              }
+
+              /* Get global norm value */
+              host_sync_point.arrive_and_wait();
+              norm += device_norm;
+
+              host_sync_point.arrive_and_wait();
+
+              if (my_subarray.device_i == 0) {
+                final_norm = sqrt(norm);
+                norm = 0.0;
+              }
+            }
+
+            host_sync_point.arrive_and_wait();
+            /* Ensure all communications complete before next iteration */
+            q.wait();
+            host_sync_point.arrive_and_wait();
+          }
+        });
+
+    // For Nx 1024 the norm at 100 should be 2.282558.
+    if (fabs(final_norm - 2.282558) < 0.001)
+      printf("OK\n");
+    else
+      printf("FAIL! Delta == %f\n", fabs(final_norm - 2.282558));
+    return 0;
+}

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -940,8 +940,8 @@ pocl_basic_get_mem_info_ext (cl_device_id dev, const void *ptr,
   pocl_basic_usm_allocation_t *item = NULL;
   DL_FOREACH (usm_allocations, item)
   {
-    POCL_MSG_WARN ("PTR: %p ITEM_PTR: %p SIZE: %zu\n", ptr, item->ptr,
-                   item->size);
+    POCL_MSG_PRINT_MEMORY ("PTR: %p ITEM_PTR: %p SIZE: %zu\n", ptr, item->ptr,
+                           item->size);
     if ((ptr >= item->ptr)
         && ((const char *)ptr < ((const char *)item->ptr + item->size)))
     {

--- a/lib/CL/pocl_build.c
+++ b/lib/CL/pocl_build.c
@@ -774,7 +774,8 @@ compile_and_link_program(int compile_program,
     {
       cl_device_id device = program->devices[device_i];
 
-      if (cl_c_version && check_device_supports (device, cl_c_version))
+      if (!pocl_get_bool_option ("POCL_IGNORE_CL_STD", 0) && cl_c_version
+          && check_device_supports (device, cl_c_version))
         {
           APPEND_TO_BUILD_LOG_GOTO (
               build_error_code,


### PR DESCRIPTION
Can now run a multi-device SYCL variation of the jacobian solver over PoCL-R.

Also add env POCL_IGNORE_CL_STD (for OpenMP offload via ipcx).