### PR TITLE
USM refactoring and fixes

### DIFF
--- a/lib/CL/clEnqueueMemFillINTEL.c
+++ b/lib/CL/clEnqueueMemFillINTEL.c
@@ -42,7 +42,8 @@ POname (clEnqueueMemFillINTEL) (cl_command_queue command_queue, void *dst_ptr,
   if (errcode != CL_SUCCESS)
     return errcode;
 
-  pocl_command_enqueue (command_queue, cmd);
+  if (cmd != NULL)
+    pocl_command_enqueue (command_queue, cmd);
 
   return CL_SUCCESS;
 }

--- a/lib/CL/clGetDeviceInfo.c
+++ b/lib/CL/clGetDeviceInfo.c
@@ -412,12 +412,45 @@ POname(clGetDeviceInfo)(cl_device_id   device,
                                         param_value, param_value_size_ret);
     return CL_SUCCESS; /* gracefully no-op in case the driver fails to handle
                           the query */
+
+  /** cl_intel_unified_shared_memory queries **/
+  case CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL:
+  case CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL:
+  case CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL:
+  case CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL:
+  case CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL:
+    {
+      cl_bitfield caps;
+      switch (param_name)
+        {
+        case CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL:
+          caps = device->host_usm_capabs;
+          break;
+        case CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL:
+          caps = device->device_usm_capabs;
+          break;
+        case CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL:
+          caps = device->single_shared_usm_capabs;
+          break;
+        case CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL:
+          caps = device->cross_shared_usm_capabs;
+          break;
+        case CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL:
+          caps = device->system_shared_usm_capabs;
+          break;
+        default:
+          caps = 0;
+        }
+      POCL_RETURN_GETINFO (cl_bitfield, caps);
+    }
   }
 
-  if(device->ops->get_device_info_ext != NULL) {
-    return device->ops->get_device_info_ext(device, param_name, param_value_size,
-                                            param_value, param_value_size_ret);
-  }
+  if (device->ops->get_device_info_ext != NULL)
+    {
+      return device->ops->get_device_info_ext (device, param_name,
+                                               param_value_size, param_value,
+                                               param_value_size_ret);
+    }
 
   return CL_INVALID_VALUE;
 }

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -131,7 +131,6 @@ pocl_basic_init_device_ops(struct pocl_device_ops *ops)
   ops->compute_local_size = pocl_default_local_size_optimizer;
 
   ops->get_device_info_ext = pocl_basic_get_device_info_ext;
-  ops->get_mem_info_ext = pocl_basic_get_mem_info_ext;
   ops->set_kernel_exec_info_ext = pocl_basic_set_kernel_exec_info_ext;
 
   ops->svm_free = pocl_basic_svm_free;
@@ -810,44 +809,7 @@ pocl_basic_usm_alloc (cl_device_id dev, unsigned alloc_type,
   int errcode = CL_SUCCESS;
   void *ptr = NULL;
 
-  switch (alloc_type)
-    {
-    case CL_MEM_TYPE_HOST_INTEL:
-      POCL_GOTO_ERROR_ON ((dev->host_usm_capabs == 0), CL_INVALID_OPERATION,
-                          "Device does not support Host USM allocations\n");
-      break;
-    case CL_MEM_TYPE_DEVICE_INTEL:
-      POCL_GOTO_ERROR_ON ((dev->device_usm_capabs == 0), CL_INVALID_OPERATION,
-                          "Device does not support Device USM allocations\n");
-      break;
-    case CL_MEM_TYPE_SHARED_INTEL:
-      POCL_GOTO_ERROR_ON ((dev->single_shared_usm_capabs == 0),
-                          CL_INVALID_OPERATION,
-                          "Device does not support Shared USM allocations\n");
-      break;
-    default:
-      POCL_GOTO_ERROR_ON (1, CL_INVALID_PROPERTY,
-                          "Unknown USM AllocType requested\n");
-    }
-
   ptr = pocl_aligned_malloc (MAX_EXTENDED_ALIGNMENT, size);
-
-  if (ptr != NULL)
-    {
-      pocl_basic_usm_allocation_t *all
-          = malloc (sizeof (pocl_basic_usm_allocation_t));
-      POCL_GOTO_ERROR_COND ((all == NULL), CL_OUT_OF_HOST_MEMORY);
-      all->ptr = ptr;
-      all->size = size;
-      all->flags = flags;
-      all->alloc_type = alloc_type;
-      POCL_LOCK (usm_lock);
-      DL_APPEND (usm_allocations, all);
-      POCL_UNLOCK (usm_lock);
-
-      POCL_MSG_PRINT_MEMORY ("USM ALLOCATED: PTR: %p SIZE: %zu\n", all->ptr,
-                             all->size);
-    }
 
 ERROR:
   if (err_code)
@@ -857,46 +819,9 @@ ERROR:
 }
 
 void
