### PR TITLE
pocl_util: fix numberous deadlocks on disconnect

### DIFF
--- a/include/pocl.h
+++ b/include/pocl.h
@@ -516,6 +516,11 @@ struct _cl_command_node
   cl_device_id device;
   /* The index of the targeted device in the **program** device list. */
   unsigned program_device_i;
+  /*
+   * -1: command_failed
+   * 0: not ready
+   * 1: ready
+   */
   cl_int ready;
 
   /* fields needed by buffered commands only */

--- a/include/pocl.h
+++ b/include/pocl.h
@@ -483,10 +483,16 @@ typedef union
   _cl_command_svm_memadvise mem_advise;
 } _cl_command_t;
 
+typedef enum
+{
+  COMMAND_FAILED = -1,
+  COMMAND_NOT_READY = 0,
+  COMMAND_READY = 1,
+} command_node_state;
+
 // one item in the command queue or command buffer
 typedef struct _cl_command_node _cl_command_node;
-struct _cl_command_node
-{
+struct _cl_command_node {
   _cl_command_t command;
   cl_command_type type;
   _cl_command_node *next; // for linked-list storage
@@ -516,12 +522,7 @@ struct _cl_command_node
   cl_device_id device;
   /* The index of the targeted device in the **program** device list. */
   unsigned program_device_i;
-  /*
-   * -1: command_failed
-   * 0: not ready
-   * 1: ready
-   */
-  cl_int ready;
+  command_node_state node_state;
 
   /* fields needed by buffered commands only */
 

--- a/lib/CL/devices/almaif/almaif.cc
+++ b/lib/CL/devices/almaif/almaif.cc
@@ -719,7 +719,7 @@ bool only_custom_device_events_left(cl_event event) {
 
 void pocl_almaif_submit(_cl_command_node *Node, cl_command_queue /*CQ*/) {
 
-  Node->ready = 1;
+  Node->node_state = COMMAND_READY;
 
   struct AlmaifData *D = (AlmaifData *)Node->device->data;
   cl_event E = Node->sync.event.event;
@@ -794,8 +794,13 @@ void pocl_almaif_notify(cl_device_id Device, cl_event Event, cl_event Finished) 
     return;
   }
 
-  if (!Node->ready)
-    return;
+  if (Node->node_state != COMMAND_READY)
+    {
+      POCL_MSG_PRINT_EVENTS (
+          "almaif: command related to the notified event %lu not ready\n",
+          Event->id);
+      return;
+    }
 
   if (Event->command->type != CL_COMMAND_NDRANGE_KERNEL) {
     if (pocl_command_is_ready(Event)) {

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -538,8 +538,13 @@ pocl_basic_notify (cl_device_id device, cl_event event, cl_event finished)
       return;
     }
 
-  if (!node->ready)
-    return;
+  if (node->ready != 1)
+    {
+      POCL_MSG_PRINT_EVENTS (
+          "basic: command related to the notified event %lu not ready\n",
+          event->id);
+      return;
+    }
 
   if (pocl_command_is_ready (event))
     {

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -494,7 +494,7 @@ pocl_basic_submit (_cl_command_node *node, cl_command_queue cq)
   if (node != NULL && node->type == CL_COMMAND_NDRANGE_KERNEL)
     pocl_check_kernel_dlhandle_cache (node, CL_TRUE, CL_TRUE);
 
-  node->ready = 1;
+  node->node_state = COMMAND_READY;
   POCL_LOCK (d->cq_lock);
   pocl_command_push(node, &d->ready_list, &d->command_list);
 
@@ -538,7 +538,7 @@ pocl_basic_notify (cl_device_id device, cl_event event, cl_event finished)
       return;
     }
 
-  if (node->ready != 1)
+  if (node->node_state != COMMAND_READY)
     {
       POCL_MSG_PRINT_EVENTS (
           "basic: command related to the notified event %lu not ready\n",

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -791,6 +791,7 @@ pocl_broadcast (cl_event brc_event)
       if (target != brc_event->notify_list)
         {
           pocl_unlock_events_inorder (brc_event, target_event);
+          POname (clReleaseEvent) (target_event);
           POCL_LOCK_OBJ (brc_event);
           continue;
         }

--- a/lib/CL/devices/proxy/pocl_proxy.c
+++ b/lib/CL/devices/proxy/pocl_proxy.c
@@ -1562,8 +1562,13 @@ pocl_proxy_notify (cl_device_id device, cl_event event, cl_event finished)
       return;
     }
 
-  if (!node->ready)
-    return;
+  if (node->ready != 1)
+    {
+      POCL_MSG_PRINT_EVENTS (
+          "proxy: command related to the notified event %lu not ready\n",
+          event->id);
+      return;
+    }
 
   if (pocl_command_is_ready (node->sync.event.event))
     {

--- a/lib/CL/devices/proxy/pocl_proxy.c
+++ b/lib/CL/devices/proxy/pocl_proxy.c
@@ -1506,7 +1506,7 @@ pocl_proxy_submit (_cl_command_node *node, cl_command_queue cq)
   POCL_INIT_COND (e_d->event_cond);
   e->data = (void *)e_d;
 
-  node->ready = 1;
+  node->node_state = COMMAND_READY;
   if (pocl_command_is_ready (e))
     {
       pocl_update_event_submitted (e);
@@ -1562,7 +1562,7 @@ pocl_proxy_notify (cl_device_id device, cl_event event, cl_event finished)
       return;
     }
 
-  if (node->ready != 1)
+  if (node->node_state != COMMAND_READY)
     {
       POCL_MSG_PRINT_EVENTS (
           "proxy: command related to the notified event %lu not ready\n",

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -199,7 +199,7 @@ pocl_pthread_run (void *data, _cl_command_node *cmd)
 void
 pocl_pthread_submit (_cl_command_node *node, cl_command_queue cq)
 {
-  node->ready = 1;
+  node->node_state = COMMAND_READY;
   if (pocl_command_is_ready (node->sync.event.event))
     {
       pocl_update_event_submitted (node->sync.event.event);
@@ -246,7 +246,7 @@ pocl_pthread_notify (cl_device_id device, cl_event event, cl_event finished)
       return;
     }
 
-  if (node->ready != 1)
+  if (node->node_state != COMMAND_READY)
     {
       POCL_MSG_PRINT_EVENTS (
           "pthread: command related to the notified event %lu not ready\n",

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -246,8 +246,13 @@ pocl_pthread_notify (cl_device_id device, cl_event event, cl_event finished)
       return;
     }
 
-  if (!node->ready)
-    return;
+  if (node->ready != 1)
+    {
+      POCL_MSG_PRINT_EVENTS (
+          "pthread: command related to the notified event %lu not ready\n",
+          event->id);
+      return;
+    }
 
   if (pocl_command_is_ready (node->sync.event.event))
     {

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -1370,7 +1370,7 @@ pocl_remote_submit (_cl_command_node *node, cl_command_queue cq)
   POCL_INIT_COND (e_d->event_cond);
   e->data = (void *)e_d;
 
-  node->ready = 1;
+  node->node_state = COMMAND_READY;
   if (pocl_command_is_ready (node->sync.event.event))
     {
       pocl_update_event_submitted (node->sync.event.event);
@@ -1433,7 +1433,7 @@ pocl_remote_notify (cl_device_id device, cl_event event, cl_event finished)
       return;
     }
 
-  if (node->ready != 1)
+  if (node->node_state != COMMAND_READY)
     {
       POCL_MSG_PRINT_EVENTS (
           "remote: command related to the notified event %lu not ready\n",
@@ -2257,7 +2257,7 @@ remote_start_command (remote_device_data_t *d, _cl_command_node *node)
   cl_command_queue cq = node->sync.event.event->queue;
   if (*(cq->device->available) == CL_FALSE)
     {
-      node->ready = -1;
+      node->node_state = COMMAND_FAILED;
       goto EARLY_FINISH;
     }
   pocl_update_event_running (event);
@@ -2544,7 +2544,7 @@ pocl_remote_driver_pthread (void *cldev)
           char msg[128] = "Event ";
           strcat (msg, cstr);
 
-          if (finished->ready != 1)
+          if (finished->node_state != COMMAND_READY)
             {
               pocl_update_event_device_lost (event);
             }

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -1433,7 +1433,7 @@ pocl_remote_notify (cl_device_id device, cl_event event, cl_event finished)
       return;
     }
 
-  if (!node->ready)
+  if (node->ready != 1)
     {
       POCL_MSG_PRINT_EVENTS (
           "remote: command related to the notified event %lu not ready\n",
@@ -2257,7 +2257,7 @@ remote_start_command (remote_device_data_t *d, _cl_command_node *node)
   cl_command_queue cq = node->sync.event.event->queue;
   if (*(cq->device->available) == CL_FALSE)
     {
-      pocl_update_event_device_lost (event);
+      node->ready = -1;
       goto EARLY_FINISH;
     }
   pocl_update_event_running (event);
@@ -2544,7 +2544,14 @@ pocl_remote_driver_pthread (void *cldev)
           char msg[128] = "Event ";
           strcat (msg, cstr);
 
-          POCL_UPDATE_EVENT_COMPLETE_MSG (event, msg);
+          if (finished->ready != 1)
+            {
+              pocl_update_event_device_lost (event);
+            }
+          else
+            {
+              POCL_UPDATE_EVENT_COMPLETE_MSG (event, msg);
+            }
 
           POCL_FAST_LOCK (d->wq_lock);
         }

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -384,14 +384,17 @@ struct pocl_device_ops {
      must be locked also on return.*/
   void (*notify) (cl_device_id device, cl_event event, cl_event finished);
 
-  /* broadcast is(has to be) called by the device driver when a command is
-     completed.
-     It is used to broadcast notifications to device drivers waiting
-     this event to complete.
-     There is a default implementation for this. Use it if there is no need
-     to do anything special here.
-     The default implementation calls notify(event, target_event) for the
-     list of events waiting on 'event'. */
+  /**
+   * Broadcast is(has to be) called by the device driver when a command is
+   * completed.
+   * It is used to broadcast notifications to device drivers waiting
+   * this event to complete.
+   * There is a default implementation for this. Use it if there is no need
+   * to do anything special here.
+   * The default implementation calls notify(event, target_event) for the
+   * list of events waiting on 'event'.
+   * @warning Called with event (and its notify events) unlocked.
+   */
   void (*broadcast) (cl_event event);
 
   /* wait_event is called by clWaitForEvents() and blocks the execution until

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -675,6 +675,7 @@ pocl_create_command_struct (_cl_command_node **cmd,
   POCL_RETURN_ERROR_COND ((*cmd == NULL), CL_OUT_OF_HOST_MEMORY);
 
   (*cmd)->type = command_type;
+  (*cmd)->node_state = COMMAND_NOT_READY;
 
   event = &((*cmd)->sync.event.event);
   errcode = pocl_create_event (event, command_queue, command_type, num_buffers,
@@ -1307,6 +1308,7 @@ pocl_create_recorded_command (_cl_command_node **cmd,
   POCL_RETURN_ERROR_COND ((*cmd == NULL), CL_OUT_OF_HOST_MEMORY);
   (*cmd)->type = command_type;
   (*cmd)->buffered = 1;
+  (*cmd)->node_state = COMMAND_NOT_READY;
 
   /* pocl_cmdbuf_choose_recording_queue should have been called to ensure we
    * have a valid command queue, usually via CMDBUF_VALIDATE_COMMON_HANDLES


### PR DESCRIPTION
non exhaustive list:
* fix event being marked complete after being marked failed
* fix deadlock between event and memobj happening in pocl_update_event_finished and pocl_create_migration_commands
* fix deadlock of event trying to remove it self from wait_list of event trying notifying that it has failed.
* catch error when a event is created on a command queue that is not available

I'll add some comments to explain parts of the commit