### PR TITLE
Retry waitpid in case of EINTR for debugger compatibility.

### DIFF
--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -1813,7 +1813,11 @@ pocl_run_command (const char **args)
       if (p < 0)
         return EXIT_FAILURE;
       int status;
-      if (waitpid (p, &status, 0) < 0)
+      int ret;
+      do {
+        ret = waitpid (p, &status, 0);
+      } while (ret == -1 && errno == EINTR);
+      if (ret < 0)
         POCL_ABORT ("pocl: waitpid() failed.\n");
       if (WIFEXITED (status))
         return WEXITSTATUS (status);
@@ -1881,7 +1885,11 @@ pocl_run_command_capture_output (char *capture_string,
       *captured_bytes = total_bytes;
 
       int status;
-      if (waitpid (p, &status, 0) < 0)
+      int ret;
+      do {
+        ret = waitpid (p, &status, 0);
+      } while (ret == -1 && errno == EINTR);
+      if (ret < 0)
         POCL_ABORT ("pocl: waitpid() failed.\n");
 
       close (out[0]);


### PR DESCRIPTION
Running under LLDB seems to cause `waitpid` to return `EINTR`:

```
pocl: waitpid() failed.
Process 18432 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
    frame #0: 0x000000019205e600 libsystem_kernel.dylib`__pthread_kill + 8
libsystem_kernel.dylib`__pthread_kill:
->  0x19205e600 <+8>:  b.lo   0x19205e620    ; <+40>
    0x19205e604 <+12>: pacibsp
    0x19205e608 <+16>: stp    x29, x30, [sp, #-0x10]!
    0x19205e60c <+20>: mov    x29, sp
Target 0: (julia) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  * frame #0: 0x000000019205e600 libsystem_kernel.dylib`__pthread_kill + 8
    frame #1: 0x0000000192096f70 libsystem_pthread.dylib`pthread_kill + 288
    frame #2: 0x0000000191fa3908 libsystem_c.dylib`abort + 128
    frame #3: 0x00000001225f24c8 libpocl.2.13.0.dylib`pocl_run_command + 312
    frame #4: 0x00000001226194fc libpocl.2.13.0.dylib`pocl_driver_build_binary + 2764
    frame #5: 0x00000001225d27b8 libpocl.2.13.0.dylib`compile_and_link_program + 3288
    frame #6: 0x00000001225d1ac8 libpocl.2.13.0.dylib`clBuildProgram + 72