### PR TITLE
Replace POCL_PATH_LD by a more generic semicolon-separated POCL_ARGS_CLANG.

### DIFF
--- a/doc/sphinx/source/using.rst
+++ b/doc/sphinx/source/using.rst
@@ -311,12 +311,22 @@ pocl.
  The following variables are available:
 
   * **POCL_PATH_CLANG** -- Path to the clang executable.
-  * **POCL_PATH_LD** -- Path to the ld executable used by clang.
   * **POCL_PATH_LLVM_LINK** -- Path to the llvm-link executable.
   * **POCL_PATH_LLVM_OPT** -- Path to the llvm-opt executable.
   * **POCL_PATH_LLVM_LLC** -- Path to the llc executable.
   * **POCL_PATH_LLVM_SPIRV** -- Path to the llvm-spirv executable.
   * **POCL_PATH_SPIRV_LINK** -- Path to the spirv-link executable.
+
+- **POCL_ARGS_XXX**
+
+ String. These variables can be used to pass additional arguments to executables
+ that pocl invokes during compilation, linking, etc. Multiple arguments can be
+ passed by separating them with a semicolon.
+
+ The following variables are available:
+
+  * **POCL_ARGS_CLANG** -- Additional arguments to pass to clang.
+
 
 - **POCL_SIGFPE_HANDLER**
 

--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -1047,14 +1047,18 @@ int pocl_invoke_clang(cl_device_id Device, const char** Args) {
   while (*ArgsEnd++ != nullptr) {}
   llvm::SmallVector<const char*, 0> ArgsArray(Args, ArgsEnd);
 
-  std::string LDPath;
-  if (const char* LDOverride = pocl_get_path("LD", nullptr)) {
-    LDPath = "--ld-path=" + std::string(LDOverride);
-    ArgsArray.push_back(LDPath.c_str());
+  int NumExtraArgs;
+  const char *ExtraArgs = pocl_get_args("CLANG", &NumExtraArgs);
+  const char *ExtraArg = ExtraArgs;
+  for (int i = 0; i < NumExtraArgs; ++i) {
+    ArgsArray.push_back(ExtraArg);
+    ExtraArg += strlen(ExtraArg) + 1;
   }
 
   std::unique_ptr<clang::driver::Compilation> C(
       TheDriver.BuildCompilation(ArgsArray));
+
+  free((void *)ExtraArgs);
 
   if (C && !C->containsError()) {
     SmallVector<std::pair<int, const clang::driver::Command *>, 4> FailingCommands;

--- a/lib/CL/pocl_runtime_config.c
+++ b/lib/CL/pocl_runtime_config.c
@@ -59,7 +59,6 @@ pocl_get_string_option (const char *key, const char *default_value)
   return val != NULL ? val : default_value;
 }
 
-/* Returns a string, but can be overriden by a POCL_PATH env var. */
 const char *
 pocl_get_path (const char *name, const char *default_value)
 {
@@ -68,9 +67,6 @@ pocl_get_path (const char *name, const char *default_value)
   return pocl_get_string_option (key, default_value);
 }
 
-/* Returns `n` null-terminated strings representing arguments
-   for an invocation. Can be set using the POCL_ARGS env vars.
-   If the env var is not set, returns NULL and sets `n` to zero. */
 char *
 pocl_get_args (const char *name, int *n)
 {

--- a/lib/CL/pocl_runtime_config.c
+++ b/lib/CL/pocl_runtime_config.c
@@ -67,3 +67,31 @@ pocl_get_path (const char *name, const char *default_value)
   snprintf (key, sizeof (key), "POCL_PATH_%s", name);
   return pocl_get_string_option (key, default_value);
 }
+
+/* Returns `n` null-terminated strings representing arguments
+   for an invocation. Can be set using the POCL_ARGS env vars.
+   If the env var is not set, returns NULL and sets `n` to zero. */
+char *
+pocl_get_args (const char *name, int *n)
+{
+  char key[256];
+  snprintf (key, sizeof (key), "POCL_ARGS_%s", name);
+  const char *val = getenv (key);
+  if (val == NULL)
+    {
+      *n = 0;
+      return NULL;
+    }
+
+  char *args = strdup (val);
+  *n = 1;
+  for (char *p = args; *p; ++p)
+    {
+      if (*p == ';')
+        {
+          *p = 0;
+          ++(*n);
+        }
+    }
+  return args;
+}

--- a/lib/CL/pocl_runtime_config.h
+++ b/lib/CL/pocl_runtime_config.h
@@ -43,6 +43,9 @@ const char* pocl_get_string_option(const char *key, const char *default_value);
 POCL_EXPORT
 const char *pocl_get_path (const char *name, const char *default_value);
 
+POCL_EXPORT
+char *pocl_get_args (const char *name, int *n);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/CL/pocl_runtime_config.h
+++ b/lib/CL/pocl_runtime_config.h
@@ -40,9 +40,46 @@ int pocl_get_bool_option(const char *key, int default_value);
 POCL_EXPORT
 const char* pocl_get_string_option(const char *key, const char *default_value);
 
+/**
+ * \brief Gets a path as specified in the environment, or a default value.
+ *
+ * This function retrieves the user-specified path to an executable `name` as
+ * specified in the environment variable `POCL_PATH_<name>`. If the environment
+ * variable is not set, the function returns the provided default value.
+ *
+ * \param name The name of the path being queried. This is used to construct
+ * the environment variable name.
+ *
+ * \param default_value The default value to return if the environment variable
+ * is not set.
+ *
+ * \return A pointer to a string containing the path, either from the
+ * environment variable or the default value.
+ */
 POCL_EXPORT
 const char *pocl_get_path (const char *name, const char *default_value);
 
+/**
+ * \brief Gets environment-specified arguments for invoking a binary.
+ *
+ * This function retrieves user-specified arguments from the
+ * semicolon-separated environment variable `POCL_ARGS_<name>`, that should
+ * also be passed when invoking the executable `name`. If the environment
+ * variable is not set, the function returns NULL and sets `n` to zero.
+ * Otherwise, `n` is set to the number of arguments found in the string, and
+ * the function returns a pointer to a sequence of null-terminated strings.
+ *
+ * \param name The name of the executable for which the arguments are intended.
+ * This is used to construct the environment variable name.
+ *
+ * \param n Pointer to an integer where the number of arguments will be stored.
+ *
+ * \return A pointer to a sequence of null-terminated strings containing the
+ * arguments, or NULL if the environment variable is not set.
+ *
+ * \note The returned string should be freed by the caller to avoid memory
+ * leaks.
+ */
 POCL_EXPORT
 char *pocl_get_args (const char *name, int *n);
 


### PR DESCRIPTION
Implements https://github.com/pocl/pocl/pull/1621#issuecomment-2421560334.

Semicolon-separated for now, without dealing with escaping. I considered using more obscure characters as a separator, but that may be problematic on platforms like Windows.