### PR TITLE
poclr: fix build on arch linux

### DIFF
--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -574,7 +574,7 @@ pocl_remote_init (unsigned j, cl_device_id device, const char *parameters)
 
   POCL_INIT_LOCK (d->mem_lock);
 
-  if (pocl_network_fetch_devinfo (device, 0, NULL, 0, NULL))
+  if (pocl_network_fetch_devinfo (device, 0, 0, NULL,  NULL))
     return CL_DEVICE_NOT_FOUND;
 
   assert (device->short_name);

--- a/pocld/daemon.cc
+++ b/pocld/daemon.cc
@@ -21,6 +21,7 @@
    IN THE SOFTWARE.
 */
 
+#include <algorithm>
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 #include <net/if.h>

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -23,6 +23,7 @@
    IN THE SOFTWARE.
 */
 
+#include <algorithm>
 #include <cassert>
 #include <cstdio>
 #include <filesystem>


### PR DESCRIPTION
Building on arch linux had the unfortunate
issue of not finding std::find and std::for_each
unless explicitly importing algorithm.
There was also a case of a size and null pointer
being swapped which caused a casting error.