### PR TITLE
pthread: Add workgroup function builtin kernels

### DIFF
--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -490,7 +490,7 @@ static void
 basic_command_scheduler (pocl_basic_data_t *d)
 {
   _cl_command_node *node;
-  
+
   /* execute commands from ready list */
   while ((node = d->ready_list))
     {
@@ -517,7 +517,7 @@ pocl_basic_submit (_cl_command_node *node, cl_command_queue cq)
       if (!program->builtin_kernel_attributes)
         {
           node->command.run.device_data
-            = pocl_check_kernel_dlhandle_cache (node, CL_TRUE, CL_TRUE);
+            = pocl_check_kernel_dlhandle_cache (node, CL_TRUE, CL_TRUE, NULL);
         }
     }
 
@@ -592,7 +592,7 @@ pocl_basic_compile_kernel (_cl_command_node *cmd, cl_kernel kernel,
   char *saved_name = NULL;
   pocl_sanitize_builtin_kernel_name (kernel, &saved_name);
   if (cmd != NULL && cmd->type == CL_COMMAND_NDRANGE_KERNEL)
-    pocl_check_kernel_dlhandle_cache (cmd, CL_FALSE, specialize);
+    pocl_check_kernel_dlhandle_cache (cmd, CL_FALSE, specialize, NULL);
   pocl_restore_builtin_kernel_name (kernel, saved_name);
 }
 

--- a/lib/CL/devices/common.h
+++ b/lib/CL/devices/common.h
@@ -58,78 +58,138 @@
 #define POCL_DEVICES_PREFERRED_VECTOR_WIDTH_HALF POCL_DEVICES_PREFERRED_VECTOR_WIDTH_SHORT
 #define POCL_DEVICES_NATIVE_VECTOR_WIDTH_HALF POCL_DEVICES_NATIVE_VECTOR_WIDTH_SHORT
 
-#ifdef __cplusplus  
+#ifdef __cplusplus
 extern "C" {
 #endif
 
-POCL_EXPORT
-void pocl_fill_dev_image_t (dev_image_t *di, struct pocl_argument *parg,
-                            cl_device_id device);
+  typedef struct pocl_dlhandle_cache_item pocl_dlhandle_cache_item;
+  struct pocl_dlhandle_cache_item
+  {
+    pocl_kernel_hash_t hash;
 
-POCL_EXPORT
-void pocl_fill_dev_sampler_t (dev_sampler_t *ds, struct pocl_argument *parg);
+    /* The specialization properties. */
+    /* The local dimensions. */
+    size_t local_wgs[3];
+    /* If global offset must be zero for this WG function version. */
+    int goffs_zero;
+    int specialize;
+    /* Maximum grid dimension this WG function works with. */
+    size_t max_grid_dim_width;
 
-POCL_EXPORT
-void pocl_exec_command (_cl_command_node *node);
+    void *wg;
+    void *dlhandle;
+    pocl_dlhandle_cache_item *next;
+    pocl_dlhandle_cache_item *prev;
+    unsigned ref_count;
+  };
 
-POCL_EXPORT
-char *pocl_cpu_build_hash (cl_device_id device);
+  POCL_EXPORT
+  char *pocl_cpu_build_hash (cl_device_id device);
 
-POCL_EXPORT
-void pocl_broadcast (cl_event event);
+  POCL_EXPORT
+  void pocl_broadcast (cl_event event);
 
-POCL_EXPORT
-void pocl_init_dlhandle_cache ();
+  // pocl_lock_t pocl_dlhandle_lock;
 
-POCL_EXPORT
-char *pocl_check_kernel_disk_cache (_cl_command_node *cmd, int specialized);
+  POCL_EXPORT
+  void pocl_fill_dev_image_t (dev_image_t *di,
+                              struct pocl_argument *parg,
+                              cl_device_id device);
 
-POCL_EXPORT
-size_t pocl_cmd_max_grid_dim_width (_cl_command_run *cmd);
+  POCL_EXPORT
+  void pocl_fill_dev_sampler_t (dev_sampler_t *ds, struct pocl_argument *parg);
 
-POCL_EXPORT
-void *pocl_check_kernel_dlhandle_cache (_cl_command_node *command,
-                                        int retain,
-                                        int specialize);
+  POCL_EXPORT
+  void pocl_exec_command (_cl_command_node *node);
 
-POCL_EXPORT
-void pocl_release_dlhandle_cache (void *dlhandle_cache_item);
+  POCL_EXPORT
+  void pocl_broadcast (cl_event event);
 
-POCL_EXPORT
-void pocl_setup_device_for_system_memory(cl_device_id device);
+  POCL_EXPORT
+  void pocl_init_dlhandle_cache ();
 
-POCL_EXPORT
-void pocl_reinit_system_memory();
+  POCL_EXPORT
+  char *pocl_check_kernel_disk_cache (_cl_command_node *cmd, int specialized);
 
-POCL_EXPORT
-void pocl_set_buffer_image_limits(cl_device_id device);
+  POCL_EXPORT
+  size_t pocl_max_grid_dim_width (const ulong local_size[3],
+                                  const ulong num_groups[3]);
 
-POCL_EXPORT
-void* pocl_aligned_malloc_global_mem(cl_device_id device, size_t align, size_t size);
+  POCL_EXPORT
+  size_t pocl_cmd_max_grid_dim_width (_cl_command_run *cmd);
 
-POCL_EXPORT
-void pocl_free_global_mem(cl_device_id device, void *ptr, size_t size);
+  POCL_EXPORT
+  void *pocl_check_kernel_dlhandle_cache (_cl_command_node *command,
+                                          int retain,
+                                          int specialize,
+                                          char *dylib_name);
 
-void pocl_print_system_memory_stats();
+  /* Look for a dlhandle in the dlhandle cache for the given kernel command.
+      If found, push the handle up in the cache to improve cache hit speed,
+      and return it. Otherwise return NULL. The caller should hold
+      pocl_dlhandle_lock. */
+  POCL_EXPORT
+  pocl_dlhandle_cache_item *
+  fetch_dlhandle_cache_item (const void *hash,
+                             const ulong local_size[3],
+                             int specialize,
+                             const ulong global_offset[3],
+                             const ulong num_groups[3]);
 
-POCL_EXPORT
-void pocl_init_default_device_infos (cl_device_id dev,
-                                     const char *device_extensions);
+  /* TODO: Refactor the two following functions to not dlopen twice */
+  POCL_EXPORT
+  void *pocl_get_symbol (const char *symbol_name, const char *dylib_name);
 
-POCL_EXPORT
-void pocl_setup_opencl_c_with_version (cl_device_id dev, int supports_30);
+  POCL_EXPORT
+  pocl_dlhandle_cache_item *pocl_add_cache_item (const void *hash,
+                                                 const ulong local_size[3],
+                                                 int retain,
+                                                 int specialize,
+                                                 const ulong global_offset[3],
+                                                 const ulong num_groups[3],
+                                                 const char *dylib_name,
+                                                 const char *kernel_name);
 
-POCL_EXPORT
-void pocl_setup_extensions_with_version (cl_device_id dev);
+  POCL_EXPORT
+  void pocl_release_dlhandle_cache (void *dlhandle_cache_item);
 
-POCL_EXPORT
-void pocl_setup_ils_with_version (cl_device_id dev);
+  POCL_EXPORT
+  void pocl_setup_device_for_system_memory (cl_device_id device);
 
-POCL_EXPORT
-void pocl_setup_features_with_version (cl_device_id dev);
+  POCL_EXPORT
+  void pocl_reinit_system_memory ();
 
-POCL_EXPORT
-void pocl_setup_builtin_kernels_with_version (cl_device_id dev);
+  POCL_EXPORT
+  void pocl_set_buffer_image_limits (cl_device_id device);
+
+  POCL_EXPORT
+  void *pocl_aligned_malloc_global_mem (cl_device_id device,
+                                        size_t align,
+                                        size_t size);
+
+  POCL_EXPORT
+  void pocl_free_global_mem (cl_device_id device, void *ptr, size_t size);
+
+  void pocl_print_system_memory_stats ();
+
+  POCL_EXPORT
+  void pocl_init_default_device_infos (cl_device_id dev,
+                                       const char *device_extensions);
+
+  POCL_EXPORT
+  void pocl_setup_opencl_c_with_version (cl_device_id dev, int supports_30);
+
+  POCL_EXPORT
+  void pocl_setup_extensions_with_version (cl_device_id dev);
+
+  POCL_EXPORT
+  void pocl_setup_ils_with_version (cl_device_id dev);
+
+  POCL_EXPORT
+  void pocl_setup_features_with_version (cl_device_id dev);
+
+  POCL_EXPORT
+  void pocl_setup_builtin_kernels_with_version (cl_device_id dev);
 
 #ifdef __cplusplus
 }

--- a/lib/CL/devices/common_driver.c
+++ b/lib/CL/devices/common_driver.c
@@ -31,11 +31,11 @@
 
 #include "pocl_cl.h"
 #include "pocl_timing.h"
-#include "utlist.h"
+#include "pocl_util.h"
 
 // for pocl_aligned_malloc
-#include "pocl_util.h"
 #include "pocl_file_util.h"
+
 // for SPIR-V handling
 #include "pocl_cache.h"
 
@@ -1077,7 +1077,6 @@ pocl_driver_build_poclbinary (cl_program program, cl_uint device_i)
 
   return CL_SUCCESS;
 }
