### PR TITLE
remote: Rework reconnection code

### DIFF
--- a/lib/CL/clGetDeviceInfo.c
+++ b/lib/CL/clGetDeviceInfo.c
@@ -64,9 +64,6 @@ POname(clGetDeviceInfo)(cl_device_id   device,
 {
   POCL_RETURN_ERROR_COND ((!IS_CL_OBJECT_VALID (device)), CL_INVALID_DEVICE);
 
-  POCL_RETURN_ERROR_COND ((*(device->available) == CL_FALSE),
-                          CL_DEVICE_NOT_AVAILABLE);
-
   switch (param_name)
   {
   case CL_DEVICE_IMAGE_SUPPORT:

--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -24,16 +24,16 @@
    IN THE SOFTWARE.
 */
 #include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include <errno.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <signal.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -44,6 +44,7 @@
 #include "pocl_cl.h"
 #include "pocl_image_util.h"
 #include "pocl_networking.h"
+#include "pocl_threads.h"
 #include "pocl_timing.h"
 #include "pocl_util.h"
 #include "remote.h"
@@ -112,6 +113,10 @@ static uint64_t last_message_id = 1992;
 static uint64_t last_peer_id = 42;
 
 // TODO these are copypaste from C++
+#ifndef POLLRDHUP
+#define PULLRDHUP 0
+#endif
+#define POLLFD_ERROR_BITS (POLLHUP | POLLERR | POLLNVAL | POLLRDHUP)
 
 #define CHECK_READ_INNER(readb, timeout_flag)                                 \
   do                                                                          \
@@ -123,15 +128,16 @@ static uint64_t last_peer_id = 42;
             continue;                                                         \
           else                                                                \
             {                                                                 \
-              fprintf (stderr,                                                \
-                       "error %i on read() call at " __FILE__ ":%i\n", e,     \
-                       __LINE__);                                             \
+              POCL_MSG_PRINT_REMOTE ("error %i on read() call at " __FILE__   \
+                                     ":%i, trying to reconnect\n",            \
+                                     e, __LINE__);                            \
               goto TRY_RECONNECT;                                             \
             }                                                                 \
         }                                                                     \
       if (readb == 0)                                                         \
         {                                                                     \
-          fprintf (stderr, "Filedescriptor closed (server disconnect).\n");   \
+          POCL_MSG_PRINT_REMOTE ("Filedescriptor closed (server "             \
+                                 "disconnect). Trying to reconect.\n");       \
           goto TRY_RECONNECT;                                                 \
         }                                                                     \
     }                                                                         \
@@ -147,8 +153,9 @@ static uint64_t last_peer_id = 42;
       if (res < 0)                                                            \
         {                                                                     \
           int e = errno;                                                      \
-          fprintf (stderr, "error %i on write() call at " __FILE__ ":%i\n",   \
-                   e, __LINE__);                                              \
+          POCL_MSG_PRINT_REMOTE ("error %i on write() call at " __FILE__      \
+                                 ":%i, trying to reconnect\n",                \
+                                 e, __LINE__);                                \
           goto TRY_RECONNECT;                                                 \
         }                                                                     \
     }                                                                         \
@@ -220,7 +227,6 @@ struct network_queue
   pocl_cond_t cond;
   pocl_thread_t thread_id;
   int exit_requested;
-  int *fd;
 };
 
 typedef struct network_queue_arg
@@ -228,19 +234,20 @@ typedef struct network_queue_arg
   remote_server_data_t *remote;
   network_queue *in_flight;
   network_queue *ours;
+  socket_data_t *socket_data;
 } network_queue_arg;
 
 #define SETUP_NETW_Q(n, f)                                                    \
   POCL_INIT_LOCK (n->mutex);                                                  \
-  POCL_INIT_COND (n->cond);                                                   \
-  n->fd = f;
+  POCL_INIT_COND (n->cond);
 
