### PR TITLE
proxy: update to new organization of mem_objs

### DIFF
--- a/tests/runtime/test_queue_creation_with_hints.c
+++ b/tests/runtime/test_queue_creation_with_hints.c
@@ -25,9 +25,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <CL/cl_ext.h>
-
 #include "poclu.h"
+
+#include <CL/cl_ext.h>
 
 int
 main ()


### PR DESCRIPTION
Do note that i've only tested this on x86 with example0 and not yet on android

This commit updates the proxy device to get
its mem_objs from the node instead of the event,
as is now done in all other devices.
There is also a fix in one of the tests for
when pocl is renamed.