-
 
 int
 pocl_driver_build_opencl_builtins (cl_program program, cl_uint device_i)

--- a/lib/CL/devices/pthread/CMakeLists.txt
+++ b/lib/CL/devices/pthread/CMakeLists.txt
@@ -23,20 +23,56 @@
 #
 #=============================================================================
 
-if(MSVC)
-  set_source_files_properties( pocl-pthread.h pthread.c pthread_scheduler.c PROPERTIES LANGUAGE CXX )
-endif(MSVC)
+# To add a new BiK to pthread, add it to 4 places (needs to be refactored to
+# reside in 1 place only):
+# 2x common_driver.c (pocl_driver_free_program() and pocl_driver_add_host_builtins())
+# 1x pthread_scheduler.c (pocl_pthread_prepare_kernel())
+# 1x pthread.c (pocl_pthread_init())
 
-set(SOURCES pocl-pthread.h pthread.c pthread_scheduler.c)
-if(APPLE)
-  list(APPEND SOURCES pthread_barrier.c)
-endif(APPLE)
+# TODO: The options below should be probably made device-specific (they exist in
+# basic device as well)
+
+# these are needed in order to have POCL messages working in the BiKs
+set(LOGGING_SOURCES ../../pocl_debug.h ../../pocl_debug.c ../../pocl_threads.c ../../pocl_threads.h ../../pocl_timing.c ../../pocl_timing.h)
+
+if(ANDROID)
+    find_library(ANDROID_LOG_LIB log REQUIRED)
+else(ANDROID)
+    set(ANDROID_LOG_LIB "")
+endif(ANDROID)
+
+function(add_pocl_host_builtin_library name)
+    add_library(${name} SHARED ${ARGN})
+    # make the logging files private
+    target_sources(${name} PRIVATE ${LOGGING_SOURCES})
+    harden("${name}")
+    set_target_properties(${name} PROPERTIES PREFIX "lib" SUFFIX ".so")
+    target_link_libraries(${name} PUBLIC ${ANDROID_LOG_LIB})
+    install(TARGETS ${name} LIBRARY DESTINATION "${POCL_INSTALL_PRIVATE_LIBDIR}" COMPONENT "lib")
+endfunction()
+
+### Vector addition test BiK
+set(VECADD_BIK_LIB pocl_pthread_add_i8)
+add_pocl_host_builtin_library(${VECADD_BIK_LIB}
+        builtin-kernels/pocl_add_i8.cpp
+        builtin-kernels/pocl_add_i8.h)
+set_target_properties(${VECADD_BIK_LIB} PROPERTIES LINKER_LANGUAGE CXX)
+
+### Other pthread stuff
+if (MSVC)
+    set_source_files_properties(pocl-pthread.h pthread.c pthread_scheduler.c PROPERTIES LANGUAGE CXX)
+endif (MSVC)
+
+set(SOURCES pocl-pthread.h pthread.c pthread_scheduler.c builtin-kernels/metadata.h)
+if (APPLE)
+    list(APPEND SOURCES pthread_barrier.c)
+endif (APPLE)
 add_pocl_device_library(pocl-devices-pthread ${SOURCES})
 
