### PR TITLE
CUDA: relax CL_DEVICE_MAX_MEM_ALLOC_SIZE limit

### DIFF
--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -557,7 +557,7 @@ pocl_cuda_init (unsigned j, cl_device_id dev, const char *parameters)
   size_t memfree = 0, memtotal = 0;
   if (ret != CL_INVALID_DEVICE)
     result = cuMemGetInfo (&memfree, &memtotal);
-  dev->max_mem_alloc_size = max (memtotal / 4, 128 * 1024 * 1024);
+  dev->max_mem_alloc_size = max (memfree, 128 * 1024 * 1024);
   dev->global_mem_size = memtotal;
 
   dev->svm_allocation_priority = 2;


### PR DESCRIPTION
Relax the limit from 1/4 * CL_DEVICE_GLOBAL_MEM_SIZE to currently available free memory reported by cuMemGetInfo() at device initialization time.

Motivation: enable a HeCBench case, running on chipStar/OpenCL->PoCL/CUDA->RTX3060, to allocate ~4GiB buffers.

Edit: was: Relax the limit from 1/4 to 1/2 * CL_DEVICE_GLOBAL_MEM_SIZE.