### PR TITLE
remote: Abstract sockets away from business logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,6 @@ option(ENABLE_POCL_BUILDING "When OFF, env var POCL_BUILDING has no effect. Defa
 
 option(ENABLE_PRINTF_IMMEDIATE_FLUSH "[currently only applies to CPU drivers] if enabled, printf is flushed immediately when encountered, instead of after all NDRange workgroups are finished" ON)
 
-option(ENABLE_VSOCK "Enable vsock transport in the remote driver" OFF)
-
 option(ENABLE_LLVM_FILECHECKS "Enable kernel compiler/autovectorizer filechecks using the given FileCheck binary defined in LLVM_FILECHECK_BIN. Note: the checks are tested against recent Intel X86/SIMD CPUs for now.")
 
 if(WIN32)
@@ -741,21 +739,14 @@ if(UNIX)
   CHECK_SYMBOL_EXISTS("dladdr"
                       "dlfcn.h"
                       HAVE_DLADDR)
-  if(ENABLE_VSOCK)
-    find_file(
-      HAVE_LINUX_VSOCK_H
-      NAMES
-        linux/vm_sockets.h
-      PATHS
-        /usr/include
-    )
 
-    if(NOT HAVE_LINUX_VSOCK_H)
-      message(FATAL_ERROR "Could not find vsock header file. Please \
-        make sure that the kernel is configured with vsock support.
-    ")
-    endif()
-  endif()
+  find_file(
+    HAVE_LINUX_VSOCK_H
+    NAMES
+      linux/vm_sockets.h
+    PATHS
+      /usr/include
+  )
 
   unset(CMAKE_REQUIRED_DEFINITIONS)
   unset(CMAKE_REQUIRED_FLAGS)
@@ -776,6 +767,7 @@ else()
   set(HAVE_UTIME 0)
   set(HAVE_DLADDR 0)
   set(HAVE_VALGRIND 0)
+  unset(HAVE_LINUX_VSOCK_H)
 endif()
 
 ######################################################################################
@@ -2372,6 +2364,9 @@ MESSAGE(STATUS "ENABLE_PROXY_DEVICE: ${ENABLE_PROXY_DEVICE}")
 MESSAGE(STATUS "ENABLE_PROXY_DEVICE_INTEROP: ${ENABLE_PROXY_DEVICE_INTEROP}")
 MESSAGE(STATUS "ENABLE_REMOTE_SERVER: ${ENABLE_REMOTE_SERVER}")
 MESSAGE(STATUS "ENABLE_REMOTE_CLIENT: ${ENABLE_REMOTE_CLIENT}")
+if (ENABLE_REMOTE_SERVER OR  ENABLE_REMOTE_CLIENT)
+  MESSAGE(STATUS "HAVE_LINUX_VSOCK_H: ${HAVE_LINUX_VSOCK_H}")
+endif ()
 MESSAGE(STATUS "ENABLE_D2D_MIG: ${ENABLE_D2D_MIG}")
 MESSAGE(STATUS "ENABLE_RDMA: ${ENABLE_RDMA}")
 MESSAGE(STATUS "ENABLE_CL_GET_GL_CONTEXT: ${ENABLE_CL_GET_GL_CONTEXT}")

--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -51,8 +51,6 @@
 
 #cmakedefine ENABLE_SIGNAL_HANDLERS
 
-#cmakedefine ENABLE_VSOCK
-
 #cmakedefine ENABLE_RELOCATION
 
 #cmakedefine ENABLE_EGL_INTEROP
@@ -73,6 +71,8 @@
 #cmakedefine HAVE_FORK
 
 #cmakedefine HAVE_VFORK
+
+#cmakedefine HAVE_LINUX_VSOCK_H
 
 #cmakedefine HAVE_CLOCK_GETTIME
 

--- a/lib/CL/CMakeLists.txt
+++ b/lib/CL/CMakeLists.txt
@@ -223,10 +223,6 @@ if(APPLE)
   list(APPEND POCL_LIB_SOURCES "pthread_barrier.c")
 endif()
 
-if(ENABLE_RDMA)
-  list(APPEND POCL_LIB_SOURCES "pocl_rdma.c")
-endif()
-
 set(LIBPOCL_OBJS "$<TARGET_OBJECTS:libpocl_unlinked_objs>"
                  "$<TARGET_OBJECTS:pocl_cache>")
 

--- a/lib/CL/devices/remote/CMakeLists.txt
+++ b/lib/CL/devices/remote/CMakeLists.txt
@@ -23,16 +23,20 @@
 #
 #=============================================================================
 
+set(POCL_REMOTE_CLIENT_SOURCES
+    remote.h remote.c communication.h communication.c
+      ../../pocl_networking.h ../../pocl_networking.c)
+
+if(ENABLE_RDMA)
+    list(APPEND POCL_REMOTE_CLIENT_SOURCES ../../pocl_rdma.h ../../pocl_rdma.c)
+endif()
+
 if(MSVC)
-  set_source_files_properties(
-      remote.h remote.c communication.h communication.c
-      ../../pocl_networking.h ../../pocl_networking.c
-      PROPERTIES LANGUAGE CXX )
+  set_source_files_properties(${POCL_REMOTE_CLIENT_SOURCES}
+                              PROPERTIES LANGUAGE CXX)
 endif(MSVC)
 
-add_pocl_device_library("pocl-devices-remote"
-    remote.h remote.c communication.h communication.c ../../pocl_networking.h
-    ../../pocl_networking.c)
+add_pocl_device_library("pocl-devices-remote" ${POCL_REMOTE_CLIENT_SOURCES})
 
 if(ENABLE_LOADABLE_DRIVERS AND ENABLE_RDMA)
   target_link_libraries("pocl-devices-remote" PRIVATE RDMAcm::RDMAcm IBVerbs::verbs)

--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -47,7 +47,6 @@
 #include "pocl_image_util.h"
 #include "pocl_networking.h"
 #include "pocl_timing.h"
-#include "pocl_util.h"
 #include "remote.h"
 #include "utlist.h"
 #include <CL/cl.h>
@@ -62,13 +61,14 @@
 #include <linux/vm_sockets.h>
 #endif
 
-// TODO mess
+/* TODO mess */
 #include "communication.h"
 
-// https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_MRG/1.2/html/Realtime_Tuning_Guide/sect-Realtime_Tuning_Guide-Application_Tuning_and_Deployment-TCP_NODELAY_and_Small_Buffer_Writes.html
-// https://eklitzke.org/the-caveats-of-tcp-nodelay
-// to be used with TCP_NODELAY:
-// ssize_t writev(int fildes, const struct iovec *iov, int iovcnt);
+/* https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_MRG/1.2/html/Realtime_Tuning_Guide/sect-Realtime_Tuning_Guide-Application_Tuning_and_Deployment-TCP_NODELAY_and_Small_Buffer_Writes.html
+ */
+/* https://eklitzke.org/the-caveats-of-tcp-nodelay */
+/* to be used with TCP_NODELAY:
+ * ssize_t writev(int fildes, const struct iovec *iov, int iovcnt); */
 #include <poll.h>
 #include <sys/uio.h>
 
@@ -112,8 +112,6 @@
 
 static uint64_t last_message_id = 1992;
 static uint64_t last_peer_id = 42;
-
-// TODO these are copypaste from C++
 
 #define CHECK_READ_INNER(readb, timeout_flag)                                 \
   do                                                                          \
@@ -237,15 +235,15 @@ typedef struct network_queue_arg
   POCL_INIT_COND (n->cond);                                                   \
   n->connection = c;
 
-// n->dev = device; n->devd = devd; n->d = d; s = server data
+/* n->dev = device; n->devd = devd; n->d = d; s = server data */
 #define SETUP_NETW_Q_ARG(n, s, o)                                             \
   n = calloc (1, sizeof (network_queue_arg));                                 \
   n->in_flight = d->inflight_queue;                                           \
   n->ours = o;                                                                \
   n->remote = s;
 
-// ##################################################################################
-// ##################################################################################
+/*****************************************************************************/
+/*****************************************************************************/
 
 SMALL_VECTOR_HELPERS (buffer_ids, remote_server_data_t, uint32_t, buffer_ids)
 
@@ -257,8 +255,8 @@ SMALL_VECTOR_HELPERS (image_ids, remote_server_data_t, uint32_t, image_ids)
 
 SMALL_VECTOR_HELPERS (sampler_ids, remote_server_data_t, uint32_t, sampler_ids)
 
-// ##################################################################################
-// ##################################################################################
+/*****************************************************************************/
+/*****************************************************************************/
 
 #define PKT_THRESHOLD 1200
 
@@ -281,11 +279,11 @@ read_full (transport_info_t *connection,
       size_t remain = total - readb;
       res = read (connection->fd, ptr + readb, remain);
       if (res < 0)
-        { // ERROR
+        { /* ERROR */
           return -1;
         }
       if (res == 0)
-        { // EOF
+        { /* EOF */
           return 0;
         }
       POCL_ATOMIC_ADD (sinfo->rx_bytes_confirmed, (uint64_t)res);
@@ -346,7 +344,7 @@ writev_full (transport_info_t *connection,
       total += sizes[i];
     }
 
-  // TODO there has to be a better way to handle this
+  /* TODO there has to be a better way to handle this */
   if (total >= THRESHOLD)
     {
 
@@ -405,7 +403,7 @@ finish_running_cmd (network_command *running_cmd)
     }
   else
     {
-      // setup event timestamps
+      /* setup event timestamps */
       cl_event e = running_cmd->data.async.node->sync.event.event;
       cl_command_type type = running_cmd->data.async.node->type;
 
@@ -433,8 +431,8 @@ finish_running_cmd (network_command *running_cmd)
               running_cmd->client_write_start_timestamp_ns);
         }
       while (end <= start);
-      // TODO this compares times of write() syscalls, but that may not be
-      // equal to transfer times
+      /* TODO this compares times of write() syscalls, but that may not be
+       * equal to transfer times */
       uint64_t local_writing_ns = end - start;
 
       assert (running_cmd->reply.server_read_end_timestamp_ns
@@ -443,13 +441,13 @@ finish_running_cmd (network_command *running_cmd)
           = running_cmd->reply.server_read_end_timestamp_ns
             - running_cmd->reply.server_read_start_timestamp_ns;
 
-      // in theory, local_writing should be +- equal remote reading, select
-      // larger
+      /* in theory, local_writing should be +- equal remote reading, select
+       * larger */
       uint64_t client_to_remote = remote_reading_ns > local_writing_ns
                                       ? remote_reading_ns
                                       : local_writing_ns;
 
-      // TODO we don't have the timings for remote writing
+      /* TODO we don't have the timings for remote writing */
       uint64_t remote_writing_ns = 0;
 
       /* No-op until reader has finished writing timestamps (should never be
@@ -463,7 +461,7 @@ finish_running_cmd (network_command *running_cmd)
       while (end <= start);
       uint64_t local_reading_ns = end - start;
 
-      // should be +- equal, select larger
+      /* should be +- equal, select larger */
       uint64_t remote_to_client = local_reading_ns > remote_writing_ns
                                       ? local_reading_ns
                                       : remote_writing_ns;
@@ -660,8 +658,8 @@ pocl_network_disconnect (remote_server_data_t *data,
   return (close (connection->fd));
 }
 
-/// NOTE: remember to update NUM_SERVER_SOCKET_THREADS to reflect the actual
-/// number of threads that may be using the same sockets
+/** NOTE: remember to update NUM_SERVER_SOCKET_THREADS to reflect the actual
+ * number of threads that may be using the same sockets */
 static void
 pocl_remote_reconnect_sockets (remote_server_data_t *remote)
 {
@@ -670,8 +668,8 @@ pocl_remote_reconnect_sockets (remote_server_data_t *remote)
     remote->address_with_port);
   POCL_ATOMIC_CAS (&remote->available, CL_TRUE, CL_FALSE);
 
-  // Gather all threads here to sleep. Last one to arrive replaces both
-  // sockets and wakes up all the others when done.
+  /* Gather all threads here to sleep. Last one to arrive replaces both
+   * sockets and wakes up all the others when done. */
   remote->threads_awaiting_reconnect += 1;
   POCL_MSG_PRINT_REMOTE (
     "pocl_remote_reconnect_sockets: currently %d threads waiting\n",
@@ -682,7 +680,7 @@ pocl_remote_reconnect_sockets (remote_server_data_t *remote)
       return;
     }
 
-  // close old handles to avoid exceeding the open fd limit
+  /* close old handles to avoid exceeding the open fd limit */
   pocl_network_disconnect (remote, &remote->fast_connection);
   pocl_network_disconnect (remote, &remote->slow_connection);
 
@@ -691,7 +689,7 @@ pocl_remote_reconnect_sockets (remote_server_data_t *remote)
                          " on %s\n",
                          remote->session, remote->address_with_port);
 
-  // Got the lock, reconnect
+  /* Got the lock, reconnect */
   int status = 0;
   status |= pocl_network_connect (remote, &remote->fast_connection,
                                   remote->fast_port, NETWORK_BUF_SIZE_FAST, 1,
@@ -699,7 +697,7 @@ pocl_remote_reconnect_sockets (remote_server_data_t *remote)
   status |= pocl_network_connect (remote, &remote->slow_connection,
                                   remote->slow_port, NETWORK_BUF_SIZE_SLOW, 0,
                                   NULL);
-  // TODO: reconnect RDMA somehow?
+  /* TODO: reconnect RDMA somehow? */
 
   if (status == CL_SUCCESS)
     {
@@ -707,13 +705,13 @@ pocl_remote_reconnect_sockets (remote_server_data_t *remote)
                              remote->address_with_port);
       POCL_ATOMIC_CAS (&remote->available, CL_FALSE, CL_TRUE);
       remote->threads_awaiting_reconnect = 0;
-      // Wake up all other threads
+      /* Wake up all other threads */
       POCL_BROADCAST_COND (remote->setup_lock.cond);
       return;
     }
   else
     {
-      // Try again next iteration
+      /* Try again next iteration */
       remote->threads_awaiting_reconnect -= 1;
       return;
     }
@@ -747,9 +745,8 @@ pocl_remote_reader_pthread (void *aa)
           POCL_UNLOCK (remote->setup_lock.mutex);
         }
 
-      // block until there is something to read.
-      // this is especially needed to get accurate
-      // profiling timestamps for read commands
+      /* Block until there is something to read. This is especially needed to
+       * get accurate profiling timestamps for read commands. */
       pfd.fd = connection.fd;
       nevs = poll (&pfd, 1, -1);
       if (nevs < 1)
@@ -761,19 +758,19 @@ pocl_remote_reader_pthread (void *aa)
           continue;
         }
 
-      // READ MSG
+      /* READ MSG */
       ReplyMsg_t rep;
       uint64_t start_ts = pocl_gettimemono_ns ();
       readb = read_full (&connection, &rep, sizeof (ReplyMsg_t), remote);
-      CHECK_READ_TIMEOUT (readb); // TODO: continue instead of abort
+      CHECK_READ_TIMEOUT (readb); /* TODO: continue instead of abort */
 
-      // we have a message
+      /* we have a message */
       assert ((size_t)readb == sizeof (ReplyMsg_t));
       POCL_MSG_PRINT_REMOTE (
         "READER THR: MESSAGE READ, TYPE:  %u  ID: %zu  SIZE: %zu\n",
         rep.message_type, rep.msg_id, readb);
 
-      // find it
+      /* find it */
       network_command *running_cmd = NULL;
       POCL_LOCK (inflight->mutex);
       DL_FOREACH (inflight->queue, running_cmd)
@@ -785,9 +782,9 @@ pocl_remote_reader_pthread (void *aa)
         }
       if (!running_cmd)
         {
-          // Not found in queue. This can happen when the remote resends
-          // old replies after reconnecting to make sure none got lost on the
-          // way
+          /* Not found in queue. This can happen when the remote resends old
+           * replies after reconnecting to make sure none got lost on the way
+           */
           POCL_UNLOCK (inflight->mutex);
           continue;
         }
@@ -804,7 +801,7 @@ pocl_remote_reader_pthread (void *aa)
       assert (running_cmd->status == NETCMD_WRITTEN);
       running_cmd->status = NETCMD_READ;
 
-      // READ EXTRA DATA
+      /* READ EXTRA DATA */
       if (running_cmd->reply.data_size > 0)
         {
           if (running_cmd->reply.strings_size > 0)
@@ -845,7 +842,7 @@ pocl_remote_rdma_reader_pthread (void *aa)
     {
       POCL_UNLOCK (this->mutex);
 
-      // Block until an RDMA (receive) completion occurs
+      /* Block until an RDMA (receive) completion occurs */
       struct ibv_cq *comp_queue;
       void *context;
       if (ibv_get_cq_event (rdma_data->comp_channel_in, &comp_queue, &context))
@@ -853,7 +850,7 @@ pocl_remote_rdma_reader_pthread (void *aa)
           POCL_MSG_ERR ("Get RDMA channel event failed");
         }
 
-      // Receive operations should go into the in-queue
+      /* Receive operations should go into the in-queue */
       assert (comp_queue == rdma_data->cq_in);
 
       struct ibv_wc wc = {};
@@ -869,21 +866,21 @@ pocl_remote_rdma_reader_pthread (void *aa)
         {
           const char *status_msg = ibv_wc_status_str (wc.status);
           POCL_MSG_ERR ("RDMA receive request failed - unrecoverable error");
-          // TODO: Some failures here could be recoverable
+          /* TODO: Some failures here could be recoverable */
         }
 
       POCL_MSG_PRINT_REMOTE ("RDMA RECEIVE: ID: %lu \n", wc.wr_id);
 
-      // FIND THE RELEVANT COMMAND FROM QUEUE
+      /* FIND THE RELEVANT COMMAND FROM QUEUE */
 
       network_command *cmd = NULL;
 
-      // Loop until a command matching the work completion id is found
+      /* Loop until a command matching the work completion id is found */
       POCL_LOCK (this->mutex);
       while (1)
         {
 
-          // TODO: Inefficiently checking the entire queue for every loop
+          /* TODO: Inefficiently checking the entire queue for every loop */
           DL_FOREACH (this->queue, cmd)
           {
             if (cmd->request.msg_id == wc.wr_id)
@@ -898,20 +895,20 @@ pocl_remote_rdma_reader_pthread (void *aa)
               break;
             }
 
-          // WAIT FOR NEW COMMANDS
+          /* WAIT FOR NEW COMMANDS */
 
           POCL_LOCK (this->mutex);
-          // wait for main reader to pass a new command
+          /* wait for main reader to pass a new command */
           POCL_WAIT_COND (this->cond, this->mutex);
         }
 
-      // UPDATE COMMAND EXTRA DATA
+      /* UPDATE COMMAND EXTRA DATA */
 
       uint32_t write_size = wc.byte_len;
 
       assert (cmd->rep_extra_size == write_size);
 
-      // REMOVE COMMAND FROM QUEUE
+      /* REMOVE COMMAND FROM QUEUE */
       POCL_ATOMIC_STORE (cmd->client_read_start_timestamp_ns, start_ts);
 
       POCL_LOCK (this->mutex);
@@ -966,8 +963,8 @@ pocl_remote_rdma_writer_pthread (void *aa)
           rdma_buffer_info_t *s;
           HASH_FIND (hh, remote->rdma_keys, &mem_id, sizeof (uint32_t), s);
 
-          // XXX: registering and deregistering memory regions in a tight loop
-          // should be avoided
+          /* XXX: registering and deregistering memory regions in a tight loop
+           * should be avoided */
           struct ibv_mr *mem_region = rdma_register_mem_region (
               rdma_data, (void *)cmd->req_extra_data, cmd->req_extra_size);
 
@@ -984,7 +981,7 @@ pocl_remote_rdma_writer_pthread (void *aa)
           write_wr.num_sge = 1;
           write_wr.opcode = IBV_WR_RDMA_WRITE;
 
-          // TODO: we probably don't actually need this
+          /* TODO: we probably don't actually need this */
           uint64_t offset = 0;
 
           write_wr.wr.rdma.rkey = s->remote_rkey;
@@ -1019,7 +1016,7 @@ pocl_remote_rdma_writer_pthread (void *aa)
                   POCL_MSG_ERR ("Get RDMA channel event failed\n");
                 }
 
-              // Send operations should go into the out-queue
+              /* Send operations should go into the out-queue */
               assert (comp_queue == rdma_data->cq_out);
 
               if (ibv_poll_cq (comp_queue, 1, &wc) != 1)
@@ -1044,7 +1041,7 @@ pocl_remote_rdma_writer_pthread (void *aa)
                       "RDMA send request failed - unrecoverable error %i\n",
                       wc.status);
                   break;
