### PR TITLE
cl_intel_subgroups_char and removal of an illegal assertion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1313,13 +1313,14 @@ __opencl_c_atomic_scope_device __opencl_c_program_scope_global_variables \
 __opencl_c_atomic_scope_all_devices __opencl_c_generic_address_space \
 __opencl_c_work_group_collective_functions")
 
-# Host CPU device: extensions only enabled when conformance is OFF
+# Host CPU device: Unfinished/undertested extensions only advertised when conformance
+# is OFF.
 if(NOT ENABLE_CONFORMANCE)
   set(HOST_DEVICE_EXTENSIONS "${HOST_DEVICE_EXTENSIONS} \
       cl_pocl_svm_rect cl_pocl_command_buffer_svm \
       cl_pocl_command_buffer_host_buffer")
   set(HOST_DEVICE_EXTENSIONS "${HOST_DEVICE_EXTENSIONS} cl_khr_subgroup_ballot \
-cl_khr_subgroup_shuffle cl_intel_subgroups cl_intel_subgroups_short \
+cl_khr_subgroup_shuffle cl_intel_subgroups cl_intel_subgroups_short cl_intel_subgroups_char \
 cl_ext_float_atomics cl_intel_required_subgroup_size")
   # read-write images are still partially broken
   set( HOST_DEVICE_FEATURES_30  "${HOST_DEVICE_FEATURES_30} __opencl_c_read_write_images")