-// n->dev = device; n->devd = devd; n->d = d; s = server data
-#define SETUP_NETW_Q_ARG(n, s, o)                                             \
+// n->dev = device; n->devd = devd; n->d = d; s = server data, sd = socket_data
+#define SETUP_NETW_Q_ARG(n, s, o, sd)                                         \
   n = calloc (1, sizeof (network_queue_arg));                                 \
   n->in_flight = d->inflight_queue;                                           \
   n->ours = o;                                                                \
-  n->remote = s;
+  n->remote = s;                                                              \
+  n->socket_data = sd;
 
 // ##################################################################################
 // ##################################################################################
@@ -260,10 +267,8 @@ SMALL_VECTOR_HELPERS (sampler_ids, remote_server_data_t, uint32_t, sampler_ids)
 
 #define PKT_THRESHOLD 1200
 
-#define NUM_SERVER_SOCKET_THREADS 4
-
 /* TODO these are duplicated in C++ */
-ssize_t
+static ssize_t
 read_full (int fd, void *p, size_t total, remote_server_data_t *sinfo)
 {
 
@@ -293,8 +298,7 @@ read_full (int fd, void *p, size_t total, remote_server_data_t *sinfo)
 
   return (ssize_t)(total);
 }
-
-int
+static int
 write_full (int fd, void *p, size_t total, remote_server_data_t *sinfo)
 {
 
@@ -326,7 +330,7 @@ write_full (int fd, void *p, size_t total, remote_server_data_t *sinfo)
 
 #define THRESHOLD 1200
 
-int
+static int
 writev_full (int fd, size_t num, void **arys, size_t *sizes,
              remote_server_data_t *sinfo)
 {
@@ -537,7 +541,6 @@ finish_running_cmd (network_command *running_cmd)
       POCL_MEM_FREE (running_cmd);
     }
 }
-
 static cl_int
 pocl_network_connect (remote_server_data_t *data, int *fd, unsigned port,
                       int bufsize, int is_fast, ReplyMsg_t *reply_out)
