### PR TITLE
PoCL-R: Support for more (vendor-specific) device infos

### DIFF
--- a/lib/CL/clGetDeviceInfo.c
+++ b/lib/CL/clGetDeviceInfo.c
@@ -67,6 +67,9 @@ POname(clGetDeviceInfo)(cl_device_id   device,
   POCL_RETURN_ERROR_COND ((*(device->available) == CL_FALSE),
                           CL_DEVICE_NOT_AVAILABLE);
 
+  POCL_MSG_PRINT_INFO ("clGetDeviceInfo query of param %x for %s\n",
+                       param_name, device->short_name);
+
   switch (param_name)
   {
   case CL_DEVICE_IMAGE_SUPPORT:
@@ -243,7 +246,7 @@ POname(clGetDeviceInfo)(cl_device_id   device,
     POCL_RETURN_GETINFO (cl_ulong, device->half_fp_config);
   case CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF       :
     POCL_RETURN_DEVICE_INFO_WITH_EXT_CHECK(cl_uint, device->preferred_vector_width_half, cl_khr_fp16);
-  case CL_DEVICE_HOST_UNIFIED_MEMORY               : 
+  case CL_DEVICE_HOST_UNIFIED_MEMORY:
     POCL_RETURN_GETINFO(cl_bool, device->host_unified_memory);
   case CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR          : 
     POCL_RETURN_DEVICE_INFO_WITH_IMPL_CHECK(cl_uint, device->native_vector_width_char);

--- a/lib/CL/devices/remote/communication.h
+++ b/lib/CL/devices/remote/communication.h
@@ -3,7 +3,7 @@
 
    Copyright (c) 2018 Michal Babej / Tampere University of Technology
    Copyright (c) 2019-2023 Jan Solanti / Tampere University
-   Copyright (c) 2023 Pekka Jääskeläinen / Intel Finland Oy
+   Copyright (c) 2023-2024 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to
@@ -308,10 +308,11 @@ cl_int pocl_network_free_device (cl_device_id device);
 
 cl_int pocl_network_setup_peer_mesh ();
 
-cl_int pocl_network_setup_devinfo (cl_device_id device,
-                                   remote_device_data_t *ddata,
-                                   remote_server_data_t *data, uint32_t pid,
-                                   uint32_t did);
+cl_int pocl_network_fetch_devinfo (cl_device_id device,
+                                   cl_device_info specific_info,
+                                   size_t param_value_size,
+                                   void *param_value,
+                                   size_t *param_value_size_ret);
 
 cl_int pocl_network_create_buffer (remote_device_data_t *d, cl_mem mem,
                                    void **device_addr);

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -334,6 +334,8 @@ pocl_remote_init_device_ops (struct pocl_device_ops *ops)
   ops->free = pocl_remote_free;
   ops->get_mapping_ptr = pocl_driver_get_mapping_ptr;
   ops->free_mapping_ptr = pocl_driver_free_mapping_ptr;
+
+  ops->get_device_info_ext = pocl_remote_get_device_info_ext;
   ops->set_kernel_exec_info_ext = pocl_remote_set_kernel_exec_info_ext;
 
   ops->can_migrate_d2d = pocl_remote_can_migrate_d2d;
@@ -572,9 +574,7 @@ pocl_remote_init (unsigned j, cl_device_id device, const char *parameters)
 
   POCL_INIT_LOCK (d->mem_lock);
 
-  if (pocl_network_setup_devinfo (device, d, d->server,
-                                  d->remote_platform_index,
-                                  d->remote_device_index))
+  if (pocl_network_fetch_devinfo (device, 0, NULL, 0, NULL))
     return CL_DEVICE_NOT_FOUND;
 
   assert (device->short_name);
@@ -2648,4 +2648,15 @@ pocl_remote_set_kernel_exec_info_ext (cl_device_id dev,
     default:
       return CL_INVALID_VALUE;
     }
+}
+
+cl_int
+pocl_remote_get_device_info_ext (cl_device_id device,
+                                 cl_device_info param_name,
+                                 size_t param_value_size,
+                                 void *param_value,
+                                 size_t *param_value_size_ret)
+{
+  return pocl_network_fetch_devinfo (device, param_name, param_value_size,
+                                     param_value, param_value_size_ret);
 }

--- a/pocld/shared_cl_context.hh
+++ b/pocld/shared_cl_context.hh
@@ -96,7 +96,8 @@ public:
   virtual int freeQueue(uint32_t queue_id) = 0;
 
   virtual int getDeviceInfo(uint32_t device_id, DeviceInfo_t &i,
-                            std::vector<std::string>& strings) = 0;
+                            std::vector<std::string> &strings,
+                            cl_device_info SpecificInfo) = 0;
 
   virtual int createSampler(uint32_t sampler_id, uint32_t normalized,
                             uint32_t address, uint32_t filter) = 0;

--- a/pocld/virtual_cl_context.cc
+++ b/pocld/virtual_cl_context.cc
@@ -1104,7 +1104,8 @@ void VirtualCLContext::DeviceInfo(Request *req, Reply *rep) {
   // The first string starts at offset 1.
   rep->rep.strings_size = 1;
 
-  SharedContextList[req->req.pid]->getDeviceInfo(req->req.did, info, strings);
+  SharedContextList[req->req.pid]->getDeviceInfo(req->req.did, info, strings,
+                                                 req->req.m.device_info.id);
 
   for (const std::string &str : strings)
     rep->rep.strings_size += str.size() + 1;


### PR DESCRIPTION
* Pass (vendor-specific) device infos as raw data from the device to the host to implement.
* Implement host_unified_memory and max_num_sub_groups device queries.