-                  // TODO: Some other failures here could also be recoverable
+                  /* TODO: Some other failures here could be recoverable */
                 }
 
               POCL_ATOMIC_STORE (cmd->client_write_end_timestamp_ns,
@@ -1059,14 +1056,14 @@ pocl_remote_rdma_writer_pthread (void *aa)
 
           rdma_unregister_mem_region (mem_region);
 
-          // Hand command over to reply receiver thread
+          /* Hand command over to reply receiver thread */
 
           POCL_LOCK (this->mutex);
           DL_DELETE (this->queue, cmd);
         }
       else
         {
-          // no cmds, wait for one to arrive
+          /* no cmds, wait for one to arrive */
           POCL_WAIT_COND (this->cond, this->mutex);
         }
     }
@@ -1174,7 +1171,7 @@ pocl_remote_writer_pthread (void *aa)
               POCL_UNLOCK (cmd->receiver->mutex);
             }
 
-          // WRITE DATA
+          /* WRITE DATA */
           if (cmd->req_extra_data2)
             {
               void *ptrs[5]
@@ -1244,8 +1241,8 @@ pocl_remote_writer_pthread (void *aa)
                 resending = 0;
               continue;
             }
-          // hack: wake regularly to check if the readers are waiting to get
-          // reconnected
+          /* hack: wake regularly to check if the readers are waiting to get
+           * reconnected */
           POCL_TIMEDWAIT_COND (this->cond, this->mutex, 1000000); /* 1sec */
           POCL_LOCK (remote->setup_lock.mutex);
           if (remote->threads_awaiting_reconnect > 0)
@@ -1268,8 +1265,8 @@ wait_on_netcmd (network_command *n)
   POCL_UNLOCK (n->data.sync.mutex);
 }
 
-// ##################################################################################
-// ##################################################################################
+/*****************************************************************************/
+/*****************************************************************************/
 
 static void *
 traffic_monitor_pthread (void *arg)
