### PR TITLE
fixes for 6.0

### DIFF
--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1710,6 +1710,7 @@ pocl_init_default_device_infos (cl_device_id dev,
 #ifdef ENABLE_LLVM
 
   dev->llvm_target_triplet = OCL_KERNEL_TARGET;
+  dev->kernellib_fallback_name = NULL;
 
   char kernellib[POCL_MAX_PATHNAME_LENGTH] = "kernel-";
   char kernellib_fallback[POCL_MAX_PATHNAME_LENGTH];
@@ -1730,9 +1731,9 @@ pocl_init_default_device_infos (cl_device_id dev,
   strcpy(kernellib_fallback, kernellib);
   strcat(kernellib_fallback, OCL_KERNEL_TARGET_CPU);
   strcat(kernellib, dev->llvm_cpu);
+  dev->kernellib_fallback_name = strdup(kernellib_fallback);
 #endif
   dev->kernellib_name = strdup(kernellib);
-  dev->kernellib_fallback_name = strdup(kernellib_fallback);
   dev->kernellib_subdir = "host";
   dev->llvm_abi = pocl_get_llvm_cpu_abi ();
 

--- a/lib/CL/devices/common_utils.c
+++ b/lib/CL/devices/common_utils.c
@@ -247,7 +247,7 @@ pocl_cpu_init_common (cl_device_id device)
 /* called from kernel setup code.
  * Sets up the actual arguments, except the local ones. */
 void
-setup_kernel_arg_array (kernel_run_command *k)
+pocl_setup_kernel_arg_array (kernel_run_command *k)
 {
   struct pocl_argument *al;
 
@@ -324,7 +324,7 @@ setup_kernel_arg_array (kernel_run_command *k)
  * they're set up by 1) memcpy from kernel_run_command, 2) all
  * local args are set to thread-local "local memory" storage. */
 void
-setup_kernel_arg_array_with_locals (void **arguments, void **arguments2,
+pocl_setup_kernel_arg_array_with_locals (void **arguments, void **arguments2,
                                     kernel_run_command *k, char *local_mem,
                                     size_t local_mem_size)
 {
@@ -404,7 +404,7 @@ setup_kernel_arg_array_with_locals (void **arguments, void **arguments2,
 /* called from kernel teardown code.
  * frees the actual arguments, except the local ones. */
 void
-free_kernel_arg_array (kernel_run_command *k)
+pocl_free_kernel_arg_array (kernel_run_command *k)
 {
   cl_uint i;
   pocl_kernel_metadata_t *meta = k->kernel->meta;
@@ -439,7 +439,7 @@ free_kernel_arg_array (kernel_run_command *k)
 /* called from each driver thread.
  * frees the local arguments. */
 void
-free_kernel_arg_array_with_locals (void **arguments, void **arguments2,
+pocl_free_kernel_arg_array_with_locals (void **arguments, void **arguments2,
                                    kernel_run_command *k)
 {
   pocl_kernel_metadata_t *meta = k->kernel->meta;

--- a/lib/CL/devices/common_utils.h
+++ b/lib/CL/devices/common_utils.h
@@ -83,19 +83,19 @@ POCL_EXPORT
 cl_int pocl_cpu_init_common (cl_device_id device);
 
 POCL_EXPORT
-void setup_kernel_arg_array (kernel_run_command *k);
+void pocl_setup_kernel_arg_array (kernel_run_command *k);
 
 POCL_EXPORT
-void setup_kernel_arg_array_with_locals (void **arguments, void **arguments2,
+void pocl_setup_kernel_arg_array_with_locals (void **arguments, void **arguments2,
                                          kernel_run_command *k,
                                          char *local_mem,
                                          size_t local_mem_size);
 
 POCL_EXPORT
-void free_kernel_arg_array (kernel_run_command *k);
+void pocl_free_kernel_arg_array (kernel_run_command *k);
 
 POCL_EXPORT
-void free_kernel_arg_array_with_locals (void **arguments, void **arguments2,
+void pocl_free_kernel_arg_array_with_locals (void **arguments, void **arguments2,
                                         kernel_run_command *k);
 
 #ifdef __cplusplus

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -279,7 +279,7 @@ work_group_scheduler (kernel_run_command *k,
 
   assert (end_index >= start_index);
 
-  setup_kernel_arg_array_with_locals (
+  pocl_setup_kernel_arg_array_with_locals (
       (void **)&arguments, (void **)&arguments2, k, thread_data->local_mem,
       scheduler.local_mem_size);
   memcpy (&pc, &k->pc, sizeof (struct pocl_context));
@@ -337,7 +337,7 @@ work_group_scheduler (kernel_run_command *k,
       write (STDOUT_FILENO, pc.printf_buffer, position);
     }
 
-  free_kernel_arg_array_with_locals ((void **)&arguments, (void **)&arguments2,
+  pocl_free_kernel_arg_array_with_locals ((void **)&arguments, (void **)&arguments2,
                                      k);
 
   return 1;
@@ -360,7 +360,7 @@ work_group_scheduler (kernel_run_command *k,
     struct pocl_context pc;
     void *local_mem = malloc (scheduler.local_mem_size);
 
-    setup_kernel_arg_array_with_locals ((void **)&arguments,
+    pocl_setup_kernel_arg_array_with_locals ((void **)&arguments,
                                         (void **)&arguments2, k, local_mem,
                                         scheduler.local_mem_size);
     memcpy (&pc, &k->pc, sizeof (struct pocl_context));
@@ -402,7 +402,7 @@ work_group_scheduler (kernel_run_command *k,
       }
 #endif
 
-    free_kernel_arg_array_with_locals ((void **)&arguments,
+    pocl_free_kernel_arg_array_with_locals ((void **)&arguments,
                                        (void **)&arguments2, k);
 
     free (local_mem);
@@ -424,7 +424,7 @@ finalize_kernel_command (struct pool_thread_data *thread_data,
   printf("### kernel %s finished\n", k->cmd->command.run.kernel->name);
 #endif
 
-  free_kernel_arg_array (k);
+  pocl_free_kernel_arg_array (k);
 
   pocl_release_dlhandle_cache (k->cmd);
 
@@ -483,7 +483,7 @@ pocl_pthread_prepare_kernel (void *data, _cl_command_node *cmd)
   run_cmd->ref_count = 0;
   POCL_FAST_INIT (run_cmd->lock);
 
-  setup_kernel_arg_array (run_cmd);
+  pocl_setup_kernel_arg_array (run_cmd);
 
   pocl_update_event_running (cmd->sync.event.event);
 

--- a/lib/CL/devices/tbb/tbb_scheduler.cc
+++ b/lib/CL/devices/tbb/tbb_scheduler.cc
@@ -106,9 +106,9 @@ public:
                           (SchedData->printf_buf_size * CurThreadID);
     struct pocl_context PC;
 
-    setup_kernel_arg_array_with_locals((void **)&Arguments,
-                                       (void **)&Arguments2, K, LocalMem,
-                                       SchedData->local_mem_size);
+    pocl_setup_kernel_arg_array_with_locals((void **)&Arguments,
+                                            (void **)&Arguments2, K, LocalMem,
+                                            SchedData->local_mem_size);
     memcpy(&PC, &K->pc, sizeof(struct pocl_context));
 
 #ifndef ENABLE_PRINTF_IMMEDIATE_FLUSH
@@ -146,15 +146,15 @@ public:
     }
 #endif
 
-    free_kernel_arg_array_with_locals((void **)&Arguments, (void **)&Arguments2,
-                                      K);
+    pocl_free_kernel_arg_array_with_locals((void **)&Arguments,
+                                           (void **)&Arguments2, K);
   }
   WorkGroupScheduler(kernel_run_command *K, const pocl_tbb_scheduler_data *D)
       : RunCmd(K), SchedData(D) {}
 };
 
 static void finalizeKernelCommand(kernel_run_command *RunCmd) {
-  free_kernel_arg_array(RunCmd);
+  pocl_free_kernel_arg_array(RunCmd);
 
   pocl_release_dlhandle_cache(RunCmd->cmd);
 
@@ -209,7 +209,7 @@ prepareKernelCommand(pocl_tbb_scheduler_data *SchedData,
   RunCmd->kernel_args = Cmd->command.run.arguments;
   RunCmd->next = NULL;
 
-  setup_kernel_arg_array(RunCmd);
+  pocl_setup_kernel_arg_array(RunCmd);
 
   pocl_update_event_running(Cmd->sync.event.event);
 

--- a/lib/CL/pocl_llvm_utils.cc
+++ b/lib/CL/pocl_llvm_utils.cc
@@ -256,7 +256,7 @@ const struct kernellib_features {
 const char *pocl_get_distro_kernellib_variant() {
   StringMap<bool> Features;
 
-#if defined(__x86_64__)
+#if defined(__i386__) || defined(__x86_64__)
   if (!llvm::sys::getHostCPUFeatures(Features)) {
     POCL_MSG_WARN("LLVM can't get host CPU flags!\n");
     return NULL;
@@ -294,7 +294,7 @@ const char *pocl_get_distro_kernellib_variant() {
 const char *pocl_get_distro_cpu_name(const char *kernellib_variant) {
   StringMap<bool> Features;
 
-#if defined(__x86_64__)
+#if defined(__i386__) || defined(__x86_64__)
   if (!llvm::sys::getHostCPUFeatures(Features)) {
     POCL_MSG_WARN("LLVM can't get host CPU flags!\n");
     return NULL;


### PR DESCRIPTION
i386 distro builds are still broken in 5.0 since there were some related non-conflicting changes between I submitted the patch and it got applied
these two patches have been part of the Debian packages for 5.0 since the beginning, I just lost track of submitting them

there are some new exported symbols lacking the pocl_ prefix, add it