### PR TITLE
loopvec: Gid iterator for easier loopvec + LLVM IR checking infra

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -484,7 +484,7 @@ jobs:
       fail-fast: false
       matrix:
         # 15 to 17 should work, however 17 currently fails two tests (fp16)
-        llvm: [16]
+        llvm: [17]
         config: [openasip]
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,6 +251,8 @@ option(ENABLE_PRINTF_IMMEDIATE_FLUSH "[currently only applies to CPU drivers] if
 
 option(ENABLE_VSOCK "Enable vsock transport in the remote driver" OFF)
 
+option(ENABLE_LLVM_FILECHECKS "Enable kernel compiler/autovectorizer filechecks using the given FileCheck binary defined in LLVM_FILECHECK_BIN. Note: the checks are tested against recent Intel X86/SIMD CPUs for now.")
+
 if (ENABLE_PROXY_DEVICE)
   set(VISIBILITY_HIDDEN_DEFAULT OFF)
 else()
@@ -2240,6 +2242,7 @@ if (ENABLE_LLVM)
   MESSAGE(STATUS "LLVM_AS: ${LLVM_AS}")
   MESSAGE(STATUS "LLVM_LINK: ${LLVM_LINK}")
   MESSAGE(STATUS "LLVM_LLI: ${LLVM_LLI}")
+  MESSAGE(STATUS "LLVM_FILECHECK_BIN: ${LLVM_FILECHECK_BIN}")
   MESSAGE(STATUS "WITH_LLVM_CONFIG (User preferred llvm-config): ${WITH_LLVM_CONFIG}")
 endif()
 

--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -48,6 +48,14 @@ else()
     DOC "llvm-config executable")
 endif()
 
+if(ENABLE_LLVM_FILECHECKS)
+  if(IS_ABSOLUTE "${LLVM_FILECHECK_BIN}" AND EXISTS "${LLVM_FILECHECK_BIN}")
+    message(STATUS "LLVM IR checks enabled using ${LLVM_FILECHECK_BIN}.")
+  else()
+    message(FATAL_ERROR "${LLVM_FILECHECK_BIN} not found!")
+  endif()
+endif()
+
 set(WITH_LLVM_CONFIG "${WITH_LLVM_CONFIG}" CACHE PATH "Path to preferred llvm-config")
 
 if(NOT LLVM_CONFIG)

--- a/doc/sphinx/source/notes_6_1.rst
+++ b/doc/sphinx/source/notes_6_1.rst
@@ -51,3 +51,8 @@ most notable/user facing ones are listed below:
 Deprecation/feature removal notices
 ===================================
 
+ * The old "work-item replication" work-group function generation
+   method will be removed in the next release. It seems not provide
+   any benefits anymore over simply fully unrolling the result of
+   "loops".
+

--- a/doc/sphinx/source/notes_6_1.rst
+++ b/doc/sphinx/source/notes_6_1.rst
@@ -14,7 +14,15 @@ CPU drivers
 Work-group vectorization improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The WG vectorization with the 'loopvec' method is enabled again.
+* Improve work-group vectorization of kernels which use the global
+  id as the iteration variable. Now the loop vectorizer should
+  generate wide loads/stores more often than falling back to
+  scatter/gather.
+* The WG vectorization with the 'loopvec' method is enabled again,
+  there was an issue when upgrading to the latest LLVM version.
+  Now there's a regression test in place for avoiding accidents
+  like this in the futre.
+
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Miscellaneous

--- a/doc/sphinx/source/using.rst
+++ b/doc/sphinx/source/using.rst
@@ -381,32 +381,27 @@ pocl.
  multiple work items. Legal values:
 
  * **auto**   -- Choose the best available method depending on the
-              kernel and the work group size. Use
-              POCL_FULL_REPLICATION_THRESHOLD=N to set the
-              maximum local size for a work group to be
-              replicated fully with 'repl'. Otherwise,
-              'loops' is used.
+              kernel and the work group size. Currently always defaults
+              to **loopvec**.
 
- * **loops**  -- Create for-loops that execute the work items
-              (under stabilization). The drawback is the
-              need to save the thread contexts in arrays.
+ * **loops**  -- Create parallel for-loops that execute the work items.
 
               The loops will be unrolled a certain number of
               times of which maximum can be controlled with
               POCL_WILOOPS_MAX_UNROLL_COUNT=N environment
               variable (default is to not perform unrolling).
 
- * **loopvec** -- Create work-item for-loops (see 'loops') and execute
-               the LLVM LoopVectorizer. The loops are not unrolled
-               but the unrolling decision is left to the generic
-               LLVM passes (the default).
+ * **loopvec** -- Create parallel work-item for-loops (see 'loops') and execute
+               the LLVM vectorizers. LLVM loop unrolling is disabled and
+               the unrolling decisions are left to the generic loop vectorizer.
 
  * **repl**   -- Replicate and chain all work items. This results
               in more easily scalarizable private variables, thus
               might avoid storing work-item context to memory.
               However, the code bloat is increased with larger
-              WG sizes.
-    
+              WG sizes. **Deprecated - will be removed in the next
+              release. Use "loops" and full unrolling.**
+
  * **cbs**    -- Use continuation-based synchronization to execute work-items
               on non-SPMD devices.
               CBS is expected to work for kernels that 'loops' does not support.

--- a/examples/example0/CMakeLists.txt
+++ b/examples/example0/CMakeLists.txt
@@ -2,6 +2,7 @@
 #   CMake build system files
 #
 #   Copyright (c) 2019 pocl developers
+#                 2024 Pekka Jääskeläinen / Intel Finland Oy
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a copy
 #   of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +33,7 @@ add_executable("example0" example0.c example0_exec.c example0.cl)
 
 target_link_libraries("example0" ${POCLU_LINK_OPTIONS})
 
-add_test(NAME "examples/example0" COMMAND "example0")
+add_test_pocl(NAME "examples/example0" COMMAND "example0" LLVM_FILECHECK "example0.fc" WORKITEM_HANDLER "loopvec")
 
 if (ENABLE_SPIRV)
   add_test(NAME "examples/example0_spirv" COMMAND "example0" "v")
@@ -62,4 +63,3 @@ if (ENABLE_TCE)
   set_property(TEST "examples/example0"
     APPEND PROPERTY LABELS "tce;almaif")
 endif()
-

--- a/examples/example0/example0.fc
+++ b/examples/example0/example0.fc
@@ -1,0 +1,8 @@
+# A smoke test for autovectorization with a small WG loop without
+# a barrier and with integer arithmetics.
+
+# CHECK: load <8 x i32>
+# CHECK: mul <8 x i32>
+# CHECK: load <8 x i32>
+
+