-if(ENABLE_LOADABLE_DRIVERS)
-  target_link_libraries(pocl-devices-pthread PRIVATE pocl-devices-basic ${PTHREAD_LIBRARY})
-endif()
+if (ENABLE_LOADABLE_DRIVERS)
+    target_link_libraries(pocl-devices-pthread PRIVATE pocl-devices-basic ${PTHREAD_LIBRARY})
+endif ()
 
 if(ENABLE_HOST_CPU_DEVICES_OPENMP)
-  target_link_libraries(pocl-devices-pthread PRIVATE OpenMP::OpenMP_C)
+    target_link_libraries(pocl-devices-pthread PRIVATE OpenMP::OpenMP_C)
 endif()

--- a/lib/CL/devices/pthread/builtin-kernels/metadata.h
+++ b/lib/CL/devices/pthread/builtin-kernels/metadata.h
@@ -1,0 +1,27 @@
+//
+// Created by rabijl on 28.11.2023.
+// This file contains metadata on builtin kernels that can be loaded as an so.
+//
+
+#ifndef POCL_METADATA_H
+#define POCL_METADATA_H
+
+#define NUM_PTHREAD_BUILTIN_HOST_KERNELS 1
+static char *const kernel_names[NUM_PTHREAD_BUILTIN_HOST_KERNELS] = {
+  "pocl.add.i8",
+};
+
+// Make sure LD_LIBRARY_PATH is set to contain the .so files
+static char *const dylib_names[NUM_PTHREAD_BUILTIN_HOST_KERNELS] = {
+  "libpocl_pthread_add_i8.so",
+};
+
+static const char *const init_fn_names[NUM_PTHREAD_BUILTIN_HOST_KERNELS] = {
+  "init_pocl_add_i8",
+};
+
+static const char *const free_fn_names[NUM_PTHREAD_BUILTIN_HOST_KERNELS] = {
+  "free_pocl_add_i8",
+};
+
+#endif // POCL_METADATA_H