--- a/include/_clang_opencl.h
+++ b/include/_clang_opencl.h
@@ -1,13 +1,14 @@
-/* This file includes opencl-c.h from Clang and fixes a few pocl extras.
+/* This file adds declarations missing from opencl-c.h.
 
    Copyright (c) 2011-2017 Pekka Jääskeläinen / TUT
+                 2024 Pekka Jääskeläinen / Intel Finland Oy
    Copyright (c) 2017 Michal Babej / Tampere University of Technology
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -17,9 +18,9 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #ifndef _CLANG_OPENCL_H
@@ -89,6 +90,230 @@ double16 _CL_OVERLOADABLE _CL_READNONE fast_normalize (double16 p);
 
 double _CL_OVERLOADABLE _CL_READNONE dot (double8 p0, double8 p1);
 double _CL_OVERLOADABLE _CL_READNONE dot (double16 p0, double16 p1);
+
+#endif
+
+#if defined(cl_intel_subgroups_char)
+/* The char version is missing from opencl-c.h */
+char _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_broadcast (char, uint sub_group_local_id);
+char2 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_broadcast (char2, uint sub_group_local_id);
+char3 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_broadcast (char3, uint sub_group_local_id);
+char4 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_broadcast (char4, uint sub_group_local_id);
+char8 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_broadcast (char8, uint sub_group_local_id);
+
+uchar _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_broadcast (uchar, uint sub_group_local_id);
+uchar2 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_broadcast (uchar2, uint sub_group_local_id);
+uchar3 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_broadcast (uchar3, uint sub_group_local_id);
+uchar4 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_broadcast (uchar4, uint sub_group_local_id);
+uchar8 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_broadcast (uchar8, uint sub_group_local_id);
+
+char _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle (char, uint);
+char2 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle (char2, uint);
+char3 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle (char3, uint);
+char4 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle (char4, uint);
+char8 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle (char8, uint);
+char16 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle (char16, uint);
+
+uchar _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle (uchar, uint);
+uchar2 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle (uchar2, uint);
+uchar3 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle (uchar3, uint);
+uchar4 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle (uchar4, uint);
+uchar8 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle (uchar8, uint);
+uchar16 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle (uchar16, uint);
+
+char _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_down (char cur,
+                                                                 char next,
+                                                                 uint);
+char2 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_down (char2 cur,
+                                                                  char2 next,
+                                                                  uint);
+char3 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_down (char3 cur,
+                                                                  char3 next,
+                                                                  uint);
+char4 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_down (char4 cur,
+                                                                  char4 next,
+                                                                  uint);
+char8 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_down (char8 cur,
+                                                                  char8 next,
+                                                                  uint);
+char16 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_down (char16 cur,
+                                                                   char16 next,
+                                                                   uint);
+
+uchar _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_down (uchar cur,
+                                                                  uchar next,
+                                                                  uint);
+uchar2 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_down (uchar2 cur,
+                                                                   uchar2 next,
+                                                                   uint);
+uchar3 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_down (uchar3 cur,
+                                                                   uchar3 next,
+                                                                   uint);
+uchar4 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_down (uchar4 cur,
+                                                                   uchar4 next,
+                                                                   uint);
+uchar8 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_down (uchar8 cur,
+                                                                   uchar8 next,
+                                                                   uint);
+uchar16 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_shuffle_down (uchar16 cur, uchar16 next, uint);
+
+char _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_up (char cur,
+                                                               char next,
+                                                               uint);
+char2 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_up (char2 cur,
+                                                                char2 next,
+                                                                uint);
+char3 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_up (char3 cur,
+                                                                char3 next,
+                                                                uint);
+char4 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_up (char4 cur,
+                                                                char4 next,
+                                                                uint);
+char8 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_up (char8 cur,
+                                                                char8 next,
+                                                                uint);
+char16 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_up (char16 cur,
+                                                                 char16 next,
+                                                                 uint);
+
+uchar _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_up (uchar cur,
+                                                                uchar next,
+                                                                uint);
+uchar2 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_up (uchar2 cur,
+                                                                 uchar2 next,
+                                                                 uint);
+uchar3 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_up (uchar3 cur,
+                                                                 uchar3 next,
+                                                                 uint);
+uchar4 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_up (uchar4 cur,
+                                                                 uchar4 next,
+                                                                 uint);
+uchar8 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_up (uchar8 cur,
+                                                                 uchar8 next,
+                                                                 uint);
+uchar16 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_up (uchar16 cur,
+                                                                  uchar16 next,
+                                                                  uint);
+
+char _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_xor (char, uint);
+char2 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_xor (char2, uint);
+char3 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_xor (char3, uint);
+char4 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_xor (char4, uint);
+char8 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_xor (char8, uint);
+char16 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_xor (char16,
+                                                                  uint);
+
+uchar _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_xor (uchar, uint);
+uchar2 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_xor (uchar2,
+                                                                  uint);
+uchar3 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_xor (uchar3,
+                                                                  uint);
+uchar4 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_xor (uchar4,
+                                                                  uint);
+uchar8 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_xor (uchar8,
+                                                                  uint);
+uchar16 _CL_OVERLOADABLE _CL_READNONE intel_sub_group_shuffle_xor (uchar16,
+                                                                   uint);
+
+char _CL_OVERLOADABLE _CL_READNONE intel_sub_group_reduce_add (char x);
+uchar _CL_OVERLOADABLE _CL_READNONE intel_sub_group_reduce_add (uchar x);
+char _CL_OVERLOADABLE _CL_READNONE intel_sub_group_reduce_min (char x);
+uchar _CL_OVERLOADABLE _CL_READNONE intel_sub_group_reduce_min (uchar x);
+char _CL_OVERLOADABLE _CL_READNONE intel_sub_group_reduce_max (char x);
+uchar _CL_OVERLOADABLE _CL_READNONE intel_sub_group_reduce_max (uchar x);
+
+char _CL_OVERLOADABLE _CL_READNONE intel_sub_group_scan_exclusive_add (char x);
+uchar _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_scan_exclusive_add (uchar x);
+char _CL_OVERLOADABLE _CL_READNONE intel_sub_group_scan_exclusive_min (char x);
+uchar _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_scan_exclusive_min (uchar x);
+char _CL_OVERLOADABLE _CL_READNONE intel_sub_group_scan_exclusive_max (char x);
+uchar _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_scan_exclusive_max (uchar x);
+
+char _CL_OVERLOADABLE _CL_READNONE intel_sub_group_scan_inclusive_add (char x);
+uchar _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_scan_inclusive_add (uchar x);
+char _CL_OVERLOADABLE _CL_READNONE intel_sub_group_scan_inclusive_min (char x);
+uchar _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_scan_inclusive_min (uchar x);
+char _CL_OVERLOADABLE _CL_READNONE intel_sub_group_scan_inclusive_max (char x);
+uchar _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_scan_inclusive_max (uchar x);
+
+#if defined(__opencl_c_images)
+uchar _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc (read_only image2d_t, int2);
+uchar2 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc2 (read_only image2d_t, int2);
+uchar4 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc4 (read_only image2d_t, int2);
+uchar8 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc8 (read_only image2d_t, int2);
+#endif // defined(__opencl_c_images)
+
+#if defined(__opencl_c_read_write_images)
+uchar _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc (read_write image2d_t, int2);
+uchar2 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc2 (read_write image2d_t, int2);
+uchar4 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc4 (read_write image2d_t, int2);
+uchar8 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc8 (read_write image2d_t, int2);
+#endif // defined(__opencl_c_read_write_images)
+
+uchar _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc (const __global uchar *p);
+uchar2 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc2 (const __global uchar *p);
+uchar4 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc4 (const __global uchar *p);
+uchar8 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc8 (const __global uchar *p);
+
+#if defined(__opencl_c_images)
+void _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_write_uc (write_only image2d_t, int2, uchar);
+void _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_write_uc2 (write_only image2d_t, int2, uchar2);
+void _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_write_uc4 (write_only image2d_t, int2, uchar4);
+void _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_write_uc8 (write_only image2d_t, int2, uchar8);
+#endif // defined(__opencl_c_images)
+
+#if defined(__opencl_c_read_write_images)
+void _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_write_uc (read_write image2d_t, int2, uchar);
+void _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_write_uc2 (read_write image2d_t, int2, uchar2);
+void _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_write_uc4 (read_write image2d_t, int2, uchar4);
+void _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_write_uc8 (read_write image2d_t, int2, uchar8);
+#endif // defined(__opencl_c_read_write_images)
+
+void _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_write_uc (__global uchar *p, uchar data);
+void _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_write_uc2 (__global uchar *p, uchar2 data);
+void _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_write_uc4 (__global uchar *p, uchar4 data);
+void _CL_OVERLOADABLE intel_sub_group_block_write_uc8 (__global uchar *p,
+                                                       uchar8 data);
 
 #endif
 