--- a/include/opencl-c.h
+++ b/include/opencl-c.h
@@ -13736,8 +13736,9 @@ half __ovld atomic_fetch_min_explicit(volatile atomic_half *,
                                       half, memory_order, memory_scope);
 half __ovld atomic_fetch_max_explicit(volatile atomic_half *,
                                       half, memory_order, memory_scope);
-#endif // defined(__opencl_c_ext_fp16_global_atomic_min_max) &&                \
-    defined(__opencl_c_ext_fp16_local_atomic_min_max)
+#endif
+// defined(__opencl_c_ext_fp16_global_atomic_min_max) &&  \
+//    defined(__opencl_c_ext_fp16_local_atomic_min_max)
 
 #if defined(__opencl_c_ext_fp32_global_atomic_min_max)
 float __ovld atomic_fetch_min(volatile __global atomic_float *, float);
@@ -13777,8 +13778,9 @@ float __ovld atomic_fetch_min_explicit(volatile atomic_float *,
                                        float, memory_order, memory_scope);
 float __ovld atomic_fetch_max_explicit(volatile atomic_float *,
                                        float, memory_order, memory_scope);
-#endif // defined(__opencl_c_ext_fp32_global_atomic_min_max) &&                \
-    defined(__opencl_c_ext_fp32_local_atomic_min_max)
+#endif
+// defined(__opencl_c_ext_fp32_global_atomic_min_max) &&
+//    defined(__opencl_c_ext_fp32_local_atomic_min_max)
 
 #if defined(cl_khr_int64_base_atomics) && defined(cl_khr_int64_extended_atomics)
 #if defined(__opencl_c_ext_fp64_global_atomic_min_max)
@@ -13819,10 +13821,13 @@ double __ovld atomic_fetch_min_explicit(volatile atomic_double *,
                                         double, memory_order, memory_scope);
 double __ovld atomic_fetch_max_explicit(volatile atomic_double *,
                                         double, memory_order, memory_scope);
-#endif // defined(__opencl_c_ext_fp64_global_atomic_min_max) &&                \
-    defined(__opencl_c_ext_fp64_local_atomic_min_max)
-#endif // defined(cl_khr_int64_base_atomics) &&                                \
-    defined(cl_khr_int64_extended_atomics)
+#endif
+/* defined(__opencl_c_ext_fp64_global_atomic_min_max) &&
+   defined(__opencl_c_ext_fp64_local_atomic_min_max) */
+
+#endif
+/* defined(cl_khr_int64_base_atomics) &&
+   defined(cl_khr_int64_extended_atomics) */
 
 #if defined(__opencl_c_ext_fp16_global_atomic_add)
 half __ovld atomic_fetch_add(volatile __global atomic_half *, half);
@@ -13862,8 +13867,10 @@ half __ovld atomic_fetch_add_explicit(volatile atomic_half *,
                                       half, memory_order, memory_scope);
 half __ovld atomic_fetch_sub_explicit(volatile atomic_half *,
                                       half, memory_order, memory_scope);
-#endif // defined(__opencl_c_ext_fp16_global_atomic_add) &&                    \
-    defined(__opencl_c_ext_fp16_local_atomic_add)
+#endif
+
+/* defined(__opencl_c_ext_fp16_global_atomic_add) &&
+   defined(__opencl_c_ext_fp16_local_atomic_add) */
 
 #if defined(__opencl_c_ext_fp32_global_atomic_add)
 float __ovld atomic_fetch_add(volatile __global atomic_float *, float);
@@ -13903,8 +13910,10 @@ float __ovld atomic_fetch_add_explicit(volatile atomic_float *,
                                        float, memory_order, memory_scope);
 float __ovld atomic_fetch_sub_explicit(volatile atomic_float *,
                                        float, memory_order, memory_scope);
-#endif // defined(__opencl_c_ext_fp32_global_atomic_add) &&                    \
-    defined(__opencl_c_ext_fp32_local_atomic_add)
+#endif
+
+/* defined(__opencl_c_ext_fp32_global_atomic_add) &&
+   defined(__opencl_c_ext_fp32_local_atomic_add) */
 
 #if defined(cl_khr_int64_base_atomics) && defined(cl_khr_int64_extended_atomics)
 #if defined(__opencl_c_ext_fp64_global_atomic_add)
@@ -13945,10 +13954,15 @@ double __ovld atomic_fetch_add_explicit(volatile atomic_double *,
                                         double, memory_order, memory_scope);
 double __ovld atomic_fetch_sub_explicit(volatile atomic_double *,
                                         double, memory_order, memory_scope);
-#endif // defined(__opencl_c_ext_fp64_global_atomic_add) &&                    \
-    defined(__opencl_c_ext_fp64_local_atomic_add)
-#endif // defined(cl_khr_int64_base_atomics) &&                                \
-    defined(cl_khr_int64_extended_atomics)
+#endif
+
+/* defined(__opencl_c_ext_fp64_global_atomic_add) &&
+   defined(__opencl_c_ext_fp64_local_atomic_add) */
+
+#endif
+
+/* defined(cl_khr_int64_base_atomics) &&
+   defined(cl_khr_int64_extended_atomics) */
 
 #endif // cl_ext_float_atomics
 