--- a/lib/CL/devices/pthread/builtin-kernels/pocl_add_i8.cpp
+++ b/lib/CL/devices/pthread/builtin-kernels/pocl_add_i8.cpp
@@ -1,0 +1,51 @@
+#include <CL/cl.h>
+#include <cstdio>
+#include <pocl_cl.h>
+#include <pocl_debug.h>
+#include <pocl_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+namespace {
+bool INITIALIZED = false;
+}
+
+void init_pocl_add_i8() {
+  POCL_MSG_PRINT_INFO("Initializing\n");
+  INITIALIZED = true;
+}
+
+void free_pocl_add_i8() {
+  POCL_MSG_PRINT_INFO("De-initializing\n");
+  INITIALIZED = false;
+}
+
+// TODO: Hard-code wg size 1 to the cache item
+// TODO: Add macro for adding the surrounding _pocl_kernel_..._workgroup
+void _pocl_kernel_pocl_add_i8_workgroup(cl_uchar *args, cl_uchar *context,
+                                        cl_ulong group_x, cl_ulong group_y,
+                                        cl_ulong group_z) {
+  if (INITIALIZED) {
+    POCL_MSG_PRINT_INFO("Initialized\n");
+
+    void **arguments = *(void ***)(args);
+    char *in1_data = (char *)(arguments[0]);
+    char *in2_data = (char *)(arguments[1]);
+    char *out_data = (char *)(arguments[2]);
+
+    // TODO: Do not have hard-coded upper bound. This requires supporting
+    // wg sizes of cache item != 1 which I'm not sure is possible because
+    // they're created statically.
+    for (int i = 0; i < 8; ++i) {
+      out_data[i] = in1_data[i] + in2_data[i];
+    }
+  } else {
+    POCL_MSG_ERR("ERROR: Vector addition not initalized!\n");
+  }
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/CL/devices/pthread/builtin-kernels/pocl_add_i8.h
+++ b/lib/CL/devices/pthread/builtin-kernels/pocl_add_i8.h
@@ -1,0 +1,30 @@
+#ifndef POCL_PTHREAD_ADD_I8_H
+#define POCL_PTHREAD_ADD_I8_H
+
+#include <CL/cl.h>
+#include <pocl_cl.h>
+#include <pocl_types.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  POCL_EXPORT
+  void init_pocl_add_i8 ();
+
+  POCL_EXPORT
+  void free_pocl_add_i8 ();
+
+  POCL_EXPORT
+  void _pocl_kernel_pocl_add_i8_workgroup (cl_uchar *args,
+                                           cl_uchar *context,
+                                           ulong group_x,
+                                           ulong group_y,
+                                           ulong group_z);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // POCL_PTHREAD_ADD_I8_H

--- a/lib/CL/devices/pthread/pocl-pthread.h
+++ b/lib/CL/devices/pthread/pocl-pthread.h
@@ -33,4 +33,7 @@ GEN_PROTOTYPES (pthread)
 #include "prototypes.inc"
 GEN_PROTOTYPES (basic)
 
+POCL_EXPORT
+int pocl_pthread_add_host_builtins (cl_program program, cl_uint device_i);
+
 #endif /* POCL_PTHREAD_H */

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -32,6 +32,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "builtin-kernels/metadata.h"
 #include "common.h"
 #include "common_driver.h"
 #include "pocl-pthread.h"
@@ -329,8 +330,8 @@ work_group_scheduler (kernel_run_command *k,
                  gids[0], gids[1], gids[2]);
 #endif
           pocl_set_default_rm ();
-          k->workgroup ((uint8_t*)arguments, (uint8_t*)&pc,
-			gids[0], gids[1], gids[2]);
+          k->workgroup ((uint8_t *)arguments, (uint8_t *)&pc, gids[0], gids[1],
+                        gids[2]);
         }
     }
   while (get_wg_index_range (k, &start_index, &end_index, &last_wgs,
@@ -464,9 +465,20 @@ pocl_pthread_prepare_kernel (void *data, _cl_command_node *cmd)
   pocl_driver_build_gvar_init_kernel (program, dev_i, cmd->device,
                                       pocl_cpu_gvar_init_callback);
 
+  char *dylib_name = NULL;
+  for (int i = 0; i < NUM_PTHREAD_BUILTIN_HOST_KERNELS; ++i)
+    {
+      if (strcmp (kernel->name, kernel_names[i]) == 0)
+        {
+          dylib_name = dylib_names[i];
+          break;
+        }
+    }
+
   char *saved_name = NULL;
   pocl_sanitize_builtin_kernel_name (kernel, &saved_name);
-  void *ci = pocl_check_kernel_dlhandle_cache (cmd, CL_TRUE, CL_TRUE);
+  void *ci
+    = pocl_check_kernel_dlhandle_cache (cmd, CL_TRUE, CL_TRUE, dylib_name);
   cmd->command.run.device_data = ci;
   pocl_restore_builtin_kernel_name (kernel, saved_name);
 


### PR DESCRIPTION
We needed a bunch of builtin kernels on the pthread device for internal testing and initially went with an similar approach as was introduced in #1521 . This however caused deadlocks in our use case (multiple interdependent command queues) since the builtin kernels block the pthread scheduler. To fix this we decided to make use of the existing infrastructure for dynamically loading LLVM-generated workgroup functions by moving the builtin kernels to separate dynamic libraries and adding the ability to manually specify the library name to load into the driver's dynamic library cache for kernels, and formulating the BiK functions as workgroup functions.

This is a bit of a departure from #1521 and I'm not entirely sure how well it works with the recent DBK work or if this is even a direction that we want to take with builtin kernels. The interesting bits are the dlhandle cache stuff in common.c (which I am quite tempted to pull into its own files at this point) as well as the (relative lack of) changes to pthread_scheduler.c.