### PR TITLE
CUDA: advertise cl_ext_buffer_device_address

### DIFF
--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -1,6 +1,7 @@
 /* pocl-cuda.c - driver for CUDA devices
 
    Copyright (c) 2016-2017 James Price / University of Bristol
+                 2024 Henry Linjamäki / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to
@@ -588,6 +589,19 @@ pocl_cuda_init (unsigned j, cl_device_id dev, const char *parameters)
   // See e.g.
   // https://forums.developer.nvidia.com/t/max-size-of-cuda-arguments/50218
   dev->max_parameter_size = 4352;
+
+  // Since cSVM is supported, enable cl_ext_buffer_device_address
+  // (BDA) only if the unified addressing (UA; also known as unified
+  // virtual address space) is supported on the device. Without UA,
+  // SVM and BDA may not co-exist due to address aliasing.
+  int ua = 0;
+  cuDeviceGetAttribute (&ua, CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING,
+                        data->device);
+  if (ua)
+    {
+      // The returned pointer (original dev->extensions) is a literal string.
+      pocl_str_append (&dev->extensions, " cl_ext_buffer_device_address");
+    }
 
 #if (CUDA_DEVICE_CL_VERSION_MAJOR >= 3)
   dev->features = CUDA_DEVICE_FEATURES_30;

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -3,6 +3,7 @@
    Copyright (c) 2012-2019 Pekka Jääskeläinen
                  2020-2024 PoCL Developers
                  2024 Pekka Jääskeläinen / Intel Finland Oy
+                 2024 Henry Linjamäki / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to
@@ -2850,6 +2851,23 @@ pocl_str_tolower(char *out, const char *in)
   for (i = 0; in[i] != '\0'; i++)
     out[i] = tolower(in[i]);
   out[i] = '\0';
+}
+
+const char *
+pocl_str_append (const char **dst, const char *src)
+{
+  assert (src);
+  assert (dst && *dst);
+  unsigned src_len = strlen (src);
+  unsigned dst_len = strlen (*dst);
+  char *new_dst = calloc (dst_len + src_len + 1, 1);
+  if (new_dst == NULL)
+    return NULL;
+  strncpy (new_dst, *dst, dst_len);
+  strncpy (new_dst + dst_len, src, src_len);
+  const char *old_dst = *dst;
+  *dst = new_dst;
+  return old_dst;
 }
 
 int

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -1,6 +1,7 @@
 /* OpenCL runtime library: pocl_util utility functions
 
    Copyright (c) 2012-2024 PoCL Developers
+                 2024 Henry Linjamäki / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to
@@ -340,6 +341,14 @@ void pocl_str_toupper (char *out, const char *in);
 
 POCL_EXPORT
 void pocl_str_tolower (char *out, const char *in);
+
+/* Concatenates *dst and src strings into a new string and replaces
+ * the dst with it.
+ *
+ * The original *dst is returned with unchanged contents. On an error,
+ * NULL is returned and dst is unchanged. */
+POCL_EXPORT
+const char *pocl_str_append (const char **dst, const char *src);
 
 #ifdef __cplusplus
 }

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -361,6 +361,7 @@ set_property(TEST
   "runtime/test_user_event"
   "runtime/clSetMemObjectDestructorCallback"
   "runtime/test_deviceside_enqueue"
+  "runtime/test_device_address"
   ${OCL_30_TESTS}
   APPEND PROPERTY LABELS "cuda")
 


### PR DESCRIPTION
Enabled runtime/test_device_address as it passed on RTX 3060 at least.