### PR TITLE
Fix return err value in clGetEvent(Profiling)Info

### DIFF
--- a/lib/CL/clGetEventInfo.c
+++ b/lib/CL/clGetEventInfo.c
@@ -27,8 +27,7 @@ CL_API_ENTRY cl_int CL_API_CALL POname (clGetEventInfo) (
     cl_event event, cl_event_info param_name, size_t param_value_size,
     void *param_value, size_t *param_value_size_ret) CL_API_SUFFIX__VERSION_1_0
 {
-  POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (event)),
-                          CL_INVALID_COMMAND_QUEUE);
+  POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (event)), CL_INVALID_EVENT);
 
   POCL_LOCK_OBJ (event);
   cl_int s = event->status;

--- a/lib/CL/clGetEventProfilingInfo.c
+++ b/lib/CL/clGetEventProfilingInfo.c
@@ -34,8 +34,7 @@ POname(clGetEventProfilingInfo)(cl_event event,
 {
   size_t const value_size = sizeof(cl_ulong);
 
-  POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (event)),
-                          CL_INVALID_COMMAND_QUEUE);
+  POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (event)), CL_INVALID_EVENT);
 
   POCL_RETURN_ERROR_ON((event->queue == NULL),
     CL_PROFILING_INFO_NOT_AVAILABLE, "Cannot return profiling info for user events\n");


### PR DESCRIPTION
According to https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/clGetEventInfo.html and https://registry.khronos.org/OpenCL/sdk/1.0/docs/man/xhtml/clGetEventProfilingInfo.html, the returned value should be CL_INVALID_EVENT if the event is not a valid object.