-pocl_basic_usm_free (cl_device_id dev, void *svm_ptr)
+pocl_basic_usm_free (cl_device_id dev, void *usm_ptr)
 {
-  POCL_LOCK (usm_lock);
-  pocl_basic_usm_allocation_t *item = NULL, *tmp = NULL;
-  DL_FOREACH_SAFE (usm_allocations, item, tmp)
-  {
-    if (item->ptr == svm_ptr)
-      {
-        DL_DELETE (usm_allocations, item);
-        free (item);
-        break;
-      }
-  }
-  POCL_UNLOCK (usm_lock);
-
-  /* we should always find it, b/c there are checks
-   * in the runtime API (clMemFreeINTEL) */
-  assert (item != NULL);
-  pocl_aligned_free (svm_ptr);
-}
-
-static cl_bitfield
-pocl_basic_get_mem_caps (cl_device_id device, cl_device_info Type)
-{
-  switch (Type)
-    {
-    case CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL:
-      return device->host_usm_capabs;
-    case CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL:
-      return device->device_usm_capabs;
-    case CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL:
-      return device->single_shared_usm_capabs;
-    case CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL:
-      return device->cross_shared_usm_capabs;
-    case CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL:
-      return device->system_shared_usm_capabs;
-    default:
-      assert (0 && "unhandled switch value");
-    }
-  return 0;
+  pocl_aligned_free (usm_ptr);
 }
 
 cl_int