@@ -545,7 +548,6 @@ pocl_network_connect (remote_server_data_t *data, int *fd, unsigned port,
   const int32_t one = 1;
   const int32_t zero = 0;
   int socket_fd;
-  *fd = -1;
   unsigned addrlen = 0;
 
 #ifdef USE_UDS
@@ -637,69 +639,56 @@ pocl_network_connect (remote_server_data_t *data, int *fd, unsigned port,
 }
 
 static cl_int
-pocl_network_disconnect (remote_server_data_t *data, int fd)
+pocl_network_disconnect (int *fd, pocl_lock_t *lock)
 {
-  shutdown (fd, SHUT_RDWR);
-  return (close (fd));
+  int res = 0;
+  if (lock)
+    POCL_LOCK (*lock);
+  /* <0 is invalid and 0,1,2 are stdio/stderr */
+  if (*fd > 2)
+    {
+      shutdown (*fd, SHUT_RDWR);
+      res = close (*fd);
+      *fd = -1;
+    }
+  if (lock)
+    POCL_UNLOCK (*lock);
+  return res;
 }
 
-/// NOTE: remember to update NUM_SERVER_SOCKET_THREADS to reflect the actual
-/// number of threads that may be using the same sockets
-static void
-pocl_remote_reconnect_sockets (remote_server_data_t *remote)
+/// socket_data->setup_mutex is expected to be locked when this function is
+/// called.
+static cl_int
+pocl_remote_reconnect_socket (remote_server_data_t *remote,
+                              socket_data_t *socket_data)
 {
-  POCL_MSG_PRINT_REMOTE (
-      "Disabling devices on %s until connection is restored\n",
-      remote->address_with_port);
-  POCL_ATOMIC_CAS (&remote->available, CL_TRUE, CL_FALSE);
-
-  // Gather all threads here to sleep. Last one to arrive replaces both sockets
-  // and wakes up all the others when done.
-  remote->threads_awaiting_reconnect += 1;
-  POCL_MSG_PRINT_REMOTE (
-      "pocl_remote_reconnect_sockets: currently %d threads waiting\n",
-      remote->threads_awaiting_reconnect);
-  if (remote->threads_awaiting_reconnect < NUM_SERVER_SOCKET_THREADS)
+  if (socket_data->fd != -1)
     {
-      POCL_WAIT_COND (remote->setup_lock.cond, remote->setup_lock.mutex);
-      return;
+      POCL_ATOMIC_INC (remote->threads_awaiting_reconnect);
+      POCL_ATOMIC_CAS (&remote->available, CL_TRUE, CL_FALSE);
+      pocl_network_disconnect (&socket_data->fd, NULL);
     }
-
-  // close old handles to avoid exceeding the open fd limit
-  close (remote->fast_socket_fd);
-  close (remote->slow_socket_fd);
 
   uint64_t session = 0;
-  POCL_MSG_PRINT_REMOTE ("Attempting to connect to session %" PRIu64
-                         " on %s\n",
-                         remote->session, remote->address_with_port);
+  POCL_MSG_PRINT_REMOTE (
+    "Attempting to connect to session %" PRIu64 " on %s:%d (%s)\n",
+    remote->session, remote->address,
+    socket_data->is_fast ? remote->fast_port : remote->slow_port,
+    socket_data->is_fast ? "fast" : "slow");
 
-  // Got the lock, reconnect
-  int status = 0;
-  status |= pocl_network_connect (remote, &remote->fast_socket_fd,
-                                  remote->fast_port, NETWORK_BUF_SIZE_FAST, 1,
-                                  NULL);
-  status |= pocl_network_connect (remote, &remote->slow_socket_fd,
-                                  remote->slow_port, NETWORK_BUF_SIZE_SLOW, 0,
-                                  NULL);
+  int res = pocl_network_connect (
+    remote, &socket_data->fd,
+    socket_data->is_fast ? remote->fast_port : remote->slow_port,
+    NETWORK_BUF_SIZE_FAST, socket_data->is_fast, NULL);
+  if (res == CL_SUCCESS)
+    {
+      socket_data->reconnect_count += 1;
+      int waiting = POCL_ATOMIC_DEC (remote->threads_awaiting_reconnect);
+      if (waiting == 0)
+        POCL_ATOMIC_CAS (&remote->available, CL_FALSE, CL_TRUE);
+    }
+  return res;
   // TODO: reconnect RDMA somehow?
-
-  if (status == CL_SUCCESS)
-    {
-      POCL_MSG_PRINT_REMOTE ("Connection restored, enabling devices on %s\n",
-                             remote->address_with_port);
-      POCL_ATOMIC_CAS (&remote->available, CL_FALSE, CL_TRUE);
-      remote->threads_awaiting_reconnect = 0;
-      // Wake up all other threads
-      POCL_BROADCAST_COND (remote->setup_lock.cond);
-      return;
-    }
-  else
-    {
-      // Try again next iteration
-      remote->threads_awaiting_reconnect -= 1;
-      return;
-    }
 }
 
 static void *
@@ -709,39 +698,59 @@ pocl_remote_reader_pthread (void *aa)
   remote_server_data_t *remote = a->remote;
   network_queue *inflight = a->in_flight;
   network_queue *this = a->ours;
-  POCL_MEM_FREE (a);
+  socket_data_t *socket_data = a->socket_data;
 
   ssize_t readb;
-  struct pollfd pfd;
-  pfd.events = POLLIN;
+  struct pollfd pfd[2];
+  pfd[0].events = POLLIN;
+  pfd[1].events = POLLIN;
+  pfd[1].fd = socket_data->notify_pipe_r;
   int nevs;
+  uint8_t tmp_byte;
+  POCL_MEM_FREE (a);
+#ifdef SIGPIPE
+  POCL_IGNORE_SIGNAL_IN_THREAD (SIGPIPE);
+#endif
 
   while (!this->exit_requested)
     {
-      POCL_LOCK (remote->setup_lock.mutex);
-      int fd = *this->fd;
-      POCL_UNLOCK (remote->setup_lock.mutex);
-      if (0)
+      POCL_LOCK (socket_data->setup_mutex);
+      int fd = socket_data->fd;
+      POCL_UNLOCK (socket_data->setup_mutex);
+      if (fd < 0)
         {
         TRY_RECONNECT:
-          POCL_LOCK (remote->setup_lock.mutex);
-          pocl_remote_reconnect_sockets (remote);
-          fd = *this->fd;
-          POCL_UNLOCK (remote->setup_lock.mutex);
+          POCL_LOCK (socket_data->setup_mutex);
+          int reconnected = pocl_remote_reconnect_socket (remote, socket_data);
+          fd = socket_data->fd;
+          if (reconnected == CL_SUCCESS)
+            {
+              POCL_BROADCAST_COND (socket_data->setup_cond);
+              POCL_UNLOCK (socket_data->setup_mutex);
+            }
+          else
+            goto TRY_RECONNECT;
         }
 
       // block until there is something to read.
       // this is especially needed to get accurate
       // profiling timestamps for read commands
-      pfd.fd = fd;
-      nevs = poll (&pfd, 1, -1);
+      pfd[0].fd = fd;
+      nevs = poll (pfd, 2, -1);
       if (nevs < 1)
-        {
           continue;
-        }
-      else if (!(pfd.revents & POLLIN))
+      else
         {
-          continue;
+          if (pfd[1].revents & POLLIN)
+            {
+              read (pfd[1].fd, &tmp_byte, sizeof (tmp_byte));
+              if (tmp_byte == 1)
+                goto TRY_RECONNECT;
+            }
+          if (pfd[0].revents & POLLFD_ERROR_BITS)
+            goto TRY_RECONNECT;
+          if (!(pfd[0].revents & POLLIN))
+            continue;
         }
 
       // READ MSG
@@ -753,8 +762,8 @@ pocl_remote_reader_pthread (void *aa)
       // we have a message
       assert ((size_t)readb == sizeof (ReplyMsg_t));
       POCL_MSG_PRINT_REMOTE (
-          "READER THR: MESSAGE READ, TYPE:  %u  ID: %zu  SIZE: %zu\n",
-          rep.message_type, rep.msg_id, readb);
+        "READER THR: MESSAGE READ, FD: %d TYPE:  %u  ID: %zu  SIZE: %zu\n", fd,
+        rep.message_type, rep.msg_id, readb);
 
       // find it
       network_command *running_cmd = NULL;
@@ -1066,62 +1075,33 @@ pocl_remote_writer_pthread (void *aa)
   network_queue_arg *a = aa;
   network_queue *this = a->ours;
   remote_server_data_t *remote = a->remote;
+  socket_data_t *socket_data = a->socket_data;
+  int fd = -1;
+  int reconnect_count = 0;
   POCL_MEM_FREE (a);
-  int resending = 0;
-  network_command *backup[5] = { NULL };
-  int backup_idx = 0;
+#ifdef SIGPIPE
+  POCL_IGNORE_SIGNAL_IN_THREAD (SIGPIPE);
+#endif
+  POCL_LOCK (socket_data->setup_mutex);
+  fd = socket_data->fd;
+  reconnect_count = socket_data->reconnect_count;
+  POCL_UNLOCK (socket_data->setup_mutex);
 
   network_command *cmd;
   POCL_LOCK (this->mutex);
   while (!this->exit_requested)
     {
-      if (resending)
-        cmd = backup[backup_idx];
-      else
-        cmd = this->queue;
+      cmd = this->queue;
+
       if (cmd)
         {
-          if (!resending)
-            DL_DELETE (this->queue, cmd);
+          DL_DELETE (this->queue, cmd);
           POCL_UNLOCK (this->mutex);
-          POCL_LOCK (remote->setup_lock.mutex);
-          int fd = *this->fd;
-          POCL_UNLOCK (remote->setup_lock.mutex);
-
           if (POCL_ATOMIC_LOAD (cmd->client_write_start_timestamp_ns) == 0)
             POCL_ATOMIC_STORE (cmd->client_write_start_timestamp_ns,
                                pocl_gettimemono_ns ());
 
-          if (0)
-            {
-            TRY_RECONNECT:
-              POCL_LOCK (remote->setup_lock.mutex);
-              pocl_remote_reconnect_sockets (remote);
-              fd = *this->fd;
-              POCL_UNLOCK (remote->setup_lock.mutex);
-              resending = 1;
-              backup_idx = 0;
-            }
-
-          if (resending)
-            {
-              if (cmd->status >= NETCMD_READ)
-                {
-                  /* backup was not needed after all */
-                  /* XXX: deduplicate with code at the end of the loop? */
-                  backup[backup_idx] = NULL;
-                  backup_idx
-                      = (backup_idx + 1)
-                        % (sizeof (backup) / sizeof (network_command *));
-                  if (backup_idx == 0)
-                    resending = 0;
-                  continue;
-                }
-            }
-          else
-            {
-              assert (cmd->status == NETCMD_STARTED);
-            }
+          assert (cmd->status == NETCMD_STARTED);
 
           uint32_t msg_size = request_size (cmd->request.message_type);
 
@@ -1147,15 +1127,29 @@ pocl_remote_writer_pthread (void *aa)
                        cmd->request.client_did, cmd->request.did,
                        cmd->request.message_type, 0);
 
-          if (!resending)
+          POCL_LOCK (cmd->receiver->mutex);
+          DL_APPEND (cmd->receiver->queue, cmd);
+          POCL_UNLOCK (cmd->receiver->mutex);
+
+          POCL_LOCK (socket_data->setup_mutex);
+          if (0)
             {
-              backup[backup_idx] = cmd;
-              backup_idx = (backup_idx + 1)
-                           % (sizeof (backup) / sizeof (network_command *));
-              POCL_LOCK (cmd->receiver->mutex);
-              DL_APPEND (cmd->receiver->queue, cmd);
-              POCL_UNLOCK (cmd->receiver->mutex);
+            /* This is only hit if there is an error from CHECK_WRITE */
+            TRY_RECONNECT:
+              /* Only sleep if the reader thread has *not* reconnected yet */
+              if (reconnect_count == socket_data->reconnect_count)
+                {
+                  POCL_MSG_PRINT_REMOTE (
+                    "(%s) writer waiting for reader to reconnect\n",
+                    socket_data->is_fast ? "fast" : "slow");
+                  uint8_t one = 1;
+                  write (socket_data->notify_pipe_w, &one, sizeof (one));
+                  POCL_WAIT_COND (socket_data->setup_cond,
+                                  socket_data->setup_mutex);
+                }
             }
+          fd = socket_data->fd;
+          reconnect_count = socket_data->reconnect_count;
 
           // WRITE DATA
           if (cmd->req_extra_data2)
@@ -1198,6 +1192,7 @@ pocl_remote_writer_pthread (void *aa)
                   write_full (fd, &msg_size, sizeof (uint32_t), remote));
               CHECK_WRITE (write_full (fd, &cmd->request, msg_size, remote));
             }
