### PR TITLE
CUDA: Support subgroup ballot & shuffles for recent SM archs and others

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2126,6 +2126,10 @@ if(ENABLE_TESTS)
     # make check & make check_tier1
     add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} "--output-on-failure" -j ${HOST_CPU_CORECOUNT} ${COMMAND_USES_TERMINAL})
     add_custom_target(check_tier1 COMMAND ${CMAKE_CTEST_COMMAND} "--output-on-failure" -L "'internal|piglit|PyOpenCL|conformance_suite_micro|shoc|chipStar'" -j ${HOST_CPU_CORECOUNT} ${COMMAND_USES_TERMINAL})
+
+    add_custom_target(check-cuda COMMAND
+      "${CMAKE_SOURCE_DIR}/tools/scripts/run_cuda_tests"
+      "--output-on-failure" -j ${HOST_CPU_CORECOUNT} ${COMMAND_USES_TERMINAL})
 endif()
 
 if(ENABLE_EXAMPLES)

--- a/doc/sphinx/source/notes_6_0.rst
+++ b/doc/sphinx/source/notes_6_0.rst
@@ -163,6 +163,13 @@ CUDA driver
 
 Various smaller fixes and enhancements, for example:
 
+* Added `sub_group_shuffle` and `sub_group_shuffle_xor` support for
+  the following data types: `char`, `uchar`, `short`, `ushort`, `int`,
+  `uint` and `float`. `cl_khr_subgroup_shuffle` device extension is
+  advertised when device is capable. Note: support for `long`, `ulong`
+  and `double` data types are missing.
+* Aixed kernel compilation for device programs with subgroup ballot
+  and shuffles for recent SM architectures (SM >= 8.0).
 * Fixed clLinkProgram and clCompileProgram to work correctly
 * Fixed memory leaks in clReleaseProgram
 * `CL_DEVICE_MAX_MEM_ALLOC_SIZE` limit increased to free memory reported by `cuMemGetInfo`

--- a/doc/sphinx/source/notes_6_0.rst
+++ b/doc/sphinx/source/notes_6_0.rst
@@ -168,7 +168,7 @@ Various smaller fixes and enhancements, for example:
   `uint` and `float`. `cl_khr_subgroup_shuffle` device extension is
   advertised when device is capable. Note: support for `long`, `ulong`
   and `double` data types are missing.
-* Aixed kernel compilation for device programs with subgroup ballot
+* Fixed kernel compilation for device programs with subgroup ballot
   and shuffles for recent SM architectures (SM >= 8.0).
 * Fixed clLinkProgram and clCompileProgram to work correctly
 * Fixed memory leaks in clReleaseProgram

--- a/lib/CL/devices/cuda/pocl-ptx-gen.cc
+++ b/lib/CL/devices/cuda/pocl-ptx-gen.cc
@@ -98,7 +98,7 @@ static bool verifyModule(llvm::Module *Module, const char *step) {
 }
 
 int pocl_ptx_gen(void *llvm_module, const char *PTXFilename, const char *Arch,
-                 const char *LibDevicePath, int HasOffsets,
+                 unsigned PtxVersion, const char *LibDevicePath, int HasOffsets,
                  void **AlignmentMapPtr) {
 
   llvm::Module *Module = (llvm::Module *)llvm_module;
@@ -170,13 +170,13 @@ int pocl_ptx_gen(void *llvm_module, const char *PTXFilename, const char *Arch,
   // TODO: Set options?
   llvm::TargetOptions Options;
 
-  // TODO: CPU and features?
+  auto Features = std::string("+ptx") + std::to_string(PtxVersion);
 #ifdef LLVM_OLDER_THAN_16_0
   std::unique_ptr<llvm::TargetMachine> Machine(
-      Target->createTargetMachine(Triple, Arch, "+ptx40", Options, llvm::None));
+      Target->createTargetMachine(Triple, Arch, Features, Options, llvm::None));
 #else
-  std::unique_ptr<llvm::TargetMachine> Machine(
-      Target->createTargetMachine(Triple, Arch, "+ptx40", Options, std::nullopt));
+  std::unique_ptr<llvm::TargetMachine> Machine(Target->createTargetMachine(
+      Triple, Arch, Features, Options, std::nullopt));
 #endif
   llvm::legacy::PassManager Passes;
 

--- a/lib/CL/devices/cuda/pocl-ptx-gen.h
+++ b/lib/CL/devices/cuda/pocl-ptx-gen.h
@@ -42,8 +42,8 @@ int findLibDevice(char LibDevicePath[PATH_MAX], const char *Arch);
 /* Generate a PTX file from an LLVM bitcode file. */
 /* Returns zero on success, non-zero on failure. */
 int pocl_ptx_gen (void *llvm_module, const char *PTXFilename, const char *Arch,
-                  const char *LibDevicePath, int HasOffsets,
-                  void **AlignmentMapPtr);
+                  unsigned PtxVersion, const char *LibDevicePath,
+                  int HasOffsets, void **AlignmentMapPtr);
 
 int pocl_cuda_create_alignments (void *llvm_module, void **AlignmentMapPtr);
 

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -2850,6 +2850,35 @@ pocl_str_toupper(char *out, const char *in)
   out[i] = '\0';
 }
 
