### PR TITLE
Add trailing `/` into OCL_ICD_VENDORS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2073,11 +2073,13 @@ file(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/CTestCustom.cmake" CONTENT "
   set(ENV{POCL_BUILDING} \"1\")
 ")
 else()
+# Old OCL ICD Loaders may not recognize PoCL without the trailing '/' in the
+# OCL_ICD_VENDORS.
 file(GENERATE OUTPUT "${CMAKE_BINARY_DIR}/CTestCustom.cmake" CONTENT "
   ${SAN_EXTRA}
   set(ENV{POCL_ENABLE_UNINIT} \"1\")
   set(ENV{POCL_BUILDING} \"1\")
-  set(ENV{OCL_ICD_VENDORS} \"${CMAKE_BINARY_DIR}/ocl-vendors\")
+  set(ENV{OCL_ICD_VENDORS} \"${CMAKE_BINARY_DIR}/ocl-vendors/\")
 ")
 endif()
 

--- a/tools/scripts/devel-envs.sh
+++ b/tools/scripts/devel-envs.sh
@@ -3,7 +3,8 @@ libs_subdir=.
 
 # source this while in the pocl build dir
 export POCL_BUILDING=1
-export OCL_ICD_VENDORS=$PWD/ocl-vendors
+# Old OCL ICD Loaders may not recognize PoCL without the trailing '/'.
+export OCL_ICD_VENDORS=$PWD/ocl-vendors/
 
 # AMDSDK supports the overriding via other env name.
 export OPENCL_VENDOR_PATH=$OCL_ICD_VENDORS


### PR DESCRIPTION
Add trailing `/` into OCL_ICD_VENDORS so POCL gets recognized by OpenCL ICD Loader versions prior
https://github.com/KhronosGroup/OpenCL-ICD-Loader/pull/91.