+          POCL_UNLOCK (socket_data->setup_mutex);
 
           POCL_ATOMIC_STORE (cmd->client_write_end_timestamp_ns,
                              pocl_gettimemono_ns ());
@@ -1205,37 +1200,11 @@ pocl_remote_writer_pthread (void *aa)
           TP_MSG_SENT (cmd->request.msg_id, cmd->event_id,
                        cmd->request.client_did, cmd->request.did,
                        cmd->request.message_type, 1);
-
-          if (resending)
-            {
-              backup[backup_idx] = NULL;
-              backup_idx = (backup_idx + 1)
-                           % (sizeof (backup) / sizeof (network_command *));
-              if (backup_idx == 0)
-                resending = 0;
-            }
           POCL_LOCK (this->mutex);
         }
       else
         {
-          if (resending)
-            {
-              backup_idx = (backup_idx + 1)
-                           % (sizeof (backup) / sizeof (network_command *));
-              if (backup_idx == 0)
-                resending = 0;
-              continue;
-            }
-          // hack: wake regularly to check if the readers are waiting to get
-          // reconnected
-          struct timespec deadline;
-          clock_gettime (CLOCK_REALTIME, &deadline);
-          deadline.tv_sec += 1;
-          POCL_TIMEDWAIT_COND (this->cond, this->mutex, deadline);
-          POCL_LOCK (remote->setup_lock.mutex);
-          if (remote->threads_awaiting_reconnect > 0)
-            pocl_remote_reconnect_sockets (remote);
-          POCL_UNLOCK (remote->setup_lock.mutex);
+          POCL_WAIT_COND (this->cond, this->mutex);
         }
     }
 
