### PR TITLE
Defined built-in kernel (DBK) prototyping with matmul (WiP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1301,7 +1301,8 @@ set(HOST_DEVICE_EXTENSIONS "cl_khr_byte_addressable_store cl_khr_global_int32_ba
 cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics \
 cl_khr_local_int32_extended_atomics cl_khr_3d_image_writes \
 cl_khr_command_buffer cl_khr_command_buffer_multi_device cl_khr_subgroups \
-cl_intel_unified_shared_memory cl_ext_buffer_device_address")
+cl_intel_unified_shared_memory cl_ext_buffer_device_address \
+cl_exp_tensor cl_exp_defined_builtin_kernels")
 
 # Host CPU device: list of OpenCL 3.0 features that are always enabled
 # TODO: __opencl_c_atomic_scope_all_devices works with CPU device but not others

--- a/include/CL/cl_exp_defined_builtin_kernels.h
+++ b/include/CL/cl_exp_defined_builtin_kernels.h
@@ -1,0 +1,84 @@
+
+#ifndef OPENCL_EXP_DEFINED_BUILTIN_KERNELS
+#define OPENCL_EXP_DEFINED_BUILTIN_KERNELS
+
+#include <CL/cl_exp_tensor.h>
+
+#define CL_DBK_UNAVAILABLE 0x8101
+#define CL_DBK_INVALID_ATTRIBUTE 0x8102
+
+typedef cl_properties cl_dbk_properties;
+
+enum cl_dbk_property
+{
+  // Maximum relative error in ULPs allowed for the results respect to
+  // infinitely precise result.
+  CL_DBK_PROPERTY_MAX_RELATIVE_ERROR = 1, // <float>
+
+  // Built-in kernel attributes are immutable values (this allows
+  // drivers to specialize their kernels). CL_DBK_MUTABLE_ATTR
+  // followed by attribute index (cl_uint) enables the attribute to be
+  // mutable via clSetKernelArg(attribute_index, ...).
+  CL_DBK_PROPERTY_MUTABLE_ATTR, // <cl_uint>
+
+  // Allows the results of the DBK to fluctuate* with the exactly same
+  // inputs across kernel launches.
+  //
+  // *: CL_DBK_PROPERTY_MAX_RELATIVE_ERROR must still be respected if present.
+  //
+  // Drivers may ignore this property.
+  CL_DBK_PROPERTY_NON_DETERMINISTIC,
+
+  // Allow driver to trade off accuracy for speed by allowing it to flush
+  // denormals to zero.
+  //
+  // Drivers may ignore this property, meaning the behavior is not guaranteed.
+  CL_DBK_PROPERTY_ALLOW_FTZ
+};
+
+typedef cl_kernel (CL_API_CALL *clCreateBuiltinKernelWithAttributesEXP_fn) (
+    cl_program prog, const char *kernel_name, const void *kernel_attributes,
+    cl_int *errcode_ret);
+
+extern CL_API_ENTRY cl_kernel CL_API_CALL
+clCreateBuiltinKernelWithAttributesEXP (cl_program prog,
+                                        const char *kernel_name,
+                                        const void *kernel_attributes,
+                                        cl_int *errcode_ret);
+
+// Name: "khr_gemm"
+// General multiply operation for matrices.
+//
+// Note that this also performs matrix-vector operations by setting
+// tensor shapes accordingly.
+typedef struct _cl_dbk_attributes_khr_gemm
+{
+  const cl_tensor_desc *a;
+  const cl_tensor_desc *b;
+  const cl_tensor_desc *c_in;
+  const cl_tensor_desc *c_out;
+  cl_int trans_a;
+  cl_int trans_b;
+  // Pointers to scaler values. Type depends on the tensor operands. E.g.
+  // CL_TENSOR_FLOAT --> cl_float, CL_TENSOR_DOUBLE --> cl_double.
+  const void *alpha;
+  const void *beta;
+  const cl_dbk_properties *kernel_props;
+} cl_dbk_attributes_khr_gemm;
+
+// Name: "khr_matmul" Matrix multiplication. Alias for khr_gemm with
+// alpha and beta set to 1 and 0, respectively
+//
+// Note that this also performs matrix-vector operations by setting
+// tensor shapes accordingly.
+typedef struct _cl_dbk_attributes_khr_matmul
+{
+  const cl_tensor_desc *a;
+  const cl_tensor_desc *b;
+  const cl_tensor_desc *c;
+  cl_int trans_a;
+  cl_int trans_b;
+  const cl_dbk_properties *kernel_props;
+} cl_dbk_attributes_khr_matmul;
+
+#endif // OPENCL_EXP_DEFINED_BUILTIN_KERNELS

--- a/include/CL/cl_exp_tensor.h
+++ b/include/CL/cl_exp_tensor.h
@@ -1,0 +1,133 @@
+
+#ifndef OPENCL_EXP_TENSOR_H
+#define OPENCL_EXP_TENSOR_H
+#include <CL/opencl.h>
+
+typedef cl_ulong cl_tensor_shape;
+typedef cl_uint cl_tensor_dim;
+typedef cl_uint cl_tensor_desc_type;
+typedef cl_uint cl_tensor_datatype;
+typedef cl_uint cl_tensor_layout_type;
+
+// cl_tensor_desc_type
+#define CL_TENSOR_DESC_BASE 1
+
+// cl_tensor_datatype
+#define CL_TENSOR_FLOAT 1
+#define CL_TENSOR_DOUBLE 2
+#define CL_TENSOR_INT 3
+// TODO: To be completed later.
+
+// cl_tensor_layout_type
+#define CL_TENSOR_LAYOUT_OPAQUE 1
+#define CL_TENSOR_LAYOUT_BLAS 2
+
+// Additions to cl_mem_object_type
+
+// A clCreateBufferWithProperties() property used for creating a tensor.
+#define CL_MEM_TENSOR 0x8000
+
+// TBC: A clCreateSubBuffer() cl_buffer_create_type used for creating a
+// subtensor for the purpose of:
+//
+// * coercing an existing buffer (non-tensor) to a tensor (or part of it).
+// * splitting large tensors to smaller ones.
+// * reshaping existing tensor to another.
+// * coercing data type of an existing tensor to other type of same size.
+#define CL_MEM_TENSOR_VIEW 0x8001
+
+typedef struct _cl_tensor_desc
+{
+  cl_tensor_desc_type stype; // Must be CL_TENSOR_DESC_BASE
+  void *next;
+
+  // The rank of the tensor.
+  cl_uint rank;
+
+  // The shape of the tensor described by an array. Describes number
+  // of elements in the tensor dimensions starting with "outermost"
+  // dimension first. E.g. {..., NumOf2DBlocks, NumOf1DBlocks,
+  // NumEltsIn1D}.  (This convention is tentatively chosen for
+  // matching python, numpy and popular ML frameworks).
+  //
+  // Conditions:
+  //
+  // * Must be non-NULL.
+  //
+  // * Lenght of the array must be at least <rank> elements.
+  //
+  // * TBC: A dimension can be zero meaning the size is unspeficied. However,
+  //   commands involing tensors must have fully specified shape.
+  const cl_tensor_shape *shape;
+
+  // The element type of the tensor.
+  cl_tensor_datatype dtype;
+
+  // Optional data layout description. Must be NULL or one of
+  // cl_tensor_layout_* structures in the below.
+  //
+  // If NULL, cl{Enqueue,Command}{ImportFrom,ExportTo}Tensor must be
+  // used for transferring data from or to tensor. If a pointer to the
+  // tensor data is aquired (somehow), dereferencing that pointer is
+  // undefined behavior.
+  const void *layout;
+} cl_tensor_desc;
+
+// All tensor layout descriptions start with the following common
+// initial sequence.
+typedef struct _cl_tensor_layout_base
+{
+  cl_tensor_layout_type stype;
+  // Vulkan style extension mechanism. Must be NULL if not used.
+  void *next;
+} cl_tensor_layout_base;
+
+// Describes data layout similar to one used in BLAS APIs.
+typedef struct _cl_tensor_layout_blas
+{
+  cl_tensor_layout_type stype; // Must be set to CL_TENSOR_LAYOUT_BLAS.
+  void *next;
+
+  // Leading tensor dimensions. This describes which elements along
+  // tensor dimensions are laid out first in the memory. Tensor
+  // coodrinates (tensor_coords = {x0, x1, ..., x2}) map to buffer
+  // (buffer_offset) as followed:
+  //
+  //   size_t index = 0;
+  //   for (unsigned i = 0; i < tensor_rank; i++) {
+  //      index += tensor_coords[leading_dims[i]] * leading_strides[i];
+  //   size_t buffer_offset = index;
+  //
+  // Conditions:
+  //
+  // * Array length must be at least 'tensor_rank - 1' (last dimension
+  //   is implied)
+  //
+  // * Each tensor dimension 0..<tensor_rank - 1> must appear ones in
+  //   the array.
+  const cl_tensor_dim *leading_dims;
+
+  // Strides of the leading dimensions. Array length must be at least
+  // (tensor_rank - 1) and following assertion must hold:
+  //
+  //   for (unsigned i = 0; i < tensor_rank - 1; i++) {
+  //     size_t tensor_slice_size = 1;
+  //     for (unsigned j = 0; j <= i; j++)
+  //       tensor_slice_size *= tensor_shape[j];
+  //     assert(leading_dims[i] >= tensor_slize_size);
+  //   }
+  //
+  // TBC: Allow leading_strides == NULL in which case the tensor data
+  //      is non-strided (e.g. for matrices there is no gaps between
+  //      columns/rows) for convenience?
+  const size_t *leading_strides;
+
+  // TBC: This field specifies an optional alignment guarantee for the
+  // first element (an element at coordinate = (0, 0, ..., 0)). The
+  // value must be 0 or power-of-two. If zero, the alignment inferred from
+  // the dtype. This could also be a layout extension.
+  //size_t base_alignment;
+
+} cl_tensor_layout_blas;
+
+#endif // OPENCL_EXP_TENSOR_H

--- a/include/CL/opencl.h
+++ b/include/CL/opencl.h
@@ -22,9 +22,10 @@ extern "C" {
 #endif
 
 #include <CL/cl.h>
-#include <CL/cl_gl.h>
+#include <CL/cl_exp_defined_builtin_kernels.h>
 #include <CL/cl_ext.h>
 #include <CL/cl_ext_pocl.h>
+#include <CL/cl_gl.h>
 
 #ifdef __cplusplus
 }

--- a/lib/CL/CMakeLists.txt
+++ b/lib/CL/CMakeLists.txt
@@ -196,6 +196,7 @@ set(POCL_LIB_SOURCES  "clCreateContextFromType.c"
                    "clEnqueueSVMMemcpyRectPOCL.c"
                    "clEnqueueSVMMemfillRectPOCL.c"
                    "clSetKernelArgDevicePointer.c"
+                   "clCreateBuiltinKernelWithAttributes.cc"
 )
 
 if(ANDROID)
@@ -280,6 +281,12 @@ endif(MSVC)
 
 # this is so that we don't compile twice when building both libpocl and libOpenCL
 add_library("libpocl_unlinked_objs" OBJECT ${POCL_LIB_SOURCES})
+
+# TEMPORARY HACK:
+set(LIBXSMM_DIR "/mnt/md1/linehill/pocl-space/install-libxsmm")
+target_include_directories(libpocl_unlinked_objs
+  PRIVATE "${LIBXSMM_DIR}/include")
+
 harden("libpocl_unlinked_objs")
 
 #################################################################
@@ -318,6 +325,17 @@ if(ANDROID)
 endif()
 
 list(APPEND POCL_PRIVATE_LINK_LIST ${LIBMATH} ${CMAKE_DL_LIBS} ${PTHREAD_LIBRARY})
+
+# TEMPORARY HACK:
+set(LIBXSMM "${LIBXSMM_DIR}/lib/libxsmm.a")
+
+# Link a BLAS library for xsmm
+#
+# TODO: BLAS is optional for libxsmm but what limitations would be
+#       imposed if the BLAS is dropped?
+find_library(LIBBLAS NAMES blas REQUIRED)
+
+list(APPEND POCL_PRIVATE_LINK_LIST ${LIBXSMM} ${LIBBLAS})
 
 # see lib/CMakeLists.txt
 set(POCL_TRANSITIVE_LIBS ${POCL_PRIVATE_LINK_LIST} PARENT_SCOPE)

--- a/lib/CL/clCreateBuffer.c
+++ b/lib/CL/clCreateBuffer.c
@@ -351,8 +351,239 @@ ERROR:
 
   return mem;
 }
-POsym (clCreateBuffer)
+POsym (clCreateBuffer);
 
+// TBC: We probably want to limit tensor rank - should it be
+//      documented in the spec or queried at runtime?
+#define MAX_TENSOR_RANK (8u)
+
+// Check the tensor layout is well defined. Return non-zero if there
+// is an error.
+static int
+check_tensor_layout (cl_uint rank, const cl_tensor_shape *shape,
+                     const cl_tensor_layout_base *tlayout)
+{
+  // Checked already at check_tensor_desc().
+  assert (rank > 0 && rank <= MAX_TENSOR_RANK);
+
+  // '!tlayout' is same as tlayout->stype == CL_TENSOR_LAYOUT_OPAQUE.
+  if (!tlayout || tlayout->stype == CL_TENSOR_LAYOUT_OPAQUE)
+    {
+      // TODO: check memory flags.
+      //
+      // * CL_MEM_{COPY,HOST}_host_ptr -> Error due to unspecified
+      //   mapping of the host data to tensor coordinates.
+      //
+      // * CL_MEM_ALLOC_HOST_PTR -> Error for the same reason as for
+      //   CL_MEM_{COPY,HOST}_host_ptr. Could be valid but not
+      //   sensible as users may not know how the tensor elements are
+      //   mapped to the allocation. Perhaps, we could support this
+      //   case, if we extend the clGetMemObjectInfo() to return the
+      //   datalayout the driver picked (and wants to expose)?
+      return 0;
+    }
+
+  // Not currently supporting any tensor layout extensions.
+  POCL_RETURN_ERROR_ON (tlayout->next, 1,
+                        "Unsupported tensor layout extension.");
+
+  switch (tlayout->stype)
+    {
+    case CL_TENSOR_LAYOUT_OPAQUE:
+    default:
+      return 0;
+    case CL_TENSOR_LAYOUT_BLAS:
+      {
+        cl_tensor_layout_blas *blas_layout = (cl_tensor_layout_blas *)tlayout;
+
+        POCL_RETURN_ERROR_ON (!blas_layout->leading_dims, 1,
+                              "NULL leading_dims array!");
+        POCL_RETURN_ERROR_ON (!blas_layout->leading_strides, 1,
+                              "NULL leading_strides array!");
+
+        // Check leading_dims array does not point out-of-rank dimensions
+        // nor the same dimension index does not appear twice.
+        //
+        // tensor_rank == 4: leading_dims = {0, 2, 1} --> Ok.
+        // tensor_rank == 4: leading_dims = {0, 4, 1} --> error.
+        // tensor_rank == 4: leading_dims = {1, 1, 0} --> error.
+        unsigned defined_dims = 0;
+        const cl_tensor_dim *ld = blas_layout->leading_dims;
+        for (unsigned i = 0; i < rank - 1; i++)
+          {
+            POCL_RETURN_ERROR_ON (ld[i] >= rank, 1,
+                                  "out-of-bounds tensor dimension!");
+            POCL_RETURN_ERROR_ON ((defined_dims & (1u << ld[i])), 1,
+                                  "Dimension defined twice!");
+            defined_dims |= (1u << ld[i]);
+          }
+
+        const size_t *ls = blas_layout->leading_strides;
+        size_t prev_stride = 0;
+        for (unsigned i = 0; i < rank - 1; i++)
+          {
+            // Check the stride configuration does not cause aliasing.
+            POCL_RETURN_ERROR_ON (ls[i] <= shape[ld[i]] * prev_stride, 1,
+                                  "Invalid stride value.");
+            prev_stride = ls[i];
+          }
+
+        return 0;
+      }
+    }
+  assert (!"Unreachable!");
+}
+
+// Checks validity the the tensor shape. Returns non-zero on error.
+static int
+check_tensor_desc (const cl_tensor_desc *tdesc)
+{
+  // Invalid to pass NULL tensor description in clCreateBufferWithProperties.
+  POCL_RETURN_ERROR_ON ((!tdesc), 1, "tensor desc is NULL.");
+
+  // Currently no tensor extensions.
+  POCL_RETURN_ERROR_ON ((tdesc->stype != CL_TENSOR_DESC_BASE || tdesc->next),
+                        1, "Unsupported tensor extension.");
+
+  // TBC: Should there be upper limit for tensor rank?
+  POCL_RETURN_ERROR_ON ((tdesc->rank > MAX_TENSOR_RANK), 1,
+                        "Unsupported tensor rank.");
+
+  POCL_RETURN_ERROR_ON ((!tdesc->shape), 1,
+                        "Tensor shape array must not be NULL!");
+
+  for (unsigned i = 0; i < tdesc->rank; i++)
+    POCL_RETURN_ERROR_ON ((tdesc->shape[i] == 0), 1,
+                          "Tensor shape must be fully specified!");
+
+  POCL_RETURN_ERROR_ON (
+      (check_tensor_layout (tdesc->rank, tdesc->shape,
+                            (const cl_tensor_layout_base *)tdesc->layout)),
+      1, "invalid tensor layout.");
+
+  return 0;
+}
+
+static void *
+duplicate (const void *src, size_t num_objects, size_t object_size)
+{
+  void *new_objects = calloc (num_objects, object_size);
+  if (!new_objects)
+    return NULL;
+  memcpy (new_objects, src, object_size * num_objects);
+  return new_objects;
+}
+
+#define DUPLICATE(source_ptr, num_objects, object_type)                       \
+  duplicate ((source_ptr), (num_objects), sizeof (object_type));
+
+// Duplicates the tensor description (deep copy). The 'tdesc' must be valid.
+static cl_tensor_desc *
+duplicate_tensor_desc (const cl_tensor_desc *tdesc)
+{
+  if (!tdesc)
+    return NULL;
+
+  assert (!tdesc->next && "UNIMPLEMENTED: deep copy of tensor extensions.");
+
+  cl_tensor_desc *new_tdesc = DUPLICATE (tdesc, 1, cl_tensor_desc);
+  cl_tensor_shape *new_shape
+      = DUPLICATE (tdesc->shape, tdesc->rank, cl_tensor_dim);
+  cl_tensor_layout_blas *new_layout = NULL;
+  cl_tensor_dim *new_ld_dims = NULL;
+  size_t *new_ld_strides = NULL;
+
+  if (!new_tdesc || !new_shape)
+    goto error;
+
+  new_tdesc->shape = new_shape;
+  if (!tdesc->layout)
+    return new_tdesc;
+
+  switch (((const cl_tensor_layout_base *)tdesc->layout)->stype)
+    {
+    default:
+    case CL_TENSOR_LAYOUT_OPAQUE:
+      return NULL;
+
+    case CL_TENSOR_LAYOUT_BLAS:
+      {
+        cl_tensor_layout_blas *blas_layout
+            = (cl_tensor_layout_blas *)tdesc->layout;
+        new_layout = DUPLICATE (blas_layout, 1, cl_tensor_layout_blas);
+        new_ld_dims = DUPLICATE (blas_layout->leading_dims, tdesc->rank - 1,
+                                 cl_tensor_dim);
+        new_ld_strides = DUPLICATE (blas_layout->leading_strides,
+                                    tdesc->rank - 1, size_t);
+
+        if (!new_layout || !new_ld_dims || !new_ld_strides)
+          goto error;
+
+        new_layout->leading_dims = new_ld_dims;
+        new_layout->leading_strides = new_ld_strides;
+        new_tdesc->layout = new_layout;
+        return new_tdesc;
+      }
+    }
+  assert (!"Unreachable!");
+  return NULL;
+
+error:
+  free (new_tdesc);
+  free (new_shape);
+  free (new_layout);
+  free (new_ld_dims);
+  free (new_ld_strides);
+  return NULL;
+}
+
+static cl_int
+parse_properties (const cl_mem_properties *prop_ptr, cl_mem target)
+{
+  // Assuming cl_mem::num_properties and cl_mem::properties are zero prior
+  // parsing.
+  assert (target->num_properties == 0 && "Already parsed cl_mem properties?");
+
+  if (!prop_ptr)
+    {
+      return CL_SUCCESS;
+    }
+
+  if (*prop_ptr == 0)
+    {
+      target->num_properties = 1;
+      target->properties[0] = 0;
+      return CL_SUCCESS;
+    }
+
+  while (*prop_ptr)
+    {
+      switch (*prop_ptr)
+        {
+        default:
+          return CL_INVALID_PROPERTY;
+        case CL_MEM_TENSOR:
+          {
+            const cl_tensor_desc *tdesc = (const cl_tensor_desc *)prop_ptr[1];
+            prop_ptr += 2; // = CL_MEM_TENSOR and its value.
+
+            POCL_RETURN_ERROR_ON ((check_tensor_desc (tdesc)),
+                                  CL_INVALID_PROPERTY,
+                                  "invalid tensor description.");
+
+            target->tensor_desc = duplicate_tensor_desc (tdesc);
+            POCL_RETURN_ERROR_ON (
+                (!target->tensor_desc), CL_OUT_OF_HOST_MEMORY,
+                "Couldn't allocate space for tensor description.");
+
+            target->is_tensor = 1;
+            return CL_SUCCESS;
+          }
+        }
+    }
+  assert (!"Unreachable!");
+  return CL_OUT_OF_HOST_MEMORY;
+}
 
 CL_API_ENTRY cl_mem CL_API_CALL POname (clCreateBufferWithProperties)(
                                cl_context                context,
@@ -364,19 +595,16 @@ CL_API_ENTRY cl_mem CL_API_CALL POname (clCreateBufferWithProperties)(
 CL_API_SUFFIX__VERSION_3_0
 {
   int errcode;
-  /* pocl doesn't support any extra properties ATM */
-  POCL_GOTO_ERROR_ON ((properties && properties[0] != 0), CL_INVALID_PROPERTY,
-                      "PoCL doesn't support any properties on buffers yet\n");
 
   cl_mem mem_ret = POname(clCreateBuffer) (context, flags, size,
                                            host_ptr, errcode_ret);
   if (mem_ret == NULL)
     return NULL;
 
-  if (properties && properties[0] == 0)
+  if ((errcode = parse_properties (properties, mem_ret)) != CL_SUCCESS)
     {
-      mem_ret->num_properties = 1;
-      mem_ret->properties[0] = 0;
+      POname (clReleaseMemObject) (mem_ret);
+      goto ERROR;
     }
 
   return mem_ret;

--- a/lib/CL/clCreateBuiltinKernelWithAttributes.cc
+++ b/lib/CL/clCreateBuiltinKernelWithAttributes.cc
@@ -1,0 +1,480 @@
+// OpenCL runtime library: clCreateBuiltinKernelWithAttributesEXP()
+
+// Copyright (c) 2024 Henry Linjamäki / Intel Finland Oy
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "pocl_cl.h"
+
+#define HAVE_LIBXSMM // TODO: Have CMake define this.
+#ifdef HAVE_LIBXSMM
+#include <libxsmm.h>
+#endif
+
+#include <cstring>
+#include <functional>
+#include <string>
+#include <vector>
+
+// TODO: Move to utils, refactor clCreateKernel().
+extern unsigned long kernel_c;
+extern "C" void pocl_program_insert_kernel_thsafe(cl_program program,
+                                                  cl_kernel kernel) {
+  POCL_LOCK_OBJ(program);
+  LL_PREPEND(program->kernels, kernel);
+  POCL_RETAIN_OBJECT_UNLOCKED(program);
+  POCL_UNLOCK_OBJ(program);
+  POCL_ATOMIC_INC(kernel_c);
+}
+
+class TensorDescView {
+  const cl_tensor_desc *OriginalDesc = nullptr;
+
+public:
+  TensorDescView(const cl_tensor_desc *TDesc) {
+    if (!TDesc || !TDesc->shape)
+      return;
+
+    // TODO: assert the data layout is valid.
+
+    OriginalDesc = TDesc;
+  }
+
+  bool valid() const noexcept { return OriginalDesc; }
+  operator bool() const noexcept { return valid(); }
+
+  size_t rank() const noexcept {
+    assert(valid());
+    return OriginalDesc->rank;
+  }
+
+  size_t operator[](size_t I) const noexcept {
+    assert(valid());
+    assert(I < rank());
+    return OriginalDesc->shape[I];
+  }
+
+  bool shapeEquals(const TensorDescView &Other) {
+    assert(valid());
+    if (!Other.valid() || rank() != Other.rank())
+      return false;
+
+    for (unsigned I = 0, E = rank(); I < E; I++)
+      if (operator[](I) != Other[I])
+        return false;
+
+    return true;
+  }
+
+  cl_tensor_datatype dtype() const noexcept {
+    assert(valid());
+    return OriginalDesc->dtype;
+  }
+
+  size_t numElements() const noexcept {
+    assert(valid());
+    size_t Result = 1;
+    for (unsigned I = 0, E = rank(); I < E; I++)
+      Result *= operator[](I);
+    assert(Result);
+    return Result;
+  }
+
+  std::string toString() const {
+    std::string Result = "(";
+    for (unsigned I = 0, E = rank(); I < E; I++) {
+      if (I != 0)
+        Result += ", ";
+      Result += std::to_string(operator[](I));
+    }
+    // TODO: dtype
+    Result += ")";
+    // TODO: layout
+    return Result;
+  }
+
+  // Get the stride for the 'Dim'th (zero-based) leading dimension,
+  // measured in tensor elements. Applicable for 2D+ tensors with BLAS
+  // datalayout.
+  //
+  // NthDim can be rank() - 1 or more in which case the result is
+  // getBlasStrideInElts(rank - 2) * shape[trailing_dimension].
+  size_t getBlasStrideInElts(unsigned Dim) const {
+    assert(valid());
+    assert(rank() >= 2);
+    assert(OriginalDesc->layout && "Does not have data layout!");
+    const auto *BaseDL =
+        reinterpret_cast<const cl_tensor_layout_base *>(OriginalDesc->layout);
+    assert(
+        BaseDL->stype == CL_TENSOR_LAYOUT_BLAS &&
+        "The method must not be called for tesnors with non-BLAS data layouts");
+
+    const auto &BlasDL =
+        *reinterpret_cast<const cl_tensor_layout_blas *>(BaseDL);
+
+    if (Dim < rank() - 1)
+      return BlasDL.leading_strides[Dim];
+
+    return BlasDL.leading_strides[rank() - 1] * operator[](
+                                                    getTrailingDim(BlasDL));
+  }
+
+  bool isBlasRowMajor() const {
+    assert(valid());
+    assert(OriginalDesc->layout && "Does not have data layout!");
+    const auto *BaseDL =
+        reinterpret_cast<const cl_tensor_layout_base *>(OriginalDesc->layout);
+    assert(
+        BaseDL->stype == CL_TENSOR_LAYOUT_BLAS &&
+        "The method must not be called for tesnors with non-BLAS data layouts");
+    assert(rank() >= 2 && "Not a (batched) matrix!");
+
+    const auto &BlasDL =
+        *reinterpret_cast<const cl_tensor_layout_blas *>(BaseDL);
+    return BlasDL.leading_dims[0] == (rank() - 1u);
+  }
+
+private:
+  unsigned getTrailingDim(const cl_tensor_layout_blas &BlasDL) const {
+    assert(valid());
+    assert(rank() < sizeof(unsigned) * 8u &&
+           "Too many dimensions for the bitset.");
+
+    unsigned DimSet = (1u << rank()) - 1;
+    for (unsigned I = 0; I < rank() - 1; I++)
+      DimSet &= ~(1u << BlasDL.leading_dims[I]);
+
+    assert(__builtin_popcount(DimSet) == 1 && "Invalid data layout?");
+    unsigned TrailingDim = __builtin_ctz(DimSet);
+    assert(TrailingDim < rank());
+    return TrailingDim;
+  }
+};
+
+static pocl_kernel_metadata_t *getKernelMetadata(cl_program Program,
+                                                 const std::string KernelName) {
+  for (size_t I = 0, E = Program->num_kernels; I != E; I++) {
+    if (KernelName == Program->kernel_meta[I].name)
+      return &Program->kernel_meta[I];
+  }
+  assert(!"Missing kernel metadata!");
+}
+
+static void runDBK(_cl_command_node *Cmd, void *Data) {
+  auto *Runner = static_cast<std::function<void(_cl_command_node &)> *>(Data);
+  (*Runner)(*Cmd);
+}
+
+static void releaseDBK(void *Data) {
+  if (Data)
+    delete static_cast<std::function<void(cl_kernel)> *>(Data);
+}
+
+template <typename PtrT>
+static PtrT getBufferDataAs(const _cl_command_node &Cmd, unsigned ArgIdx) {
+  const auto &Arg = Cmd.command.run.arguments[ArgIdx];
+  if (Arg.is_raw_ptr)
+    return static_cast<PtrT>(Arg.value);
+
+  auto Mem = *static_cast<cl_mem *>(Arg.value);
+  auto *Ptr =
+      static_cast<char *>(Mem->device_ptrs[Cmd.device->global_mem_id].mem_ptr);
+  Ptr += Arg.offset;
+  return reinterpret_cast<PtrT>(Ptr);
+}
+
+static cl_int createGemmKernel(cl_program Program, bool TransposeA,
+                               bool TransposeB, TensorDescView A,
+                               TensorDescView B, TensorDescView *CIOpt,
+                               TensorDescView CO, const void *AlphaAttr,
+                               const void *BetaAttr, cl_kernel &Kernel) {
+  assert(!Kernel && "Kernel handle is already populated!");
+
+  auto LogError = [](cl_int ErrorCode, const std::string Msg) -> cl_int {
+    if (!Msg.empty())
+      POCL_MSG_ERR("%s", Msg.c_str());
+    return ErrorCode;
+  };
+
+  if (!A || !B || !CO)
+    return LogError(CL_DBK_INVALID_ATTRIBUTE, "Null attribute.");
+
+  // TBC: 4D+ tensor could be supported by treating the additional
+  //      dimensions as batch dimensions - but it might not be
+  //      worthwhile due the extra work to support them and processing
+  //      overhead they may impose.
+  if (A.rank() > 3)
+    return LogError(CL_DBK_INVALID_ATTRIBUTE,
+                    "Unsupported high-degree tensors.");
+
+  if (A.rank() != B.rank() || B.rank() != CO.rank())
+    // TODO: Should we have something like CL_DBK_INVALID_TENSOR_SHAPE?
+    return LogError(CL_DBK_INVALID_ATTRIBUTE, "Rank mismatch.");
+
+  if (CIOpt && !CIOpt->shapeEquals(CO))
+    return LogError(CL_DBK_INVALID_ATTRIBUTE,
+                    "Tensor shape mismatch between c_in and c_out.");
+
+  // FIXME: check tensor shapes are correct respect to the transpose
+  //        configurations.
+
+  size_t BatchDims = A.rank() - 2;
+
+  // CO[b][m][n] = sigma_over_m_n_k(A[b][m][k] * B[b][k][n]) + CI[b][m][n].
+  auto Am = A[BatchDims + 0];
+  auto Ak = A[BatchDims + 1];
+  auto Bk = B[BatchDims + 0];
+  auto Bn = B[BatchDims + 1];
+  auto COm = CO[BatchDims + 0];
+  auto COn = CO[BatchDims + 1];
+
+  if (Ak != Bk || Am != COm || Bn != COn)
+    // TODO: Should have more descriptive error code? Or would it be better
+    //       to have error logging like the cl_program has for building?
+    return LogError(CL_DBK_INVALID_ATTRIBUTE, "Matrix shape mismatch.");
+
+  // Check batch dimensions match.
+  size_t BatchSize = A.rank() == 3 ? A[0] : 1;
+  if (BatchSize > 1 && (BatchSize != B[0] || B[0] != CO[0]))
+    return LogError(CL_DBK_INVALID_ATTRIBUTE, "Batch size mismatch.");
+
+  if (BatchSize > 1 && CIOpt && (*CIOpt)[0] != CO[0])
+    return LogError(CL_DBK_INVALID_ATTRIBUTE, "Batch size mismatch.");
+
+  if (A.dtype() != B.dtype())
+    return LogError(CL_DBK_INVALID_ATTRIBUTE,
+                    "dtype mismatch between A and B.");
+
+  if (CIOpt && CIOpt->dtype() != CO.dtype())
+    return LogError(CL_DBK_INVALID_ATTRIBUTE,
+                    "dtype mismatch between input and output C.");
+
+  // TODO: We probably need to have support for mixed input/output
+  // precisions to be able to fit results of large, low precision input
+  // matrices. precision inputs. E.g.
+  //
+  //  * i8 x i8   --> i32
+  //  * f16 x f16 --> f32
+  if (A.dtype() != CO.dtype())
+    return LogError(CL_DBK_INVALID_ATTRIBUTE, "Unsupported I/O dtype");
+
+  // TODO: extend support for other data types.
+  if (A.dtype() != CL_TENSOR_FLOAT)
+    return LogError(CL_DBK_UNAVAILABLE, "Unimplemented dtype support.");
+
+  // TODO: check validity of data layouts of the tensors. Now assume
+  // they are correct and they are using BLAS-like layout.
+
+  float Alpha = 1.0f, Beta = 0.0f;
+  if (AlphaAttr)
+    std::memcpy(&Alpha, AlphaAttr, sizeof(float));
+  if (BetaAttr)
+    std::memcpy(&Beta, BetaAttr, sizeof(float));
+
+  // libxsmm does not support arbitrary alpha and beta (for now).
+  // [https://github.com/libxsmm/libxsmm/wiki/Development#longer-term-issues].
+  if (Alpha != 1.0f || !(Beta == 0.0f || Beta == 1.0f))
+    LogError(CL_DBK_UNAVAILABLE,
+             "UNIMPLEMENTED: arbitrary alpha and beta attributes");
+
+  // Attributes seems to be correct - proceed to create a matmul/gemm
+  // implementation.
+
+  Kernel = (_cl_kernel *)std::calloc(1, sizeof(_cl_kernel));
+  if (!Kernel)
+    return LogError(CL_OUT_OF_HOST_MEMORY,
+                    "Couldn't allocate storage for cl_kernel!");
+  POCL_INIT_OBJECT(Kernel);
+  Kernel->meta = getKernelMetadata(Program, CIOpt ? "khr_gemm" : "khr_matmul");
+  Kernel->data = (void **)calloc(Program->num_devices, sizeof(void *));
+  // TODO: Emit unique name for each unique DBK instance as debugging aid.
+  // TODO: Does .name claim ownership?
+  Kernel->name = "a_pocl_gemm_impl";
+  Kernel->context = Program->context;
+  Kernel->program = Program;
+
+  assert(Kernel->meta->num_args == (3 + !!CIOpt));
+  auto ArgSpace = static_cast<pocl_argument *>(
+      calloc(Kernel->meta->num_args, sizeof(pocl_argument)));
+  Kernel->dyn_arguments = ArgSpace;
+
+  size_t Lda = A.getBlasStrideInElts(0);
+  size_t Ldb = B.getBlasStrideInElts(0);
+  size_t Ldc = CO.getBlasStrideInElts(0);
+  size_t ABatchStrideInElts = A.getBlasStrideInElts(1);
+  size_t BBatchStrideInElts = B.getBlasStrideInElts(1);
+  size_t CBatchStrideInElts = CO.getBlasStrideInElts(1);
+
+#ifdef HAVE_LIBXSMM
+  // libxsmm expects data in column-major format but we can feed it
+  // row-major data by transposing the inputs and and the output.
+  bool LibTransposeA = TransposeA ^ A.isBlasRowMajor();
+  bool LibTransposeB = TransposeB ^ B.isBlasRowMajor();
+  int Flags = (LibTransposeA ? LIBXSMM_GEMM_FLAG_TRANS_A : 0) |
+              (LibTransposeB ? LIBXSMM_GEMM_FLAG_TRANS_B : 0);
+
+  std::function<void(float *Dst, const _cl_command_node &Cmd, size_t BatchNum)>
+      LoadCBatch;
+  std::function<void(float *Dst, const _cl_command_node &Cmd, size_t BatchNum)>
+      StoreCBatch;
+
+  if (CIOpt && Beta != 0.0f) {
+    if (CIOpt->isBlasRowMajor()) {
+      // Need to convert C input to column-major.
+      LoadCBatch = [=](float *Batch, const _cl_command_node &Cmd,
+                       size_t BatchNum) -> void {
+        auto *CIData = getBufferDataAs<float *>(Cmd, 2);
+        auto *Src = &CIData[BatchNum * CBatchStrideInElts];
+        libxsmm_otrans(Batch, Src, sizeof(float), COm, COn, Ldc, COm);
+      };
+    } else {
+      LoadCBatch = [=](float *Batch, const _cl_command_node &Cmd,
+                       size_t BatchNum) -> void {
+        auto *CIData = getBufferDataAs<float *>(Cmd, 2);
+        auto *Src = &CIData[BatchNum * CBatchStrideInElts];
+        libxsmm_matcopy(Batch, Src, sizeof(float), COm, COn, Ldc, COm);
+      };
+    }
+  } else {
+    LoadCBatch = [=](float *Batch, const _cl_command_node &Cmd,
+                     size_t BatchNum) -> void {
+      // Zero-initialize.
+      libxsmm_matcopy(Batch, nullptr, sizeof(float), COm, COn, Ldc, COm);
+    };
+  }
+
+  unsigned COKernelArgIdx = 2 + !!CIOpt;
+  if (CO.isBlasRowMajor()) {
+    // Results are always in column-major.
+    StoreCBatch = [=](float *Batch, const _cl_command_node &Cmd,
+                      size_t BatchNum) -> void {
+      auto *COData = getBufferDataAs<float *>(Cmd, COKernelArgIdx);
+      auto *Dst = &COData[BatchNum * CBatchStrideInElts];
+      libxsmm_otrans(Dst, Batch, sizeof(float), COm, COn, COm, Ldc);
+    };
+  } else {
+    StoreCBatch = [=](float *Batch, const _cl_command_node &Cmd,
+                      size_t BatchNum) -> void {
+      auto *COData = getBufferDataAs<float *>(Cmd, COKernelArgIdx);
+      auto *Dst = &COData[BatchNum * CBatchStrideInElts];
+      libxsmm_matcopy(Dst, Batch, sizeof(float), COm, COn, COm, Ldc);
+    };
+  }
+
+  if (auto MatmulInstance = libxsmm_mmfunction<float>(Flags, COm, COn, Ak, Lda,
+                                                      Ldb, COm, Alpha, Beta)) {
+    auto *RunnerData = new std::function<void(_cl_command_node &)>(
+        [=](_cl_command_node &Cmd) -> void {
+          auto *AData = getBufferDataAs<float *>(Cmd, 0);
+          auto *BData = getBufferDataAs<float *>(Cmd, 1);
+
+          // TODO: Optimization: There is codegen for batched matmul
+          //       in libxsmm we could use.
+          std::vector<float> CTemp(COm * COn, 0.0f);
+          for (size_t Batch = 0; Batch < BatchSize; Batch++) {
+            LoadCBatch(CTemp.data(), Cmd, Batch);
+            MatmulInstance(&AData[Batch * ABatchStrideInElts],
+                           &BData[Batch * BBatchStrideInElts], CTemp.data());
+            StoreCBatch(CTemp.data(), Cmd, Batch);
+          }
+        });
+
+    Kernel->custom_runner = runDBK;
+    Kernel->custom_runner_data = static_cast<void *>(RunnerData);
+    Kernel->release_custom_runner_data = releaseDBK;
+    pocl_program_insert_kernel_thsafe(Program, Kernel);
+
+    return CL_SUCCESS;
+  }
+#endif // HAVE_LIBXSMM
+
+  free(Kernel);
+  free(ArgSpace);
+  return LogError(CL_DBK_UNAVAILABLE, "Unsupported matmul/gemm configuration.");
+}
+
+static cl_int implementation(cl_kernel &Kernel, cl_program Program,
+                             const char *KernelName,
+                             const void *KernelAttributes) noexcept try {
+
+  if (!KernelName)
+    return CL_INVALID_VALUE;
+
+  if (!IS_CL_OBJECT_VALID(Program))
+    return CL_INVALID_PROGRAM;
+
+  assert(Program->num_devices != 0);
+  assert(Program->num_builtin_kernels > 0);
+  assert(Program->concated_builtin_names);
+
+  std::string BiKNames(Program->concated_builtin_names);
+  if (BiKNames.find(KernelName) == std::string::npos)
+    return CL_INVALID_KERNEL_NAME;
+
+  if (std::string(KernelName) == "khr_gemm") {
+    auto &Attrs =
+        *static_cast<const _cl_dbk_attributes_khr_gemm *>(KernelAttributes);
+
+    if (!Attrs.alpha || !Attrs.beta)
+      return CL_DBK_INVALID_ATTRIBUTE;
+
+    // TODO: check alpha and beta values are sensible (e.g. not NaNs
+    //       or infinities).
+
+    TensorDescView A(Attrs.a);
+    TensorDescView B(Attrs.b);
+    TensorDescView CI(Attrs.c_in);
+    TensorDescView CO(Attrs.c_out);
+    return createGemmKernel(Program, Attrs.trans_a, Attrs.trans_b, A, B, &CI,
+                            CO, Attrs.alpha, Attrs.beta, Kernel);
+  }
+
+  if (std::string(KernelName) == "khr_matmul") {
+    auto &Attrs =
+        *static_cast<const _cl_dbk_attributes_khr_matmul *>(KernelAttributes);
+    TensorDescView A(Attrs.a);
+    TensorDescView B(Attrs.b);
+    TensorDescView CO(Attrs.c);
+    return createGemmKernel(Program, Attrs.trans_a, Attrs.trans_b, A, B,
+                            nullptr, CO, nullptr, nullptr, Kernel);
+  }
+
+  return CL_DBK_UNAVAILABLE;
+} catch (std::bad_alloc &) {
+  POCL_MSG_ERR("Caught std::bad_alloc");
+  return CL_OUT_OF_HOST_MEMORY;
+} catch (...) {
+  assert(!"Caught unhandled exception!");
+  return CL_OUT_OF_HOST_MEMORY;
+}
+
+extern "C" CL_API_ENTRY cl_kernel CL_API_CALL
+POname(clCreateBuiltinKernelWithAttributesEXP)(
+    cl_program Program, const char *KernelName, const void *KernelAttributes,
+    cl_int *ErrCodeRet) CL_API_SUFFIX__VERSION_3_0 {
+
+  cl_kernel Kernel = nullptr;
+  cl_int ErrCode =
+      implementation(Kernel, Program, KernelName, KernelAttributes);
+  if (ErrCodeRet)
+    *ErrCodeRet = ErrCode;
+  return Kernel;
+}
+
+POsym(clCreateBuiltinKernelWithAttributesEXP)

--- a/lib/CL/clGetExtensionFunctionAddressForPlatform.c
+++ b/lib/CL/clGetExtensionFunctionAddressForPlatform.c
@@ -209,6 +209,9 @@ CL_API_SUFFIX__VERSION_1_2
   if (strcmp (func_name, "clCreateBufferWithPropertiesINTEL") == 0)
     return (void *)&POname (clCreateBufferWithProperties);
 
+  if (strcmp (func_name, "clCreateBuiltinKernelWithAttributesEXP") == 0)
+    return (void *)&POname (clCreateBuiltinKernelWithAttributesEXP);
+
   POCL_MSG_ERR ("unknown platform extension requested: %s\n", func_name);
   return NULL;
 }

--- a/lib/CL/devices/builtin_kernels.cc
+++ b/lib/CL/devices/builtin_kernels.cc
@@ -14,10 +14,11 @@
 #define WRITE_BUF                                                              \
   POCL_ARG_TYPE_POINTER, CL_KERNEL_ARG_ADDRESS_GLOBAL,                         \
       CL_KERNEL_ARG_ACCESS_NONE, CL_KERNEL_ARG_TYPE_RESTRICT
-#define POD_ARG                                                                \
+#define POD_ARG_ATTRS                                                          \
   POCL_ARG_TYPE_NONE, CL_KERNEL_ARG_ADDRESS_PRIVATE,                           \
       CL_KERNEL_ARG_ACCESS_NONE, CL_KERNEL_ARG_TYPE_NONE
-#define POD_ARG_32b POD_ARG, 4
+#define POD_ARG(num_bits) POD_ARG_ATTRS, ((num_bits + 7u) / 8u)
+#define POD_ARG_32b POD_ARG(32)
 #define READ_PIPE                                                              \
   POCL_ARG_TYPE_PIPE, CL_KERNEL_ARG_ADDRESS_GLOBAL, CL_KERNEL_ARG_ACCESS_NONE, \
       CL_KERNEL_ARG_TYPE_NONE, 4
@@ -313,14 +314,34 @@ BIKD pocl_BIDescriptors[BIKERNELS] = {
              BIArg("uchar64", "in",  READ_PIPE),
              BIArg("uchar64", "out", WRITE_PIPE),
          }),
+    BIKD(POCL_CDBI_DBK_KHR_GEMM,
+         "khr_gemm",
+         {
+           // The types are placeholders
+           BIArg("unsigned char*", "a", READ_BUF),
+           BIArg("unsigned char*", "b", READ_BUF),
+           BIArg("unsigned char*", "c_in", READ_BUF),
+           BIArg("unsigned char*", "c_out", WRITE_BUF),
+         },
+         0,
+         /* isa_dbk= */ true),
+    BIKD(POCL_CDBI_DBK_KHR_MATMUL,
+         "khr_matmul",
+         {
+           BIArg("unsigned char*", "a", READ_BUF),
+           BIArg("unsigned char*", "b", READ_BUF),
+           BIArg("unsigned char*", "c", WRITE_BUF),
+         },
+         0,
+         /* isa_dbk= */ true),
 };
 
 BIKD::BIKD(BuiltinKernelId KernelIdentifier, const char *KernelName,
            const std::vector<pocl_argument_info> &ArgInfos,
-           unsigned local_mem_size)
+           unsigned local_mem_size, bool isa_dbk)
     : KernelId(KernelIdentifier) {
 
-  builtin_kernel = 1;
+  builtin_kernel = isa_dbk ? POCL_DBK : POCL_BIK;
   builtin_max_global_work = {0, 0, 0};
   name = strdup(KernelName);
   num_args = ArgInfos.size();

--- a/lib/CL/devices/builtin_kernels.hh
+++ b/lib/CL/devices/builtin_kernels.hh
@@ -80,6 +80,8 @@ enum BuiltinKernelId : uint16_t {
   POCL_CDBI_MAGNITUDE_P512 = 35,
   POCL_CDBI_ORIENTED_NONMAX_P512 = 36,
   POCL_CDBI_GAUSSIAN3X3_P512 = 37,
+  POCL_CDBI_DBK_KHR_GEMM = 38,
+  POCL_CDBI_DBK_KHR_MATMUL = 39,
   POCL_CDBI_LAST,
   POCL_CDBI_JIT_COMPILER = 0xFFFF
 };
@@ -113,9 +115,9 @@ struct BIArg : public pocl_argument_info
 // BIKD = Built-in Kernel Descriptor
 struct BIKD : public pocl_kernel_metadata_t
 {
-  BIKD (BuiltinKernelId KernelId, const char *KernelName,
-        const std::vector<pocl_argument_info> &ArgInfos,
-        unsigned local_mem_size = 0);
+  BIKD(BuiltinKernelId KernelId, const char *KernelName,
+       const std::vector<pocl_argument_info> &ArgInfos,
+       unsigned local_mem_size = 0, bool isa_dbk = false);
 
   ~BIKD() {
     for (size_t i = 0; i < num_args; ++i) {
@@ -128,7 +130,6 @@ struct BIKD : public pocl_kernel_metadata_t
 
   BuiltinKernelId KernelId;
 };
-
 
 #define BIKERNELS POCL_CDBI_LAST
 POCL_EXPORT extern BIKD pocl_BIDescriptors[BIKERNELS];

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1765,8 +1765,10 @@ pocl_init_default_device_infos (cl_device_id dev,
           = strdup ("pocl.add.i8;"
                     "org.khronos.openvx.scale_image.nn.u8;"
                     "org.khronos.openvx.scale_image.bl.u8;"
-                    "org.khronos.openvx.tensor_convert_depth.wrap.u8.f32");
-      dev->num_builtin_kernels = 4;
+                    "org.khronos.openvx.tensor_convert_depth.wrap.u8.f32;"
+                    "khr_gemm;"
+                    "khr_matmul;");
+      dev->num_builtin_kernels = 6;
     }
 }
 
@@ -1893,7 +1895,9 @@ static const cl_name_version OPENCL_EXTENSIONS[]
       { CL_MAKE_VERSION (0, 9, 0), "cl_pocl_svm_rect" },
       { CL_MAKE_VERSION (0, 9, 0), "cl_pocl_command_buffer_svm" },
       { CL_MAKE_VERSION (0, 9, 0), "cl_pocl_command_buffer_host_buffer" },
-      { CL_MAKE_VERSION (0, 9, 0), "cl_pocl_command_buffer_host_exec" } };
+      { CL_MAKE_VERSION (0, 9, 0), "cl_pocl_command_buffer_host_exec" },
+      { CL_MAKE_VERSION (0, 1, 0), "cl_exp_tensor" },
+      { CL_MAKE_VERSION (0, 1, 0), "cl_exp_defined_builtin_kernels" } };
 
 const size_t OPENCL_EXTENSIONS_NUM
     = sizeof (OPENCL_EXTENSIONS) / sizeof (OPENCL_EXTENSIONS[0]);

