### PR TITLE
CPU: Fix missing isinf(half) and isinf(halfn)

### DIFF
--- a/lib/kernel/host/CMakeLists.txt
+++ b/lib/kernel/host/CMakeLists.txt
@@ -342,6 +342,10 @@ else()
   set(KERNEL_SOURCES ${SOURCES_GENERIC})
 endif()
 
+if(HOST_CPU_ENABLE_CL_KHR_FP16)
+  list(APPEND KERNEL_SOURCES isinf_half.cl)
+endif()
+
 if(HOST_DEVICE_CL_VERSION_MAJOR GREATER_EQUAL 2)
 if(MIPS)
   message(STATUS "OpenCL 2.0 atomics are currently broken on MIPS")

--- a/lib/kernel/host/CMakeLists.txt
+++ b/lib/kernel/host/CMakeLists.txt
@@ -289,7 +289,8 @@ if(HOST_CPU_ENABLE_CL_KHR_FP16)
     round.cl
     sin.cl
     sqrt.cl
-    trunc.cl)
+    trunc.cl
+    isinf_half.cl)
 endif()
 
 
@@ -340,10 +341,6 @@ if(ENABLE_SLEEF)
   set(KERNEL_SOURCES ${SOURCES_WITH_SLEEF})
 else()
   set(KERNEL_SOURCES ${SOURCES_GENERIC})
-endif()
-
-if(HOST_CPU_ENABLE_CL_KHR_FP16)
-  list(APPEND KERNEL_SOURCES isinf_half.cl)
 endif()
 
 if(HOST_DEVICE_CL_VERSION_MAJOR GREATER_EQUAL 2)

--- a/lib/kernel/isinf_half.cl
+++ b/lib/kernel/isinf_half.cl
@@ -1,0 +1,34 @@
+/* OpenCL built-in library: isinf()
+
+   Copyright (c) 2024 Henry Linjamäki / Intel Finland Oy
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+#include "templates.h"
+
+int __attribute__((overloadable)) isinf(half a) {
+  return __builtin_isinf(a);
+}
+
+IMPLEMENT_BUILTIN_L_V(isinf, short2, half2, half, lo, hi)
+IMPLEMENT_BUILTIN_L_V(isinf, short3, half3, half, lo, s2)
+IMPLEMENT_BUILTIN_L_V(isinf, short4, half4, half, lo, hi)
+IMPLEMENT_BUILTIN_L_V(isinf, short8, half8, half, lo, hi)
+IMPLEMENT_BUILTIN_L_V(isinf, short16, half16, half, lo, hi)

--- a/tests/kernel/CMakeLists.txt
+++ b/tests/kernel/CMakeLists.txt
@@ -136,6 +136,9 @@ add_test_pocl(NAME "kernel/test_short16"
 add_test_pocl(NAME "kernel/test_frexp_modf"
               COMMAND "kernel" "test_frexp_modf")
 
+add_test_pocl(NAME "kernel/test_halfs"
+              COMMAND "kernel" "test_halfs")
+
 foreach(VARIANT ${VARIANTS})
   set_tests_properties("kernel/test_min_max_${VARIANT}" "kernel/test_length_distance_${VARIANT}"
     "kernel/test_fmin_fmax_fma_${VARIANT}" "kernel/test_local_struct_array_${VARIANT}"

--- a/tests/kernel/test_halfs.cl
+++ b/tests/kernel/test_halfs.cl
@@ -1,23 +1,28 @@
-kernel 
-void test_min_max() {
-/*    +FAIL: max(a,b)[0] type=uint2 a=0x15b348c9 b=0xf88e7d07 want=0xf88e7d07 got=0x15b348c9
-      +FAIL: min(a,b)[0] type=uint2 a=0x15b348c9 b=0xf88e7d07 want=0x15b348c9 got=0xf88e7d07 */
-    volatile uint2 a = (uint2)(0x15b348c9, 0x15b348c9);
-    volatile uint2 b = (uint2)(0xf88e7d07, 0xf88e7d07);
-    uint2 max_ = max(a, b);
-    uint2 min_ = min(a, b);
-    if (max_[0] != 0xf88e7d07 || min_[0] != 0x15b348c9) {
-        printf("max(a,b)[0] type=uint2 a=0x15b348c9 b=0xf88e7d07 want=0xf88e7d07 got=%x\n", max_[0]);
-        printf("min(a,b)[0] type=uint2 a=0x15b348c9 b=0xf88e7d07 want=0x15b348c9 got=%x\n", min_[0]);
-    }
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-    volatile float4 va = (float4)(3.0f, 5.0f, -2.0f, -9.0f);
-    volatile float4 vb = (float4)(2.0f, -4.4f, -1.0f, -20.0f); 
-    float4 vmax = max(va, vb);
-    float4 vmin = min(va, vb);
+global half a = INFINITY;
+global half b = 1.0h;
+global half8 va = (half8)(INFINITY);
+global half8 vb = (half8)(1.0h);
 
-    if (any(vmax != (float4)(3.0f, 5.0f, -1.0f, -9.0f)) ||
-        any(vmin != (float4)(2.0f, -4.4f, -2.0f, -20.0f))) {
-        printf("min or max on float4 failed.\n");
-    }
+/* This prevents compiler to optimize away test inputs without volatile keyword.
+ */
+kernel void touch_testdata(half a_init, half b_init, half va_init,
+                           half vb_init) {
+  a = a_init;
+  b = b_init;
+  va = va_init;
+  vb = vb_init;
+}
+
+kernel
+void test_halfs() {
+  if (!isinf(a))
+    printf("FAIL at line %d\n", __LINE__ - 1);
+  if (isinf(b))
+    printf("FAIL at line %d\n", __LINE__ - 1);
+  if (!all(isinf(va) == (short8)(-1)))
+    printf("FAIL at line %d\n", __LINE__ - 1);
+  if (!all(isinf(vb) == (short8)(0)))
+    printf("FAIL at line %d\n", __LINE__ - 1);
 }


### PR DESCRIPTION
They were missing because `isinf()` definitions were pulled from `lib/kernel/libclc*` which doesn't have overloads for `half` scalar and vectors.

Resolves #1562.