@@ -1335,6 +1304,17 @@ start_engines (remote_server_data_t *d, remote_device_data_t *devd,
   d->inflight_queue = calloc (1, sizeof (network_queue));
   SETUP_NETW_Q (d->inflight_queue, 0);
 
+  int res;
+  int pipe_pair[2];
+  res = pipe (pipe_pair);
+  assert (res == 0);
+  d->fast_socket.notify_pipe_r = pipe_pair[0];
+  d->fast_socket.notify_pipe_w = pipe_pair[1];
+  pipe (pipe_pair);
+  assert (res == 0);
+  d->slow_socket.notify_pipe_r = pipe_pair[0];
+  d->slow_socket.notify_pipe_w = pipe_pair[1];
+
 #ifdef ENABLE_TRAFFIC_MONITOR
   d->traffic_monitor = calloc (1, sizeof (network_queue));
   SETUP_NETW_Q (d->traffic_monitor, 0);
@@ -1350,27 +1330,33 @@ start_engines (remote_server_data_t *d, remote_device_data_t *devd,
   SETUP_NETW_Q (d->rdma_write_queue, 0);
 #endif
 
+  d->slow_write_queue = calloc (1, sizeof (network_queue));
+  SETUP_NETW_Q (d->slow_write_queue, &d->slow_socket.fd);
+  d->slow_socket.writer_mutex = &d->slow_write_queue->mutex;
+  d->slow_socket.writer_cond = &d->slow_write_queue->cond;
+
+  d->fast_write_queue = calloc (1, sizeof (network_queue));
+  SETUP_NETW_Q (d->fast_write_queue, &d->fast_socket.fd);
+  d->fast_socket.writer_mutex = &d->fast_write_queue->mutex;
+  d->fast_socket.writer_cond = &d->fast_write_queue->cond;
+
   d->slow_read_queue = calloc (1, sizeof (network_queue));
-  SETUP_NETW_Q (d->slow_read_queue, &d->slow_socket_fd);
-  SETUP_NETW_Q_ARG (a, d, d->slow_read_queue);
+  SETUP_NETW_Q (d->slow_read_queue, &d->slow_socket.fd);
+  SETUP_NETW_Q_ARG (a, d, d->slow_read_queue, &d->slow_socket);
   POCL_CREATE_THREAD (d->slow_read_queue->thread_id,
                       pocl_remote_reader_pthread, a);
 
   d->fast_read_queue = calloc (1, sizeof (network_queue));
-  SETUP_NETW_Q (d->fast_read_queue, &d->fast_socket_fd);
-  SETUP_NETW_Q_ARG (a, d, d->fast_read_queue);
+  SETUP_NETW_Q (d->fast_read_queue, &d->fast_socket.fd);
+  SETUP_NETW_Q_ARG (a, d, d->fast_read_queue, &d->fast_socket);
   POCL_CREATE_THREAD (d->fast_read_queue->thread_id,
                       pocl_remote_reader_pthread, a);
 
-  d->slow_write_queue = calloc (1, sizeof (network_queue));
-  SETUP_NETW_Q (d->slow_write_queue, &d->slow_socket_fd);
-  SETUP_NETW_Q_ARG (a, d, d->slow_write_queue);
+  SETUP_NETW_Q_ARG (a, d, d->slow_write_queue, &d->slow_socket);
   POCL_CREATE_THREAD (d->slow_write_queue->thread_id,
                       pocl_remote_writer_pthread, a);
 
-  d->fast_write_queue = calloc (1, sizeof (network_queue));
-  SETUP_NETW_Q (d->fast_write_queue, &d->fast_socket_fd);
-  SETUP_NETW_Q_ARG (a, d, d->fast_write_queue);
+  SETUP_NETW_Q_ARG (a, d, d->fast_write_queue, &d->fast_socket);
   POCL_CREATE_THREAD (d->fast_write_queue->thread_id,
                       pocl_remote_writer_pthread, a);
 
@@ -1472,8 +1458,11 @@ find_or_create_server (const char *address_with_port, unsigned port,
   else
     strncpy (d->address, address_with_port,
              strchr (address_with_port, ':') - address_with_port);
-  POCL_INIT_LOCK (d->setup_lock.mutex);
-  POCL_INIT_COND (d->setup_lock.cond);
+  POCL_INIT_LOCK (d->slow_socket.setup_mutex);
+  POCL_INIT_COND (d->slow_socket.setup_cond);
+  POCL_INIT_LOCK (d->fast_socket.setup_mutex);
+  POCL_INIT_COND (d->fast_socket.setup_cond);
+  d->fast_socket.is_fast = 1;
 
   // TODO: delet this
   // In RealWorldUse(tm) peers should not need a separate interface for
@@ -1514,7 +1503,7 @@ find_or_create_server (const char *address_with_port, unsigned port,
 #endif
 
   ReplyMsg_t hsr;
-  if (pocl_network_connect (d, &d->fast_socket_fd, d->fast_port,
+  if (pocl_network_connect (d, &d->fast_socket.fd, d->fast_port,
                             NETWORK_BUF_SIZE_FAST, 1, &hsr))
     {
       POCL_MSG_ERR ("Could not connect to server\n");
@@ -1535,7 +1524,7 @@ find_or_create_server (const char *address_with_port, unsigned port,
 
   d->peer_port = hsr.m.get_session.peer_port;
 
-  if (pocl_network_connect (d, &d->slow_socket_fd, d->slow_port,
+  if (pocl_network_connect (d, &d->slow_socket.fd, d->slow_port,
                             NETWORK_BUF_SIZE_SLOW, 0, NULL))
     {
       POCL_MSG_ERR ("Could not connect to server\n");
@@ -1670,19 +1659,19 @@ find_or_create_server (const char *address_with_port, unsigned port,
   uint32_t msg_size = request_size (req.message_type);
 
   ssize_t writeb, readb;
-  writeb = write (d->fast_socket_fd, &msg_size, sizeof (msg_size));
+  writeb = write (d->fast_socket.fd, &msg_size, sizeof (msg_size));
   assert ((size_t)(writeb) == sizeof (msg_size));
-  writeb = write (d->fast_socket_fd, &req, msg_size);
+  writeb = write (d->fast_socket.fd, &req, msg_size);
   assert ((size_t)(writeb) == msg_size);
 
   ReplyMsg_t rep;
-  readb = read (d->fast_socket_fd, &rep, sizeof (ReplyMsg_t));
+  readb = read (d->fast_socket.fd, &rep, sizeof (ReplyMsg_t));
   assert ((size_t)(readb) == sizeof (ReplyMsg_t));
   assert (rep.message_type == MessageType_ServerInfoReply);
 
   d->num_platforms = rep.obj_id;
   d->platform_devices = malloc (rep.data_size);
-  readb = read (d->fast_socket_fd, d->platform_devices, rep.data_size);
+  readb = read (d->fast_socket.fd, d->platform_devices, rep.data_size);
   assert ((size_t)(readb) == rep.data_size);
   // *************************************
   size_t num_plat_devs
@@ -1737,8 +1726,8 @@ release_server (remote_server_data_t *d)
   SMALL_VECTOR_DESTROY (d, sampler_ids, INITIAL_ARRAY_CAP);
 
   // disconnect sockets.
-  pocl_network_disconnect (d, d->fast_socket_fd);
-  pocl_network_disconnect (d, d->slow_socket_fd);
+  pocl_network_disconnect (&d->fast_socket.fd, &d->fast_socket.setup_mutex);
+  pocl_network_disconnect (&d->slow_socket.fd, &d->slow_socket.setup_mutex);
 
 #ifdef ENABLE_RDMA
   rdma_uninitialize (&d->rdma_data);

--- a/lib/CL/devices/remote/communication.h
+++ b/lib/CL/devices/remote/communication.h
@@ -30,8 +30,9 @@
 #include "messages.h"
 #include "pocl.h"
 
-#include "utlist_addon.h"
+#include "pocl_threads.h"
 #include "utlist.h"
+#include "utlist_addon.h"
 
 #ifdef ENABLE_RDMA
 #include "pocl_rdma.h"
@@ -168,6 +169,21 @@ struct network_command
   } data;
 };
 
+typedef struct socket_data_s
+{
+  int fd;
+  int is_fast;
+  pocl_lock_t setup_mutex;
+  pocl_cond_t setup_cond;
+  size_t reconnect_count;
+  pocl_lock_t *writer_mutex;
+  pocl_cond_t *writer_cond;
+  int notify_pipe_r;
+  int notify_pipe_w;
+} socket_data_t;
+
+#define NUM_THREADS_PER_SOCKET 2
+
 #define INITIAL_ARRAY_CAP 1024
 
 // in nanoseconds
@@ -191,16 +207,15 @@ typedef struct remote_server_data_s
   uint64_t session;
   uint8_t authkey[AUTHKEY_LENGTH];
   uint32_t available;
-  sync_t setup_lock;
   int threads_awaiting_reconnect;
-  int slow_socket_fd;
-  int fast_socket_fd;
 
   uint32_t num_platforms;
   uint32_t num_devices;
   uint32_t *platform_devices;
 
   // network handling threads / ids
+  socket_data_t slow_socket;
+  socket_data_t fast_socket;
   network_queue *slow_read_queue;
   network_queue *fast_read_queue;
   network_queue *inflight_queue;

--- a/lib/CL/devices/remote/remote.h
+++ b/lib/CL/devices/remote/remote.h
@@ -79,6 +79,6 @@ typedef struct peer_list_s peer_list_t;
 
 peer_list_t *pocl_remote_get_peer_list (int base_id, unsigned device_count);
 
-cl_int pocl_remote_setup_peer_mesh ();
+cl_int pocl_remote_setup_peer_mesh (struct pocl_device_ops *ops);
 
 #endif /* POCL_REMOTE_H */

--- a/lib/CL/pocl_threads.h
+++ b/lib/CL/pocl_threads.h
@@ -32,6 +32,7 @@
 #endif
 
 #include <pthread.h>
+#include <signal.h>
 
 typedef pthread_mutex_t pocl_lock_t;
 typedef pthread_cond_t pocl_cond_t;
@@ -138,6 +139,16 @@ extern "C"
 #define POCL_WAIT_COND(c, m) PTHREAD_CHECK (pthread_cond_wait (&c, &m))
 #define POCL_TIMEDWAIT_COND(c, m, t)                                          \
   PTHREAD_CHECK2 (ETIMEDOUT, pthread_cond_timedwait (&c, &m, &t))
+
+#define POCL_IGNORE_SIGNAL_IN_THREAD(s)                                       \
+  do                                                                          \
+    {                                                                         \
+      sigset_t signal_mask;                                                   \
+      sigemptyset (&signal_mask);                                             \
+      sigaddset (&signal_mask, SIGPIPE);                                      \
+      PTHREAD_CHECK (pthread_sigmask (SIG_BLOCK, &signal_mask, NULL));        \
+    }                                                                         \
+  while (0)
 
 #define POCL_CREATE_THREAD(thr, func, arg)                                    \
   PTHREAD_CHECK (pthread_create (&thr, NULL, func, arg))


### PR DESCRIPTION
Apparently the old reconnection code was reliant on undefined behaviour that does not work very well on Linux, which became apparent while benchmarking reconnection. Implemented a more correct solution with pipes for signaling between thread pairs instead, as well as a couple of drive-by fixes.