### PR TITLE
Major WILoops cleanup via removing cond barrier region peeling and explicit unrolling

### DIFF
--- a/doc/sphinx/source/notes_6_1.rst
+++ b/doc/sphinx/source/notes_6_1.rst
@@ -72,4 +72,7 @@ Deprecation/feature removal notices
    method was removed to clean up the kernel compiler. It did not
    anymore have any use cases that could not be covered by fully
    unrolling "loops".
-
+ * The "loops" method does no longer unroll loops explicitly via
+   the environment variable POCL_WILOOPS_MAX_UNROLL_COUNT, which
+   was removed in this release. Unrolling decisions are delegated
+   to standard LLVM optimizations.

--- a/doc/sphinx/source/using.rst
+++ b/doc/sphinx/source/using.rst
@@ -409,15 +409,11 @@ pocl.
               [this thesis](https://joameyer.de/hipsycl/Thesis_JoachimMeyer.pdf).
 
  * **loops**  -- Create parallel for-loops that execute the work items.
+              Automatically falls back to **cbs** for kernels with barrier usage
+              that would lead to very complex control flow structures.
 
-              The loops will be unrolled a certain number of
-              times of which maximum can be controlled with
-              POCL_WILOOPS_MAX_UNROLL_COUNT=N environment
-              variable (default is to not perform unrolling).
-
- * **loopvec** -- Create parallel work-item for-loops (see 'loops') and execute
-               the standard LLVM vectorizers. LLVM loop unrolling is disabled and
-               the unrolling decisions are left to the generic loop vectorizer.
+ * **loopvec** -- Create parallel work-item for-loops with 'loops' and execute
+               the standard LLVM vectorizers.
 
 - **POCL_WORK_GROUP_SPECIALIZATION**
 

--- a/lib/CL/pocl_llvm_wg.cc
+++ b/lib/CL/pocl_llvm_wg.cc
@@ -525,6 +525,17 @@ static void addStage2PassesToPipeline(cl_device_id Dev,
   // don't forget to register it in registerPassBuilderPasses
   if (!Dev->spmd) {
     addPass(Passes, "simplifycfg");
+
+#if LLVM_MAJOR > 17
+    // StructurizeCFG doesn't like switches.
+    addPass(Passes, "lower-switch");
+    // Gotos and LLVM CFG optimizations can produce unstructured control flow
+    // cases that make it difficult or impossible to form clean parallel
+    // regions. StructurizeCFG takes care of them and helps us to use WIloops
+    // instead of CBS for more cases.
+    addPass(Passes, "structurizecfg");
+#endif
+
     addPass(Passes, "loop-simplify");
 
     // required for OLD PM

--- a/lib/CL/pocl_llvm_wg.cc
+++ b/lib/CL/pocl_llvm_wg.cc
@@ -3,7 +3,7 @@
 
    Copyright (c) 2013 Kalle Raiskila
                  2013-2019 Pekka Jääskeläinen
-                 2023 Pekka Jääskeläinen / Intel Finland Oy
+                 2023-2024 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/lib/llvmopencl/Barrier.h
+++ b/lib/llvmopencl/Barrier.h
@@ -50,7 +50,7 @@ namespace pocl {
       }
     }
 
-    static bool IsLoopWithBarrier(llvm::Loop &L) {
+    static bool isLoopWithBarrier(llvm::Loop &L) {
       for (llvm::Loop::block_iterator i = L.block_begin(), e = L.block_end();
            i != e; ++i) {
         for (llvm::BasicBlock::iterator j = (*i)->begin(), e = (*i)->end();

--- a/lib/llvmopencl/Barrier.h
+++ b/lib/llvmopencl/Barrier.h
@@ -115,6 +115,15 @@ namespace pocl {
       return false;
     }
 
+    static Barrier *findInBasicBlock(llvm::BasicBlock *BB) {
+      for (llvm::BasicBlock::iterator I = BB->begin(), E = BB->end(); I != E;
+           ++I) {
+        if (llvm::isa<pocl::Barrier>(I))
+          return llvm::cast<pocl::Barrier>(I);
+      }
+      return nullptr;
+    }
+
     // Returns true in case the given basic block starts with a barrier,
     // that is, contains a branch instruction after possible PHI nodes.
     static bool startsWithBarrier(const llvm::BasicBlock *BB) {

--- a/lib/llvmopencl/DebugHelpers.h
+++ b/lib/llvmopencl/DebugHelpers.h
@@ -72,13 +72,23 @@ bool chopBBs (llvm::Function &F, llvm::Pass &P);
   };
 };
 
-// Controls the debug output from Kernel.cc parallel region generation:
-//#define DEBUG_PR_CREATION
+// Controls the debug output from BarrierTailReplication.cc.
+//#define DEBUG_BARRIER_REPL
 
-// Controls the debug output from ImplicitConditionalBarriers.cc:
+// Controls the debug output from ImplicitConditionalBarriers.cc.
 //#define DEBUG_COND_BARRIERS
 
-// Controls the debug output from PHIsToAllocas.cc
+// Controls the debug output from PHIsToAllocas.cc.
 //#define DEBUG_PHIS_TO_ALLOCAS
+
+// Controls the debug output from Kernel.cc parallel region generation.
+//#define DEBUG_PR_CREATION
+
+// Controls the debug output from WorkitemLoops.cc parallel region generation.
+//#define DEBUG_WORK_ITEM_LOOPS
+
+// Enable CFG dumps from various spots during the kernel compilation.
+//#define POCL_KERNEL_COMPILER_DUMP_CFGS
+
 
 #endif

--- a/lib/llvmopencl/ImplicitConditionalBarriers.cc
+++ b/lib/llvmopencl/ImplicitConditionalBarriers.cc
@@ -31,6 +31,7 @@ IGNORE_COMPILER_WARNING("-Wmaybe-uninitialized")
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 
 #include "Barrier.h"
+#include "DebugHelpers.h"
 #include "ImplicitConditionalBarriers.h"
 #include "LLVMUtils.h"
 #include "VariableUniformityAnalysis.h"
@@ -42,8 +43,6 @@ POP_COMPILER_DIAGS
 #include <iostream>
 
 #include "pocl.h"
-
-// #define DEBUG_COND_BARRIERS
 
 #define PASS_NAME "implicit-cond-barriers"
 #define PASS_CLASS pocl::ImplicitConditionalBarriers
@@ -85,6 +84,11 @@ ImplicitConditionalBarriers::run(llvm::Function &F,
   WorkitemHandlerType WIH = FAM.getResult<WorkitemHandlerChooser>(F).WIH;
   if (WIH == WorkitemHandlerType::CBS)
     return PreservedAnalyses::all();
+
+#ifdef POCL_KERNEL_COMPILER_DUMP_CFGS
+  dumpCFG(F, F.getName().str() + "_before_implicit_cond_barriers.dot", nullptr,
+          nullptr);
+#endif
 
   llvm::PostDominatorTree &PDT = FAM.getResult<PostDominatorTreeAnalysis>(F);
   llvm::DominatorTree &DT = FAM.getResult<DominatorTreeAnalysis>(F);
@@ -188,6 +192,11 @@ ImplicitConditionalBarriers::run(llvm::Function &F,
 #ifdef DEBUG_COND_BARRIERS
   std::cerr << "### After implicit conditional barrier handling:" << std::endl;
   F.dump();
+#endif
+
+#ifdef POCL_KERNEL_COMPILER_DUMP_CFGS
+  dumpCFG(F, F.getName().str() + "_after_implicit_cond_barriers.dot", nullptr,
+          nullptr);
 #endif
 
   return Changed ? PAChanged : PreservedAnalyses::all();

--- a/lib/llvmopencl/KernelCompilerUtils.h
+++ b/lib/llvmopencl/KernelCompilerUtils.h
@@ -27,6 +27,8 @@
 #define LID_G_NAME(DIM) (std::string("_local_id_") + (char)('x' + DIM))
 // Generates the name for the global magic variable for the global id iterator.
 #define GID_G_NAME(DIM) (std::string("_global_id_") + (char)('x' + DIM))
+// Generates the name for the global magic variable for the local sizes.
+#define LSIZE_G_NAME(DIM) (std::string("_local_size_") + (char)('x' + DIM))
 // The name of the mangled get_global_id builtin function.
 #define GID_BUILTIN_NAME "_Z13get_global_idj"
 

--- a/lib/llvmopencl/LoopBarriers.cc
+++ b/lib/llvmopencl/LoopBarriers.cc
@@ -148,7 +148,7 @@ static bool processLoopWithBarriers(Loop &L, llvm::DominatorTree &DT,
 static bool processLoop(Loop &L, llvm::DominatorTree &DT,
                         VariableUniformityAnalysisResult &VUA) {
 
-  if (Barrier::IsLoopWithBarrier(L))
+  if (Barrier::isLoopWithBarrier(L))
     return processLoopWithBarriers(L, DT, VUA);
 
   // This is a loop without a barrier. Ensure we have a non-barrier
@@ -168,7 +168,7 @@ static bool processLoop(Loop &L, llvm::DominatorTree &DT,
   // to the innermost loop if we process that first, ruining the
   // idea for multi-level loops.
   Loop *ParentLoop = L.getParentLoop();
-  if (!(ParentLoop == nullptr || Barrier::IsLoopWithBarrier(*ParentLoop)))
+  if (!(ParentLoop == nullptr || Barrier::isLoopWithBarrier(*ParentLoop)))
     return false;
 
   BasicBlock *Preheader = L.getLoopPreheader();

--- a/lib/llvmopencl/WorkitemHandler.cc
+++ b/lib/llvmopencl/WorkitemHandler.cc
@@ -483,7 +483,7 @@ llvm::AllocaInst *WorkitemHandler::createAlignedAndPaddedContextAlloca(
     GlobalVariable *LocalSize;
     LoadInst *LocalSizeLoad[3];
     for (int i = 0; i < 3; ++i) {
-      std::string Name = LID_G_NAME(i);
+      std::string Name = LSIZE_G_NAME(i);
       LocalSize = cast<GlobalVariable>(M->getOrInsertGlobal(Name, ST));
       LocalSizeLoad[i] = Builder.CreateLoad(ST, LocalSize);
     }

--- a/lib/llvmopencl/WorkitemHandler.cc
+++ b/lib/llvmopencl/WorkitemHandler.cc
@@ -540,7 +540,7 @@ llvm::AllocaInst *WorkitemHandler::createAlignedAndPaddedContextAlloca(
 #ifdef DEBUG_WORK_ITEM_LOOPS
     std::cerr << "### VariableDebugMeta :  ";
     VariableDebugMeta->dump();
-    std::cerr << "### sizeBits :  " << sizeBits << "  alignBits: " << alignBits
+    std::cerr << "### sizeBits :  " << SizeBits << "  alignBits: " << AlignBits
               << "\n";
 #endif
 

--- a/lib/llvmopencl/WorkitemHandler.cc
+++ b/lib/llvmopencl/WorkitemHandler.cc
@@ -3,6 +3,7 @@
 //
 // Copyright (c) 2011-2012 Carlos Sánchez de La Lama / URJC and
 //               2012-2019 Pekka Jääskeläinen
+//               2023-2024 Pekka Jääskeläinen / Intel Finland Oy
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -619,19 +620,19 @@ WorkitemHandler::createContextArrayGEP(llvm::AllocaInst *CtxArrayAlloca,
 ///
 /// Currently the only known reason to not mark them is to workaround a VPlan
 /// crash that occurs with volatile memory accesses inside the parallel
-/// WI-loops. Thus, we return true only in case of LLVM 19 and if the loop
-/// contains volatile accesses. The PoCL issue:
-/// https://github.com/pocl/pocl/issues/1556
+/// WI-loops. Thus, we return false only in case of using LLVM 17+,
+/// where the issue is producible, and if the loop contains volatile accesses.
+/// The PoCL issue: https://github.com/pocl/pocl/issues/1556
 ///
-/// We could make this Loop-specific, but it seems not worth the effort at
-/// this point as WorkitemLoops doesn't have a loop at hand when it needs it
-/// and luckily volatile usage is not common and ruins the perf anyhow.
+/// We could make this Loop/PRegion-specific, but it seems not worth the effort
+/// at this point as WorkitemLoops doesn't have a ready loop at hand when it
+/// needs to annotate it, and luckily volatile usage is not common and ruins
+/// the perf anyhow.
 ///
-/// \param F the function to check.
 /// \return False in case we should _not_ add the parallel loop metadata,
 /// even though the loop is known to be parallel.
 bool WorkitemHandler::canAnnotateParallelLoops() {
-#if LLVM_MAJOR == 19
+#if LLVM_MAJOR >= 17
   for (auto &BB : *K) {
     for (auto &I : BB) {
       if (I.isVolatile())

--- a/lib/llvmopencl/WorkitemHandlerChooser.cc
+++ b/lib/llvmopencl/WorkitemHandlerChooser.cc
@@ -90,7 +90,7 @@ WorkitemHandlerType ChooseWorkitemHandler(Function &F,
   // Check if this is a kernel WILoops is able and willing to handle.
   // Otherwise, fall back to CBS.
   if (Result == WorkitemHandlerType::LOOPS &&
-      !WorkitemLoops::CanHandleKernel(F, AM))
+      !WorkitemLoops::canHandleKernel(F, AM))
     Result = WorkitemHandlerType::CBS;
 
   return Result;

--- a/lib/llvmopencl/WorkitemLoops.h
+++ b/lib/llvmopencl/WorkitemLoops.h
@@ -44,7 +44,7 @@ public:
   // Returns false in case the WG generator can or should not handle the given
   // kernel. It might refuse to handle trickiest of conditional barrier
   // scenarios which would result in non-vectorizable loops anyhow.
-  static bool CanHandleKernel(llvm::Function &K,
+  static bool canHandleKernel(llvm::Function &K,
                               llvm::FunctionAnalysisManager &AM);
 };
 

--- a/tests/workgroup/CMakeLists.txt
+++ b/tests/workgroup/CMakeLists.txt
@@ -101,8 +101,9 @@ add_test_pocl(NAME "workgroup/unconditional_barriers"
               EXPECTED_OUTPUT "basic_barriers_2_2_2_2.stdout"
               COMMAND "run_kernel" "basic_barriers.cl" 2 2 2 2)
 
+# This case should now automatically fall back to CBS.
 add_test_pocl(NAME "workgroup/conditional_barrier_loopvec"
-              EXPECTED_OUTPUT "cond_barriers_1_2_1_1_loopvec.stdout"
+              EXPECTED_OUTPUT "cond_barriers_1_2_1_1_cbs.stdout"
               COMMAND "run_kernel" "conditional_barriers.cl" 1 2 1 1
               WORKITEM_HANDLER "loopvec")
 add_test_pocl(NAME "workgroup/conditional_barrier_cbs"

--- a/tests/workgroup/CMakeLists.txt
+++ b/tests/workgroup/CMakeLists.txt
@@ -2,6 +2,7 @@
 #   CMake build system files
 #
 #   Copyright (c) 2014-2019 pocl developers
+#                 2024 Pekka Jääskeläinen / Intel Finland Oy
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a copy
 #   of this software and associated documentation files (the "Software"), to deal

--- a/tests/workgroup/CMakeLists.txt
+++ b/tests/workgroup/CMakeLists.txt
@@ -141,6 +141,12 @@ add_test_pocl(NAME "workgroup/range_md_large_grid"
               EXPECTED_OUTPUT ""
               COMMAND "run_kernel" "range_md.cl" "1000" "128" "1" "1")
 
+# This used trigger a forever looping CFG case due to getting unstructured
+# CFG produced by jump threading.
+add_test_pocl(NAME "workgroup/do_while_with_barrier"
+              EXPECTED_OUTPUT ""
+              COMMAND "run_kernel" "do_while_with_barrier.cl" "1" "2" "1" "1")
+
 # These tests are now always ran with the basic device with a predefined
 # work-group execution order. Their printout verification depends
 # on it.

--- a/tests/workgroup/cond_barriers_1_2_1_1_loopvec.stdout
+++ b/tests/workgroup/cond_barriers_1_2_1_1_loopvec.stdout
@@ -1,7 +1,0 @@
-LOCAL_ID=0 before if
-LOCAL_ID=1 before if
-LOCAL_ID=0 inside if
-LOCAL_ID=1 inside if
-LOCAL_ID=0 after if
-LOCAL_ID=1 after if
-OK

--- a/tests/workgroup/do_while_with_barrier.cl
+++ b/tests/workgroup/do_while_with_barrier.cl
@@ -1,0 +1,54 @@
+/* do_while_with_barrier.cl -
+   A reproducer for a WI-loop formation issue reduced from
+   conformance/src/conformance/test_conformance/basic/test_local.cpp
+
+   Copyright (c) 2024 Pekka Jääskeläinen / Intel Finland Oy
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#define printf(__X, __Y) // printf (__X, __Y)
+
+__kernel void
+test_kernel (__global int *output)
+{
+  int tid = get_local_id (0);
+  int lsize = get_local_size(0);
+
+  output[tid] = 0;
+  if (lsize == 1)
+    if (tid == 0) {
+      output[0] = 1;
+      return;
+    }
+
+  do {
+    barrier(CLK_LOCAL_MEM_FENCE);
+    lsize /= 2;
+  } while (lsize);
+
+  /* Note, the tid == 0 check must be the same as in the early
+     return. There's likely some unexpected preopt messing the CFG up,
+     converting it to what the WI-loop formation cannot handle.*/
+  if (tid == 0) {
+    output[0] = 1;
+    /* It gets stuck here. */
+    printf ("lid %lu\n", get_local_id(0));
+  }
+}

--- a/tests/workgroup/for_with_divergent_return.cl
+++ b/tests/workgroup/for_with_divergent_return.cl
@@ -3,7 +3,7 @@ test_kernel (global int *output)
 {
   int gid_x = get_global_id (0);
 
-  for (volatile int i = 0; i < INT_MAX; ++i)
+  for (volatile int i = 0; i < 100; ++i)
     {
       if (i == 1 && gid_x == 0)
         {


### PR DESCRIPTION
Handle cond barriers with CBS. Do not handle kernels with non-uniform predicates with WILoops (for now). These used to be handled by "peeling" the first iteration of the work-item loop to check if the barrier is taken or not, but it complicates the parallel region formation and control flow construction quite a bit without known benchmark benefits. The produced peeled loops are also not easily vectorizable, thus the performance won't be good anyhow for SIMD.

For VLIW/ILP the peeling might be useful though, but it still doesn't justify the complexity add.

Remove peeling as well as explicit unrolling code to simplify the WILoops handling a lot.

Also always add an clean entry node to the parallel region to add context restores to, which simplifies PR handling in various places.