@@ -906,90 +831,19 @@ pocl_basic_get_device_info_ext (cl_device_id device, cl_device_info param_name,
 {
   switch (param_name)
     {
-    case CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL:
-    case CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL:
-    case CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL:
-    case CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL:
-    case CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL:
-      {
-        cl_bitfield caps = pocl_basic_get_mem_caps (device, param_name);
-        POCL_RETURN_GETINFO (cl_bitfield, caps);
-      }
-
     case CL_DEVICE_SUB_GROUP_SIZES_INTEL:
-    {
-      /* We can basically support fixing any WG size with the CPU devices, but
-         let's report something semi-sensible here for vectorization aid. */
-      size_t sizes[] = { 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 };
-      POCL_RETURN_GETINFO_ARRAY (size_t, sizeof (sizes) / sizeof (size_t),
-                                 sizes);
-    }
+      {
+        /* We can basically support fixing any WG size with the CPU devices,
+           but let's report something semi-sensible here for vectorization aid.
+         */
+        size_t sizes[] = { 1, 2, 4, 8, 16, 32, 64, 128, 256, 512 };
+        POCL_RETURN_GETINFO_ARRAY (size_t, sizeof (sizes) / sizeof (size_t),
+                                   sizes);
+      }
     default:
-    POCL_MSG_ERR ("Unknown param_name for get_device_info_ext: %u\n",
-                  param_name);
-    return CL_INVALID_VALUE;
-    }
-}
-
-cl_int
-pocl_basic_get_mem_info_ext (cl_device_id dev, const void *ptr,
-                             cl_uint param_name, size_t param_value_size,
-                             void *param_value, size_t *param_value_size_ret)
-{
-  POCL_LOCK (usm_lock);
-  pocl_basic_usm_allocation_t *item = NULL;
-  DL_FOREACH (usm_allocations, item)
-  {
-    POCL_MSG_PRINT_MEMORY ("PTR: %p ITEM_PTR: %p SIZE: %zu\n", ptr, item->ptr,
-                           item->size);
-    if ((ptr >= item->ptr)
-        && ((const char *)ptr < ((const char *)item->ptr + item->size)))
-    {
-      break;
-    }
-  }
-  POCL_UNLOCK (usm_lock);
-
-  switch (param_name)
-    {
-
-    case CL_MEM_ALLOC_TYPE_INTEL:
-    {
-      if (item == NULL)
-          POCL_RETURN_GETINFO (cl_uint, CL_MEM_TYPE_UNKNOWN_INTEL);
-      else
-          POCL_RETURN_GETINFO (cl_uint, item->alloc_type);
-    }
-    case CL_MEM_ALLOC_BASE_PTR_INTEL:
-    {
-      if (item == NULL)
-          POCL_RETURN_GETINFO (void *, NULL);
-      else
-          POCL_RETURN_GETINFO (void *, item->ptr);
-    }
-    case CL_MEM_ALLOC_SIZE_INTEL:
-    {
-      if (item == NULL)
-          POCL_RETURN_GETINFO (size_t, 0);
-      else
-          POCL_RETURN_GETINFO (size_t, item->size);
-    }
-    case CL_MEM_ALLOC_DEVICE_INTEL:
-    {
-      if (item == NULL)
-          POCL_RETURN_GETINFO (cl_device_id, NULL);
-      else
-          POCL_RETURN_GETINFO (cl_device_id, dev);
-    }
-    case CL_MEM_ALLOC_FLAGS_INTEL:
-    {
-      if (item == NULL)
-          POCL_RETURN_GETINFO (cl_mem_alloc_flags_intel, 0);
-      else
-          POCL_RETURN_GETINFO (cl_mem_alloc_flags_intel, item->flags);
-    }
-    default:
-    return CL_INVALID_VALUE;
+      POCL_MSG_ERR ("Unknown param_name for get_device_info_ext: %u\n",
+                    param_name);
+      return CL_INVALID_VALUE;
     }
 }
 

--- a/lib/CL/devices/common_driver.h
+++ b/lib/CL/devices/common_driver.h
@@ -127,35 +127,44 @@ int pocl_driver_build_source (cl_program program,
                               const char **header_include_names,
                               int link_program);
 POCL_EXPORT
-  int pocl_driver_build_binary (cl_program program, cl_uint device_i,
-                                int link_program, int spir_build);
+int pocl_driver_build_binary (cl_program program,
+                              cl_uint device_i,
+                              int link_program,
+                              int spir_build);
 POCL_EXPORT
-  int pocl_driver_link_program (cl_program program, cl_uint device_i,
-                                cl_uint num_input_programs,
-                                const cl_program *input_programs,
-                                int create_library);
+int pocl_driver_link_program (cl_program program,
+                              cl_uint device_i,
+                              cl_uint num_input_programs,
+                              const cl_program *input_programs,
+                              int create_library);
 POCL_EXPORT
-  int pocl_driver_free_program (cl_device_id device, cl_program program,
+int pocl_driver_free_program (cl_device_id device,
+                              cl_program program,
+                              unsigned program_device_i);
+POCL_EXPORT
+int pocl_driver_setup_metadata (cl_device_id device,
+                                cl_program program,
                                 unsigned program_device_i);
 POCL_EXPORT
-  int pocl_driver_setup_metadata (cl_device_id device, cl_program program,
-                                  unsigned program_device_i);
+int pocl_driver_supports_binary (cl_device_id device,
+                                 size_t length,
+                                 const char *binary);
 POCL_EXPORT
-  int pocl_driver_supports_binary (cl_device_id device, size_t length,
-                                   const char *binary);
-POCL_EXPORT
-  int pocl_driver_build_poclbinary (cl_program program, cl_uint device_i);
+int pocl_driver_build_poclbinary (cl_program program, cl_uint device_i);
 
 POCL_EXPORT
-  int pocl_driver_build_opencl_builtins (cl_program program, cl_uint device_i);
+int pocl_driver_build_opencl_builtins (cl_program program, cl_uint device_i);
 
 POCL_EXPORT
-  void pocl_driver_build_gvar_init_kernel (cl_program program, cl_uint dev_i,
-                             cl_device_id device, gvar_init_callback_t callback);
+void pocl_driver_build_gvar_init_kernel (cl_program program,
+                                         cl_uint dev_i,
+                                         cl_device_id device,
+                                         gvar_init_callback_t callback);
 
 POCL_EXPORT
-  void pocl_cpu_gvar_init_callback(cl_program program, cl_uint dev_i,
-                                   _cl_command_node *fake_cmd);
+void pocl_cpu_gvar_init_callback (cl_program program,
+                                  cl_uint dev_i,
+                                  _cl_command_node *fake_cmd);
 
 #ifdef __cplusplus
 }

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -244,7 +244,6 @@ pocl_cuda_init_device_ops (struct pocl_device_ops *ops)
   ops->notify_event_finished = pocl_cuda_notify_event_finished;
 
   ops->get_device_info_ext = pocl_cuda_get_device_info_ext;
-  ops->get_mem_info_ext = NULL; // pocl_cuda_get_mem_info_ext;
   ops->set_kernel_exec_info_ext = pocl_cuda_set_kernel_exec_info_ext;
 
   ops->build_source = pocl_driver_build_source;

--- a/lib/CL/devices/level0/level0-driver.cc
+++ b/lib/CL/devices/level0/level0-driver.cc
@@ -2004,15 +2004,17 @@ Level0Device::Level0Device(Level0Driver *Drv, ze_device_handle_t DeviceH,
     POCL_MSG_PRINT_LEVEL0("SVM disabled for device\n");
   }
 
-  HostMemCaps = convertZeAllocCaps(MemAccessProperties.hostAllocCapabilities);
-  DeviceMemCaps =
+  ClDev->host_usm_capabs = HostMemCaps =
+      convertZeAllocCaps(MemAccessProperties.hostAllocCapabilities);
+  ClDev->device_usm_capabs = DeviceMemCaps =
       convertZeAllocCaps(MemAccessProperties.deviceAllocCapabilities);
-  SingleSharedCaps = convertZeAllocCaps(
+  ClDev->single_shared_usm_capabs = SingleSharedCaps = convertZeAllocCaps(
       MemAccessProperties.sharedSingleDeviceAllocCapabilities);
   CrossSharedCaps = convertZeAllocCaps(
       MemAccessProperties.sharedCrossDeviceAllocCapabilities);
   SystemSharedCaps =
       convertZeAllocCaps(MemAccessProperties.sharedSystemAllocCapabilities);
+
   // the minimum capability required for USM
   if (DeviceMemCaps & ZE_MEMORY_ACCESS_CAP_FLAG_RW) {
     Extensions.append(" cl_intel_unified_shared_memory");

--- a/lib/CL/devices/level0/pocl-level0.cc
+++ b/lib/CL/devices/level0/pocl-level0.cc
@@ -159,7 +159,6 @@ void pocl_level0_init_device_ops(struct pocl_device_ops *Ops) {
   Ops->free_sampler = pocl_level0_free_sampler;
 
   Ops->get_device_info_ext = pocl_level0_get_device_info_ext;
-  Ops->get_mem_info_ext = pocl_level0_get_mem_info_ext;
   Ops->set_kernel_exec_info_ext = pocl_level0_set_kernel_exec_info_ext;
 }
 
@@ -1458,40 +1457,6 @@ typedef cl_uint cl_unified_shared_memory_type_intel;
 #define CL_MEM_TYPE_SHARED_INTEL        0x4199
 
 */
-
-cl_int pocl_level0_get_mem_info_ext(cl_device_id Dev,
-                                    const void *ptr,
-                                    cl_uint param_name,
-                                    size_t param_value_size,
-                                    void * param_value,
-                                    size_t * param_value_size_ret) {
-  Level0Device *Device = (Level0Device *)Dev->data;
-
-  switch (param_name) {
-  case CL_MEM_ALLOC_TYPE_INTEL: {
-    cl_unified_shared_memory_type_intel Type = Device->getMemType(ptr);
-    POCL_RETURN_GETINFO(cl_unified_shared_memory_type_intel, Type);
-  }
-  case CL_MEM_ALLOC_BASE_PTR_INTEL: {
-    void *Ptr = Device->getMemBasePtr(ptr);
-    POCL_RETURN_GETINFO(void *, Ptr);
-  }
-  case CL_MEM_ALLOC_SIZE_INTEL: {
-    size_t Size = Device->getMemSize(ptr);
-    POCL_RETURN_GETINFO(size_t, Size);
-  }
-  case CL_MEM_ALLOC_DEVICE_INTEL: {
-    cl_device_id DeviceID = Device->getMemAssoc(ptr);
-    POCL_RETURN_GETINFO(cl_device_id, DeviceID);
-  }
-  case CL_MEM_ALLOC_FLAGS_INTEL: {
-    cl_mem_alloc_flags_intel Flags = Device->getMemFlags(ptr);
-    POCL_RETURN_GETINFO(cl_mem_alloc_flags_intel, Flags);
-  }
-  default:
-    return CL_INVALID_VALUE;
-  }
-}
 
 /*
 

--- a/lib/CL/devices/prototypes.inc
+++ b/lib/CL/devices/prototypes.inc
@@ -213,11 +213,6 @@
                                          size_t param_value_size,             \
                                          void * param_value,                  \
                                          size_t * param_value_size_ret);      \
-  cl_int pocl_##__DRV__##_get_mem_info_ext(cl_device_id dev, const void *ptr, \
-                                         cl_uint param_name,                  \
-                                         size_t param_value_size,             \
-                                         void * param_value,                  \
-                                         size_t * param_value_size_ret);      \
   cl_int pocl_##__DRV__##_set_kernel_exec_info_ext (cl_device_id dev,                        \
                                       unsigned program_device_i, \
                                       cl_kernel kernel,   \

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -571,6 +571,9 @@ pocl_remote_init (unsigned j, cl_device_id device, const char *parameters)
   if (setup_svm_memory_pool (device) == 0)
     {
       device->svm_caps = CL_DEVICE_SVM_COARSE_GRAIN_BUFFER;
+      device->device_usm_capabs = device->host_usm_capabs
+        = device->single_shared_usm_capabs
+        = CL_UNIFIED_SHARED_MEMORY_ACCESS_INTEL;
 
       /* The CG SVM support can be used for "pinned buffers" as well and
          USM. */

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -1165,6 +1165,19 @@ struct _context_destructor_callback
   context_destructor_callback_t *next;
 };
 
+/**
+ * Enumeration for raw buffer/pointer types managed by PoCL.
+ */
+typedef enum
+{
+  /* SVM from OpenCL 2.0. */
+  POCL_RAW_PTR_SVM = 0,
+  /* Intel USM extension. */
+  POCL_RAW_PTR_INTEL_USM,
+  /* cl_ext_buffer_device_address. */
+  POCL_RAW_PTR_DEVICE_BUFFER
+} pocl_raw_pointer_kind;
+
 typedef struct _pocl_raw_ptr pocl_raw_ptr;
 struct _pocl_raw_ptr
 {
@@ -1172,10 +1185,23 @@ struct _pocl_raw_ptr
   void *vm_ptr;
   /* The device address, if known. NULL if not. */
   void *dev_ptr;
+  /* The owner device of the allocation, if any. Should be set to non-null for
+     USM Device. */
+  cl_device_id device;
+
   size_t size;
-  /* A CL_MEM_DEVICE_ADDRESS cl_mem with device and host ptr the same. This is
-     for internal bookkeeping and automated buffer migration purposes. */
+  /* A cl_mem for internal bookkeeping and implicit buffer migration. */
   cl_mem shadow_cl_mem;
+
+  /* The raw pointer/buffer API used for the allocation. */
+  pocl_raw_pointer_kind kind;
+
+  struct
+  {
+    cl_mem_alloc_flags_intel flags;
+    unsigned alloc_type;
+  } usm_properties;
+
   struct _pocl_raw_ptr *prev, *next;
 };
 

--- a/lib/CL/pocl_llvm_wg.cc
+++ b/lib/CL/pocl_llvm_wg.cc
@@ -969,7 +969,7 @@ static int convertBCorSPV(char *InputPath,
   CompilationArgs.push_back("-o");
   CompilationArgs.push_back(HiddenOutputPath);
   CompilationArgs.push_back(HiddenInputPath);
-  CompilationArgs2.reserve(CompilationArgs.size() + 1);
+  CompilationArgs2.resize(CompilationArgs.size() + 1);
   for (unsigned i = 0; i < CompilationArgs.size(); ++i)
     CompilationArgs2[i] = (char *)CompilationArgs[i].data();
   CompilationArgs2[CompilationArgs.size()] = nullptr;

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -1368,8 +1368,8 @@ void pocl_command_enqueue (cl_command_queue command_queue,
 
   ++command_queue->command_count;
 
-  /* in case of in-order queue, synchronize to previously enqueued command
-     if available */
+  /* In case of in-order queue, synchronize to the previously enqueued command,
+     if available. */
   if (!(command_queue->properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE))
     {
       POCL_MSG_PRINT_EVENTS ("In-order Q; adding event syncs\n");

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -166,6 +166,8 @@ int pocl_buffer_boundcheck_3d(const size_t buffer_size, const size_t *origin,
 /**
  * Finds an SVM/USM allocation where the host pointer is in.
  *
+ * Locks the context for mutual exclusion.
+ *
  * @return an allocation (info) where it is found, NULL if not found.
  */
 pocl_raw_ptr *pocl_find_raw_ptr_with_vm_ptr (cl_context context,
@@ -175,6 +177,8 @@ pocl_raw_ptr *pocl_find_raw_ptr_with_vm_ptr (cl_context context,
  * Finds a cl_mem allocation where the device pointer is mapped.
  *
  * The cl_mem allocation should be allocated with CL_MEM_BUFFER_DEVICE_ADDRESS.
+ *
+ * Locks the context for mutual exclusion.
  *
  * @return an allocation where the device pointer is in, NULL if not found.
  */

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -2556,6 +2556,8 @@ int SharedCLContext::fillBuffer(uint64_t ev_id, uint32_t cq_id,
     fillB(cl_ulong4);
   case 64:
     fillB(cl_ulong8);
+  case 128:
+    fillB(cl_ulong16);
   default:
     err = CL_INVALID_ARG_VALUE;
   }


### PR DESCRIPTION
Moved more of the USM handling to the API layer, enabled by
the common raw pointer book keeping functionality.

Fix clEnqueueMemFillINTEL() for the new shadow buffering scheme.

Advertise USM from Remote in case SVM enabled.