@@ -1356,7 +1353,7 @@ static void
 start_engines (remote_server_data_t *d, remote_device_data_t *devd,
                cl_device_id device)
 {
-  // start alll background threads for IO
+  /* start alll background threads for IO */
   network_queue_arg *a;
 
   d->inflight_queue = calloc (1, sizeof (network_queue));
@@ -1402,12 +1399,12 @@ start_engines (remote_server_data_t *d, remote_device_data_t *devd,
 #ifdef ENABLE_RDMA
   if (d->use_rdma)
     {
-      // rdma thread for reader
+      /* rdma thread for reader */
       SETUP_NETW_Q_ARG (a, d, d->rdma_read_queue);
       POCL_CREATE_THREAD (d->rdma_read_queue->thread_id,
                           pocl_remote_rdma_reader_pthread, a);
 
-      // rdma thread for writer
+      /* rdma thread for writer */
       SETUP_NETW_Q_ARG (a, d, d->rdma_write_queue);
       POCL_CREATE_THREAD (d->rdma_write_queue->thread_id,
                           pocl_remote_rdma_writer_pthread, a);
@@ -1418,7 +1415,7 @@ start_engines (remote_server_data_t *d, remote_device_data_t *devd,
 static void
 stop_engines (remote_server_data_t *d)
 {
-  // Inform the server that it's time to go
+  /* Inform the server that it's time to go */
   remote_server_data_t *data = d;
   remote_server_data_t *ddata = d;
   CREATE_SYNC_NETCMD;
@@ -1431,7 +1428,7 @@ stop_engines (remote_server_data_t *d)
   SEND_REQ_FAST;
   wait_on_netcmd (netcmd);
 
-  // stop threads and wait for them.
+  /* stop threads and wait for them */
 #define NOTIFY_SHUTDOWN(queue)                                                \
   POCL_LOCK ((queue)->mutex);                                                 \
   (queue)->exit_requested = 1;                                                \
@@ -1482,14 +1479,15 @@ find_or_create_server (const char *address_with_port, unsigned port,
       }
   }
 
-  // new server
+  /* new server */
   remote_server_data_t *d = calloc (1, sizeof (remote_server_data_t));
   d->refcount = 1;
   d->peer_id = POCL_ATOMIC_INC (last_peer_id);
   d->available = CL_TRUE;
   d->threads_awaiting_reconnect = 0;
 
-  // pocl_network_init_device ensures address_with_port actually contains port
+  /* pocl_network_init_device ensures address_with_port actually contains
+   * port */
   if (address_with_port[0] == '/')
     {
       d->fast_connection.domain = TransportDomain_Unix;
@@ -1534,11 +1532,11 @@ find_or_create_server (const char *address_with_port, unsigned port,
   d->slow_port = port + 1;
 
 #ifdef ENABLE_RDMA
-  // TODO: re-enable once client RDMA has been reworked to match server
-  // communication
+  /* TODO: re-enable once client RDMA has been reworked to match server
+   * communication */
   if (CL_TRUE || rdma_init_id (&d->rdma_data) == 0)
     {
-      // hs.m.get_session.use_rdma = 0;
+      /* hs.m.get_session.use_rdma = 0; */
     }
   else
     {
@@ -1580,12 +1578,12 @@ find_or_create_server (const char *address_with_port, unsigned port,
   DL_APPEND (servers, d);
 
 #ifdef ENABLE_RDMA
-  d->use_rdma = 0; // hsr.m.create_session.rdma_supported;
+  d->use_rdma = 0; /* hsr.m.create_session.rdma_supported; */
   if (d->use_rdma)
     {
-      // TODO: RDMA connect could be moved to its own function
+      /* TODO: RDMA connect could be moved to its own function */
 
-      // RDMA ADDRESS RESOLVE
+      /* RDMA ADDRESS RESOLVE */
 
       const int timeout_ms = 5000;
 
@@ -1605,7 +1603,7 @@ find_or_create_server (const char *address_with_port, unsigned port,
       n = getaddrinfo (d->address, rdma_port_str, &hints, &resolv_addr);
       if (n < 0)
         {
-          // TODO: Return an error
+          /* TODO: Return an error */
           assert (n >= 0);
           return NULL;
         }
@@ -1613,7 +1611,7 @@ find_or_create_server (const char *address_with_port, unsigned port,
                                  resolv_addr->ai_addr, timeout_ms);
       if (error)
         {
-          // TODO: Return an error
+          /* TODO: Return an error */
           assert (!error);
           return NULL;
         }
@@ -1622,24 +1620,24 @@ find_or_create_server (const char *address_with_port, unsigned port,
       error = rdma_get_cm_event (d->rdma_data.cm_channel, &event);
       if (error)
         {
-          // TODO: Return an error
+          /* TODO: Return an error */
           assert (!error);
           return NULL;
         }
       if (event->event != RDMA_CM_EVENT_ADDR_RESOLVED)
         {
-          // TODO: Return an error
+          /* TODO: Return an error */
           assert (event->event == RDMA_CM_EVENT_ADDR_RESOLVED);
           return NULL;
         }
       rdma_ack_cm_event (event);
 
-      // RDMA ROUTE RESOLVE
-      // This fills out our ibv context i.e. cm_id->verbs
+      /* RDMA ROUTE RESOLVE */
+      /* This fills out our ibv context i.e. cm_id->verbs */
       error = rdma_resolve_route (d->rdma_data.cm_id, timeout_ms);
       if (error)
         {
-          // TODO: Return an error
+          /* TODO: Return an error */
           assert (!error);
           return NULL;
         }
@@ -1647,13 +1645,13 @@ find_or_create_server (const char *address_with_port, unsigned port,
       error = rdma_get_cm_event (d->rdma_data.cm_channel, &event);
       if (error)
         {
-          // TODO: Return an error
+          /* TODO: Return an error */
           assert (!error);
           return NULL;
         }
       if (event->event != RDMA_CM_EVENT_ROUTE_RESOLVED)
         {
-          // TODO: Return an error
+          /* TODO: Return an error */
           assert (event->event == RDMA_CM_EVENT_ROUTE_RESOLVED);
           return NULL;
         }
@@ -1661,7 +1659,7 @@ find_or_create_server (const char *address_with_port, unsigned port,
 
       rdma_init_cq (&d->rdma_data);
 
-      // RDMA CONNECT
+      /* RDMA CONNECT */
 
       struct rdma_conn_param conn_param = {};
       conn_param.initiator_depth = 1;
@@ -1672,7 +1670,7 @@ find_or_create_server (const char *address_with_port, unsigned port,
       error = rdma_connect (d->rdma_data.cm_id, &conn_param);
       if (error)
         {
-          // TODO: Return an error
+          /* TODO: Return an error */
           assert (!error);
           return NULL;
         }
@@ -1680,13 +1678,13 @@ find_or_create_server (const char *address_with_port, unsigned port,
       error = rdma_get_cm_event (d->rdma_data.cm_channel, &event);
       if (error)
         {
-          // TODO: Return an error
+          /* TODO: Return an error */
           assert (!error);
           return NULL;
         }
       if (event->event != RDMA_CM_EVENT_ESTABLISHED)
         {
-          // TODO: Return an error
+          /* TODO: Return an error */
           assert (event->event == RDMA_CM_EVENT_ESTABLISHED);
           return NULL;
         }
@@ -1695,7 +1693,7 @@ find_or_create_server (const char *address_with_port, unsigned port,
     }
 #endif
 
-  // initial ServerInfo reply/response
+  /* initial ServerInfo reply/response */
   RequestMsg_t req;
   memset (&req, 0, sizeof (RequestMsg_t));
   req.message_type = MessageType_ServerInfo;
@@ -1718,10 +1716,10 @@ find_or_create_server (const char *address_with_port, unsigned port,
   d->platform_devices = malloc (rep.data_size);
   readb = read (d->fast_connection.fd, d->platform_devices, rep.data_size);
   assert ((size_t)(readb) == rep.data_size);
-  // *************************************
+  /****************************************/
   size_t num_plat_devs
-      = rep.data_size
-        / sizeof (uint32_t); //= device_counts.size() * sizeof(uint32_t);
+    = rep.data_size
+      / sizeof (uint32_t); /* = device_counts.size() * sizeof(uint32_t); */
   d->num_devices = 0;
   for (size_t i = 0; i < num_plat_devs; ++i)
     d->num_devices += d->platform_devices[i];
@@ -1729,7 +1727,7 @@ find_or_create_server (const char *address_with_port, unsigned port,
   POCL_MSG_PRINT_REMOTE ("Connected to %s:%d which has %d devices\n",
                          d->address, d->fast_port, d->num_devices);
 
-  /*********************************/
+  /****************************************/
 
   SMALL_VECTOR_INIT (d, uint32_t, buffer_ids, INITIAL_ARRAY_CAP);
 
@@ -1757,7 +1755,7 @@ release_server (remote_server_data_t *d)
 
   DL_DELETE (servers, d);
 
-  // shutdown all threads.
+  /* shutdown all threads */
   stop_engines (d);
 
   SMALL_VECTOR_DESTROY (d, buffer_ids, INITIAL_ARRAY_CAP);
@@ -1770,7 +1768,7 @@ release_server (remote_server_data_t *d)
 
   SMALL_VECTOR_DESTROY (d, sampler_ids, INITIAL_ARRAY_CAP);
 
-  // disconnect sockets.
+  /* disconnect sockets */
   pocl_network_disconnect (d, &d->fast_connection);
   pocl_network_disconnect (d, &d->slow_connection);
 
@@ -1806,13 +1804,13 @@ pocl_network_init_device (cl_device_id device, remote_device_data_t *ddata,
       char *second_colon = strchr (colon + 1, ':');
       if (second_colon)
         {
-          // vsock:vm:port
+          /* vsock:vm:port */
           strncpy (address, tmp, second_colon - tmp);
           port = (unsigned)atoi (strchr (colon + 1, ':') + 1);
         }
       else
         {
-          // vsock:vm
+          /* vsock:vm */
           strcpy (address, tmp);
         }
     }
@@ -1849,7 +1847,7 @@ pocl_network_init_device (cl_device_id device, remote_device_data_t *ddata,
                         did, data->num_devices);
   ddata->server = data;
 
-  // TODO let user specify platform
+  /* TODO let user specify platform */
   uint32_t pid = 0;
   while (did >= data->platform_devices[pid])
     {
@@ -1975,15 +1973,15 @@ pocl_network_fetch_devinfo (cl_device_id device,
   if (devinfo->builtin_kernels)
     device->builtin_kernel_list = GET_STRING (devinfo->builtin_kernels);
 
-  // This one is deprecated (and seems to be always 128)
+  /* This one is deprecated (and seems to be always 128) */
   device->min_data_type_align_size = 128;
 
   ddata->device_svm_region_start_addr = devinfo->svm_pool_start_address;
   ddata->device_svm_region_size = devinfo->svm_pool_size;
 
   D (vendor_id);
-  // TODO
-  // D(device_id);
+  /* TODO:
+   * D(device_id); */
   D (address_bits);
   D (mem_base_addr_align);
 
@@ -2059,8 +2057,8 @@ pocl_network_fetch_devinfo (cl_device_id device,
   D (printf_buffer_size);
   D (profiling_timer_resolution);
 
-  // ####################################################
-  // ####################################################
+  /****************************************/
+  /****************************************/
 
   if (devinfo->image_support == CL_FALSE)
     {
@@ -2104,8 +2102,7 @@ pocl_network_fetch_devinfo (cl_device_id device,
         }
     }
 
-  // LLVM triple + cpu type => for compilation
-  // build hash => for binaries
+  /*  LLVM triple + cpu type => for compilation; build hash => for binaries */
   free (devinfo);
   return 0;
 }
@@ -2122,17 +2119,17 @@ pocl_network_free_device (cl_device_id device)
   return 0;
 }
 
-// ###########################################################################
-// ###########################################################################
-// ###########################################################################
+/*****************************************************************************/
+/*****************************************************************************/
+/*****************************************************************************/
 
-// SYNCHRONOUS
+/* SYNCHRONOUS COMMANDS */
 
 cl_int
 pocl_network_create_buffer (remote_device_data_t *ddata, cl_mem mem,
                             void **device_addr)
 {
-  // = (remote_device_data_t *)device->data;
+  /* = (remote_device_data_t *)device->data; */
   REMOTE_SERV_DATA2;
 
   RETURN_IF_REMOTE_ID (buffer, mem->id);
@@ -2184,8 +2181,8 @@ pocl_network_create_buffer (remote_device_data_t *ddata, cl_mem mem,
   s->mem_id = mem->id;
   s->remote_vaddr = info.server_vaddr;
   s->remote_rkey = info.server_rkey;
-  // NOTE: mem_id here is the name of the struct field holding the hashmap key,
-  // not the local variable
+  /* NOTE: mem_id here is the name of the struct field holding the hashmap key,
+   * not the local variable */
   HASH_ADD (hh, data->rdma_keys, mem_id, sizeof (uint32_t), s);
 #endif
 
@@ -2289,7 +2286,7 @@ pocl_network_setup_metadata (char *buffer, size_t total_size,
         p[i].name = strdup (temp_kernel.name);
         p[i].num_args = temp_kernel.num_args;
 
-        // because have to return total local size
+        /* because have to return total local size */
         p[i].num_locals = 1;
         p[i].local_sizes = calloc (1, sizeof (size_t));
         p[i].local_sizes[0] = temp_kernel.total_local_size;
@@ -2339,7 +2336,7 @@ pocl_network_setup_metadata (char *buffer, size_t total_size,
 
             p[i].arg_info[j].type_name = strdup (temp_arg.type_name);
             p[i].arg_info[j].type_qualifier = temp_arg.type_qualifier;
-            // TODO there's no way to get this from OpenCL API currently.
+            /* TODO: there's no way to get this from OpenCL API currently. */
             p[i].arg_info[j].type_size = 0;
           }
         }
@@ -2408,7 +2405,7 @@ pocl_network_build_or_link_program (
   size_t i, j;
   REMOTE_SERV_DATA2;
 
-  // TODO
+  /* TODO */
   RETURN_IF_REMOTE_ID (program, prog_id);
 
   CREATE_SYNC_NETCMD;
@@ -2781,9 +2778,9 @@ pocl_network_free_image (remote_device_data_t *ddata, uint32_t image_id)
   return 0;
 }
 
-// ##################################################################################
-// ##################################################################################
-// ##################################################################################
+/*****************************************************************************/
+/*****************************************************************************/
+/*****************************************************************************/
 
 cl_int
 pocl_network_migrate_d2d (uint32_t cq_id, uint32_t mem_id, uint32_t size_id,
@@ -2797,7 +2794,7 @@ pocl_network_migrate_d2d (uint32_t cq_id, uint32_t mem_id, uint32_t size_id,
   remote_device_data_t *ddata = dest;
   remote_server_data_t *data = dest->server;
 
-  // request
+  /* request */
   CREATE_ASYNC_NETCMD;
 
   ID_REQUEST (MigrateD2D, mem_id);
@@ -2831,7 +2828,7 @@ pocl_network_read (uint32_t cq_id, remote_device_data_t *ddata,
   REMOTE_SERV_DATA2;
   assert (size > 0);
 
-  // request
+  /* request */
   CREATE_ASYNC_NETCMD;
 
   ID_REQUEST (ReadBuffer, mem_id);
@@ -2843,7 +2840,7 @@ pocl_network_read (uint32_t cq_id, remote_device_data_t *ddata,
   req->m.read.is_svm = is_svm;
   if (is_svm)
     req->obj_id = (uint64_t)host_ptr + ddata->svm_region_offset;
-  // REPLY
+  /* REPLY */
   netcmd->rep_extra_data = host_ptr;
   netcmd->rep_extra_size = size;
 
@@ -2874,7 +2871,7 @@ pocl_network_write (uint32_t cq_id, remote_device_data_t *ddata,
   if (is_svm)
     req->obj_id = (uint64_t)host_ptr + ddata->svm_region_offset;
 
-  // REQUEST
+  /* REQUEST */
   netcmd->req_extra_data = host_ptr;
   netcmd->req_extra_size = size;
 
@@ -2953,7 +2950,7 @@ pocl_network_read_rect (uint32_t cq_id, remote_device_data_t *ddata,
   req->m.read_rect.buffer_slice_pitch = buffer_slice_pitch;
   req->m.read_rect.host_bytes = size;
 
-  // REPLY data
+  /* REPLY data */
   netcmd->rep_extra_data = host_ptr;
   netcmd->rep_extra_size = size;
 
@@ -2993,7 +2990,7 @@ pocl_network_write_rect (uint32_t cq_id, remote_device_data_t *ddata,
   req->m.write_rect.buffer_slice_pitch = buffer_slice_pitch;
   req->m.write_rect.host_bytes = size;
 
-  // REQUEST
+  /* REQUEST */
   netcmd->req_extra_data = host_ptr;
   netcmd->req_extra_size = size;
 
@@ -3250,7 +3247,7 @@ pocl_network_write_image_rect (uint32_t cq_id, remote_device_data_t *ddata,
   req->m.write_image_rect.region.z = region[2];
   req->m.write_image_rect.host_bytes = size;
 
-  // REQUEST
+  /* REQUEST */
   netcmd->req_extra_data = host_ptr;
   netcmd->req_extra_size = size;
 
@@ -3324,7 +3321,7 @@ pocl_network_read_image_rect (uint32_t cq_id, remote_device_data_t *ddata,
   req->cq_id = cq_id;
   req->obj_id = src_remote_id;
 
-  // REPLY
+  /* REPLY */
   netcmd->rep_extra_data = p;
   netcmd->rep_extra_size = size;
 

--- a/lib/CL/devices/remote/communication.h
+++ b/lib/CL/devices/remote/communication.h
@@ -29,6 +29,7 @@
 
 #include "messages.h"
 #include "pocl.h"
+#include "pocl_threads.h"
 
 #include "utlist_addon.h"
 #include "utlist.h"
@@ -173,6 +174,22 @@ struct network_command
 // in nanoseconds
 #define POCL_REMOTE_RECONNECT_TIMEOUT_NS 60 * 1000000000L
 
+typedef enum transport_domain_e
+{
+  /** Unix domain socket */
+  TransportDomain_Unix,
+  /** IPv4 or IPv6 */
+  TransportDomain_Inet,
+  /** VSOCK VirtIO socket */
+  TransportDomain_Vsock,
+} transport_domain_t;
+
+typedef struct transport_info_s
+{
+  transport_domain_t domain;
+  int fd;
+} transport_info_t;
+
 typedef struct remote_server_data_s
 {
   char address[MAX_ADDRESS_SIZE];
@@ -193,8 +210,9 @@ typedef struct remote_server_data_s
   uint32_t available;
   sync_t setup_lock;
   int threads_awaiting_reconnect;
-  int slow_socket_fd;
-  int fast_socket_fd;
+
+  transport_info_t slow_connection;
+  transport_info_t fast_connection;
 
   uint32_t num_platforms;
   uint32_t num_devices;

--- a/lib/CL/devices/remote/communication.h
+++ b/lib/CL/devices/remote/communication.h
@@ -29,6 +29,7 @@
 
 #include "messages.h"
 #include "pocl.h"
+#include "pocl_networking.h"
 #include "pocl_threads.h"
 
 #include "utlist_addon.h"
@@ -173,22 +174,6 @@ struct network_command
 
 // in nanoseconds
 #define POCL_REMOTE_RECONNECT_TIMEOUT_NS 60 * 1000000000L
-
-typedef enum transport_domain_e
-{
-  /** Unix domain socket */
-  TransportDomain_Unix,
-  /** IPv4 or IPv6 */
-  TransportDomain_Inet,
-  /** VSOCK VirtIO socket */
-  TransportDomain_Vsock,
-} transport_domain_t;
-
-typedef struct transport_info_s
-{
-  transport_domain_t domain;
-  int fd;
-} transport_info_t;
 
 typedef struct remote_server_data_s
 {

--- a/lib/CL/pocl_networking.h
+++ b/lib/CL/pocl_networking.h
@@ -27,6 +27,7 @@
 #ifndef POCL_NETWORKING_H
 #define POCL_NETWORKING_H
 
+/** Tag for transport_info_t to indicate the type of the socket */
 typedef enum transport_domain_e
 {
   /** Unix domain socket */
@@ -37,6 +38,9 @@ typedef enum transport_domain_e
   TransportDomain_Vsock,
 } transport_domain_t;
 
+/** Wrapper struct that holds everything the communication (read/write)
+ * functions need to function, starting with a tag to indicate what kind of
+ * connection this is */
 typedef struct transport_info_s
 {
   transport_domain_t domain;

--- a/lib/CL/pocl_networking.h
+++ b/lib/CL/pocl_networking.h
@@ -24,8 +24,6 @@
 
 #include <stdint.h>
 
-#include "pocl_export.h"
-
 #ifndef POCL_NETWORKING_H
 #define POCL_NETWORKING_H
 
@@ -55,14 +53,14 @@ extern "C"
                                                     int is_fast,
                                                     int ai_family);
   /**
-   * host_freeaddrinfo - free addrinfo obtained from host_*() functions
+   * pocl_freeaddrinfo - free addrinfo obtained from host_*() functions
    * @ai: pointer to addrinfo to free
    *
-   * The addrinfos returned by host_*() functions may not have been allocated
+   * The addrinfos returned by pocl_*() functions may not have been allocated
    * by a call to getaddrinfo(3).  It is not safe to free them directly with
    * freeaddrinfo(3).  Use this function instead.
    */
-  extern void host_freeaddrinfo (struct addrinfo *ai);
+  extern void pocl_freeaddrinfo (struct addrinfo *ai);
 
   /*
    * vsock_hostname_addrinfo - Custom 'getaddrinfo' for vsock addresses

--- a/lib/CL/pocl_networking.h
+++ b/lib/CL/pocl_networking.h
@@ -27,6 +27,22 @@
 #ifndef POCL_NETWORKING_H
 #define POCL_NETWORKING_H
 
+typedef enum transport_domain_e
+{
+  /** Unix domain socket */
+  TransportDomain_Unix,
+  /** IPv4 or IPv6 */
+  TransportDomain_Inet,
+  /** VSOCK VirtIO socket */
+  TransportDomain_Vsock,
+} transport_domain_t;
+
+typedef struct transport_info_s
+{
+  transport_domain_t domain;
+  int fd;
+} transport_info_t;
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/pocld/CMakeLists.txt
+++ b/pocld/CMakeLists.txt
@@ -127,6 +127,14 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 
   find_package(Threads REQUIRED)
 
+  find_file(
+    HAVE_LINUX_VSOCK_H
+    NAMES
+      linux/vm_sockets.h
+    PATHS
+      /usr/include
+  )
+
   list(APPEND P_LINK_LIST ${OPENCL} Threads::Threads)
 
   set(POCL_INSTALL_PUBLIC_BINDIR "${CMAKE_INSTALL_PREFIX}/bin")
@@ -190,4 +198,3 @@ if (STANDALONE EQUAL 0)
   install(TARGETS pocld RUNTIME
         DESTINATION "${POCL_INSTALL_PUBLIC_BINDIR}")
 endif()
-

--- a/pocld/CMakeLists.txt
+++ b/pocld/CMakeLists.txt
@@ -43,7 +43,7 @@ set(SOURCES pocld.cc daemon.hh daemon.cc cmdline.h cmdline.c
             shared_cl_context.cc shared_cl_context.hh
             virtual_cl_context.cc virtual_cl_context.hh
             cmd_queue.cc cmd_queue.hh common.cc common.hh
-            request.hh request.cc
+            connection.hh connection.cc request.hh request.cc
             reply_th.cc reply_th.hh request_th.cc request_th.hh
             peer_handler.cc peer_handler.hh
             peer.cc peer.hh tracing.h traffic_monitor.hh traffic_monitor.cc)

--- a/pocld/common.cc
+++ b/pocld/common.cc
@@ -27,7 +27,7 @@
 
 #include <arpa/inet.h>
 #include <cassert>
-#ifdef ENABLE_VSOCK
+#ifdef HAVE_LINUX_VSOCK_H
 #include <linux/vm_sockets.h>
 #endif
 #include <netdb.h>
@@ -168,7 +168,7 @@ std::string describe_sockaddr(struct sockaddr *addr, unsigned addr_size) {
   else if (addr->sa_family == AF_INET6)
     inet_ntop(addr->sa_family, &((struct sockaddr_in6 *)addr)->sin6_addr,
               ip_str.data(), ip_str.capacity());
-#ifdef ENABLE_VSOCK
+#ifdef HAVE_LINUX_VSOCK_H
   else if (addr->sa_family == AF_VSOCK) {
     struct sockaddr_vm *vm_addr = (sockaddr_vm *)addr;
 

--- a/pocld/common.cc
+++ b/pocld/common.cc
@@ -155,6 +155,9 @@ uint64_t transfer_size(const RequestMsg_t &msg) {
   case MessageType_MigrateD2D:
     return msg.m.migrate.size;
     break;
+  case MessageType_Shutdown:
+    return 0;
+    break;
   default:
     assert(!"Unhandled RDMA message");
     return 0;

--- a/pocld/common.cc
+++ b/pocld/common.cc
@@ -23,6 +23,7 @@
 */
 
 #include "common.hh"
+#include "pocl_networking.h"
 #include "traffic_monitor.hh"
 
 #include <arpa/inet.h>
@@ -33,69 +34,6 @@
 #include <netdb.h>
 #include <sys/uio.h>
 #include <unistd.h>
-
-ssize_t read_full(int fd, void *p, size_t total, TrafficMonitor *tm) {
-  //      float_time_point start = Time::now();
-
-  size_t readb = 0;
-  ssize_t res;
-  char *ptr = static_cast<char *>(p);
-  if (tm)
-    tm->rxRequested(total);
-  while (readb < total) {
-    size_t remain = total - readb;
-    res = ::read(fd, ptr + readb, remain);
-    if (res < 0) {
-      int e = errno;
-      if (e == EAGAIN || e == EWOULDBLOCK)
-        continue;
-      else
-        return -1;
-    }
-    if (res == 0) { // EOF
-      return 0;
-    }
-    readb += (size_t)res;
-    if (tm)
-      tm->rxConfirmed(res);
-  }
-
-  return static_cast<ssize_t>(total);
-  //      float_time_point end = Time::now();
-  //      float_sec elapsed_seconds = end-start;
-  //      std::cerr << "read " << total << " bytes   @ " <<
-  //      elapsed_seconds.count() << "\n";
-}
-
-int write_full(int fd, void *p, size_t total, TrafficMonitor *tm) {
-  //      float_time_point start = Time::now();
-
-  size_t written = 0;
-  ssize_t res;
-  char *ptr = static_cast<char *>(p);
-  if (tm)
-    tm->txSubmitted(total);
-  while (written < total) {
-    size_t remain = total - written;
-    res = ::write(fd, ptr + written, remain);
-    if (res < 0) {
-      int e = errno;
-      if (e == EAGAIN || e == EWOULDBLOCK)
-        continue;
-      else
-        return -1;
-    }
-    written += (size_t)res;
-    if (tm)
-      tm->txConfirmed(res);
-  }
-  return 0;
-
-  //      float_time_point end = Time::now();
-  //      float_sec elapsed_seconds = end-start;
-  //      std::cerr << "written " << total << " bytes   @ " <<
-  //      elapsed_seconds.count() << "\n";
-}
 
 void replyID(Reply *rep, ReplyMessageType t, uint32_t id) {
   rep->rep.message_type = t;

--- a/pocld/common.hh
+++ b/pocld/common.hh
@@ -50,6 +50,7 @@ using float_time_point = std::chrono::time_point<Time, float_sec>;
 #define MS_PER_S 1000
 
 #include "pocl_debug.h"
+#include "pocl_networking.h"
 #include "request.hh"
 
 #ifdef ENABLE_RDMA
@@ -246,10 +247,6 @@ typedef std::array<size_t, 3> sizet_vec3;
 
 class TrafficMonitor;
 
-ssize_t read_full(int fd, void *p, size_t total, TrafficMonitor *);
-
-int write_full(int fd, void *p, size_t total, TrafficMonitor *);
-
 std::string describe_sockaddr(struct sockaddr *addr, unsigned addr_size);
 
 #ifdef ENABLE_RDMA
@@ -263,8 +260,10 @@ struct RdmaRemoteBufferData {
 };
 #endif
 
+class Connection;
+
 struct PeerConnection {
-  int Fd;
+  std::shared_ptr<Connection> Conn;
   uint64_t PeerId;
 #ifdef ENABLE_RDMA
   std::shared_ptr<RdmaConnection> Rdma;
@@ -272,8 +271,8 @@ struct PeerConnection {
 };
 
 struct ClientConnections_t {
-  int fd_command;
-  int fd_stream;
+  std::shared_ptr<Connection> low_latency;
+  std::shared_ptr<Connection> bulk_throughput;
   std::mutex *incoming_peer_mutex;
   std::pair<std::condition_variable, std::vector<PeerConnection>>
       *incoming_peer_queue;

--- a/pocld/common.hh
+++ b/pocld/common.hh
@@ -321,12 +321,12 @@ public:
   Reply(Request *r)
       : rep(), req(r), extra_size(0), event(nullptr) {
     assert(req.get());
-    rep.client_did = req->req.client_did;
-    rep.did = req->req.did;
-    rep.pid = req->req.pid;
-    rep.msg_id = req->req.msg_id;
-    rep.server_read_start_timestamp_ns = req->read_start_timestamp_ns;
-    rep.server_read_end_timestamp_ns = req->read_end_timestamp_ns;
+    rep.client_did = req->Body.client_did;
+    rep.did = req->Body.did;
+    rep.pid = req->Body.pid;
+    rep.msg_id = req->Body.msg_id;
+    rep.server_read_start_timestamp_ns = req->ReadStartTimestampNS;
+    rep.server_read_end_timestamp_ns = req->ReadEndTimestampNS;
   }
 };
 

--- a/pocld/connection.cc
+++ b/pocld/connection.cc
@@ -1,0 +1,145 @@
+/* connection.hh - Interface of a wrapper class for various connection types
+
+   Copyright (c) 2024 Jan Solanti / Tampere University
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#include <cassert>
+#include <sys/socket.h>
+
+#include "connection.hh"
+#include "pocl_networking.h"
+#include "traffic_monitor.hh"
+
+#define COMMAND_SOCKET_BUFSIZE (4 * 1024)
+#define STREAM_SOCKET_BUFSIZE (4 * 1024 * 1024)
+
+Connection::Connection(transport_domain_t Domain, int Fd,
+                       std::shared_ptr<TrafficMonitor> Meter)
+    : Domain(Domain), Fd(Fd), Meter(Meter) {}
+
+Connection::~Connection() {
+  shutdown(Fd, SHUT_RDWR);
+  close(Fd);
+}
+
+void Connection::configure(bool LowLatency) {
+  size_t BufSize = LowLatency ? COMMAND_SOCKET_BUFSIZE : STREAM_SOCKET_BUFSIZE;
+  switch (Domain) {
+  case TransportDomain_Inet:
+    // function only actually checks whether ai_family is AF_VSOCK
+    pocl_remote_client_set_socket_options(Fd, BufSize, LowLatency, AF_UNSPEC);
+    break;
+  case TransportDomain_Vsock:
+    pocl_remote_client_set_socket_options(Fd, BufSize, LowLatency, AF_VSOCK);
+    break;
+  default:
+    break;
+  }
+}
+
+ssize_t Connection::writeFull(const void *Source, size_t Bytes) {
+  size_t Written = 0;
+  ssize_t Res;
+  const char *Ptr = static_cast<const char *>(Source);
+
+  if (Meter.get())
+    Meter->txSubmitted(Bytes);
+
+  while (Written < Bytes) {
+    size_t Remaining = Bytes - Written;
+    Res = ::write(Fd, Ptr + Written, Remaining);
+    if (Res < 0) {
+      int e = errno;
+      if (e == EAGAIN || e == EWOULDBLOCK)
+        continue;
+      else
+        return -1;
+    }
+    Written += (size_t)Res;
+
+    if (Meter.get())
+      Meter->txConfirmed(Res);
+  }
+
+  return 0;
+}
+
+int Connection::readFull(void *Destination, size_t Bytes) {
+  size_t readb = 0;
+  ssize_t res;
+  char *Ptr = static_cast<char *>(Destination);
+  if (Meter.get())
+    Meter->rxRequested(Bytes);
+  while (readb < Bytes) {
+    size_t Remain = Bytes - readb;
+    res = ::read(Fd, Ptr + readb, Remain);
+    if (res < 0) {
+      int e = errno;
+      if (e == EAGAIN || e == EWOULDBLOCK)
+        continue;
+      else
+        return -1;
+    }
+    if (res == 0) { // EOF
+      return 0;
+    }
+    readb += (size_t)res;
+    if (Meter.get())
+      Meter->rxConfirmed(res);
+  }
+
+  return static_cast<ssize_t>(Bytes);
+}
+
+int Connection::readReentrant(void *Destination, size_t Bytes,
+                              size_t *Tracker) {
+  if (*Tracker == Bytes)
+    return 0;
+
+  ssize_t readb;
+  readb = ::read(Fd, (char *)Destination + *Tracker, Bytes - *Tracker);
+  if (readb < 0)
+    return errno;
+
+  if (readb == 0)
+    return EPIPE;
+
+  *Tracker += readb;
+  if (*Tracker != Bytes)
+    return EAGAIN;
+  return 0;
+}
+
+int Connection::pollableFd() { return Fd; }
+
+std::string Connection::describe() {
+  switch (Domain) {
+  case TransportDomain_Unix:
+    return "unix:fd=" + std::to_string(Fd);
+  case TransportDomain_Inet:
+    return "tcp:fd=" + std::to_string(Fd);
+  case TransportDomain_Vsock:
+    return "vsock:fd=" + std::to_string(Fd);
+  default:
+    assert(!"Unhandled transport domain");
+    return "[unknown]";
+  }
+}

--- a/pocld/connection.hh
+++ b/pocld/connection.hh
@@ -1,6 +1,6 @@
-/* traffic_monitor.hh - pocld helper for tracking network use per session
+/* connection.hh - Interface of a wrapper class for various connection types
 
-   Copyright (c) 2023 Jan Solanti / Tampere University
+   Copyright (c) 2024 Jan Solanti / Tampere University
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to
@@ -21,40 +21,45 @@
    IN THE SOFTWARE.
 */
 
-#ifndef POCLD_TRAFFIC_MONITOR_HH
-#define POCLD_TRAFFIC_MONITOR_HH
+#ifndef POCL_CONNECTION_HH
+#define POCL_CONNECTION_HH
 
-#include <atomic>
-#include <filesystem>
-#include <string>
-#include <thread>
+#include <memory>
+#include <unistd.h>
+
+#include "pocl_networking.h"
+#include "traffic_monitor.hh"
 
 #ifdef __GNUC__
 #pragma GCC visibility push(hidden)
 #endif
 
-class ExitHelper;
-
-class TrafficMonitor {
-  std::atomic_uint64_t tx_bytes_submitted;
-  std::atomic_uint64_t tx_bytes_confirmed;
-  std::atomic_uint64_t rx_bytes_requested;
-  std::atomic_uint64_t rx_bytes_confirmed;
-  ExitHelper *eh;
-  std::thread file_thread;
-  std::string client_id;
-  std::filesystem::path base_path;
-
+class Connection {
 public:
-  TrafficMonitor(ExitHelper *e, std::string &client_id);
-  ~TrafficMonitor();
+  struct Parameters {
+    int BufSize;
+    int IsFast;
+  };
 
-  void fileWriterThread();
+  Connection() = delete;
+  Connection(transport_domain_t Domain, int Fd,
+             std::shared_ptr<TrafficMonitor> Meter);
+  ~Connection();
+  void configure(bool LowLatency);
+  ssize_t writeFull(const void *Source, size_t Bytes);
+  int readFull(void *Destination, size_t Bytes);
+  int readReentrant(void *Destination, size_t Bytes, size_t *Tracker);
+  int pollableFd();
+  std::string describe();
+  transport_domain_t domain() { return Domain; }
+  void setMeter(std::shared_ptr<TrafficMonitor> M) { Meter = M; }
+  std::shared_ptr<TrafficMonitor> meter() { return Meter; }
 
-  inline void txSubmitted(uint64_t bytes) { tx_bytes_submitted += bytes; }
-  inline void txConfirmed(uint64_t bytes) { tx_bytes_confirmed += bytes; }
-  inline void rxRequested(uint64_t bytes) { rx_bytes_requested += bytes; }
-  inline void rxConfirmed(uint64_t bytes) { rx_bytes_confirmed += bytes; }
+private:
+  std::shared_ptr<TrafficMonitor> Meter;
+  transport_domain_t Domain;
+  int Fd;
+  // TODO: also wrap RdmaConnection?
 };
 
 #ifdef __GNUC__

--- a/pocld/daemon.cc
+++ b/pocld/daemon.cc
@@ -42,7 +42,7 @@
 #include "rdma.hh"
 #endif
 
-#ifdef ENABLE_VSOCK
+#ifdef HAVE_LINUX_VSOCK_H
 #include <limits.h>
 #include <linux/version.h>
 #include <linux/vm_sockets.h>
@@ -331,7 +331,7 @@ int PoclDaemon::launch(std::string ListenAddress, struct ServerPorts &Ports,
     else if (server_addr_command.ss_family == AF_INET6)
       ((struct sockaddr_in6 *)&server_addr_command)->sin6_port =
           htons(ListenPorts.command);
-#ifdef ENABLE_VSOCK
+#ifdef HAVE_LINUX_VSOCK_H
     else if (server_addr_command.ss_family == AF_VSOCK)
       ((struct sockaddr_vm *)&server_addr_command)->svm_port =
           ListenPorts.command;
@@ -353,7 +353,7 @@ int PoclDaemon::launch(std::string ListenAddress, struct ServerPorts &Ports,
     else if (server_addr_stream.ss_family == AF_INET6)
       ((struct sockaddr_in6 *)&server_addr_stream)->sin6_port =
           htons(ListenPorts.stream);
-#ifdef ENABLE_VSOCK
+#ifdef HAVE_LINUX_VSOCK_H
     else if (server_addr_command.ss_family == AF_VSOCK)
       ((struct sockaddr_vm *)&server_addr_command)->svm_port =
           ListenPorts.stream;
@@ -425,9 +425,9 @@ int PoclDaemon::launch(std::string ListenAddress, struct ServerPorts &Ports,
     if (listen_stream_fd)
       close(listen_stream_fd);
   }
-#ifdef ENABLE_VSOCK
+#ifdef HAVE_LINUX_VSOCK_H
   if (UseVsock)
-    host_freeaddrinfo(ResolvedAddress);
+    pocl_freeaddrinfo(ResolvedAddress);
   else
 #endif
     freeaddrinfo(ResolvedAddress);

--- a/pocld/daemon.cc
+++ b/pocld/daemon.cc
@@ -21,19 +21,19 @@
    IN THE SOFTWARE.
 */
 
-#include <algorithm>
 #include <arpa/inet.h>
 #include <ifaddrs.h>
+#include <memory>
 #include <net/if.h>
 #include <netdb.h>
 #include <netinet/tcp.h>
 #include <numeric>
-#include <optional>
 #include <random>
 #include <set>
 #include <sys/poll.h>
 #include <unistd.h>
 
+#include "connection.hh"
 #include "pocl_debug.h"
 #include "pocl_networking.h"
 #include "pocl_runtime_config.h"
@@ -55,8 +55,6 @@
 #endif
 #define POLLFD_ERROR_BITS (POLLHUP | POLLERR | POLLNVAL | POLLRDHUP)
 
-#define COMMAND_SOCKET_BUFSIZE (4 * 1024)
-#define STREAM_SOCKET_BUFSIZE (4 * 1024 * 1024)
 
 #define PERROR_CHECK(cond, str)                                                \
   do {                                                                         \
@@ -110,12 +108,13 @@ int listen_peers(void *data) {
     socklen_t AddressSize = sizeof(PeerAddress);
     /* NOTE: size argument must be initialized to length of actual size of the
      * addr argument */
-    int PeerFd = accept(listen_sock, &PeerAddress, &AddressSize);
-    assert(PeerFd != -1);
-    if (setsockopt(PeerFd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one)))
+    int Fd = accept(listen_sock, &PeerAddress, &AddressSize);
+    assert(Fd != -1);
+
+    if (setsockopt(Fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one)))
       POCL_MSG_ERR("peer listener: failed to set NODELAY on socket\n");
 #ifdef TCP_QUICKACK
-    if (setsockopt(PeerFd, IPPROTO_TCP, TCP_QUICKACK, &one, sizeof(one)))
+    if (setsockopt(Fd, IPPROTO_TCP, TCP_QUICKACK, &one, sizeof(one)))
       POCL_MSG_ERR("peer listener: failed to set QUICKACK on socket\n");
 #endif
     std::string addr_string =
@@ -123,6 +122,8 @@ int listen_peers(void *data) {
     POCL_MSG_PRINT_GENERAL("PL: New peer connection from %s\n",
                            addr_string.c_str());
 
+    std::shared_ptr<Connection> PeerConnection(
+        new Connection(TransportDomain_Inet, Fd, nullptr));
     ReplyMsg_t Rep;
 
 #ifdef ENABLE_RDMA
@@ -137,10 +138,9 @@ int listen_peers(void *data) {
     Request R{};
     bool ReadError;
     do {
-      ReadError = !R.read(PeerFd);
+      ReadError = !R.read(PeerConnection.get());
     } while (!R.IsFullyRead && !ReadError);
     if (ReadError) {
-      close(PeerFd);
       continue;
     }
 
@@ -156,17 +156,17 @@ int listen_peers(void *data) {
       POCL_MSG_WARN("PL: Attempted peer connection to invalid session %" PRIu64
                     " from %s\n",
                     R.req.session, addr_string.c_str());
-      close(PeerFd);
     } else {
       POCL_MSG_PRINT_INFO("PL: Peer connection from %s to session %" PRIu64
-                          ", fd_peer=%d\n",
-                          addr_string.c_str(), R.req.session, PeerFd);
+                          ", %s\n",
+                          addr_string.c_str(), R.req.session,
+                          PeerConnection->describe().c_str());
       ReplyMsg_t Rep = {};
       Rep.message_type = MessageType_PeerHandshakeReply;
       Rep.msg_id = R.req.msg_id;
       Rep.m.peer_handshake.peer_id = d->SessionPeerId.at(R.req.session);
       d->incoming_peers.at(R.req.session)
-          ->second.push_back({PeerFd, R.req.m.peer_handshake.peer_id
+          ->second.push_back({PeerConnection, R.req.m.peer_handshake.peer_id
 #ifdef ENABLE_RDMA
                               ,
                               rdma_connection
@@ -179,7 +179,7 @@ int listen_peers(void *data) {
           {*rdma_connection->id(), d->vctx_map.at(R.req.session)});
 #endif
       l.unlock();
-      write_full(PeerFd, &Rep, sizeof(Rep), nullptr);
+      PeerConnection->writeFull(&Rep, sizeof(Rep));
     }
   } while (true);
 }
@@ -321,8 +321,10 @@ int PoclDaemon::launch(std::string ListenAddress, struct ServerPorts &Ports,
                    addr_string.c_str());
       break;
     }
-    int listen_command_fd = 0;
-    int listen_stream_fd = 0;
+    int FdCommand = -1;
+    int FdStream = -1;
+    transport_domain_t Domain =
+        (UseVsock) ? TransportDomain_Vsock : TransportDomain_Inet;
     struct sockaddr_storage server_addr_command, server_addr_stream;
     std::memcpy(&server_addr_command, base_addr, base_addrlen);
     if (server_addr_command.ss_family == AF_INET)
@@ -342,9 +344,9 @@ int PoclDaemon::launch(std::string ListenAddress, struct ServerPorts &Ports,
       goto SOCKET_ERROR;
     }
 
-    listen_command_fd = socket(server_addr_command.ss_family, SOCK_STREAM,
-                               UseVsock ? 0 : IPPROTO_TCP);
-    PERROR_SKIP((listen_command_fd < 0), "command socket");
+    FdCommand = socket(server_addr_command.ss_family, SOCK_STREAM,
+                       UseVsock ? 0 : IPPROTO_TCP);
+    PERROR_SKIP((FdCommand < 0), "command socket");
 
     std::memcpy(&server_addr_stream, base_addr, base_addrlen);
     if (server_addr_stream.ss_family == AF_INET)
@@ -362,33 +364,26 @@ int PoclDaemon::launch(std::string ListenAddress, struct ServerPorts &Ports,
       POCL_MSG_ERR("SERVER: unsupported socket address family\n");
       goto SOCKET_ERROR;
     }
-    listen_stream_fd = socket(server_addr_stream.ss_family, SOCK_STREAM,
-                              UseVsock ? 0 : IPPROTO_TCP);
-    PERROR_SKIP((listen_stream_fd < 0), "stream socket");
+    FdStream = socket(server_addr_stream.ss_family, SOCK_STREAM,
+                      UseVsock ? 0 : IPPROTO_TCP);
+    PERROR_SKIP((FdStream < 0), "stream socket");
 
 #ifdef SO_REUSEADDR
-    if (setsockopt(listen_command_fd, SOL_SOCKET, SO_REUSEADDR, &one,
-                   sizeof(one)))
+    if (setsockopt(FdCommand, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)))
       POCL_MSG_ERR("SERVER: failed to set REUSEADDR on command socket\n");
-    if (setsockopt(listen_stream_fd, SOL_SOCKET, SO_REUSEADDR, &one,
-                   sizeof(one)))
+    if (setsockopt(FdStream, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)))
       POCL_MSG_ERR("SERVER: failed to set REUSEADDR on stream socket\n");
 #endif
 
-    PERROR_SKIP(
-        (bind(listen_command_fd, (struct sockaddr *)&server_addr_command,
-              base_addrlen) < 0),
-        "command bind");
-    pocl_remote_client_set_socket_options(
-        listen_command_fd, COMMAND_SOCKET_BUFSIZE, 1, ai->ai_family);
-    PERROR_SKIP((listen(listen_command_fd, 10) < 0), "command listen");
+    PERROR_SKIP((bind(FdCommand, (struct sockaddr *)&server_addr_command,
+                      base_addrlen) < 0),
+                "command bind");
+    PERROR_SKIP((listen(FdCommand, 10) < 0), "command listen");
 
-    PERROR_SKIP((bind(listen_stream_fd, (struct sockaddr *)&server_addr_stream,
+    PERROR_SKIP((bind(FdStream, (struct sockaddr *)&server_addr_stream,
                       base_addrlen) < 0),
                 "stream bind");
-    pocl_remote_client_set_socket_options(
-        listen_stream_fd, STREAM_SOCKET_BUFSIZE, 0, ai->ai_family);
-    PERROR_SKIP((listen(listen_stream_fd, 10) < 0), "stream listen");
+    PERROR_SKIP((listen(FdStream, 10) < 0), "stream listen");
 
 #ifdef ENABLE_RDMA
     rdma_listener.listen(ListenPorts.rdma);
@@ -412,18 +407,18 @@ int PoclDaemon::launch(std::string ListenAddress, struct ServerPorts &Ports,
 #endif
     );
     ++NumListenFds;
-    OpenClientFds.push_back(listen_command_fd);
-    ListenFdParams.push_back({COMMAND_SOCKET_BUFSIZE, 1});
+    OpenClientConnections.push_back(std::shared_ptr<Connection>(
+        new Connection(Domain, FdCommand, nullptr)));
     ++NumListenFds;
-    OpenClientFds.push_back(listen_stream_fd);
-    ListenFdParams.push_back({STREAM_SOCKET_BUFSIZE, 0});
+    OpenClientConnections.push_back(
+        std::shared_ptr<Connection>(new Connection(Domain, FdStream, nullptr)));
     continue;
 #undef PERROR_SKIP
   SOCKET_ERROR:
-    if (listen_command_fd)
-      close(listen_command_fd);
-    if (listen_stream_fd)
-      close(listen_stream_fd);
+    if (FdCommand > 0)
+      close(FdCommand);
+    if (FdStream > 0)
+      close(FdStream);
   }
 #ifdef HAVE_LINUX_VSOCK_H
   if (UseVsock)
@@ -459,7 +454,8 @@ int PoclDaemon::launch(std::string ListenAddress, struct ServerPorts &Ports,
   return 0;
 }
 
-VirtualContextBase *PoclDaemon::performSessionSetup(int fd, Request *R) {
+VirtualContextBase *
+PoclDaemon::performSessionSetup(std::shared_ptr<Connection> Conn, Request *R) {
   std::array<uint8_t, AUTHKEY_LENGTH> authkey;
   VirtualContextBase *ctx = nullptr;
   ClientConnections_t connections = {};
@@ -474,13 +470,11 @@ VirtualContextBase *PoclDaemon::performSessionSetup(int fd, Request *R) {
   }
   session = ++LastSessionId;
   SessionKeys.insert(std::make_pair(session, authkey));
-  if (R->req.m.get_session.fast_socket) {
-    connections.fd_command = fd;
-    connections.fd_stream = -1;
-  } else {
-    connections.fd_command = -1;
-    connections.fd_stream = fd;
-  }
+  Conn->configure(R->req.m.get_session.fast_socket);
+  if (R->req.m.get_session.fast_socket)
+    connections.low_latency = Conn;
+  else
+    connections.bulk_throughput = Conn;
 
   ReplyMsg_t Reply = {};
   Reply.message_type = MessageType_CreateOrAttachSessionReply;
@@ -502,7 +496,7 @@ VirtualContextBase *PoclDaemon::performSessionSetup(int fd, Request *R) {
   POCL_MSG_PRINT_INFO("Registered new client session %" PRIu64 " %s\n", session,
                       authkey_hex.c_str());
 
-  if (write_full(fd, &Reply, sizeof(Reply), nullptr) < 0) {
+  if (Conn->writeFull(&Reply, sizeof(Reply)) < 0) {
     POCL_MSG_ERR("Error sending session creation reply, destroying session\n");
     auto it = SessionKeys.find(session);
     if (it != SessionKeys.end())
@@ -550,10 +544,10 @@ void PoclDaemon::readAllClientSocketsThread() {
   // Collect vctxs that were used by connections to free those that are
   // not used by any connection when reconnect is not supported.
   std::set<VirtualContextBase *> DroppedVCtxs;
-  // Collect fds of closed sockets and close them in bulk at the end of the
-  // loop iteration in order to keep indices in sync
-  std::vector<int> DroppedFds;
-  bool FdsChanged = true;
+  // Collect indices of closed connections and drop them in bulk at the end of
+  // the loop iteration in order to keep indices in sync inside the poll loop
+  std::vector<std::shared_ptr<Connection>> DroppedConnections;
+  bool ConnectionsChanged = true;
   std::vector<struct pollfd> pfds;
 
   SocketContexts.clear();
@@ -563,21 +557,23 @@ void PoclDaemon::readAllClientSocketsThread() {
     /* Changes to the list of sockets should be relatively rare so let's
      * just rewrite the whole thing when it happens; it's a trivial
      * operation anyway. */
-    if (FdsChanged) {
+    if (ConnectionsChanged) {
       pfds.clear();
-      pfds.reserve(OpenClientFds.size());
-      for (const int &fd : OpenClientFds) {
+      pfds.reserve(OpenClientConnections.size());
+      for (auto &Connection : OpenClientConnections) {
         /* Unlike the other error flags POLLRDHUP is only returned if explicitly
          * polled for */
-        pfds.push_back({fd, POLLIN | POLLRDHUP, 0});
+        pfds.push_back({Connection->pollableFd(), POLLIN | POLLRDHUP, 0});
       }
-      FdsChanged = false;
+      ConnectionsChanged = false;
     }
 
+    POCL_MSG_WARN("NumListenFds: %d\n", (int)NumListenFds);
+
     /* These *really* ought to stay consistent */
-    assert(pfds.size() == OpenClientFds.size() &&
-           SocketContexts.size() == OpenClientFds.size() &&
-           IncompleteRequests.size() == OpenClientFds.size());
+    assert(pfds.size() == OpenClientConnections.size() &&
+           SocketContexts.size() == OpenClientConnections.size() &&
+           IncompleteRequests.size() == OpenClientConnections.size());
 
     /* Just block forever. If/when a socket is closed - including the client
      * listeners - it triggers a POLLERR/POLLHUP/POLLRDHUP/POLLNVAL. */
@@ -594,13 +590,13 @@ void PoclDaemon::readAllClientSocketsThread() {
     }
 
     auto accept_new_connection = [&](struct pollfd &pfd,
-                                     struct SocketParams &Params) {
+                                     Connection *Transport) {
       int ev = pfd.revents;
       pfd.revents = 0; // reset revents to 0 for the next polling round
       if (ev) {
         --NumEventFds;
         if (ev & POLLFD_ERROR_BITS) {
-          POCL_MSG_ERR("ev = 0x%X\n", ev);
+          POCL_MSG_PRINT_REMOTE("fd=%d ev = 0x%X\n", pfd.fd, ev);
           exit_helper.requestExit("Client listener socket closed", 0);
           return false;
         } else if (ev & POLLIN) {
@@ -610,20 +606,17 @@ void PoclDaemon::readAllClientSocketsThread() {
           socklen_t client_address_length = sizeof(client_address);
           /* NOTE: address length MUST be initialized to the size of the storage
            * given as the addr argument */
-          int newfd = accept(pfd.fd, (struct sockaddr *)&client_address,
+          int NewFd = accept(pfd.fd, (struct sockaddr *)&client_address,
                              &client_address_length);
-          if (newfd > 0) {
-            OpenClientFds.push_back(newfd);
+          if (NewFd > 0) {
+            OpenClientConnections.push_back(std::shared_ptr<Connection>(
+                new Connection(Transport->domain(), NewFd, nullptr)));
             SocketContexts.push_back(nullptr);
             IncompleteRequests.push_back(new Request());
-            FdsChanged = true;
-            /* XXX: Set these based on CreateOrAttachSession request instead? */
-            pocl_remote_client_set_socket_options(
-                newfd, Params.BufSize, Params.IsFast, client_address.ss_family);
+            ConnectionsChanged = true;
             std::string client_address_string = describe_sockaddr(
                 (struct sockaddr *)&client_address, client_address_length);
-            POCL_MSG_PRINT_INFO("Accepted client %s connection from %s\n",
-                                Params.IsFast ? "command" : "stream",
+            POCL_MSG_PRINT_INFO("Accepted client connection from %s\n",
                                 client_address_string.c_str());
           }
         }
@@ -636,7 +629,8 @@ void PoclDaemon::readAllClientSocketsThread() {
     bool CriticalError = false;
     for (size_t i = 0; i < NumListenFds && !CriticalError && NumEventFds > 0;
          ++i) {
-      CriticalError = !accept_new_connection(pfds.at(i), ListenFdParams.at(i));
+      CriticalError =
+          !accept_new_connection(pfds.at(i), OpenClientConnections.at(i).get());
     }
     if (CriticalError)
       break;
@@ -657,22 +651,22 @@ void PoclDaemon::readAllClientSocketsThread() {
           POCL_MSG_PRINT_GENERAL(
               "Poll says fd=%d is dead (0x%X), removing it.\n", pfds.at(i).fd,
               ev);
-          DroppedFds.push_back(pfds.at(i).fd);
+          DroppedConnections.push_back(OpenClientConnections.at(i));
           continue;
         }
 
         if (ev & POLLIN) {
           Request *R = IncompleteRequests.at(i);
-          if (R->read(pfds.at(i).fd)) {
+          if (R->read(OpenClientConnections.at(i).get())) {
             if (R->IsFullyRead) {
               if (R->req.message_type == MessageType_CreateOrAttachSession) {
                 int Fast = R->req.m.get_session.fast_socket;
                 uint64_t Session = R->req.session;
                 if (Session == 0) {
                   VirtualContextBase *ctx =
-                      performSessionSetup(pfds.at(i).fd, R);
+                      performSessionSetup(OpenClientConnections.at(i), R);
                   if (ctx == nullptr) {
-                    DroppedFds.push_back(pfds.at(i).fd);
+                    DroppedConnections.push_back(OpenClientConnections.at(i));
                   } else {
                     SocketContexts.at(i) = ctx;
                   }
@@ -683,14 +677,13 @@ void PoclDaemon::readAllClientSocketsThread() {
                     if (std::memcmp(it->second.data(), R->req.authkey,
                                     AUTHKEY_LENGTH) == 0) {
                       auto cit = ClientSessions.find(Session);
-                      std::optional<int> command_fd;
-                      std::optional<int> stream_fd;
-                      if (Fast)
-                        command_fd = pfds.at(i).fd;
-                      else
-                        stream_fd = pfds.at(i).fd;
                       assert(cit != ClientSessions.end());
-                      cit->second->updateSockets(command_fd, stream_fd);
+                      if (Fast)
+                        cit->second->replaceConnections(
+                            OpenClientConnections.at(i), nullptr);
+                      else
+                        cit->second->replaceConnections(
+                            nullptr, OpenClientConnections.at(i));
                       SocketContexts.at(i) = cit->second;
                     }
                   }
@@ -700,7 +693,7 @@ void PoclDaemon::readAllClientSocketsThread() {
                   Reply.m.get_session.session = Session;
                   memcpy(Reply.m.get_session.authkey, R->req.authkey,
                          AUTHKEY_LENGTH);
-                  write_full(pfds.at(i).fd, &Reply, sizeof(Reply), nullptr);
+                  OpenClientConnections.at(i)->writeFull(&Reply, sizeof(Reply));
                 }
                 delete R;
               } else {
@@ -784,29 +777,27 @@ void PoclDaemon::readAllClientSocketsThread() {
           } else {
             POCL_MSG_ERR("Something went wrong while reading request, closing "
                          "connection\n");
-            DroppedFds.push_back(pfds.at(i).fd);
+            DroppedConnections.push_back(OpenClientConnections.at(i));
           }
         }
       }
     }
 
     /* reap dead fds */
-    FdsChanged |= !DroppedFds.empty();
-    size_t left_to_reap = DroppedFds.size();
-    for (size_t i = 0; left_to_reap; ++i) {
-      int fd = OpenClientFds.at(i);
-      for (int d : DroppedFds) {
-        if (d == fd) {
-          close(fd);
-
+    ConnectionsChanged |= !DroppedConnections.empty();
+    size_t NumConnectionsToReap = DroppedConnections.size();
+    for (size_t i = 0;
+         i < OpenClientConnections.size() && NumConnectionsToReap != 0; ++i) {
+      for (auto &d : DroppedConnections) {
+        if (d.get() == OpenClientConnections.at(i).get()) {
           // Contexts can outlive their client connection (client may reconnect
           // later) so don't destroy them here, only remove them from the socket
           // bookkeeping list. Swap to the end of the vector & pop instead of
           // directly removing to avoid unnecessarily copying the entire rest
           // of the vector around.
 
-          std::swap(OpenClientFds.at(i), OpenClientFds.back());
-          OpenClientFds.pop_back();
+          std::swap(OpenClientConnections.at(i), OpenClientConnections.back());
+          OpenClientConnections.pop_back();
 
           std::swap(SocketContexts.at(i), SocketContexts.back());
           VirtualContextBase *vctx = SocketContexts.back();
@@ -817,11 +808,12 @@ void PoclDaemon::readAllClientSocketsThread() {
           delete IncompleteRequests.back();
           IncompleteRequests.pop_back();
           --i;
-          --left_to_reap;
+          --NumConnectionsToReap;
+          break;
         }
       }
     }
-    DroppedFds.clear();
+    DroppedConnections.clear();
 
     // TODO: The reconnect should have a time window as it holds resources.
     // Especially with SVM on, it will hold the SVMPool which can be a large
@@ -842,5 +834,5 @@ void PoclDaemon::readAllClientSocketsThread() {
   }
 
   /* Close all remaining sockets, including the client listeners */
-  std::for_each(OpenClientFds.cbegin(), OpenClientFds.cend(), &close);
+  OpenClientConnections.clear();
 }

--- a/pocld/daemon.hh
+++ b/pocld/daemon.hh
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "common.hh"
+#include "connection.hh"
 #ifdef ENABLE_RDMA
 #include "guarded_queue.hh"
 #endif
@@ -51,11 +52,6 @@ struct ServerPorts {
   /** Port for incoming client RDMAcm connections */
   uint16_t rdma;
 #endif
-};
-
-struct SocketParams {
-  int BufSize;
-  int IsFast;
 };
 
 /**
@@ -114,19 +110,19 @@ public:
   }
 
   /* returns nullptr on error */
-  VirtualContextBase *performSessionSetup(int fd, Request *R);
+  VirtualContextBase *performSessionSetup(std::shared_ptr<Connection> Conn,
+                                          Request *R);
 
 private:
   ExitHelper exit_helper;
   /** Port numbers that the server is listening on */
   struct ServerPorts ListenPorts;
-  std::vector<int> OpenClientFds;
+  std::vector<std::shared_ptr<Connection>> OpenClientConnections;
   /** Hacky helper for keeping track of which context is associated with the
    * socket at a given index so the contexts can be dropped when the socket
    * disconnects if reconnecting is not allowed. */
   std::vector<VirtualContextBase *> SocketContexts;
   size_t NumListenFds;
-  std::vector<SocketParams> ListenFdParams;
   std::mutex SessionListMtx;
   std::unordered_map<uint64_t, VirtualContextBase *> ClientSessions;
   std::unordered_map<uint64_t, std::thread> ClientSessionThreads;

--- a/pocld/peer.hh
+++ b/pocld/peer.hh
@@ -25,8 +25,10 @@
 #define PEER_HH
 
 #include <thread>
+#include <memory>
 
 #include "common.hh"
+#include "connection.hh"
 #include "guarded_queue.hh"
 
 #ifdef ENABLE_RDMA
@@ -44,7 +46,7 @@
 class Peer {
   uint64_t id;
   uint32_t handler_id;
-  std::atomic_int fd;
+  std::shared_ptr<Connection> Conn;
   VirtualContextBase *ctx;
   ExitHelper *eh;
 
@@ -53,7 +55,6 @@ class Peer {
   RequestQueueThreadUPtr reader;
   void writerThread();
   std::thread writer;
-  TrafficMonitor *netstat;
 #ifdef ENABLE_RDMA
   std::shared_ptr<RdmaConnection> rdma;
   RdmaRequestThreadUPtr rdma_reader;
@@ -68,11 +69,11 @@ class Peer {
 public:
 #ifdef ENABLE_RDMA
   Peer(uint64_t id, uint32_t handler_id, VirtualContextBase *ctx,
-       ExitHelper *eh, int fd, TrafficMonitor *tm,
-       std::shared_ptr<RdmaConnection> conn);
+       ExitHelper *eh, std::shared_ptr<Connection> Conn,
+       std::shared_ptr<RdmaConnection> Rdma);
 #else
   Peer(uint64_t id, uint32_t handler_id, VirtualContextBase *ctx,
-       ExitHelper *eh, int fd, TrafficMonitor *tm);
+       ExitHelper *eh, std::shared_ptr<Connection> Conn);
 #endif
   ~Peer();
 

--- a/pocld/peer_handler.cc
+++ b/pocld/peer_handler.cc
@@ -259,7 +259,6 @@ void PeerHandler::rdmaUnregisterBuffer(uint32_t id) {
 
 PeerHandler::~PeerHandler() {
   eh->requestExit("PH Shutdown", 0);
-  for (auto &t : Peers) {
-    t.second.reset();
-  }
+  if (IncomingPeerHandler.joinable())
+    IncomingPeerHandler.join();
 }

--- a/pocld/peer_handler.hh
+++ b/pocld/peer_handler.hh
@@ -42,7 +42,6 @@
 class PeerHandler {
   uint32_t id;
   VirtualContextBase *ctx;
-  std::thread listen_thread;
   ExitHelper *eh;
 
   std::mutex *NewConnectionsMutex;
@@ -55,13 +54,14 @@ class PeerHandler {
   std::thread IncomingPeerHandler;
   void handleIncomingPeers();
 
-  TrafficMonitor *netstat;
+  std::shared_ptr<TrafficMonitor> Netstat;
 
 public:
   PeerHandler(
       uint32_t id, std::mutex *m,
       std::pair<std::condition_variable, std::vector<PeerConnection>> *incoming,
-      VirtualContextBase *c, ExitHelper *eh, TrafficMonitor *tm);
+      VirtualContextBase *c, ExitHelper *eh,
+      std::shared_ptr<TrafficMonitor> tm);
   ~PeerHandler();
 
   cl_int connectPeer(uint64_t msg_id, const char *const address, uint16_t port,

--- a/pocld/peer_handler.hh
+++ b/pocld/peer_handler.hh
@@ -78,12 +78,7 @@ public:
 #endif
 };
 
-#if 0
-// TOFIX: peers cannot be freed without crashing, let them leak for now.
 typedef std::unique_ptr<PeerHandler> PeerHandlerUPtr;
-#else
-typedef PeerHandler *PeerHandlerUPtr;
-#endif
 
 #ifdef __GNUC__
 #pragma GCC visibility pop

--- a/pocld/pocld.cc
+++ b/pocld/pocld.cc
@@ -114,10 +114,10 @@ int main(int argc, char *argv[]) {
   PoclDaemon server;
   bool UseVsock = false;
   if (ai.vsock_flag == 1) {
-#ifdef ENABLE_VSOCK
+#ifdef HAVE_LINUX_VSOCK_H
     UseVsock = true;
 #else
-    POCL_MSG_ERR("use -DENABLE_VSOCK=1 rebuild the source to use vsock\n");
+    POCL_MSG_ERR("This pocld was built without vsock support\n");
     return -1;
 #endif
   } else {

--- a/pocld/pocld_config.h.in.cmake
+++ b/pocld/pocld_config.h.in.cmake
@@ -1,5 +1,7 @@
 #cmakedefine HAVE_LTTNG_UST
 
+#cmakedefine HAVE_LINUX_VSOCK_H
+
 #cmakedefine QUEUE_PROFILING
 
 #cmakedefine FORKING

--- a/pocld/rdma_reply_th.hh
+++ b/pocld/rdma_reply_th.hh
@@ -24,6 +24,7 @@
 #ifndef POCL_RDMA_WRITE_QUEUE_HH
 #define POCL_RDMA_WRITE_QUEUE_HH
 
+#include <memory>
 #include <queue>
 
 #include <infiniband/verbs.h>
@@ -46,7 +47,7 @@ class RdmaReplyThread {
   std::condition_variable io_cond;
   ExitHelper *eh;
   std::string id_str;
-  TrafficMonitor *netstat;
+  std::shared_ptr<TrafficMonitor> Netstat;
 
   std::shared_ptr<RdmaConnection> rdma;
 
@@ -56,8 +57,9 @@ class RdmaReplyThread {
   void rdmaWriterThread();
 
 public:
-  RdmaReplyThread(VirtualContextBase *c, ExitHelper *eh, TrafficMonitor *tm,
-                  const char *id_str, std::shared_ptr<RdmaConnection> conn,
+  RdmaReplyThread(VirtualContextBase *c, ExitHelper *eh,
+                  std::shared_ptr<TrafficMonitor> tm, const char *id_str,
+                  std::shared_ptr<RdmaConnection> conn,
                   std::unordered_map<uint32_t, RdmaBufferData> *mem_regions,
                   std::mutex *mem_region_mutex);
 

--- a/pocld/rdma_request_th.cc
+++ b/pocld/rdma_request_th.cc
@@ -24,7 +24,7 @@
 #include "rdma_request_th.hh"
 
 RdmaRequestThread::RdmaRequestThread(
-    VirtualContextBase *c, ExitHelper *e, TrafficMonitor *tm,
+    VirtualContextBase *c, ExitHelper *e, std::shared_ptr<TrafficMonitor> tm,
     const char *id_str, std::shared_ptr<RdmaConnection> conn,
     std::unordered_map<uint32_t, RdmaBufferData> *mem_regions,
     std::mutex *mem_regions_mutex)

--- a/pocld/rdma_request_th.cc
+++ b/pocld/rdma_request_th.cc
@@ -101,14 +101,14 @@ void RdmaRequestThread::rdmaReaderThread() {
 
     /************** Forward the Request to virtual context ******************/
     Request *request = new Request;
-    request->req = requests_buf.at(wc.wr_id);
+    request->Body = requests_buf.at(wc.wr_id);
 
     POCL_MSG_PRINT_GENERAL(
         "%s: received IBV_SEND for message ID: %" PRIu64 " type: %s\n",
-        id_str.c_str(), uint64_t(request->req.msg_id),
-        request_to_str((RequestMessageType)request->req.message_type));
+        id_str.c_str(), uint64_t(request->Body.msg_id),
+        request_to_str((RequestMessageType)request->Body.message_type));
 
-    switch (request->req.message_type) {
+    switch (request->Body.message_type) {
     case MessageType_ConnectPeer:
     case MessageType_DeviceInfo:
     case MessageType_CreateBuffer:
@@ -153,7 +153,7 @@ void RdmaRequestThread::rdmaReaderThread() {
       break;
     }
     case MessageType_NotifyEvent: {
-      virtualContext->notifyEvent(request->req.event_id, CL_SUCCESS);
+      virtualContext->notifyEvent(request->Body.event_id, CL_SUCCESS);
       delete request;
       break;
     }

--- a/pocld/rdma_request_th.hh
+++ b/pocld/rdma_request_th.hh
@@ -25,6 +25,7 @@
 #ifndef POCL_RDMA_REQUEST_TH_HH
 #define POCL_RDMA_REQUEST_TH_HH
 
+#include <memory>
 #include <queue>
 
 #include <infiniband/verbs.h>
@@ -46,7 +47,7 @@ class RdmaRequestThread {
   std::condition_variable io_cond;
   ExitHelper *eh;
   std::string id_str;
-  TrafficMonitor *netstat;
+  std::shared_ptr<TrafficMonitor> netstat;
 
   std::shared_ptr<RdmaConnection> connection;
 
@@ -56,8 +57,9 @@ class RdmaRequestThread {
   void rdmaReaderThread();
 
 public:
-  RdmaRequestThread(VirtualContextBase *c, ExitHelper *eh, TrafficMonitor *tm,
-                    const char *id_str, std::shared_ptr<RdmaConnection> conn,
+  RdmaRequestThread(VirtualContextBase *c, ExitHelper *eh,
+                    std::shared_ptr<TrafficMonitor> tm, const char *id_str,
+                    std::shared_ptr<RdmaConnection> conn,
                     std::unordered_map<uint32_t, RdmaBufferData> *mem_regions,
                     std::mutex *mem_regions_mutex);
 

--- a/pocld/reply_th.hh
+++ b/pocld/reply_th.hh
@@ -44,12 +44,12 @@ class ReplyQueueThread {
   std::mutex ConnectionGuard;
   std::condition_variable ConnectionNotifier;
   std::shared_ptr<Connection> Conn;
-  std::string id_str;
+  std::string ThreadIdentifier;
   VirtualContextBase *virtualContext;
-  std::vector<Reply *> io_inflight;
+  std::vector<Reply *> IOInflight;
   std::mutex io_mutex;
-  std::condition_variable io_cond;
-  std::thread io_thread;
+  std::condition_variable IONotifier;
+  std::thread IOThread;
   ExitHelper *eh;
   TrafficMonitor *netstat;
 

--- a/pocld/request.hh
+++ b/pocld/request.hh
@@ -28,6 +28,7 @@
 #include <cstring>
 #include <vector>
 
+#include "connection.hh"
 #include "messages.h"
 
 #ifdef __GNUC__
@@ -35,7 +36,6 @@
 #endif
 
 class Request {
-
 public:
   /** Size, in bytes, of the main request body (up to sizeof RequestMsg_t) */
   uint32_t req_size;
@@ -82,10 +82,10 @@ public:
    * socket. Set at the very end of the read() function. */
   bool IsFullyRead;
 
-  /** Incrementally reads the request from given fd. Returns true on success and
-   * false if an error occurs while reading. Call repeatedly until `fully_read`
-   * gets set to true. */
-  bool read(int fd);
+  /** Incrementally reads the request from given Connection. Returns true on
+   * success and false if an error occurs while reading. Call repeatedly until
+   * `fully_read` gets set to true. */
+  bool read(Connection *);
 };
 
 #ifdef __GNUC__

--- a/pocld/request.hh
+++ b/pocld/request.hh
@@ -37,54 +37,53 @@
 
 class Request {
 public:
-  /** Size, in bytes, of the main request body (up to sizeof RequestMsg_t) */
-  uint32_t req_size;
-  /** Tracker for how many bytes of req_size have been read from the network
-   * socket */
-  size_t req_size_read;
-  /** Main body of the reuqest */
-  RequestMsg_t req;
-  /** Tracker for how many bytes of the main request body have been read from
-   * the network socket */
-  size_t req_read;
+  /// Size, in bytes, of the main request body (up to sizeof RequestMsg_t)
+  uint32_t BodySize;
+  /// Tracker for how many bytes of req_size have been read from the network
+  /// socket
+  size_t BodySizeBytesRead;
+  /// Main body of the reuqest
+  RequestMsg_t Body;
+  /// Tracker for how many bytes of the main request body have been read from
+  /// the network socket
+  size_t BodyBytesRead;
 
-  /** List of event ids that must complete before this Request can be processed
-   */
-  std::vector<uint64_t> waitlist;
-  /** Tracker for how many bytes of the waitlist have been read */
-  size_t waitlist_read;
+  /// List of event ids that must complete before this Request can be processed
+  std::vector<uint64_t> Waitlist;
+  /// Tracker for how many bytes of the waitlist have been read
+  size_t WaitlistBytesRead;
 
-  /** Auxiliary data required for the Request (buffer contents, program binaries
-   * etc) */
-  std::vector<uint8_t> extra_data;
-  /** Size of the auxiliary data buffer */
-  uint64_t extra_size;
-  /** Tracker for how many bytes of the auxiliary data buffer have been read
-   * from the network socket */
-  size_t extra_read;
+  /// Auxiliary data required for the Request (buffer contents, program binaries
+  /// etc)
+  std::vector<uint8_t> ExtraData;
+  /// Size of the auxiliary data buffer
+  uint64_t ExtraDataSize;
+  /// Tracker for how many bytes of the auxiliary data buffer have been read
+  /// from the network socket
+  size_t ExtraDataBytesRead;
 
-  /** Second auxiliary data required for the Request */
-  std::vector<uint8_t> extra_data2;
-  /** Size of the auxiliary data buffer */
-  uint64_t extra_size2;
-  /** Tracker for how many bytes of the second auxiliary data buffer have been
-   * read from the network socket */
-  size_t extra_read2;
+  /// Second auxiliary data required for the Request
+  std::vector<uint8_t> ExtraData2;
+  /// Size of the auxiliary data buffer
+  uint64_t ExtraData2Size;
+  /// Tracker for how many bytes of the second auxiliary data buffer have been
+  /// read from the network socket
+  size_t ExtraData2BytesRead;
 
-  /** Server side timestamp for when reading the request from the network socket
-   * started */
-  uint64_t read_start_timestamp_ns;
-  /** Server side timestamp for when the last bit of data for the request has
-   * been successfully read from the network socket. */
-  uint64_t read_end_timestamp_ns;
+  /// Server side timestamp for when reading the request from the network socket
+  /// started
+  uint64_t ReadStartTimestampNS;
+  /// Server side timestamp for when the last bit of data for the request has
+  /// been successfully read from the network socket.
+  uint64_t ReadEndTimestampNS;
 
-  /** Flag indicating that the request has been fully read from the network
-   * socket. Set at the very end of the read() function. */
+  /// Flag indicating that the request has been fully read from the network
+  /// socket. Set at the very end of the read() function.
   bool IsFullyRead;
 
-  /** Incrementally reads the request from given Connection. Returns true on
-   * success and false if an error occurs while reading. Call repeatedly until
-   * `fully_read` gets set to true. */
+  /// Incrementally reads the request from given Connection. Returns true on
+  /// success and false if an error occurs while reading. Call repeatedly until
+  /// `fully_read` gets set to true.
   bool read(Connection *);
 };
 

--- a/pocld/request_th.cc
+++ b/pocld/request_th.cc
@@ -75,7 +75,12 @@ void RequestQueueThread::readThread() {
       ConnectionNotifier.wait(l);
 
     pfd.fd = InboundConnection->pollableFd();
-    NumEvents = poll(&pfd, 1, -1);
+    /* HACK: Timeout after 1s so peer request threads don't get stuck when the
+     * session is being shut down. */
+    NumEvents = poll(&pfd, 1, 1000);
+    if (NumEvents == 0)
+      continue;
+
     if (NumEvents < 0) {
       int e = errno;
       if (e == EINTR)

--- a/pocld/request_th.hh
+++ b/pocld/request_th.hh
@@ -38,11 +38,11 @@
 class RequestQueueThread {
   std::mutex ConnectionGuard;
   std::condition_variable ConnectionNotifier;
-  std::shared_ptr<Connection> Conn;
+  std::shared_ptr<Connection> InboundConnection;
   VirtualContextBase *virtualContext;
-  std::thread io_thread;
+  std::thread IOThread;
   ExitHelper *eh;
-  std::string id_str;
+  std::string ThreadIdentifier;
 
 public:
   RequestQueueThread(std::shared_ptr<Connection> Conn, VirtualContextBase *c,

--- a/pocld/request_th.hh
+++ b/pocld/request_th.hh
@@ -25,6 +25,8 @@
 #ifndef POCL_REMOTE_REQUEST_TH_HH
 #define POCL_REMOTE_REQUEST_TH_HH
 
+#include <condition_variable>
+
 #include "common.hh"
 #include "traffic_monitor.hh"
 #include "virtual_cl_context.hh"
@@ -34,19 +36,21 @@
 #endif
 
 class RequestQueueThread {
-  std::atomic_int *fd;
+  std::mutex ConnectionGuard;
+  std::condition_variable ConnectionNotifier;
+  std::shared_ptr<Connection> Conn;
   VirtualContextBase *virtualContext;
   std::thread io_thread;
   ExitHelper *eh;
   std::string id_str;
-  TrafficMonitor *netstat;
 
 public:
-  RequestQueueThread(std::atomic_int *fd, VirtualContextBase *c, ExitHelper *eh,
-                     TrafficMonitor *tm, const char *id_str);
+  RequestQueueThread(std::shared_ptr<Connection> Conn, VirtualContextBase *c,
+                     ExitHelper *eh, const char *id_str);
 
   ~RequestQueueThread();
 
+  void setConnection(std::shared_ptr<Connection> NewConnection);
   void readThread();
 };
 

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdio>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -1255,7 +1256,11 @@ bool createSPIRVWithSVMOffset(const std::vector<unsigned char> *InputSPV,
   char *TempDirName = strdup(
       (std::filesystem::temp_directory_path() / "pocl-r-XXXXXX").c_str());
 
-  mkdtemp(TempDirName);
+  if (mkdtemp(TempDirName) == nullptr) {
+    POCL_MSG_ERR("Failed to create temp directory at %s: %s\n", TempDirName,
+                 strerror(errno));
+    return false;
+  }
 
   std::filesystem::path TempDir(TempDirName);
 

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -798,19 +798,19 @@ int SharedCLContext::waitAndDeleteEvent(uint64_t event_id) {
 
 void SharedCLContext::queuedPush(Request *req) {
   // handle default queues
-  if (req->req.cq_id == DEFAULT_QUE_ID) {
-    req->req.cq_id += req->req.did;
+  if (req->Body.cq_id == DEFAULT_QUE_ID) {
+    req->Body.cq_id += req->Body.did;
   }
 
-  if (isCommandReceived(req->req.event_id)) {
+  if (isCommandReceived(req->Body.event_id)) {
     delete req;
     return;
   }
 
-  uint32_t cq_id = req->req.cq_id;
+  uint32_t cq_id = req->Body.cq_id;
   POCL_MSG_PRINT_GENERAL("SHCTX %u QUEUED PUSH QID %" PRIu32 " DID %" PRIu32
                          "\n",
-                         plat_id, cq_id, uint32_t(req->req.did));
+                         plat_id, cq_id, uint32_t(req->Body.did));
 
   {
     std::unique_lock<std::mutex> lock(MainMutex);

--- a/pocld/traffic_monitor.cc
+++ b/pocld/traffic_monitor.cc
@@ -27,6 +27,8 @@
 #include <sstream>
 #include <thread>
 
+#include "common.hh"
+#include "pocl_debug.h"
 #include "traffic_monitor.hh"
 
 TrafficMonitor::TrafficMonitor(ExitHelper *e, std::string &client_id)

--- a/pocld/virtual_cl_context.hh
+++ b/pocld/virtual_cl_context.hh
@@ -26,7 +26,6 @@
 #define POCL_REMOTE_VIRTUAL_CL_HH
 
 #include "common.hh"
-#include <optional>
 
 #ifdef __GNUC__
 #pragma GCC visibility push(hidden)
@@ -39,7 +38,8 @@ class VirtualContextBase {
 public:
   virtual ~VirtualContextBase() {}
 
-  virtual void updateSockets(std::optional<int>, std::optional<int>) = 0;
+  virtual void replaceConnections(std::shared_ptr<Connection> Command,
+                                  std::shared_ptr<Connection> Stream) = 0;
 
   virtual void nonQueuedPush(Request *req) = 0;
 


### PR DESCRIPTION
This should help make the remote a bit more flexible at runtime by abstracting away some of the socket- and TCP-specific parts and tacking on some metadata to the connection handle. The end goal is to eventually also support transports that don't map directly to the socket API. Maybe even merge the socket and RDMA code paths at some point.

As part of that I've changed vsock support from a default-off option to always be enabled if the requisite header is present. Eventually it would be nice to revive the UNIX domain socket support using this setup as well.

@xvim If you are still maintaining vsock support, could you check that this didn't break anything related to that? There should not be any changes, but I don't have any setup at hand where I could confirm that.