### PR TITLE
Remove C standard includes in kernel builtin sources

### DIFF
--- a/lib/kernel/subgroups.c
+++ b/lib/kernel/subgroups.c
@@ -27,9 +27,9 @@
    intel_reqd_sub_group_size metadata.
  */
 
-#include <math.h>
-
 #include "work_group_alloca.h"
+
+#define INFINITY (__builtin_inf())
 
 size_t _CL_OVERLOADABLE get_local_id (unsigned int dimindx);
 size_t _CL_OVERLOADABLE get_local_linear_id (void);

--- a/lib/kernel/work_group.c
+++ b/lib/kernel/work_group.c
@@ -22,8 +22,8 @@
 */
 
 #include "work_group_alloca.h"
-#include <math.h>
-#include <stdio.h>
+
+#define INFINITY (__builtin_inf())
 
 size_t _CL_OVERLOADABLE get_local_id (unsigned int dimindx);
 size_t _CL_OVERLOADABLE get_local_linear_id (void);


### PR DESCRIPTION
Remove the C standard includes which are not guaranteed to be provided under -ffreestanding. Replace `INFINITY` with `__builtin_inf()`.

Fixes a compilation issue on MSVC toolchain.