--- a/include/_clang_opencl.h
+++ b/include/_clang_opencl.h
@@ -22,16 +22,19 @@
    THE SOFTWARE.
 */
 
-#ifndef _OPENCL_H_
+#ifndef _CLANG_OPENCL_H
+#define _CLANG_OPENCL_H
 
 /* Use the declarations shipped with Clang. */
+#ifndef _OPENCL_H_
 /* Check for _OPENCL_H already here because the kernel compiler loads the
    header beforehand, but cannot find the file due to include paths not
    set up. */
 #include <opencl-c.h>
+#endif
 
-/* Missing declarations from opencl-c.h. Some of the geometric builtins are
-   defined only up to 4 vectors, but we implement them all: */
+/* Some of the geometric builtins are defined only up to 4 vectors, but we
+   implement them all: */
 #ifdef cl_khr_fp16
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 half _CL_OVERLOADABLE _CL_READNONE length (half8 p);

--- a/lib/kernel/subgroups.cl
+++ b/lib/kernel/subgroups.cl
@@ -46,8 +46,6 @@ sub_group_barrier (memory_scope scope)
   work_group_barrier (CLK_GLOBAL_MEM_FENCE);
 }
 
-
-
 int _CL_OVERLOADABLE
 sub_group_any (int predicate)
 {
@@ -182,13 +180,24 @@ __IF_FP64 (INTEL_SG_SHUFFLE_UP_T(double))
 
 INTEL_SG_BLOCK_READ_WRITE_T (uint, )
 
-#endif
-
 #ifdef cl_intel_subgroups_short
-/* https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_subgroups_short.html
+/* https://registry.khronos.org/OpenCL/extensions/intel/
+ * cl_intel_subgroups_short.html
  */
 
 INTEL_SG_BLOCK_READ_WRITE_T (ushort, _us)
+#endif
+
+#ifdef cl_intel_subgroups_char
+/* https://registry.khronos.org/OpenCL/extensions/intel/
+ * cl_intel_subgroups_char.html
+ */
+
+INTEL_SG_BLOCK_READ_WRITE_T (uchar, _uc)
+#endif
+
+#if defined(cl_intel_subgroups_short) || defined(cl_intel_subgroups_char)
 INTEL_SG_BLOCK_READ_WRITE_T (uint, _ui)
+#endif
 
 #endif

--- a/lib/llvmopencl/LLVMUtils.cc
+++ b/lib/llvmopencl/LLVMUtils.cc
@@ -251,7 +251,6 @@ isAutomaticLocal(llvm::Function *F, llvm::GlobalVariable &Var) {
   if (!llvm::isa<llvm::PointerType>(Var.getType()) || Var.isConstant())
     return false;
   if (Var.getName().startswith(FuncName + ".")) {
-    assert(isGVarUsedByFunction(&Var, F) == true);
     return true;
   }
 


### PR DESCRIPTION
With these tiny-llama-1b-chat/INT4_compressed_weights runs via OpenVINO on PoCL-CPU, but segfaults due to an indexing error.