### PR TITLE
Remove nonexisting reference to _libclang_versions_checks.h in CMakeLists.txt

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 set(PRIVATE_HEADERS _enable_all_exts.h _builtin_renames.h
                     _kernel.h _clang_opencl.h opencl-c.h opencl-c-base.h
-                    _kernel_c.h _kernel_constants.h _libclang_versions_checks.h
+                    _kernel_c.h _kernel_constants.h
                     pocl_types.h pocl_device.h pocl.h pocl_spir.h
                     pocl_image_types.h)
 


### PR DESCRIPTION
This removes last reference to  _libclang_versions_checks.h (in CMakeLists.txt), which was removed in [2ec5e820a9b5d58fb770cf9a3dc1795ca1a418d4](https://github.com/pocl/pocl/commit/2ec5e820a9b5d58fb770cf9a3dc1795ca1a418d4). 

This did not affect compilation but installation failed: 
```
CMake Error at include/cmake_install.cmake:54 (file):
  file INSTALL cannot find
  "pocl/include/_libclang_versions_checks.h":
  No such file or directory.
```