### PR TITLE
Make it possible to configure the linker path used by Clang.

### DIFF
--- a/doc/sphinx/source/using.rst
+++ b/doc/sphinx/source/using.rst
@@ -311,6 +311,7 @@ pocl.
  The following variables are available:
 
   * **POCL_PATH_CLANG** -- Path to the clang executable.
+  * **POCL_PATH_LD** -- Path to the ld executable used by clang.
   * **POCL_PATH_LLVM_LINK** -- Path to the llvm-link executable.
   * **POCL_PATH_LLVM_OPT** -- Path to the llvm-opt executable.
   * **POCL_PATH_LLVM_LLC** -- Path to the llc executable.

--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -1045,8 +1045,13 @@ int pocl_invoke_clang(cl_device_id Device, const char** Args) {
 
   const char **ArgsEnd = Args;
   while (*ArgsEnd++ != nullptr) {}
+  llvm::SmallVector<const char*, 0> ArgsArray(Args, ArgsEnd);
 
-  llvm::ArrayRef<const char*> ArgsArray(Args, ArgsEnd);
+  std::string LDPath;
+  if (const char* LDOverride = pocl_get_path("LD", nullptr)) {
+    LDPath = "--ld-path=" + std::string(LDOverride);
+    ArgsArray.push_back(LDPath.c_str());
+  }
 
   std::unique_ptr<clang::driver::Compilation> C(
       TheDriver.BuildCompilation(ArgsArray));


### PR DESCRIPTION
Another env var customization to make pocl portable. Otherwise we run into compilation failures on systems that don't have a system-wide linker:

```
      From worker 3:	error: unable to execute command: Executable "ld" doesn't exist!
      From worker 3:	error: linker command failed with exit code 1 (use -v to see invocation)
      From worker 3:	Final linking of kernel sum failed.
```

We aim to use this in Julia by redistributing a copy of lld (automatically downloaded in the user's home folder) and using that binary instead.