### PR TITLE
Fix compilation on FreeBSD.

### DIFF
--- a/lib/CL/clReleaseCommandBufferKHR.c
+++ b/lib/CL/clReleaseCommandBufferKHR.c
@@ -25,7 +25,11 @@
 #include "pocl_mem_management.h"
 #include "pocl_util.h"
 
+#if defined(__FreeBSD__)
+#include <stdlib.h>
+#else
 #include <alloca.h>
+#endif
 
 CL_API_ENTRY cl_int CL_API_CALL
 POname (clReleaseCommandBufferKHR) (cl_command_buffer_khr command_buffer)

--- a/lib/CL/devices/proxy/pocl_proxy.c
+++ b/lib/CL/devices/proxy/pocl_proxy.c
@@ -31,7 +31,9 @@
 #include "devices.h"
 
 #include <assert.h>
+#if !defined(__FreeBSD__)
 #include <alloca.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
On FreeBSD, `alloca` comes from `stdlib.h`: https://man.freebsd.org/cgi/man.cgi?alloca (vs. Linux: https://man7.org/linux/man-pages/man3/alloca.3.html).