--- a/lib/CL/pocl_llvm_metadata.cc
+++ b/lib/CL/pocl_llvm_metadata.cc
@@ -52,10 +52,10 @@ using namespace llvm;
 static inline bool is_image_type(const llvm::Type &t) {
   if (t.isPointerTy() && t.getPointerElementType()->isStructTy()) {
     llvm::StringRef name = t.getPointerElementType()->getStructName();
-    if (name.startswith("opencl.image2d_") ||
-        name.startswith("opencl.image3d_") ||
-        name.startswith("opencl.image1d_") ||
-        name.startswith("struct._pocl_image"))
+    if (name.starts_with("opencl.image2d_") ||
+        name.starts_with("opencl.image3d_") ||
+        name.starts_with("opencl.image1d_") ||
+        name.starts_with("struct._pocl_image"))
       return true;
   }
   return false;
@@ -64,7 +64,7 @@ static inline bool is_image_type(const llvm::Type &t) {
 static inline bool is_sampler_type(const llvm::Type &t) {
   if (t.isPointerTy() && t.getPointerElementType()->isStructTy()) {
     llvm::StringRef name = t.getPointerElementType()->getStructName();
-    if (name.startswith("opencl.sampler_t"))
+    if (name.starts_with("opencl.sampler_t"))
       return true;
   }
   return false;
@@ -82,8 +82,8 @@ static inline bool is_image_type(llvm::Type *ArgType,
     llvm::StringRef name(ArgInfo.type_name);
     if ((has_arg_meta & POCL_HAS_KERNEL_ARG_ACCESS_QUALIFIER) &&
         (ArgInfo.access_qualifier != CL_KERNEL_ARG_ACCESS_NONE)) {
-      if (name.startswith("image2d_") || name.startswith("image3d_") ||
-          name.startswith("image1d_") || name.startswith("_pocl_image"))
+      if (name.starts_with("image2d_") || name.starts_with("image3d_") ||
+          name.starts_with("image1d_") || name.starts_with("_pocl_image"))
         return true;
     }
   }

--- a/lib/kernel/get_global_id.c
+++ b/lib/kernel/get_global_id.c
@@ -1,24 +1,24 @@
 /* OpenCL built-in library: get_global_id()
 
    Copyright (c) 2011 Universidad Rey Juan Carlos
-   
+
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
-   
+
    The above copyright notice and this permission notice shall be included in
    all copies or substantial portions of the Software.
-   
+
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 extern const size_t _local_size_x;
@@ -33,21 +33,32 @@ extern const size_t _local_id_x;
 extern const size_t _local_id_y;
 extern const size_t _local_id_z;
 
+extern const size_t _global_id_x;
+extern const size_t _global_id_y;
+extern const size_t _global_id_z;
+
 extern const size_t _global_offset_x;
 extern const size_t _global_offset_y;
 extern const size_t _global_offset_z;
 
-size_t _CL_OVERLOADABLE _CL_READNONE _CL_OPTNONE
-get_local_id (unsigned int dimindx);
+extern const size_t _global_id_x;
+extern const size_t _global_id_y;
+extern const size_t _global_id_z;
 
-size_t _CL_OVERLOADABLE _CL_READNONE _CL_OPTNONE
-get_global_id (unsigned int dimindx)
+/* We generate the global id in WorkitemLoops using the loop iterator to make
+   the life easier for loopvec. This will be inlined and removed. */
+size_t
+_Z13get_global_idj (unsigned dim)
 {
-  switch(dimindx)
+  switch (dim)
     {
-    case 0: return _global_offset_x + _local_size_x * _group_id_x + get_local_id(0);
-    case 1: return _global_offset_y + _local_size_y * _group_id_y + get_local_id(1);
-    case 2: return _global_offset_z + _local_size_z * _group_id_z + get_local_id(2);
-    default: return 0;
+    case 0:
+      return _global_id_x;
+    case 1:
+      return _global_id_y;
+    case 2:
+      return _global_id_z;
+    default:
+      return 0;
     }
 }

--- a/lib/llvmopencl/DebugHelpers.cc
+++ b/lib/llvmopencl/DebugHelpers.cc
@@ -36,8 +36,9 @@ IGNORE_COMPILER_WARNING("-Wunused-parameter")
 #include <llvm/IR/Module.h>
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 
-#include "DebugHelpers.h"
 #include "Barrier.h"
+#include "DebugHelpers.h"
+#include "LLVMUtils.h"
 #include "Workgroup.h"
 #include "pocl_file_util.h"
 
@@ -82,13 +83,13 @@ static void printBasicBlock(
   s << ",label=\"" << b->getName().str() << ":\\n";
 
   // The work-item loop control structures.
-  if (b->getName().startswith("pregion_for_cond")) {
+  if (b->getName().starts_with("pregion_for_cond")) {
     s << "wi-loop branch\\n";
-  } else if (b->getName().startswith("pregion_for_inc")) {
+  } else if (b->getName().starts_with("pregion_for_inc")) {
     s << "local_id_* increment\\n";
-  } else if (b->getName().startswith("pregion_for_init")) {
+  } else if (b->getName().starts_with("pregion_for_init")) {
     s << "wi-loop init\\n";
-  } else if (b->getName().startswith("pregion_for_end")) {
+  } else if (b->getName().starts_with("pregion_for_end")) {
     s << "wi-loop exit\\n";
   } else {
     // analyze the contents of the BB

--- a/lib/llvmopencl/Flatten.cc
+++ b/lib/llvmopencl/Flatten.cc
@@ -74,7 +74,7 @@ static bool flattenAll(Module &M) {
 
   for (llvm::Module::iterator i = M.begin(), e = M.end(); i != e; ++i) {
     llvm::Function *f = &*i;
-    if (f->isDeclaration() || f->getName().startswith("__pocl_print") ||
+    if (f->isDeclaration() || f->getName().starts_with("__pocl_print") ||
         AuxFuncs.find(f->getName().str()) != AuxFuncs.end())
       continue;
 

--- a/lib/llvmopencl/FlattenBarrierSubs.cc
+++ b/lib/llvmopencl/FlattenBarrierSubs.cc
@@ -71,7 +71,7 @@ static bool recursivelyInlineBarrierUsers(Function *F, bool ChangeInlineFlag) {
       CallInst *CallInstr = dyn_cast<CallInst>(Instr);
       Function *Callee = CallInstr->getCalledFunction();
 
-      if ((Callee == nullptr) ||  Callee->getName().startswith("llvm."))
+      if ((Callee == nullptr) || Callee->getName().starts_with("llvm."))
         continue;
 
       if (llvm::isa<pocl::Barrier>(CallInstr))

--- a/lib/llvmopencl/Kernel.h
+++ b/lib/llvmopencl/Kernel.h
@@ -50,11 +50,6 @@ namespace pocl {
     void addLocalSizeInitCode(size_t LocalSizeX, size_t LocalSizeY,
                               size_t LocalSizeZ);
 
-    // Returns an instruction in the entry block which computes the
-    // total size of work-items in the work-group. If it doesn't
-    // exist, creates it to the end of the entry block.
-    llvm::Instruction *getWorkGroupSizeInstr();
-
     static bool isKernel(const llvm::Function &F);
 
     static bool classof(const Kernel *) { return true; }
@@ -64,8 +59,9 @@ namespace pocl {
     static bool classof(const llvm::Function *) { return true; }
 
   private:
-    // Instruction that computes the work-group size
-    llvm::Instruction *WGSizeInstr;
+    // Note: Since this class is only using llvm's inheritance mechanism for
+    // creating a convenience class, we never allocate storage for it
+    // separately, thus should not allocate any additional data here.
   };
 
 }

--- a/lib/llvmopencl/KernelCompilerUtils.h
+++ b/lib/llvmopencl/KernelCompilerUtils.h
@@ -1,0 +1,33 @@
+// Misc. helpers for kernel compilation.
+//
+// Copyright (c) 2024 Pekka Jääskeläinen / Intel Finland Oy
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#ifndef POCL_KERNEL_COMPILER_UTILS_H
+#define POCL_KERNEL_COMPILER_UTILS_H
+
+// Generates the name for the global magic variable for the local id.
+#define LID_G_NAME(DIM) (std::string("_local_id_") + (char)('x' + DIM))
+// Generates the name for the global magic variable for the global id iterator.
+#define GID_G_NAME(DIM) (std::string("_global_id_") + (char)('x' + DIM))
+// The name of the mangled get_global_id builtin function.
+#define GID_BUILTIN_NAME "_Z13get_global_idj"
+
+#endif

--- a/lib/llvmopencl/LLVMUtils.cc
+++ b/lib/llvmopencl/LLVMUtils.cc
@@ -631,6 +631,9 @@ const char *WorkgroupVariablesArray[NumWorkgroupVariables+1] = {"_local_id_x",
                                     "_global_offset_x",
                                     "_global_offset_y",
                                     "_global_offset_z",
+                                    "_global_id_x",
+                                    "_global_id_y",
+                                    "_global_id_z",
                                     "_pocl_sub_group_size",
                                     PoclGVarBufferName,
                                     NULL};
@@ -687,6 +690,15 @@ void registerFunctionAnalyses(llvm::PassBuilder &PB) {
   VariableUniformityAnalysis::registerWithPB(PB);
   WorkitemHandlerChooser::registerWithPB(PB);
   WorkItemAliasAnalysis::registerWithPB(PB);
+}
+
+/**
+ * Returns the size_t for the current target.
+ */
+llvm::Type *SizeT(llvm::Module *M) {
+  unsigned long AddressBits;
+  getModuleIntMetadata(*M, "device_address_bits", AddressBits);
+  return IntegerType::get(M->getContext(), AddressBits);
 }
 
 } // namespace pocl

--- a/lib/llvmopencl/LLVMUtils.cc
+++ b/lib/llvmopencl/LLVMUtils.cc
@@ -250,7 +250,7 @@ isAutomaticLocal(llvm::Function *F, llvm::GlobalVariable &Var) {
   std::string FuncName = F->getName().str();
   if (!llvm::isa<llvm::PointerType>(Var.getType()) || Var.isConstant())
     return false;
-  if (Var.getName().startswith(FuncName + ".")) {
+  if (Var.getName().starts_with(FuncName + ".")) {
     return true;
   }
 
@@ -420,7 +420,7 @@ bool isKernelToProcess(const llvm::Function &F) {
     return false;
   if (!F.hasName())
     return false;
-  if (F.getName().startswith("@llvm"))
+  if (F.getName().starts_with("@llvm"))
     return false;
 
   NamedMDNode *kernels = m->getNamedMetadata("opencl.kernels");
@@ -455,7 +455,7 @@ void removeUnreachableSwitchCases(llvm::Function &F) {
   for (Function::iterator FI = F.begin(), FE = F.end(); FI != FE; ++FI) {
     BasicBlock *BB = &*FI;
 
-    if (BB->hasName() && BB->getName().startswith("default.unreachable")) {
+    if (BB->hasName() && BB->getName().starts_with("default.unreachable")) {
 #ifdef DEBUG_UNREACHABLE_SWITCH_REMOVAL
       std::cerr << "##################################################\n";
       std::cerr << "### converting unreachable block: " << (void *)BB << "\n";

--- a/lib/llvmopencl/LLVMUtils.h
+++ b/lib/llvmopencl/LLVMUtils.h
@@ -55,7 +55,7 @@ namespace pocl {
 
 typedef std::map<llvm::Function*, llvm::Function*> FunctionMapping;
 
-constexpr unsigned NumWorkgroupVariables = 18;
+constexpr unsigned NumWorkgroupVariables = 21;
 extern const char *WorkgroupVariablesArray[];
 extern const std::vector<std::string> WorkgroupVariablesVector;
 constexpr unsigned NumWIFuncNames = 11;
@@ -134,6 +134,8 @@ llvm::DISubprogram *mimicDISubprogram(llvm::DISubprogram *Old,
 void registerPassBuilderPasses(llvm::PassBuilder &PB);
 
 void registerFunctionAnalyses(llvm::PassBuilder &PB);
+
+llvm::Type *SizeT(llvm::Module *M);
 
 } // namespace pocl
 

--- a/lib/llvmopencl/LLVMUtils.h
+++ b/lib/llvmopencl/LLVMUtils.h
@@ -232,4 +232,9 @@ void CloneFunctionIntoAbs(llvm::Function *NewFunc,
 #define REGISTER_OLD_FANALYSIS(PNAME, PCLASS, PDESC)                          \
   static llvm::RegisterPass<PCLASS> X (PNAME, PDESC)
 
+#if LLVM_MAJOR < 16
+// Avoid the deprecation warning with later LLVMs.
+#define starts_with startswith
+#endif
+
 #endif

--- a/lib/llvmopencl/MinLegalVecSize.cc
+++ b/lib/llvmopencl/MinLegalVecSize.cc
@@ -133,7 +133,7 @@ static uint64_t getAndFixLargestVecSize(llvm::Function *F, unsigned Justify) {
       if (Callee == nullptr)
         continue;
 
-      if (Callee->hasName() && Callee->getName().startswith("llvm."))
+      if (Callee->hasName() && Callee->getName().starts_with("llvm."))
         continue;
 
       Calls.push_back(Callee);
@@ -188,7 +188,7 @@ static bool fixMinVecSize(Module &M) {
     llvm::Function *F = &*i;
     if (F->isDeclaration())
       continue;
-    if (F->hasName() && F->getName().startswith("llvm."))
+    if (F->hasName() && F->getName().starts_with("llvm."))
       continue;
 
     // AttributeSet Attrs;
@@ -219,7 +219,7 @@ static bool fixMinVecSize(Module &M) {
     llvm::Function *F = &*i;
     if (F->isDeclaration())
       continue;
-    if (F->hasName() && F->getName().startswith("llvm."))
+    if (F->hasName() && F->getName().starts_with("llvm."))
       continue;
     if (pocl::isKernelToProcess(*F))
       continue;

--- a/lib/llvmopencl/OptimizeWorkItemFuncCalls.cc
+++ b/lib/llvmopencl/OptimizeWorkItemFuncCalls.cc
@@ -52,13 +52,13 @@ static bool optimizeWorkItemFuncCalls(Function &F) {
   // Let's avoid reoptimizing pocl_printf in the kernel compiler. It should
   // be optimized already in the bitcode library, and we do not want to
   // aggressively inline it to the kernel, causing compile time expansion.
-  if (F.getName().startswith("__pocl_print") &&
+  if (F.getName().starts_with("__pocl_print") &&
       !F.hasFnAttribute(Attribute::OptimizeNone)) {
     F.addFnAttr(Attribute::OptimizeNone);
     F.addFnAttr(Attribute::NoInline);
   }
 
-  if (F.getName().startswith("_") || F.hasFnAttribute(Attribute::OptimizeNone))
+  if (F.getName().starts_with("_") || F.hasFnAttribute(Attribute::OptimizeNone))
     return false;
 
   // Find calls to WI functions and unify them to a single call in the

--- a/lib/llvmopencl/ParallelRegion.cc
+++ b/lib/llvmopencl/ParallelRegion.cc
@@ -793,7 +793,7 @@ void ParallelRegion::LocalizeIDLoads() {
         continue;
 
       auto Callee = Call->getCalledFunction();
-      if (Callee->isDeclaration() &&
+      if (Callee != nullptr && Callee->isDeclaration() &&
           Callee->getName().equals(GID_BUILTIN_NAME)) {
         int Dim =
             cast<llvm::ConstantInt>(Call->getArgOperand(0))->getZExtValue();

--- a/lib/llvmopencl/ParallelRegion.h
+++ b/lib/llvmopencl/ParallelRegion.h
@@ -38,16 +38,13 @@ IGNORE_COMPILER_WARNING("-Wunused-parameter")
 POP_COMPILER_DIAGS
 
 #include <functional>
+#include <map>
 #include <sstream>
 #include <vector>
 
 #include "config.h"
 
 namespace pocl {
-
-#define POCL_LOCAL_ID_X_GLOBAL "_local_id_x"
-#define POCL_LOCAL_ID_Y_GLOBAL "_local_id_y"
-#define POCL_LOCAL_ID_Z_GLOBAL "_local_id_z"
 
 class Kernel;
 
@@ -134,9 +131,7 @@ class Kernel;
 
     static void GenerateTempNames(llvm::BasicBlock *bb);
 
-    llvm::Instruction* LocalIDXLoad();
-    llvm::Instruction* LocalIDYLoad();
-    llvm::Instruction* LocalIDZLoad();
+    llvm::Instruction *getOrCreateIDLoad(std::string IDGlobalName);
 
     void LocalizeIDLoads();
 
@@ -145,9 +140,9 @@ class Kernel;
   private:
     BBContainer BBs_;
 
-    llvm::Instruction* LocalIDXLoadInstr;
-    llvm::Instruction* LocalIDYLoadInstr;
-    llvm::Instruction* LocalIDZLoadInstr;
+    /// Cache for the instructions in the entry block that load the various WI
+    /// ids.
+    std::map<std::string, llvm::Instruction *> IDLoadInstrs;
 
     bool Verify();
     /// The indices of entry and exit, not pointers, for finding the BBs in the

--- a/lib/llvmopencl/SubCFGFormation.h
+++ b/lib/llvmopencl/SubCFGFormation.h
@@ -36,9 +36,12 @@
 #include <llvm/Pass.h>
 #include <llvm/Passes/PassBuilder.h>
 
+#include "WorkitemHandler.h"
+
 namespace pocl {
 
-class SubCFGFormation : public llvm::PassInfoMixin<SubCFGFormation> {
+class SubCFGFormation : public llvm::PassInfoMixin<SubCFGFormation>,
+                        WorkitemHandler {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,

--- a/lib/llvmopencl/VariableUniformityAnalysis.cc
+++ b/lib/llvmopencl/VariableUniformityAnalysis.cc
@@ -339,8 +339,8 @@ bool VariableUniformityAnalysisResult::isUniform(llvm::Function *F,
         CallInst *CallInstr = dyn_cast<CallInst>(user);
         Function *Callee = CallInstr->getCalledFunction();
         if (Callee != nullptr &&
-            (Callee->getName().startswith("llvm.lifetime.end") ||
-             Callee->getName().startswith("llvm.lifetime.start"))) {
+            (Callee->getName().starts_with("llvm.lifetime.end") ||
+             Callee->getName().starts_with("llvm.lifetime.start"))) {
 #ifdef DEBUG_UNIFORMITY_ANALYSIS
           std::cerr << "### alloca is used by llvm.lifetime" << std::endl;
           user->dump();

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -250,7 +250,7 @@ bool WorkgroupImpl::runOnModule(Module &M, FunctionVec &OldKernels) {
     // linker's switch --wrap=symbol, where calls to the "symbol" are replaced
     // with "__wrap_symbol" at link time.  These functions may not be referenced
     // until final link and being deleted by LLVM optimizations before it.
-    if (!i->isDeclaration() && !i->getName().startswith("__wrap_"))
+    if (!i->isDeclaration() && !i->getName().starts_with("__wrap_"))
       i->setLinkage(Function::InternalLinkage);
   }
 
@@ -468,7 +468,7 @@ static bool callsPrintf(Function *F) {
         continue;
       Function *callee = CallInstr->getCalledFunction();
 
-      if (callee->getName().startswith("llvm."))
+      if (callee->getName().starts_with("llvm."))
         continue;
       if (callee->getName().equals("_cl_printf"))
         return true;
@@ -599,7 +599,7 @@ static void replacePrintfCalls(Value *pb, Value *pbp, Value *pbc, bool isKernel,
         replaceCIMap.insert(
             std::pair<CallInst *, CallInst *>(CallInstr, NewCI));
       } else {
-        if (!oldF->getName().startswith("llvm."))
+        if (!oldF->getName().starts_with("llvm."))
           callsToCheck.push_back(CallInstr);
       }
     }

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -49,6 +49,7 @@ POP_COMPILER_DIAGS
 #include "Barrier.h"
 #include "BarrierTailReplication.h"
 #include "CanonicalizeBarriers.h"
+#include "KernelCompilerUtils.h"
 #include "LLVMUtils.h"
 #include "ProgramScopeVariables.h"
 #include "VariableUniformityAnalysis.h"
@@ -220,7 +221,7 @@ bool WorkgroupImpl::runOnModule(Module &M, FunctionVec &OldKernels) {
 
   HiddenArgs = 0;
   SizeTWidth = AddressBits;
-  SizeT = IntegerType::get(*C, SizeTWidth);
+  SizeT = pocl::SizeT(&M);
 
   llvm::Type *Int32T = Type::getInt32Ty(*C);
   llvm::Type *Int8T = Type::getInt8Ty(*C);
@@ -845,9 +846,41 @@ void WorkgroupImpl::privatizeGlobals(
   }
 }
 
+/**
+ * Makes the work-item context data function private.
+ *
+ * Until this point all the work-group generation passes have referred to
+ * magic global variables to access the work-item identifiers. These are
+ * converted to kernel-local allocas by this function.
+ */
 void WorkgroupImpl::privatizeContext(Function *F) {
-  char TempStr[STRING_LENGTH];
+
+  // Privatize _global_id_* to private allocas.
+  // They are referred to by WorkItemLoops to fetch the global id directly.
+
   IRBuilder<> Builder(F->getEntryBlock().getFirstNonPHI());
+
+  // For replace the global_ids with local allocas for easier
+  // data flow analysis.
+  std::vector<Value *> GlobalIdAllocas(3);
+  for (int i = 0; i < 3; ++i) {
+    if (M->getGlobalVariable(GID_G_NAME(i)) == nullptr)
+      continue;
+    GlobalIdAllocas[i] = Builder.CreateAlloca(SizeT, 0, GID_G_NAME(i));
+  }
+
+  for (Function::iterator i = F->begin(), e = F->end(); i != e; ++i) {
+    for (BasicBlock::iterator ii = i->begin(), ee = i->end(); ii != ee; ++ii) {
+      for (int j = 0; j < 3; ++j) {
+        if (M->getGlobalVariable(GID_G_NAME(j)) == nullptr)
+          continue;
+        ii->replaceUsesOfWith(M->getGlobalVariable(GID_G_NAME(j)),
+                              GlobalIdAllocas[j]);
+      }
+    }
+  }
+
+  char TempStr[STRING_LENGTH];
 
   std::vector<GlobalVariable*> LocalIdGlobals(3);
   std::vector<AllocaInst*> LocalIdAllocas(3);

--- a/lib/llvmopencl/WorkitemHandler.cc
+++ b/lib/llvmopencl/WorkitemHandler.cc
@@ -181,7 +181,7 @@ bool WorkitemHandler::fixUndominatedVariableUses(llvm::DominatorTree &DT,
               StringRef baseName;
               std::pair< StringRef, StringRef > pieces = 
                 operand->getName().rsplit('.');
-              if (pieces.second.startswith("pocl_"))
+              if (pieces.second.starts_with("pocl_"))
                 baseName = pieces.first;
               else
                 baseName = operand->getName();

--- a/lib/llvmopencl/WorkitemHandler.cc
+++ b/lib/llvmopencl/WorkitemHandler.cc
@@ -27,16 +27,20 @@ IGNORE_COMPILER_WARNING("-Wmaybe-uninitialized")
 #include <llvm/ADT/Twine.h>
 POP_COMPILER_DIAGS
 IGNORE_COMPILER_WARNING("-Wunused-parameter")
-#include "llvm/IR/Metadata.h"
-#include "llvm/IR/Constants.h"
-#include "llvm/IR/Module.h"
-#include "llvm/IR/Instructions.h"
-#include "llvm/IR/ValueSymbolTable.h"
-#include "llvm/Support/CommandLine.h"
+#include <llvm/IR/Constants.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Metadata.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/ValueSymbolTable.h>
+#include <llvm/Support/CommandLine.h>
 
-#include "WorkitemHandler.h"
-#include "Kernel.h"
 #include "DebugHelpers.h"
+#include "Kernel.h"
+#include "KernelCompilerUtils.h"
+#include "LLVMUtils.h"
+#include "WorkitemHandler.h"
+
 POP_COMPILER_DIAGS
 
 #include "pocl_llvm_api.h"
@@ -55,10 +59,10 @@ cl::opt<bool> AddWIMetadata(
     cl::desc("Adds a work item identifier to each of the instruction in "
              "work items."));
 
-void
-WorkitemHandler::Initialize(Kernel *K) {
+void WorkitemHandler::Initialize(Kernel *K_) {
 
-  llvm::Module *M = K->getParent();
+  K = K_;
+  M = K->getParent();
 
   getModuleIntMetadata(*M, "device_address_bits", AddressBits);
 
@@ -79,15 +83,13 @@ WorkitemHandler::Initialize(Kernel *K) {
     WGLocalSizeZ = 1;
 
   SizeTWidth = AddressBits;
-  SizeT = IntegerType::get(M->getContext(), SizeTWidth);
+  ST = pocl::SizeT(M);
 
-  assert ((SizeTWidth == 32 || SizeTWidth == 64) &&
-          "Only 32 and 64 bit size_t widths supported.");
+  LocalIdZGlobal = M->getOrInsertGlobal(LID_G_NAME(2), ST);
+  LocalIdYGlobal = M->getOrInsertGlobal(LID_G_NAME(1), ST);
+  LocalIdXGlobal = M->getOrInsertGlobal(LID_G_NAME(0), ST);
 
-  llvm::Type *LocalIdType = SizeT;
-  LocalIdZGlobal = M->getOrInsertGlobal(POCL_LOCAL_ID_Z_GLOBAL, LocalIdType);
-  LocalIdYGlobal = M->getOrInsertGlobal(POCL_LOCAL_ID_Y_GLOBAL, LocalIdType);
-  LocalIdXGlobal = M->getOrInsertGlobal(POCL_LOCAL_ID_X_GLOBAL, LocalIdType);
+  GlobalIdOrigins = {0, 0, 0};
 }
 
 bool WorkitemHandler::dominatesUse(llvm::DominatorTree &DT, Instruction &Inst,
@@ -246,5 +248,80 @@ WorkitemHandler::movePhiNodes(llvm::BasicBlock* Src, llvm::BasicBlock* Dst) {
     PN->moveBefore(Dst->getFirstNonPHI());
 }
 
+/**
+ * Returns the instruction in the entry block which computes the "base" for
+ * the global id which has all components except the local id offset included.
+ */
+llvm::Instruction *WorkitemHandler::getGlobalIdOrigin(int Dim) {
+  llvm::Instruction *Origin = GlobalIdOrigins[Dim];
+  if (Origin != nullptr)
+    return Origin;
+
+  GlobalVariable *LocalSize = cast<GlobalVariable>(M->getOrInsertGlobal(
+      std::string("_local_size_") + (char)('x' + Dim), ST));
+  GlobalVariable *GlobalOffset = cast<GlobalVariable>(M->getOrInsertGlobal(
+      std::string("_global_offset_") + (char)('x' + Dim), ST));
+  GlobalVariable *GroupId = cast<GlobalVariable>(
+      M->getOrInsertGlobal(std::string("_group_id_") + (char)('x' + Dim), ST));
+
+  assert(LocalSize != nullptr);
+  assert(GlobalOffset != nullptr);
+  assert(GroupId != nullptr);
+
+  IRBuilder<> Builder(K->getEntryBlock().getFirstNonPHI());
+
+  Origin = cast<llvm::Instruction>(
+      Builder.CreateBinOp(Instruction::Mul, Builder.CreateLoad(ST, LocalSize),
+                          Builder.CreateLoad(ST, GroupId)));
+
+  Origin = cast<llvm::Instruction>(Builder.CreateBinOp(
+      Instruction::Add, Builder.CreateLoad(ST, GlobalOffset), Origin));
+
+  GlobalIdOrigins[Dim] = Origin;
+
+  llvm::GlobalVariable *GlobalId =
+      cast<GlobalVariable>(M->getOrInsertGlobal(GID_G_NAME(Dim), ST));
+
+  // Initialize the global id to the first value just in case we won't create
+  // a loop for a 1-sized dimensions which would create the monotonically
+  // incrementing GID.
+  Builder.CreateStore(Origin, GlobalId);
+
+  return Origin;
+}
+
+/**
+ * Scans for usages of global id and replaces with global_id_base + local_id.
+ *
+ * This should be called for WorkitemHandlers that do not produce the global
+ * id within the handler like WILoops does.
+ */
+void WorkitemHandler::GenerateGlobalIdComputation() {
+  for (Function::iterator FI = K->begin(), FE = K->end(); FI != FE; ++FI) {
+    for (BasicBlock::iterator II = FI->begin(), IE = FI->end(); II != IE;) {
+      llvm::LoadInst *GIdLoad = dyn_cast<llvm::LoadInst>(II);
+      ++II;
+      if (GIdLoad == NULL)
+        continue;
+
+      for (int Dim = 0; Dim < 3; ++Dim) {
+        GlobalVariable *GlobalId = M->getGlobalVariable(GID_G_NAME(Dim));
+        if (GIdLoad->getOperand(0) != GlobalId) {
+          continue;
+        }
+        IRBuilder<> FBuilder(GIdLoad);
+
+        Instruction *LocalId =
+            FBuilder.CreateLoad(ST, M->getGlobalVariable(LID_G_NAME(Dim)));
+        Instruction *GlobalIdOrigin = getGlobalIdOrigin(Dim);
+
+        Instruction *GidStore = FBuilder.CreateStore(
+            FBuilder.CreateAdd(GlobalIdOrigin, LocalId), GlobalId);
+
+        break;
+      }
+    }
+  }
+}
 
 } // namespace pocl

--- a/lib/llvmopencl/WorkitemHandler.h
+++ b/lib/llvmopencl/WorkitemHandler.h
@@ -35,8 +35,11 @@
 
 namespace pocl {
 
+// Common base class for work-group function generators that includes
+// utility functionality.
 class WorkitemHandler {
 public:
+  // Should be called when starting to process a new kernel.
   virtual void Initialize (pocl::Kernel *K);
 
 protected:
@@ -45,14 +48,26 @@ protected:
   bool dominatesUse (llvm::DominatorTree &DT, llvm::Instruction &Inst,
                      unsigned OpNum);
 
+  llvm::Instruction *getGlobalIdOrigin(int dim);
+  void GenerateGlobalIdComputation();
+
   // The type of size_t for the current target.
-  llvm::Type *SizeT;
+  llvm::Type *ST;
   // The width of size_t for the current target.
   int SizeTWidth;
 
   // The Module global variables that hold the place of the current local
   // id until privatized.
   llvm::Value *LocalIdZGlobal, *LocalIdYGlobal, *LocalIdXGlobal;
+
+  // Points to the global id origin computation instructions in the entry
+  // block of the currently handled kernel. To get the global id, the current
+  // local id must be added to it.
+  std::array<llvm::Instruction *, 3> GlobalIdOrigins;
+
+  // The currently handled Kernel/Function and its Module.
+  pocl::Kernel *K;
+  llvm::Module *M;
 
   // Copies of compilation parameters
   std::string KernelName;

--- a/lib/llvmopencl/WorkitemHandlerChooser.h
+++ b/lib/llvmopencl/WorkitemHandlerChooser.h
@@ -54,6 +54,9 @@ public:
   Result run(llvm::Function &F, llvm::FunctionAnalysisManager &AM);
   static bool isRequired() { return true; }
 };
+
+WorkitemHandlerType ChooseWorkitemHandler(llvm::Function &F);
+
 } // namespace pocl
 
 #endif

--- a/lib/llvmopencl/WorkitemLoops.cc
+++ b/lib/llvmopencl/WorkitemLoops.cc
@@ -808,8 +808,9 @@ bool WorkitemLoopsImpl::handleLocalMemAllocas(Kernel &K) {
       if (!isa<CallInst>(I)) continue;
       CallInst &Call = cast<CallInst>(I);
 
-      if (Call.getCalledFunction() != LocalMemAllocaFuncDecl &&
-          Call.getCalledFunction() != WorkGroupAllocaFuncDecl) continue;
+      if (Call.getCalledFunction() == nullptr ||
+          (Call.getCalledFunction() != LocalMemAllocaFuncDecl &&
+           Call.getCalledFunction() != WorkGroupAllocaFuncDecl)) continue;
       InstructionsToFix.push_back(&Call);
     }
   }

--- a/lib/llvmopencl/WorkitemReplication.cc
+++ b/lib/llvmopencl/WorkitemReplication.cc
@@ -104,8 +104,6 @@ bool WorkitemReplicationImpl::runOnFunction(Function &F) {
 bool WorkitemReplicationImpl::processFunction(Function &F) {
   Module *M = F.getParent();
 
-//  F.viewCFG();
-
   Kernel *K = cast<Kernel> (&F);
   Initialize(K);
 
@@ -304,6 +302,7 @@ bool WorkitemReplicationImpl::processFunction(Function &F) {
   delete OriginalParallelRegions;
   OriginalParallelRegions = nullptr;
 
+  GenerateGlobalIdComputation();
   return true;
 }
 

--- a/lib/llvmopencl/linker.cpp
+++ b/lib/llvmopencl/linker.cpp
@@ -55,6 +55,7 @@ IGNORE_COMPILER_WARNING("-Wunused-parameter")
 #include "pocl_cl.h"
 #include "pocl_llvm_api.h"
 
+#include "KernelCompilerUtils.h"
 #include "LLVMUtils.h"
 #include "linker.h"
 
@@ -474,14 +475,12 @@ int link(llvm::Module *Program, const llvm::Module *Lib, std::string &Log,
           continue;
         }
 
-        if ((f == NULL) ||
-            (f->isDeclaration() &&
-             // A target might want to expose the C99 printf in case not supporting
-             // the OpenCL 1.2 printf.
-             !f->getName().equals("printf") &&
-             !f->getName().equals(pocl_sampler_handler) &&
-             !f->getName().startswith(llvm_intrins))
-           ) {
+        if ((f == NULL) || (f->isDeclaration() &&
+                            // A target might want to expose the C99 printf in
+                            // case not supporting the OpenCL 1.2 printf.
+                            !f->getName().equals("printf") &&
+                            !f->getName().equals(pocl_sampler_handler) &&
+                            !f->getName().startswith(llvm_intrins))) {
           Log.append("Cannot find symbol ");
           Log.append(r.str());
           Log.append(" in kernel library\n");

--- a/lib/llvmopencl/linker.cpp
+++ b/lib/llvmopencl/linker.cpp
@@ -122,7 +122,7 @@ static void fixCallingConv(llvm::Module *Mod, std::string &Log) {
         CallInst *CallInstr = dyn_cast<CallInst>(Instr);
         Function *Callee = CallInstr->getCalledFunction();
 
-        if ((Callee == nullptr) || Callee->getName().startswith("llvm.") ||
+        if ((Callee == nullptr) || Callee->getName().starts_with("llvm.") ||
             Callee->isDeclaration())
           continue;
 
@@ -480,7 +480,7 @@ int link(llvm::Module *Program, const llvm::Module *Lib, std::string &Log,
                             // case not supporting the OpenCL 1.2 printf.
                             !f->getName().equals("printf") &&
                             !f->getName().equals(pocl_sampler_handler) &&
-                            !f->getName().startswith(llvm_intrins))) {
+                            !f->getName().starts_with(llvm_intrins))) {
           Log.append("Cannot find symbol ");
           Log.append(r.str());
           Log.append(" in kernel library\n");

--- a/tools/scripts/format-branch.sh
+++ b/tools/scripts/format-branch.sh
@@ -24,7 +24,11 @@ trap 'rm -f $PATCHY' EXIT
 git diff main -U0 --no-color >"$PATCHY"
 
 "$RELPATH"/clang-format-diff.py -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 -style=file:"$RELPATH/style.GNU" <"$PATCHY"
-"$RELPATH"/clang-format-diff.py -regex '(.*(\.hpp$|\.hh$|\.cc$|\.cpp$))|(lib/llvmopencl/.*)|(lib/CL/devices/tce/.*)' -i -p1 -style=file:"$RELPATH/style.CPP" <"$PATCHY"
+
+# We need to recreate the diff since the old patch is stale.
+git diff main -U0 --no-color >"$PATCHY"
+
+"$RELPATH"/clang-format-diff.py -v -regex '(.*(\.hpp$|\.hh$|\.cc$|\.cpp$|lib/llvmopencl/.*$|/lib/CL/devices/tce/.*$))' -i -p1 -style=file:"$RELPATH/style.CPP" <"$PATCHY"
 
 # cd back whence we were previously
 popd > /dev/null || exit 1

--- a/tools/scripts/format-diff.sh
+++ b/tools/scripts/format-diff.sh
@@ -17,8 +17,12 @@ trap 'rm -f $PATCHY' EXIT
 
 git diff $* -U0 --no-color >$PATCHY
 
-"$RELPATH"/clang-format-diff.py -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 -style=file:"$RELPATH/style.GNU" <"$PATCHY"
-"$RELPATH"/clang-format-diff.py -regex '(.*(\.hpp$|\.hh$|\.cc$|\.cpp$))|(lib/llvmopencl/.*)|(lib/CL/devices/tce/.*)' -i -p1 -style=file:"$RELPATH/style.CPP" <"$PATCHY"
+"$RELPATH"/clang-format-diff.py -v -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 -style=file:"$RELPATH/style.GNU" <"$PATCHY"
+
+# We need to recreate the diff since the old patch is stale.
+git diff $* -U0 --no-color >$PATCHY
+
+"$RELPATH"/clang-format-diff.py -v -regex '(.*(\.hpp$|\.hh$|\.cc$|\.cpp$|lib/llvmopencl/.*$|/lib/CL/devices/tce/.*$))' -i -p1 -style=file:"$RELPATH/style.CPP" <"$PATCHY"
 
 # cd back wherever we were previously
 popd > /dev/null || exit 1

--- a/tools/scripts/run-and-check-llvm-ir
+++ b/tools/scripts/run-and-check-llvm-ir
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Copyright (c) 2024 Pekka Jääskeläinen / Intel Finland Oy
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# A script to test the parallel.bc output using LLVM's FileCheck.
+#
+# Usage:
+#
+# run-and-check-llvm-ir PATH/TO/llvm-FileCheck PATH/TO/FileCheck-file PATH/TO/opencl-app ARGS
+#
+# It then runs the given OpenCL application, letting it dump the final
+# vectorized work-group function in parallel.bc, which is then checked using
+# LLVM's FileCheck with the verification checks read from the given file.
+# This thus works only for cases when the application compiles and launches
+# a single kernel with a single local size. No error checking / user
+# friendliness is done by the script.
+
+LLVM_FILECHECK=$1
+CHECK_FILE=$2
+shift 2
+APP_CMD=$@
+
+export POCL_CACHE_DIR=$(mktemp -d /tmp/pocl-lit-test-XXXXXXXX)
+
+export POCL_LEAVE_KERNEL_COMPILER_TEMP_FILES=1
+
+$APP_CMD
+
+BC_FILE=`find $POCL_CACHE_DIR -name parallel.bc`
+LL_FILE=$POCL_CACHE_DIR/parallel-to-check.ll
+
+llvm-dis $BC_FILE -o $LL_FILE
+cat $LL_FILE | $LLVM_FILECHECK $CHECK_FILE
+RET=$?
+
+trap 'rm -fr $POCL_CACHE_DIR' EXIT
+
+if test $RET -eq 0;
+then
+    echo LLVM IR checks OK.
+    exit 0
+else
+    cat $LL_FILE
+    echo LLVM IR checks FAIL.
+    exit 1
+fi


### PR DESCRIPTION
Adds a separate monotonic global id variable

This helps the LLVM loopvec to better recognize the memory access patterns of loops which use gid instead of lid.
The first in the series of loooong (10+ years) overdue low-hanging fruits in the vectorization performance.

Also added a vectorization/LLVM IR smoke test (infra) to avoid ever again accidentally disabling the WG vectorization.

@franz can we install FileCheck in the LLVM 18 bot and enable the test there?