### PR TITLE
Subgroups support for CBS

### DIFF
--- a/lib/llvmopencl/ParallelRegion.cc
+++ b/lib/llvmopencl/ParallelRegion.cc
@@ -510,46 +510,6 @@ void ParallelRegion::addParallelLoopMetadata(
   }
 }
 
-void
-ParallelRegion::AddIDMetadata(
-    llvm::LLVMContext& context, 
-    std::size_t x, 
-    std::size_t y, 
-    std::size_t z) {
-    int counter = 1;
-    Metadata *v1[] = {
-        MDString::get(context, "WI_region"),      
-        llvm::ConstantAsMetadata::get(
-          ConstantInt::get(Type::getInt32Ty(context), pRegionId))
-    };
-    MDNode* mdRegion = MDNode::get(context, v1);  
-    Metadata *v2[] = {
-        MDString::get(context, "WI_xyz"),      
-        llvm::ConstantAsMetadata::get(
-          ConstantInt::get(Type::getInt32Ty(context), x)),
-        llvm::ConstantAsMetadata::get(
-          ConstantInt::get(Type::getInt32Ty(context), y)),      
-        llvm::ConstantAsMetadata::get(
-          ConstantInt::get(Type::getInt32Ty(context), z))};
-    MDNode* mdXYZ = MDNode::get(context, v2);
-    Metadata *v[] = {MDString::get(context, "WI_data"), mdRegion, mdXYZ};
-    MDNode *md = MDNode::get(context, v);
-
-    for (iterator i = begin(), e = end(); i != e; ++i) {
-      BasicBlock *BB = *i;
-      for (BasicBlock::iterator ii = BB->begin(); ii != BB->end(); ii++) {
-        Metadata *v3[] = {MDString::get(context, "WI_counter"),
-                          llvm::ConstantAsMetadata::get(ConstantInt::get(
-                              Type::getInt32Ty(context), counter))};
-        MDNode *mdCounter = MDNode::get(context, v3);
-        counter++;
-        ii->setMetadata("wi", md);
-        ii->setMetadata("wi_counter", mdCounter);
-      }
-    }
-}
-
-
 /**
  * Inserts a new basic block to the region, before an old basic block in
  * the region.

--- a/lib/llvmopencl/ParallelRegion.h
+++ b/lib/llvmopencl/ParallelRegion.h
@@ -107,10 +107,6 @@ class Kernel;
 
     llvm::BasicBlock* exitBB() { return at(exitIndex_); }
     llvm::BasicBlock* entryBB() { return at(entryIndex_); }
-    void AddIDMetadata(llvm::LLVMContext& context,
-                       std::size_t x = 0,
-                       std::size_t y = 0,
-                       std::size_t z = 0);
 
     void addParallelLoopMetadata(
         llvm::MDNode *Identifier,

--- a/lib/llvmopencl/SubCFGFormation.cc
+++ b/lib/llvmopencl/SubCFGFormation.cc
@@ -1523,10 +1523,12 @@ SubCFGFormation::run(llvm::Function &F, llvm::FunctionAnalysisManager &AM) {
 
   formSubCfgs(F, LI, DT, PDT, VUA);
 
-  if (canAnnotateParallelLoops(*K))
+  if (canAnnotateParallelLoops())
     for (auto *SL : LI.getLoopsInPreorder())
       if (llvm::findOptionMDForLoop(SL, PoclMDKind::WorkItemLoop))
         markLoopParallel(F, SL);
+
+  handleLocalMemAllocas();
 
   GenerateGlobalIdComputation();
   PreservedAnalyses PAChanged = PreservedAnalyses::none();

--- a/lib/llvmopencl/SubCFGFormation.cc
+++ b/lib/llvmopencl/SubCFGFormation.cc
@@ -1523,9 +1523,10 @@ SubCFGFormation::run(llvm::Function &F, llvm::FunctionAnalysisManager &AM) {
 
   formSubCfgs(F, LI, DT, PDT, VUA);
 
-  for (auto *SL : LI.getLoopsInPreorder())
-    if (llvm::findOptionMDForLoop(SL, PoclMDKind::WorkItemLoop))
-      markLoopParallel(F, SL);
+  if (canAnnotateParallelLoops(*K))
+    for (auto *SL : LI.getLoopsInPreorder())
+      if (llvm::findOptionMDForLoop(SL, PoclMDKind::WorkItemLoop))
+        markLoopParallel(F, SL);
 
   GenerateGlobalIdComputation();
   PreservedAnalyses PAChanged = PreservedAnalyses::none();

--- a/lib/llvmopencl/WorkitemHandler.cc
+++ b/lib/llvmopencl/WorkitemHandler.cc
@@ -55,15 +55,32 @@ namespace pocl {
 
 using namespace llvm;
 
-cl::opt<bool> AddWIMetadata(
-    "add-wi-metadata", cl::init(false), cl::Hidden,
-    cl::desc("Adds a work item identifier to each of the instruction in "
-             "work items."));
+// Compiler-expanded function that can be used to allocate "local memory"
+// dynamically in the work-group function. Used by SG/WG shuffle implementations
+// as temporary storage.
+constexpr const char *POCL_LOCAL_MEM_ALLOCA_FUNC_NAME =
+    "__pocl_local_mem_alloca";
 
+// Another which multiplies the given size by the number of WIs in the WG.
+constexpr const char *POCL_WORK_GROUP_ALLOCA_FUNC_NAME =
+    "__pocl_work_group_alloca";
+
+/// Start processing a new kernel.
+///
+/// Should be invoked from the work-item handlers to initialize the internal
+/// per-kernel data.
 void WorkitemHandler::Initialize(Kernel *K_) {
 
   K = K_;
   M = K->getParent();
+
+  LocalMemAllocaFuncDecl =
+      K->getParent()->getFunction(POCL_LOCAL_MEM_ALLOCA_FUNC_NAME);
+
+  WorkGroupAllocaFuncDecl =
+      K->getParent()->getFunction(POCL_WORK_GROUP_ALLOCA_FUNC_NAME);
+
+  WGSizeInstr = nullptr;
 
   getModuleIntMetadata(*M, "device_address_bits", AddressBits);
 
@@ -597,8 +614,8 @@ WorkitemHandler::createContextArrayGEP(llvm::AllocaInst *CtxArrayAlloca,
   return GEP;
 }
 
-/// Checks if it's OK to mark the work-item loops in the given function as
-/// parallel loops.
+/// Checks if it's OK to mark the work-item loops in the currently processed
+/// kernel as parallel loops.
 ///
 /// Currently the only known reason to not mark them is to workaround a VPlan
 /// crash that occurs with volatile memory accesses inside the parallel
@@ -613,9 +630,9 @@ WorkitemHandler::createContextArrayGEP(llvm::AllocaInst *CtxArrayAlloca,
 /// \param F the function to check.
 /// \return False in case we should _not_ add the parallel loop metadata,
 /// even though the loop is known to be parallel.
-bool WorkitemHandler::canAnnotateParallelLoops(llvm::Function &F) {
+bool WorkitemHandler::canAnnotateParallelLoops() {
 #if LLVM_MAJOR == 19
-  for (auto &BB : F) {
+  for (auto &BB : *K) {
     for (auto &I : BB) {
       if (I.isVolatile())
         return false;
@@ -625,6 +642,87 @@ bool WorkitemHandler::canAnnotateParallelLoops(llvm::Function &F) {
 #else
   return true;
 #endif
+}
+
+/// Returns the instruction in the entry block of the currently handled kernel
+/// which computes the total size of work-items in the work-group.
+///
+/// If it doesn't exist, creates and adds it to the end of the entry block.
+llvm::Instruction *WorkitemHandler::getWorkGroupSizeInstr() {
+
+  if (WGSizeInstr != nullptr)
+    return WGSizeInstr;
+
+  IRBuilder<> Builder(K->getEntryBlock().getTerminator());
+
+  llvm::Module *M = K->getParent();
+  GlobalVariable *GV = M->getGlobalVariable("_local_size_x");
+  if (GV != NULL) {
+    WGSizeInstr = Builder.CreateLoad(ST, GV);
+  }
+
+  GV = M->getGlobalVariable("_local_size_y");
+  if (GV != NULL) {
+    WGSizeInstr = cast<llvm::Instruction>(Builder.CreateBinOp(
+        Instruction::Mul, Builder.CreateLoad(ST, GV), WGSizeInstr));
+  }
+
+  GV = M->getGlobalVariable("_local_size_z");
+  if (GV != NULL) {
+    WGSizeInstr = cast<llvm::Instruction>(Builder.CreateBinOp(
+        Instruction::Mul, Builder.CreateLoad(ST, GV), WGSizeInstr));
+  }
+
+  return WGSizeInstr;
+}
+
+/// Converts calls to the __pocl_{work_group,local_mem}_alloca() pseudo
+/// functions to allocas in the current kernel.
+///
+/// These compiler-expanded functions are used to allocate temporary
+/// storage for subgroup implementation. Search for their usage in the
+/// bitcode library for examples.
+bool WorkitemHandler::handleLocalMemAllocas() {
+
+  std::vector<CallInst *> InstructionsToFix;
+
+  for (BasicBlock &BB : *K) {
+    for (Instruction &I : BB) {
+
+      if (!isa<CallInst>(I))
+        continue;
+      CallInst &Call = cast<CallInst>(I);
+
+      if (Call.getCalledFunction() == nullptr ||
+          (Call.getCalledFunction() != LocalMemAllocaFuncDecl &&
+           Call.getCalledFunction() != WorkGroupAllocaFuncDecl))
+        continue;
+      InstructionsToFix.push_back(&Call);
+    }
+  }
+
+  bool Changed = false;
+  for (CallInst *Call : InstructionsToFix) {
+    Value *Size = Call->getArgOperand(0);
+    Align Alignment =
+        cast<ConstantInt>(Call->getArgOperand(1))->getAlignValue();
+    Value *ExtraSize = Call->getArgOperand(2);
+
+    IRBuilder<> Builder(K->getEntryBlock().getTerminator());
+
+    if (Call->getCalledFunction() == WorkGroupAllocaFuncDecl) {
+      Instruction *WGSize = getWorkGroupSizeInstr();
+      Size = Builder.CreateBinOp(Instruction::Mul, WGSize, Size);
+      Size = Builder.CreateBinOp(Instruction::Add, Size, ExtraSize);
+    }
+    AllocaInst *Alloca = new AllocaInst(
+        llvm::Type::getInt8Ty(Call->getContext()), 0, Size, Alignment,
+        "__pocl_wg_alloca", K->getEntryBlock().getTerminator());
+    Call->replaceAllUsesWith(Alloca);
+    Call->eraseFromParent();
+    Changed = true;
+  }
+  return Changed;
 }
 
 } // namespace pocl

--- a/lib/llvmopencl/WorkitemHandler.h
+++ b/lib/llvmopencl/WorkitemHandler.h
@@ -71,7 +71,10 @@ protected:
   createContextArrayGEP(llvm::AllocaInst *CtxArrayAlloca,
                         llvm::Instruction *Before, bool AlignPadding);
 
-  bool canAnnotateParallelLoops(llvm::Function &F);
+  bool canAnnotateParallelLoops();
+  bool handleLocalMemAllocas();
+
+  llvm::Instruction *getWorkGroupSizeInstr();
 
   // The type of size_t for the current target.
   llvm::Type *ST;
@@ -86,6 +89,19 @@ protected:
   // block of the currently handled kernel. To get the global id, the current
   // local id must be added to it.
   std::array<llvm::Instruction *, 3> GlobalIdOrigins;
+
+  // Points to the __pocl_local_mem_alloca pseudo function declaration, if
+  // it's been referred to in the currently processed module.
+  llvm::Function *LocalMemAllocaFuncDecl;
+
+  // Points to the __pocl_work_group_alloca pseudo function declaration, if
+  // it's been referred to in the currently processed module.
+  llvm::Function *WorkGroupAllocaFuncDecl;
+
+  // Points to the work-group size computation instruction in the entry
+  // block of the currently handled kernel. Will be created with the first
+  // call to getWorkGroupSizeInstr.
+  llvm::Instruction *WGSizeInstr;
 
   // The currently handled Kernel/Function and its Module.
   pocl::Kernel *K;

--- a/lib/llvmopencl/WorkitemHandler.h
+++ b/lib/llvmopencl/WorkitemHandler.h
@@ -71,6 +71,8 @@ protected:
   createContextArrayGEP(llvm::AllocaInst *CtxArrayAlloca,
                         llvm::Instruction *Before, bool AlignPadding);
 
+  bool canAnnotateParallelLoops(llvm::Function &F);
+
   // The type of size_t for the current target.
   llvm::Type *ST;
   // The width of size_t for the current target.

--- a/lib/llvmopencl/WorkitemHandler.h
+++ b/lib/llvmopencl/WorkitemHandler.h
@@ -104,8 +104,6 @@ protected:
   unsigned long WGMaxGridDimWidth;
 };
 
-  extern llvm::cl::opt<bool> AddWIMetadata;
-  extern llvm::cl::opt<int> LockStepSIMDWidth;
 }
 
 #endif

--- a/tests/workgroup/loopbarriers.cl
+++ b/tests/workgroup/loopbarriers.cl
@@ -1,8 +1,3 @@
-
-/* Workaround for the VPlan/LLVM crash reported here:
-   https://github.com/pocl/pocl/issues/1556 */
-#define volatile
-
 kernel void
 test_kernel (global int *output)
 {


### PR DESCRIPTION
Implement subgroups for also CBS

With this change, the following subgroup CTS tests pass:

```
POCL_WORK_GROUP_METHOD=cbs ctest -R subgr
Test project /home/pjaaskel/src/pocl/build-cpu
    Start 407: conformance_main_subgroups
1/4 Test #407: conformance_main_subgroups ..........   Passed   34.34 sec
    Start 569: conformance_spirv_subgroups
2/4 Test #569: conformance_spirv_subgroups .........   Passed    8.47 sec
    Start 579: conformance_main_subgroups_micro
3/4 Test #579: conformance_main_subgroups_micro ....   Passed    4.58 sec
    Start 749: conformance_spirv_subgroups_micro
4/4 Test #749: conformance_spirv_subgroups_micro ...   Passed    1.91 sec

100% tests passed, 0 tests failed out of 4
```
It used to be implemented only for 'loopvec' and 'loops'.

Also the PR adds a better workaround for the VPlan/volatile issue and removes an abandoned feature of the replicated WI metadata to clean up the code.
