### PR TITLE
remove cl_half utils from poclu

### DIFF
--- a/lib/CL/pocl_cl_half_util.c
+++ b/lib/CL/pocl_cl_half_util.c
@@ -23,6 +23,12 @@
    IN THE SOFTWARE.
 */
 
+/**
+ * TODO: see if this library can be dropped for the include/CL/cl_half.h
+ *  library. The question is which rounding mode should be used in that
+ *  case.
+ */
+
 #include "pocl_cl_half_util.h"
 
 static int const shift = 13;

--- a/poclu/CMakeLists.txt
+++ b/poclu/CMakeLists.txt
@@ -26,10 +26,9 @@
 set_opencl_header_includes()
 
 if(MSVC)
-  set_source_files_properties( bswap.c misc.c "${CMAKE_CURRENT_SOURCE_DIR}/../lib/CL/pocl_cl_half_util.c" PROPERTIES LANGUAGE CXX )
+  set_source_files_properties( bswap.c misc.c PROPERTIES LANGUAGE CXX )
 endif(MSVC)
 
-add_library("poclu" STATIC bswap.c misc.c "${CMAKE_CURRENT_SOURCE_DIR}/../lib/CL/pocl_cl_half_util.c")
+add_library("poclu" STATIC bswap.c misc.c)
 
-target_include_directories("poclu" PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../lib/CL")
 harden("poclu")

--- a/poclu/misc.c
+++ b/poclu/misc.c
@@ -33,7 +33,6 @@
 
 #include "config.h"
 
-#include "pocl_cl_half_util.h"
 #include "pocl_opencl.h"
 
 cl_context
@@ -673,16 +672,4 @@ poclu_load_program (cl_context context, cl_device_id device,
   return poclu_load_program_multidev (context, &device, 1, basename,
                                       spirv, poclbin, explicit_binary,
                                       extra_build_opts, p);
-}
-
-cl_half
-poclu_float_to_cl_half (float value)
-{
-  return pocl_float_to_half (value);
-}
-
-float
-poclu_cl_half_to_float (cl_half value)
-{
-  return pocl_half_to_float (value);
 }

--- a/poclu/poclu.h
+++ b/poclu/poclu.h
@@ -226,24 +226,6 @@ POCLU_API cl_int POCLU_CALL poclu_get_multiple_devices (
     int ooo_queues);
 
 /**
- * Convert a float to a cl_half (uint16_t).
- *
- * \param value [in] float to be converted.
- * \return a converted cl_half.
- */
-POCLU_API cl_half POCLU_CALL
-poclu_float_to_cl_half(float value);
-
-/**
- * Convert a cl_half to a float.
- *
- * \param value [in] cl_half to be converted.
- * \return a converted float.
- */
-POCLU_API float POCLU_CALL
-poclu_cl_half_to_float(cl_half value);
-
-/**
  * \brief read the contents of a file.
  *
  * filename can absolute or relative, according to the fopen

--- a/tests/tce/fp16/host.cpp
+++ b/tests/tce/fp16/host.cpp
@@ -60,10 +60,6 @@ main(void)
     //float a = 23456.0f;
     float a = 3.f;
 
-    // test the poclu's half conversion functions
-    printf("through conversion: %.0f\n", 
-           poclu_cl_half_to_float(poclu_float_to_cl_half(42.0f)));
-    fflush(stdout);
     try {
         std::vector<cl::Platform> platformList;
 


### PR DESCRIPTION
@franz I thought about about using the `cl_half.h` library for pocl's internal functions, but it was not clear to me how the current implementation handles an under-/over-flow errors. Do you have any opinions?

`cl_half.h` provides these options:
```
typedef enum
{
  CL_HALF_RTE, // round to nearest even
  CL_HALF_RTZ, // round towards zero
  CL_HALF_RTP, // round towards positive infinity
  CL_HALF_RTN, // round towards negative infinity
} cl_half_rounding_mode;
```