### PR TITLE
ci: bump remote and RDMA to LLVM 18

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -358,7 +358,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: [16]
+        llvm: [18]
 
     steps:
       - name: Checkout
@@ -402,7 +402,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: [17]
+        llvm: [18]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Let's keep them at least somewhat in sync with the main workflows to rule out unrelated causes of errors.