--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -1909,7 +1909,7 @@ pocl_network_setup_devinfo (cl_device_id device, remote_device_data_t *ddata,
   device->supported_spir_v_versions
       = GET_STRING (devinfo->supported_spir_v_versions);
 
-  if (devinfo->builtin_kernels != 0)
+  if (devinfo->builtin_kernels != POCL_NON_BIK)
     device->builtin_kernel_list = GET_STRING (devinfo->builtin_kernels);
 
   // This one is deprecated (and seems to be always 128)

--- a/lib/CL/devices/vulkan/pocl-vulkan.c
+++ b/lib/CL/devices/vulkan/pocl-vulkan.c
@@ -2331,7 +2331,7 @@ parse_new_kernel (pocl_kernel_metadata_t *p, char *line)
   p->total_argument_storage_size = 0;
   p->data = NULL;
   p->build_hash = NULL;
-  p->builtin_kernel = 0;
+  p->builtin_kernel = POCL_NON_BIK;
 
   if (p->arg_info == NULL || p->name == NULL) return -1;
   return 0;

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -1532,9 +1532,20 @@ struct _cl_mem {
   cl_bool                 is_pipe;
   size_t                  pipe_packet_size;
   size_t                  pipe_max_packets;
+
+  /* Tensor Properties */
+  cl_bool is_tensor;
+  cl_tensor_desc *tensor_desc; /* Lifetime: this struct. */
 };
 
 typedef uint8_t SHA1_digest_t[SHA1_DIGEST_SIZE * 2 + 1];
+
+typedef enum
+{
+  POCL_NON_BIK = 0,
+  POCL_BIK, /* Built-in kernel. */
+  POCL_DBK  /* Defined builtin kernel. */
+} BIKType;
 
 typedef struct pocl_kernel_metadata_s
 {
@@ -1574,8 +1585,9 @@ typedef struct pocl_kernel_metadata_s
   /* per-device array of hashes */
   pocl_kernel_hash_t *build_hash;
 
-  /* If this is a BI kernel descriptor, they are statically defined in
-     the custom device driver, thus should not be freed. */
+  /* If this is a built-in kernel descriptor (= non-zero), they are
+     statically defined in the custom device driver, thus should not
+     be freed. */
   cl_bitfield builtin_kernel;
   /* maximum global work size usable with the kernel.
    * Only applies to builtin kernels */
@@ -1673,6 +1685,10 @@ struct _pocl_ptr_list_node
   struct _pocl_ptr_list_node *prev, *next;
 };
 
+typedef void (*pocl_custom_kernel_runner_fn) (_cl_command_node *cmd,
+                                              void *data);
+typedef void (*pocl_release_kernel_runner_data_fn) (void *data);
+
 struct _cl_kernel {
   POCL_ICD_OBJECT
   POCL_OBJECT;
@@ -1717,6 +1733,16 @@ struct _cl_kernel {
      We should ensure at enqueue time that all of the known raw buffers
      will be synchronized to the device. */
   char can_access_all_raw_buffers_indirectly;
+
+  /* Custom kernel runner (a host function). Used for kernels not
+     built from sources. For instance, DBKs whose execution might be
+     delegated to external libraries, like LIBXSMM. */
+  pocl_custom_kernel_runner_fn custom_runner;
+
+  /* Data passed to custom_host_runner. Pointed data is owned by this
+   * struct and released via release_kernel_runner_data(). */
+  void *custom_runner_data;
+  pocl_release_kernel_runner_data_fn release_custom_runner_data;
 
   /* for program's linked list of kernels */
   struct _cl_kernel *next;

--- a/lib/CL/pocl_intfn.h
+++ b/lib/CL/pocl_intfn.h
@@ -217,6 +217,9 @@ POdeclsym(clEnqueueSVMMemcpyRectPOCL)
 /* cl_ext_buffer_device_address */
 POdeclsym (clSetKernelArgDevicePointerEXT);
 
+/* cl_exp_defined_builtin_kernels */
+POdeclsym (clCreateBuiltinKernelWithAttributesEXP)
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/CL/pocl_ndrange_kernel.c
+++ b/lib/CL/pocl_ndrange_kernel.c
@@ -50,6 +50,11 @@ pocl_kernel_calc_wg_size (cl_command_queue command_queue, cl_kernel kernel,
    * since we are going to access them repeatedly */
   size_t max_group_size;
 
+  // Skip workgroup size calculation for DBKs. The sizes are baked in
+  // the kernels at clCreateBuiltinKernelWithAttributesEXP() time.
+  if (kernel->meta->builtin_kernel == POCL_DBK)
+    goto SKIP_WG_SIZE_CALCULATION;
+
   POCL_RETURN_ERROR_COND ((work_dim < 1), CL_INVALID_WORK_DIMENSION);
   POCL_RETURN_ERROR_ON (
       (work_dim > command_queue->device->max_work_item_dimensions),

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -52,9 +52,9 @@ if(OPENCL_HEADER_VERSION GREATER 299)
 endif()
 
 set(CXX_PROGRAMS_TO_BUILD test_device_address test_svm test_large_buf
-  test_subbuffers test_compile_n_link)
+  test_subbuffers test_compile_n_link test_dbk_matmul)
 
-add_compile_options(${OPENCL_CFLAGS})
+add_compile_options(${OPENCL_CFLAGS} -I${CMAKE_SOURCE_DIR}/include)
 
 foreach(PROG ${C_PROGRAMS_TO_BUILD})
   if(MSVC)

--- a/tests/runtime/test_dbk_matmul.cpp
+++ b/tests/runtime/test_dbk_matmul.cpp
@@ -1,0 +1,372 @@
+// Copyright (c) 2024 Henry Linjamäki / Intel Finland Oy
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "CL/opencl.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <iostream>
+#include <random>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#define ROW_MAJOR 0
+#define COL_MAJOR 1
+#define TRANSPOSE_NONE 0
+#define TRANSPOSE_A 1
+#define TRANSPOSE_B 2
+
+#define EXPECT(expr)                                                           \
+  do {                                                                         \
+    if (!(expr)) {                                                             \
+      std::cerr << __FILE__ << ":" << __LINE__ << ": error: expected '"        \
+                << #expr << "'\n";                                             \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (false)
+
+static std::tuple<cl::Platform, cl::Device> findDeviceWithMatmulDBK() noexcept {
+  std::vector<cl::Platform> Platforms;
+  std::vector<cl::Device> Devices;
+  cl::Platform::get(&Platforms);
+  cl::Device Device;
+
+  for (auto P : Platforms) {
+    P.getDevices(CL_DEVICE_TYPE_ALL, &Devices);
+    for (cl::Device &D : Devices) {
+      std::string Exts = D.getInfo<CL_DEVICE_EXTENSIONS>();
+      if (Exts.find("cl_exp_defined_builtin_kernels") == std::string::npos)
+        continue;
+
+      std::string BiKs = D.getInfo<CL_DEVICE_BUILT_IN_KERNELS>();
+      if (BiKs.find("khr_matmul") != std::string::npos) {
+        std::cerr << "Selected device: " << D.getInfo<CL_DEVICE_NAME>() << "\n";
+        return std::make_tuple(P, D);
+      }
+    }
+  }
+
+  std::cerr << "No suitable device found\n";
+  std::exit(77);
+}
+
+class TensorLayoutBLAS {
+  std::vector<cl_tensor_dim> LeadingDims;
+  std::vector<size_t> LeadingStrides;
+  cl_tensor_layout_blas Layout;
+
+public:
+  TensorLayoutBLAS(std::initializer_list<cl_tensor_dim> TheLeadingDims,
+                   std::initializer_list<size_t> TheLeadingStrides)
+      : LeadingDims(TheLeadingDims), LeadingStrides(TheLeadingStrides) {
+    Layout.stype = CL_TENSOR_LAYOUT_BLAS;
+    Layout.next = nullptr;
+    Layout.leading_dims = LeadingDims.data();
+    Layout.leading_strides = LeadingStrides.data();
+    Layout.base_alignment = 0;
+  }
+
+  const cl_tensor_layout_blas *get() const noexcept { return &Layout; }
+  // In elements.
+  size_t getSize() const noexcept { return LeadingStrides.back(); }
+  unsigned getNumLeadingDims() const noexcept { return LeadingDims.size(); }
+  const std::vector<cl_tensor_dim> &getLeadingDims() const noexcept {
+    return LeadingDims;
+  }
+};
+
+class TensorDesc {
+  std::vector<cl_tensor_shape> Shape;
+  TensorLayoutBLAS Layout;
+  cl_tensor_desc Desc;
+
+public:
+  TensorDesc(std::initializer_list<cl_tensor_shape> TheShape,
+             cl_tensor_datatype DType, const TensorLayoutBLAS &TheLayout)
+      : Shape(TheShape), Layout(TheLayout) {
+
+    assert(Layout.getNumLeadingDims() == 0 ||
+           Layout.getNumLeadingDims() == Shape.size() - 1);
+
+    Desc.stype = CL_TENSOR_DESC_BASE;
+    Desc.next = nullptr;
+    Desc.rank = Shape.size();
+    Desc.shape = Shape.data();
+    Desc.dtype = DType;
+    Desc.layout = nullptr;
+
+    if (Layout.getNumLeadingDims())
+      Desc.layout = Layout.get();
+  }
+
+  const cl_tensor_desc *get() const noexcept { return &Desc; }
+
+  unsigned rank() const noexcept { return Shape.size(); }
+
+  // In bytes.
+  unsigned elementSize() const noexcept {
+    assert(Desc.dtype == CL_TENSOR_FLOAT && "TODO: Other types.");
+    return 4;
+  }
+
+  size_t getStorageSize() const noexcept {
+    if (!Layout.getNumLeadingDims())
+      return 0;
+
+    // Awkward way to find trailing dimension.
+    auto Dims = Layout.getLeadingDims();
+    std::sort(Dims.begin(), Dims.end());
+    unsigned TrailingDim = 0;
+    while (TrailingDim < Dims.size() && TrailingDim == Dims[TrailingDim])
+      TrailingDim++;
+
+    assert(TrailingDim < rank());
+    auto Result = Layout.getSize() * Shape[TrailingDim] * elementSize();
+    return Result;
+  }
+};
+
+template <typename T>
+static cl::Buffer createTensor(cl::Context &Ctx, const TensorDesc &TDesc,
+                               T *HostPtr = nullptr, cl_int *Status = nullptr) {
+  cl_mem_properties Props[] = {
+      CL_MEM_TENSOR, reinterpret_cast<cl_mem_properties>(TDesc.get()), 0};
+
+  size_t BufSize = TDesc.getStorageSize();
+  return cl::Buffer(clCreateBufferWithProperties(
+      Ctx.get(), Props, (HostPtr ? CL_MEM_USE_HOST_PTR : 0),
+      BufSize, // TBC: zero = inherit from the tensor description.
+      const_cast<typename std::remove_cv<T>::type *>(HostPtr), Status));
+}
+
+cl::Platform Platform;
+cl::Device Dev;
+cl::Context Ctx;
+cl::Program MatmulProg;
+cl::CommandQueue CmdQ;
+clCreateBuiltinKernelWithAttributesEXP_fn createBuiltinKernelWithAttributes;
+
+void doFloatMatmul(bool ColumnMajor, unsigned Transpose, unsigned M, unsigned N,
+                   unsigned K, std::initializer_list<float> AData, unsigned Lda,
+                   std::initializer_list<float> BData, unsigned Ldb,
+                   std::vector<float> &Result, unsigned Ldc) {
+
+  float MarkerVal = 9999.0f;
+  Result = std::vector<float>((ColumnMajor ? N : M) * Ldc, MarkerVal);
+
+  TensorLayoutBLAS ATLayout = TensorLayoutBLAS({ColumnMajor ? 0u : 1u}, {Lda});
+  TensorLayoutBLAS BTLayout = TensorLayoutBLAS({ColumnMajor ? 0u : 1u}, {Ldb});
+  TensorLayoutBLAS CTLayout = TensorLayoutBLAS({ColumnMajor ? 0u : 1u}, {Ldc});
+
+  TensorDesc ATDesc({M, K}, CL_TENSOR_FLOAT, ATLayout);
+  TensorDesc BTDesc({K, N}, CL_TENSOR_FLOAT, BTLayout);
+  TensorDesc CTDesc({M, N}, CL_TENSOR_FLOAT, CTLayout);
+
+  cl_dbk_attributes_khr_matmul MatmulAttrs;
+  MatmulAttrs.a = ATDesc.get();
+  MatmulAttrs.b = BTDesc.get();
+  MatmulAttrs.c = CTDesc.get();
+  MatmulAttrs.trans_a = !!(Transpose & TRANSPOSE_A);
+  MatmulAttrs.trans_b = !!(Transpose & TRANSPOSE_B);
+  MatmulAttrs.kernel_props = nullptr;
+
+  cl_int Status;
+  auto MatmulKernel = cl::Kernel(createBuiltinKernelWithAttributes(
+      MatmulProg.get(), "khr_matmul", &MatmulAttrs, &Status));
+  EXPECT(Status == CL_SUCCESS);
+
+  auto ATensor = createTensor(Ctx, ATDesc, AData.begin(), &Status);
+  EXPECT(Status == CL_SUCCESS);
+  auto BTensor = createTensor(Ctx, BTDesc, BData.begin(), &Status);
+  EXPECT(Status == CL_SUCCESS);
+  auto CTensor = createTensor(Ctx, CTDesc, Result.data(), &Status);
+
+  MatmulKernel.setArg(0, ATensor);
+  MatmulKernel.setArg(1, BTensor);
+  MatmulKernel.setArg(2, CTensor);
+
+  // Notice the grid is NullRange. Idea is that the grid is implied by the
+  // DBK.
+  Status = CmdQ.enqueueNDRangeKernel(MatmulKernel, cl::NullRange, cl::NullRange,
+                                     cl::NullRange);
+  EXPECT(Status == CL_SUCCESS);
+  CmdQ.enqueueMapBuffer(CTensor, false, CL_MAP_READ, 0, M * N, nullptr, nullptr,
+                        &Status);
+  EXPECT(Status == CL_SUCCESS);
+  Status = CmdQ.flush();
+  EXPECT(Status == CL_SUCCESS);
+}
+
+template <typename T>
+void dump2DSlice(unsigned Rows, unsigned Cols, const std::vector<T> &A,
+                 unsigned Lda) {
+  for (unsigned I = 0; I < Rows; I++) {
+    for (unsigned J = 0; J < Cols; J++) {
+      auto AVal = A[I * Lda + J];
+      std::cerr << (J == 0 ? "" : " ") << AVal;
+    }
+    std::cerr << "\n";
+  }
+}
+
+void check2DSlice(unsigned M, unsigned N, const std::vector<float> &A,
+                  unsigned Lda, const std::vector<float> &B, unsigned Ldb,
+                  float Delta = 0.0f) {
+  unsigned ErrorCount = 0;
+  for (unsigned I = 0; I < M; I++)
+    for (unsigned J = 0; J < N; J++) {
+      auto AVal = A[I * Lda + J];
+      auto BVal = B[I * Ldb + J];
+      if (AVal != BVal) {
+        std::cerr << "error: mismatch at [" << I << ", " << J
+                  << "]: LHS=" << AVal << ", RHS=" << BVal << "\n";
+        if (++ErrorCount > 10)
+          goto LoopNestExit;
+      }
+    }
+LoopNestExit:
+  if (ErrorCount)
+    std::exit(1);
+}
+
+int main() {
+  std::tie(Platform, Dev) = findDeviceWithMatmulDBK();
+  Ctx = cl::Context(Dev);
+
+  cl_int Status;
+  MatmulProg = cl::Program(Ctx, {Dev}, "khr_matmul", &Status);
+  EXPECT(Status == CL_SUCCESS);
+
+  Status = MatmulProg.build();
+  EXPECT(Status == CL_SUCCESS);
+
+  createBuiltinKernelWithAttributes =
+      (clCreateBuiltinKernelWithAttributesEXP_fn)
+          clGetExtensionFunctionAddressForPlatform(
+              Platform(), "clCreateBuiltinKernelWithAttributesEXP");
+  EXPECT(createBuiltinKernelWithAttributes != nullptr);
+
+  CmdQ = cl::CommandQueue(Ctx, Status);
+  EXPECT(Status == CL_SUCCESS);
+
+  std::vector<float> Result;
+  std::cout << "--- Matmul 1 ---\n";
+  // Basic case. Non-strided inputs and output.
+  doFloatMatmul(COL_MAJOR, TRANSPOSE_NONE, 4, 4, 4,
+                {1.0f, 2.0f, 3.0f, 4.0f,      //
+                 5.0f, 6.0f, 7.0f, 8.0f,      //
+                 9.0f, 10.0f, 11.0f, 12.0f,   //
+                 13.0f, 14.0f, 15.0f, 16.0f}, //
+                4,
+                {0.0f, 0.0f, 0.0f, 0.0f,  //
+                 1.0f, 1.0f, 1.0f, 1.0f,  //
+                 0.0f, 0.0f, 0.0f, 0.0f,  //
+                 0.0f, 0.0f, 0.0f, 0.0f}, //
+                4, Result, 4);
+
+  check2DSlice(4, 4, Result, 4,
+               {0.0f, 0.0f, 0.0f, 0.0f,     //
+                28.0f, 32.0f, 36.0f, 40.0f, //
+                0.0f, 0.0f, 0.0f, 0.0f,     //
+                0.0f, 0.0f, 0.0f, 0.0f},
+               4);
+  std::cout << "OK" << std::endl;
+
+  std::cout << "--- Matmul 2 ---" << std::endl;
+  // Transpose an input & strided output.
+  doFloatMatmul(COL_MAJOR, TRANSPOSE_A, 4, 4, 4,
+                {1.0f, 2.0f, 3.0f, 4.0f,      //
+                 5.0f, 6.0f, 7.0f, 8.0f,      //
+                 9.0f, 10.0f, 11.0f, 12.0f,   //
+                 13.0f, 14.0f, 15.0f, 16.0f}, //
+                4,
+                {0.0f, 0.0f, 0.0f, 0.0f,  //
+                 1.0f, 1.0f, 1.0f, 1.0f,  //
+                 0.0f, 0.0f, 0.0f, 0.0f,  //
+                 0.0f, 0.0f, 0.0f, 0.0f}, //
+                4, Result, 7);
+
+  check2DSlice(4, 4, Result, 7,
+               {0.0f, 0.0f, 0.0f, 0.0f,     //
+                10.0f, 26.0f, 42.0f, 58.0f, //
+                0.0f, 0.0f, 0.0f, 0.0f,     //
+                0.0f, 0.0f, 0.0f, 0.0f},
+               4);
+  std::cout << "OK" << std::endl;
+
+  std::cout << "--- Matmul 3 ---" << std::endl;
+  // Strided inputs.
+  doFloatMatmul(COL_MAJOR, TRANSPOSE_NONE, 2, 2, 2,
+                {1.0f, 2.0f, 999.0f, 999.0f, 999.0f,   //
+                 3.0f, -4.0f, 999.0f, 999.0f, 999.0f}, //
+                5,
+                {2.0f, -1.0f, 999.0f, //
+                 2.0f, 3.0f, 999.0f}, //
+                3, Result, 2);
+
+  check2DSlice(2, 2, Result, 2, {-1.0f, 8.0f, 11.0f, -8.0f}, 2);
+  std::cout << "OK" << std::endl;
+
+  std::cout << "--- Matmul 4 ---" << std::endl;
+  // Same as above but in the row-major order.
+  doFloatMatmul(ROW_MAJOR, TRANSPOSE_NONE, 2, 2, 2,
+                {1.0f, 2.0f, 999.0f, 999.0f, 999.0f,   //
+                 3.0f, -4.0f, 999.0f, 999.0f, 999.0f}, //
+                5,
+                {2.0f, -1.0f, 999.0f, //
+                 2.0f, 3.0f, 999.0f}, //
+                3, Result, 2);
+
+  check2DSlice(2, 2, Result, 2, {6.0f, 5.0f, -2.0f, -15.0f}, 2);
+  std::cout << "OK" << std::endl;
+
+  std::cout << "--- Matmul 5 ---" << std::endl;
+  // Row-major, strided inputs and a matrix transpose.
+  doFloatMatmul(ROW_MAJOR, TRANSPOSE_A, 2, 2, 2,
+                {1.0f, 2.0f, 999.0f, 999.0f, 999.0f,   //
+                 3.0f, -4.0f, 999.0f, 999.0f, 999.0f}, //
+                5,
+                {2.0f, -1.0f, 999.0f, //
+                 2.0f, 3.0f, 999.0f}, //
+                3, Result, 2);
+
+  check2DSlice(2, 2, Result, 2, {8.0f, 8.0f, -4.0f, -14.0f}, 2);
+  std::cout << "OK" << std::endl;
+
+  std::cout << "--- Matmul 6 ---" << std::endl;
+  // Row-major, with rectangle matrix shapes.
+  doFloatMatmul(ROW_MAJOR, TRANSPOSE_NONE, 2, 2, 3,
+                {1.0f, 2.0f, -1.0f,  //
+                 3.0f, -4.0f, 2.0f}, //
+                3,
+                {2.0f, -1.0f, //
+                 1.0f, -1.0f, //
+                 2.0f, 3.0f}, //
+                2, Result, 2);
+
+  check2DSlice(2, 2, Result, 2, {2.0f, -6.0f, 6.0f, 7.0f}, 2);
+  std::cout << "OK" << std::endl;
+
+  std::cout << "--- Completed ---" << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
Introduces partially implemented matmul DBK (`khr_matmul`) which is interfaced via tensors with user-described BLAS-like datalayouts (see `tests/tuntime/test_dbk_matmul.cpp`). Execution of the kernel is delegated to [libxsmm](https://github.com/libxsmm/libxsmm). The matmul cases featured in the test source should work. Batched matmul should also work but it has not been tested.

Note there are specification updates since the first draft of the [tensor](https://htmlpreview.github.io/?https://github.com/linehill/OpenCL-Docs/blob/cl_exp_tensor/ext/cl_exp_tensor.html) and [DBK](https://htmlpreview.github.io/?https://github.com/linehill/OpenCL-Docs/blob/defined-built-in-kernels/ext/cl_khr_defined_builtin_kernels.html) specifications:

* `clCreateTensor()` is replaced with `clCreateBufferWithProperties()` and `CL_MEM_TENSOR` property combination.

* `clCreateDefinedBuiltInKernelDescriptor()` and `clCreateProgramWithDefinedBuiltInKernels()` are replaced with `clCreateBuiltinKernelWithAttributesEXP()`.

* Tensors are no longer separate objects - they are represented as `cl_mem` objects.

* Tensor data layout can be user-specified. This removes the need of having to issue tensor data import/export commands.

There is also `khr_gemm` DBK in place but attempting to create it will probably return `CL_DBK_UNAVAILABLE` unless `alpha` is one and `beta` is either zero or one (libxsmm limitation).

To build this branch, pocl needs to be configured with `-DLIBXSMM_DIR=/path/to/libxsmm` for now.