### PR TITLE
Move command enqueues out of critical section

### DIFF
--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -961,10 +961,6 @@ FINISH_VER_SETUP:
       cmd_export->command.migrate.type = ENQUEUE_MIGRATE_TYPE_D2H;
       cmd_export->command.migrate.migration_size = migration_size;
 
-      POCL_MSG_PRINT_MEMORY (
-        "Queuing a %zu-byte device-to-host migration for buf %zu%s\n",
-        migration_size, mem->id, mem->parent != NULL ? " (sub-buffer)" : "");
-
       last_migration_event = ev_export;
 
       if (ev_export_p)
@@ -1014,10 +1010,6 @@ FINISH_VER_SETUP:
           cmd_import->command.migrate.migration_size = migration_size;
         }
 
-      POCL_MSG_PRINT_MEMORY (
-        "Queuing a %zu-byte host-to-device migration for buf %zu%s\n",
-        migration_size, mem->id, mem->parent != NULL ? " (sub-buffer)" : "");
-
       /* because explicit event */
       if (ev_export)
         POname (clReleaseEvent) (ev_export);
@@ -1048,11 +1040,21 @@ FINISH_VER_SETUP:
     }
   POCL_UNLOCK_OBJ (mem);
 
-  if (do_export)
-    pocl_command_enqueue (ex_cq, cmd_export);
+  if (do_export) {
+    POCL_MSG_PRINT_MEMORY (
+      "Queuing a %zu-byte device-to-host migration for buf %zu%s\n",
+      migration_size, mem->id, mem->parent != NULL ? " (sub-buffer)" : "");
 
-  if (do_import)
+    pocl_command_enqueue (ex_cq, cmd_export);
+  }
+
+  if (do_import) {
+    POCL_MSG_PRINT_MEMORY (
+      "Queuing a %zu-byte host-to-device migration for buf %zu%s\n",
+      migration_size, mem->id, mem->parent != NULL ? " (sub-buffer)" : "");
+
     pocl_command_enqueue (dev_cq, cmd_import);
+  }
 
   return CL_SUCCESS;
 }

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -965,8 +965,6 @@ FINISH_VER_SETUP:
         "Queuing a %zu-byte device-to-host migration for buf %zu%s\n",
         migration_size, mem->id, mem->parent != NULL ? " (sub-buffer)" : "");
 
-      pocl_command_enqueue (ex_cq, cmd_export);
-
       last_migration_event = ev_export;
 
       if (ev_export_p)
@@ -1019,7 +1017,6 @@ FINISH_VER_SETUP:
       POCL_MSG_PRINT_MEMORY (
         "Queuing a %zu-byte host-to-device migration for buf %zu%s\n",
         migration_size, mem->id, mem->parent != NULL ? " (sub-buffer)" : "");
-      pocl_command_enqueue (dev_cq, cmd_import);
 
       /* because explicit event */
       if (ev_export)
@@ -1050,6 +1047,12 @@ FINISH_VER_SETUP:
         POname (clReleaseEvent) (last_migration_event);
     }
   POCL_UNLOCK_OBJ (mem);
+
+  if (do_export)
+    pocl_command_enqueue (ex_cq, cmd_export);
+
+  if (do_import)
+    pocl_command_enqueue (dev_cq, cmd_import);
 
   return CL_SUCCESS;
 }


### PR DESCRIPTION
Fixes possible deadlock where `pocl_create_migration_commands()` and `pocl_free_event_memobjs()` may try to acquire the same memory object lock. Occurs in `example1` when compiled with

```
  cmake -DENABLE_ALMAIF_DEVICE=ON -DENABLE_POCL_BUILDING=ON ..
```