### PR TITLE
Fix "Expected<T> must be checked before access or destruction."

### DIFF
--- a/lib/CL/pocl_llvm_utils.cc
+++ b/lib/CL/pocl_llvm_utils.cc
@@ -123,8 +123,11 @@ llvm::Module *parseModuleIRMem(const char *input_stream, size_t size,
       MemoryBuffer::getMemBufferCopy(input_stream_ref);
 
   auto parsed_module = parseBitcodeFile(buffer->getMemBufferRef(), *c);
-  if (!parsed_module)
+  if (auto error = parsed_module.takeError()) {
+    POCL_MSG_ERR("parseBitcodeFile failed:\n%s\n",
+                 toString(std::move(error)).c_str());
     return nullptr;
+  }
   return parsed_module.get().release();
 }
 


### PR DESCRIPTION
Fix pocl_llvm_utils.cc::parseModuleIRMem() triggered the assertion on the title when parseBitcodeFile() call returned an error. The Expected object was checked but its stored Error object was not and that triggered the assertion. In this patch the error gets checked by passing it to toString().