+char *
+pocl_strcatdup_v (size_t num_strs, const char **strs)
+{
+  assert (strs || !num_strs && "strs is NULL while num_strs > 0!");
+  switch (num_strs)
+    {
+    default:
+      break;
+    case 0:
+      return NULL;
+    case 1:
+      return strdup (strs[0]);
+    }
+
+  size_t new_size = 1; /* Place for NULL. */
+  for (size_t i = 0; i < num_strs; i++)
+    {
+      assert (strs[i]);
+      new_size += strlen (strs[i]);
+    }
+
+  char *new_str = calloc (new_size, 1);
+  if (new_str == NULL)
+    return NULL;
+  for (size_t i = 0; i < num_strs; i++)
+    strcat (new_str, strs[i]);
+  return new_str;
+}
+
 void
 pocl_str_tolower(char *out, const char *in)
 {

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -346,6 +346,14 @@ void pocl_str_toupper (char *out, const char *in);
 POCL_EXPORT
 void pocl_str_tolower (char *out, const char *in);
 
+/* Concatenates 'num_str' strings from 'strs' array together into a
+ * new string.
+ *
+ * @return NULL if num_strs == 0 or allocation failed. Otherwise, return the
+ * result. */
+POCL_EXPORT
+char *pocl_strcatdup_v (size_t num_strs, const char **strs);
+
 /* Concatenates *dst and src strings into a new string and replaces
  * the dst with it.
  *

--- a/lib/kernel/cuda/CMakeLists.txt
+++ b/lib/kernel/cuda/CMakeLists.txt
@@ -111,20 +111,56 @@ endif()
 separate_arguments(DEVICE_CL_FLAGS)
 
 
+# Kernel bitcodes generated:
+# * <triple>-sm30-ptx60lt
+#   * Includes subgroup shuffles.
+#   * Excludes subgroup ballot (see details in subgroup_ballot.cl).
+#   * Intended for targeting 3.0 <= SM <= 7.5.
+# * <triple>-sm30-ptx60-63:
+#   * Includes subgroup ballot and shuffles.
+#   * Targeted for PTX 6.0 - 6.3. This library uses intrinsics that work
+#     for both the LLVM and PTX assembler.
+#   * Intended for targeting 3.0 <= SM <= 7.5.
+# * <triple>-sm70-ptx64: Supports ballot and shfl
+#   * Excludes subgroup shuffles or ballot. The support would require
+#     use of .sync variants.
+#   * Inteded for targeting SM >=7.0.
 
-make_kernel_bc(KERNEL_BC "${LLVM_TARGET}" "BCs" 0 0 0 ${KERNEL_SOURCES})
+make_kernel_bc(KERNEL_BC_SM30_PTX60LT "${LLVM_TARGET}-sm30-ptx60lt"
+  "sm30-ptx60-63-BCs" 0 0 0 ${KERNEL_SOURCES}
+  "cuda/subgroup_shuffle.cl")
+
+make_kernel_bc(KERNEL_BC_SM30_PTX60_63 "${LLVM_TARGET}-sm30-ptx60-63"
+  "sm30-ptx60-63-BCs" 0 0 0 ${KERNEL_SOURCES}
+  "cuda/subgroup_shuffle.cl"
+  "cuda/subgroup_ballot.cl")
+
+make_kernel_bc(KERNEL_BC_SM70_PTX64 "${LLVM_TARGET}-sm70-ptx64"
+ "sm70-ptx64-BCs" 0 0 0 ${KERNEL_SOURCES})
 
 # just debug
-message(STATUS "${LLVM_TARGET} Kernel BC: ${KERNEL_BC}")
+#message(STATUS "${LLVM_TARGET} Kernel BC: ${KERNEL_BC_SM30_PTX60_63}")
 
-list(APPEND KERNEL_BC_LIST "${KERNEL_BC}")
+list(APPEND KERNEL_BC_LIST "${KERNEL_BC_SM30_PTX60LT}")
+list(APPEND KERNEL_BC_LIST "${KERNEL_BC_SM30_PTX60_63}")
+list(APPEND KERNEL_BC_LIST "${KERNEL_BC_SM70_PTX64}")
 set(KERNEL_BC_LIST "${KERNEL_BC_LIST}" PARENT_SCOPE)
 
 # a target is needed...
-add_custom_target("kernel_${LLVM_TARGET}" DEPENDS ${KERNEL_BC})
+add_custom_target("kernel_${LLVM_TARGET}_sm30_ptx60lt"
+  DEPENDS ${KERNEL_BC_SM30_PTX60LT})
+add_custom_target("kernel_${LLVM_TARGET}_sm30_ptx60_63"
+  DEPENDS ${KERNEL_BC_SM30_PTX60_63})
+add_custom_target("kernel_${LLVM_TARGET}_sm70_ptx64"
+  DEPENDS ${KERNEL_BC_SM70_PTX64})
 
-list(APPEND KERNEL_TARGET_LIST "kernel_${LLVM_TARGET}")
+list(APPEND KERNEL_TARGET_LIST "kernel_${LLVM_TARGET}_sm30_ptx60lt")
+list(APPEND KERNEL_TARGET_LIST "kernel_${LLVM_TARGET}_sm30_ptx60_63")
+list(APPEND KERNEL_TARGET_LIST "kernel_${LLVM_TARGET}_sm70_ptx64")
+
 set(KERNEL_TARGET_LIST "${KERNEL_TARGET_LIST}" PARENT_SCOPE)
 
-install(FILES "${KERNEL_BC}"
-        DESTINATION "${POCL_INSTALL_PRIVATE_DATADIR}" COMPONENT "lib")
+install(FILES
+  "${KERNEL_BC_SM30_PTX60LT}" "${KERNEL_BC_SM30_PTX60_63}"
+  "${KERNEL_BC_SM70_PTX64}"
+  DESTINATION "${POCL_INSTALL_PRIVATE_DATADIR}" COMPONENT "lib")

--- a/lib/kernel/cuda/subgroup.ll
+++ b/lib/kernel/cuda/subgroup.ll
@@ -37,17 +37,6 @@ declare void @llvm.nvvm.membar.cta() #2
 declare void @llvm.nvvm.membar.gl() #2
 
 ; Function Attrs: convergent mustprogress nounwind
-define noundef <4 x i32> @_Z16sub_group_balloti(i32 noundef %0) local_unnamed_addr #3 {
-  %2 = icmp ne i32 %0, 0
-  %3 = tail call i32 @llvm.nvvm.vote.ballot(i1 %2)
-  %4 = insertelement <4 x i32> <i32 poison, i32 0, i32 0, i32 0>, i32 %3, i64 0
-  ret <4 x i32> %4
-}
-
-; Function Attrs: convergent inaccessiblememonly nocallback nounwind
-declare i32 @llvm.nvvm.vote.ballot(i1) #4
-
-; Function Attrs: convergent mustprogress nounwind
 define noundef i32 @_Z22get_sub_group_local_idv() local_unnamed_addr #0 {
   %1 = tail call noundef i64 @_Z19get_local_linear_idv() #6
   %2 = trunc i64 %1 to i32
@@ -57,54 +46,6 @@ define noundef i32 @_Z22get_sub_group_local_idv() local_unnamed_addr #0 {
 
 ; Function Attrs: convergent nounwind
 declare noundef i64 @_Z19get_local_linear_idv() local_unnamed_addr #5
-
-; Function Attrs: convergent mustprogress nounwind
-define noundef i32 @_Z23intel_sub_group_shufflejj(i32 noundef %0, i32 noundef %1) local_unnamed_addr #0 {
-  %3 = tail call i32 @llvm.nvvm.shfl.idx.i32(i32 %0, i32 %1, i32 31)
-  ret i32 %3
-}
-
-; Function Attrs: convergent inaccessiblememonly nocallback nounwind
-declare i32 @llvm.nvvm.shfl.idx.i32(i32, i32, i32) #4
-
-; Function Attrs: convergent mustprogress nounwind
-define noundef i32 @_Z23intel_sub_group_shuffleij(i32 noundef %0, i32 noundef %1) local_unnamed_addr #0 {
-  %3 = tail call i32 @llvm.nvvm.shfl.idx.i32(i32 %0, i32 %1, i32 31)
-  ret i32 %3
-}
-
-; Function Attrs: convergent mustprogress nounwind
-define noundef float @_Z23intel_sub_group_shufflefj(float noundef %0, i32 noundef %1) local_unnamed_addr #0 {
-  %3 = tail call contract float @llvm.nvvm.shfl.idx.f32(float %0, i32 %1, i32 31)
-  ret float %3
-}
-
-; Function Attrs: convergent inaccessiblememonly nocallback nounwind
-declare float @llvm.nvvm.shfl.idx.f32(float, i32, i32) #4
-
-; Function Attrs: convergent mustprogress nounwind
-define noundef i32 @_Z27intel_sub_group_shuffle_xorij(i32 noundef %0, i32 noundef %1) local_unnamed_addr #0 {
-  %3 = tail call i32 @llvm.nvvm.shfl.bfly.i32(i32 %0, i32 %1, i32 31)
-  ret i32 %3
-}
-
-; Function Attrs: convergent inaccessiblememonly nocallback nounwind
-declare i32 @llvm.nvvm.shfl.bfly.i32(i32, i32, i32) #4
-
-; Function Attrs: convergent mustprogress nounwind
-define noundef i32 @_Z27intel_sub_group_shuffle_xorjj(i32 noundef %0, i32 noundef %1) local_unnamed_addr #0 {
-  %3 = tail call i32 @llvm.nvvm.shfl.bfly.i32(i32 %0, i32 %1, i32 31)
-  ret i32 %3
-}
-
-; Function Attrs: convergent mustprogress nounwind
-define noundef float @_Z27intel_sub_group_shuffle_xorfj(float noundef %0, i32 noundef %1) local_unnamed_addr #0 {
-  %3 = tail call contract float @llvm.nvvm.shfl.bfly.f32(float %0, i32 %1, i32 31)
-  ret float %3
-}
-
-; Function Attrs: convergent inaccessiblememonly nocallback nounwind
-declare float @llvm.nvvm.shfl.bfly.f32(float, i32, i32) #4
 
 attributes #0 = { convergent mustprogress nounwind "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="sm_70" "target-features"="+ptx75,+sm_70" }
 attributes #1 = { convergent nocallback nounwind }

--- a/lib/kernel/cuda/subgroup_ballot.cl
+++ b/lib/kernel/cuda/subgroup_ballot.cl
@@ -1,0 +1,32 @@
+/* OpenCL built-in library: subgroup functions
+
+   Copyright (c) 2024 Henry Linjamäki / Intel Finland Oy
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+uint4 _CL_OVERLOADABLE sub_group_ballot(int predicate) {
+  uint4 result = (uint4)(0u);
+  // NOTE:
+  // * LLVM/NVPTX backend requires at least SM 3.0 and PTX 6.0 to select this
+  //   intrinsic.
+  // * vote.ballot is not supported in PTX 6.4+ for SM 7.0+ architectures.
+  result.x = __nvvm_vote_ballot(!!predicate);
+  return result;
+}

--- a/lib/kernel/cuda/subgroup_shuffle.cl
+++ b/lib/kernel/cuda/subgroup_shuffle.cl
@@ -1,0 +1,70 @@
+/* OpenCL built-in library: subgroup shuffle functions
+
+   Copyright (c) 2024 Henry Linjamäki / Intel Finland Oy
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+#define SUBGROUP_SHUFFLE_I32_PT(PREFIX, TYPE)                                  \
+  TYPE _CL_OVERLOADABLE PREFIX##sub_group_shuffle(TYPE value, uint idx) {      \
+    return __nvvm_shfl_idx_i32(value, idx, 31);                                \
+  }
+
+#define SUBGROUP_SHUFFLE_I32(TYPE)                                             \
+  SUBGROUP_SHUFFLE_I32_PT(, TYPE)                                              \
+  SUBGROUP_SHUFFLE_I32_PT(intel_, TYPE)
+
+SUBGROUP_SHUFFLE_I32(char);
+SUBGROUP_SHUFFLE_I32(uchar);
+SUBGROUP_SHUFFLE_I32(short);
+SUBGROUP_SHUFFLE_I32(ushort);
+SUBGROUP_SHUFFLE_I32(int);
+SUBGROUP_SHUFFLE_I32(uint);
+
+float _CL_OVERLOADABLE sub_group_shuffle(float value, uint idx) {
+  return __nvvm_shfl_idx_f32(value, idx, 31);
+}
+
+float _CL_OVERLOADABLE intel_sub_group_shuffle(float value, uint idx) {
+  return __nvvm_shfl_idx_f32(value, idx, 31);
+}
+
+#define SUBGROUP_SHUFFLE_XOR_I32_PT(PREFIX, TYPE)                              \
+  TYPE _CL_OVERLOADABLE PREFIX##sub_group_shuffle_xor(TYPE value, uint mask) { \
+    return __nvvm_shfl_bfly_i32(value, mask, 31);                              \
+  }
+
+#define SUBGROUP_SHUFFLE_XOR_I32(TYPE)                                         \
+  SUBGROUP_SHUFFLE_XOR_I32_PT(, TYPE)                                          \
+  SUBGROUP_SHUFFLE_XOR_I32_PT(intel_, TYPE)
+
+SUBGROUP_SHUFFLE_XOR_I32(char);
+SUBGROUP_SHUFFLE_XOR_I32(uchar);
+SUBGROUP_SHUFFLE_XOR_I32(short);
+SUBGROUP_SHUFFLE_XOR_I32(ushort);
+SUBGROUP_SHUFFLE_XOR_I32(int);
+SUBGROUP_SHUFFLE_XOR_I32(uint);
+
+float _CL_OVERLOADABLE sub_group_shuffle_xor(float value, uint mask) {
+  return __nvvm_shfl_bfly_f32(value, mask, 31);
+}
+
+float _CL_OVERLOADABLE intel_sub_group_shuffle_xor(float value, uint mask) {
+  return __nvvm_shfl_bfly_f32(value, mask, 31);
+}


### PR DESCRIPTION
Add support for subgroup ballot and shuffles for SM >=8.0 architectures. Kernel code generation failed prior this patch due to high SM version because:

* LLVM disables instruction selection for certain intrinsics when targeted SM and PTX versions are high enough.

* PTX assembler removes support for some instructions (e.g. non-sync variants of ballot and shfls) after a certain PTX version.

The operations are attempted to be supported by lowering SM and PTX versions for the codegen when possible.

Other changes:

* Advertise `cl_khr_subgroup_ballot` for CUDA device when capable. However, only `sub_group_ballot()` is implemented now. This enables a HeCBench case on chipStar/PoCL-CUDA/sm_86.

* ~~Advertise `cl_khr_subgroup_shuffle` and `cl_khr_subgroup_shuffle_relative` for CUDA device when capable.~~

*  Extend subgroup shuffle support. Advertise cl_khr_subgroup_shuffle for CUDA device when capable. Note: cl_khr_subgroup_shuffle is missing support for `long`, `ulong` and `double` data types.

* Added implementations for intel_sub_group_shuffle{,_xor} for <32-bit integer data types.

* Add `pocl_strcatdup_v()`: concatentate array of strings into a new string.

* Add `check-cuda`. A shortcut for `run_cuda_tests` script.