### PR TITLE
Fixes to make OpenVINO run on the L0 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ apt install -y python3-dev libpython3-dev build-essential ocl-icd-libopencl1 \
     llvm-${LLVM_VERSION}-dev
 ```
 
+For LLVM 18 and above also `libpolly-${LLVM_VERSION}-dev libzstd-dev` are
+needed for static LLVM linkage.
+
 If your distro does not package the version of LLVM you wish to build against
 you might want to set up the
 [upstream LLVM package repository](https://apt.llvm.org/).

--- a/include/_clang_opencl.h
+++ b/include/_clang_opencl.h
@@ -34,6 +34,28 @@
 #include <opencl-c.h>
 #endif
 
+/* We can include this header directly (to patch up opencl-c.h without
+   including _kernel.h, thus need to define the attribute macros here. */
+#ifndef _CL_OVERLOADABLE
+
+#if __has_attribute(__overloadable__)
+#  define _CL_OVERLOADABLE __attribute__((__overloadable__))
+#else
+#  define _CL_OVERLOADABLE
+#endif
+
+#endif
+
+#ifndef _CL_READNONE
+
+#if __has_attribute(__const__)
+#  define _CL_READNONE __attribute__((__const__))
+#else
+#  define _CL_READNONE
+#endif
+
+#endif
+
 /* Some of the geometric builtins are defined only up to 4 vectors, but we
    implement them all: */
 #ifdef cl_khr_fp16

--- a/include/_clang_opencl.h
+++ b/include/_clang_opencl.h
@@ -285,32 +285,32 @@ uchar8 _CL_OVERLOADABLE _CL_READNONE
 intel_sub_group_block_read_uc8 (const __global uchar *p);
 
 #if defined(__opencl_c_images)
-void _CL_OVERLOADABLE _CL_READNONE
+void _CL_OVERLOADABLE
 intel_sub_group_block_write_uc (write_only image2d_t, int2, uchar);
-void _CL_OVERLOADABLE _CL_READNONE
+void _CL_OVERLOADABLE
 intel_sub_group_block_write_uc2 (write_only image2d_t, int2, uchar2);
-void _CL_OVERLOADABLE _CL_READNONE
+void _CL_OVERLOADABLE
 intel_sub_group_block_write_uc4 (write_only image2d_t, int2, uchar4);
-void _CL_OVERLOADABLE _CL_READNONE
+void _CL_OVERLOADABLE
 intel_sub_group_block_write_uc8 (write_only image2d_t, int2, uchar8);
 #endif // defined(__opencl_c_images)
 
 #if defined(__opencl_c_read_write_images)
-void _CL_OVERLOADABLE _CL_READNONE
+void _CL_OVERLOADABLE
 intel_sub_group_block_write_uc (read_write image2d_t, int2, uchar);
-void _CL_OVERLOADABLE _CL_READNONE
+void _CL_OVERLOADABLE
 intel_sub_group_block_write_uc2 (read_write image2d_t, int2, uchar2);
-void _CL_OVERLOADABLE _CL_READNONE
+void _CL_OVERLOADABLE
 intel_sub_group_block_write_uc4 (read_write image2d_t, int2, uchar4);
-void _CL_OVERLOADABLE _CL_READNONE
+void _CL_OVERLOADABLE
 intel_sub_group_block_write_uc8 (read_write image2d_t, int2, uchar8);
 #endif // defined(__opencl_c_read_write_images)
 
-void _CL_OVERLOADABLE _CL_READNONE
+void _CL_OVERLOADABLE
 intel_sub_group_block_write_uc (__global uchar *p, uchar data);
-void _CL_OVERLOADABLE _CL_READNONE
+void _CL_OVERLOADABLE
 intel_sub_group_block_write_uc2 (__global uchar *p, uchar2 data);
-void _CL_OVERLOADABLE _CL_READNONE
+void _CL_OVERLOADABLE
 intel_sub_group_block_write_uc4 (__global uchar *p, uchar4 data);
 void _CL_OVERLOADABLE intel_sub_group_block_write_uc8 (__global uchar *p,
                                                        uchar8 data);

--- a/include/_clang_opencl.h
+++ b/include/_clang_opencl.h
@@ -306,6 +306,31 @@ intel_sub_group_block_read_uc4 (const __global uchar *p);
 uchar8 _CL_OVERLOADABLE _CL_READNONE
 intel_sub_group_block_read_uc8 (const __global uchar *p);
 
+uchar _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc (const __local uchar *p);
+uchar2 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc2 (const __local uchar *p);
+uchar4 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc4 (const __local uchar *p);
+uchar8 _CL_OVERLOADABLE _CL_READNONE
+intel_sub_group_block_read_uc8 (const __local uchar *p);
+
+void _CL_OVERLOADABLE intel_sub_group_block_write_uc (__global uchar *p,
+                                                      uchar data);
+void _CL_OVERLOADABLE intel_sub_group_block_write_uc2 (__global uchar *p,
+                                                       uchar2 data);
+void _CL_OVERLOADABLE intel_sub_group_block_write_uc4 (__global uchar *p,
+                                                       uchar4 data);
+void _CL_OVERLOADABLE intel_sub_group_block_write_uc8 (__global uchar *p,
+                                                       uchar8 data);
+void _CL_OVERLOADABLE intel_sub_group_block_write_uc (__local uchar *p,
+                                                      uchar data);
+void _CL_OVERLOADABLE intel_sub_group_block_write_uc2 (__local uchar *p,
+                                                       uchar2 data);
+void _CL_OVERLOADABLE intel_sub_group_block_write_uc4 (__local uchar *p,
+                                                       uchar4 data);
+void _CL_OVERLOADABLE intel_sub_group_block_write_uc8 (__local uchar *p,
+                                                       uchar8 data);
 #if defined(__opencl_c_images)
 void _CL_OVERLOADABLE
 intel_sub_group_block_write_uc (write_only image2d_t, int2, uchar);
@@ -328,14 +353,6 @@ void _CL_OVERLOADABLE
 intel_sub_group_block_write_uc8 (read_write image2d_t, int2, uchar8);
 #endif // defined(__opencl_c_read_write_images)
 
-void _CL_OVERLOADABLE
-intel_sub_group_block_write_uc (__global uchar *p, uchar data);
-void _CL_OVERLOADABLE
-intel_sub_group_block_write_uc2 (__global uchar *p, uchar2 data);
-void _CL_OVERLOADABLE
-intel_sub_group_block_write_uc4 (__global uchar *p, uchar4 data);
-void _CL_OVERLOADABLE intel_sub_group_block_write_uc8 (__global uchar *p,
-                                                       uchar8 data);
 
 #endif
 

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -1061,9 +1061,11 @@ struct _cl_device_id {
   /* The program scope variable pass takes program-scope variables and replaces
      them by references into a buffer, and creates an initializer kernel. */
   cl_bool run_program_scope_variables_pass;
-  /* if CL_TRUE, pocl_llvm_build_program will ignore pocl's OpenCL headers
-   * and rely purely on Clang's OpenCL headers. For most drivers,
-   * this should default to CL_FALSE. */
+
+  /* If CL_TRUE, pocl_llvm_build_program will ignore pocl's OpenCL headers
+   * that perform built-in renames during OpenCL C build and relies on
+   * Clang's OpenCL header augmented with extra declarations in
+   * _clang_opencl.h. For most drivers, this should default to CL_FALSE. */
   cl_bool use_only_clang_opencl_headers;
   cl_device_exec_capabilities execution_capabilities;
   cl_command_queue_properties queue_properties;

--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -591,7 +591,12 @@ int pocl_llvm_build_program(cl_program program,
   // Use Clang's opencl-c.h header.
   po.Includes.push_back(ClangResourceDir + "/include/opencl-c-base.h");
   po.Includes.push_back(ClangResourceDir + "/include/opencl-c.h");
-  if (device->use_only_clang_opencl_headers == CL_FALSE) {
+
+  std::string ClangAugmentHeader =
+    IncludeRoot + "/include/_clang_opencl.h";
+  if (device->use_only_clang_opencl_headers) {
+    po.Includes.push_back(ClangAugmentHeader);
+  } else {
     po.Includes.push_back(KernelH);
   }
   clang::TargetOptions &ta = pocl_build.getTargetOpts();


### PR DESCRIPTION
Small patches to make OpenVINO run the tiny-llama-1b-chat model infer. via the L0 driver.

An example run:
```
samples/cpp/multinomial_causal_lm/multinomial_causal_lm ~/src/openvinino_notebooks/notebooks/llm-chatbot/tiny-llama-1b-chat/INT4_compressed_weights/ "Why is the Sun yellow?"
PoCL Level0
6 warnings generated.
12 warnings generated.
The answer, as you would expect, is because sunlight contains an abundance of atoms of iron (Fe), a naturally occurring element that is red-coloured because of the presence of one of its elements.
 
12. Why are there stars with blue-grey hues? Blue-grey colours are produced by iron-rich regions of the Sun, which contain large numbers of elements like nickel (Ni), cobalt (Co), and magnesium
```
