### PR TITLE
Ban variable length arrays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ macro(setup_cached_var VARNAME DESCRIPTION DOCS_FEATURE_IS_UNAVAILABLE DOCS_REQU
 endmacro()
 
 include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
 include(CPackComponent)
 macro(pass_through_cpack_vars)
   get_cmake_property(cpackVarsToPassthrough VARIABLES)
@@ -104,6 +105,18 @@ if(UNIX)
   else()
     message(WARNING "Don't know how to forbid this compiler from allowing implicit function declarations.")
   endif()
+endif()
+
+# MSVC does not support VLA in C++. Not even in C because it supports
+# C11 and later where the VLAs are optional. Ban VLAs for maintaining
+# MSVC portability.
+check_c_compiler_flag("-Werror=vla" HAVE_C_WERROR_VLA)
+check_cxx_compiler_flag("-Werror=vla" HAVE_CXX_WERROR_VLA)
+if(HAVE_C_WERROR_VLA)
+  add_compile_options("$<$<COMPILE_LANGUAGE:C>:-Werror=vla>")
+endif()
+if(HAVE_CXX_WERROR_VLA)
+  add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Werror=vla>")
 endif()
 
 set(MAJOR_VERSION 6)

--- a/lib/CL/clCreateCommandBufferKHR.c
+++ b/lib/CL/clCreateCommandBufferKHR.c
@@ -153,7 +153,6 @@ POname (clCreateCommandBufferKHR) (
   return cmdbuf;
 
 ERROR:
-  POCL_MEM_FREE (seen_keys);
   if (cmdbuf)
     {
       POCL_MEM_FREE (cmdbuf->queues);

--- a/lib/CL/clCreateCommandBufferKHR.c
+++ b/lib/CL/clCreateCommandBufferKHR.c
@@ -63,6 +63,7 @@ POname (clCreateCommandBufferKHR) (
     }
 
   cl_uint num_properties = 0;
+  cl_command_buffer_properties_khr *seen_keys = NULL;
   if (properties != NULL)
     {
       const cl_command_buffer_properties_khr *key = 0;
@@ -73,7 +74,9 @@ POname (clCreateCommandBufferKHR) (
         "Properties != NULL, but zero properties in array\n");
 
       unsigned i = 0;
-      cl_command_buffer_properties_khr seen_keys[num_properties];
+      seen_keys = alloca (sizeof (cl_command_buffer_properties_khr)
+                          * num_properties);
+
       for (i = 0; i < num_properties; ++i)
         seen_keys[i] = 0;
 
@@ -150,6 +153,7 @@ POname (clCreateCommandBufferKHR) (
   return cmdbuf;
 
 ERROR:
+  POCL_MEM_FREE (seen_keys);
   if (cmdbuf)
     {
       POCL_MEM_FREE (cmdbuf->queues);

--- a/lib/CL/clEnqueueCommandBufferKHR.c
+++ b/lib/CL/clEnqueueCommandBufferKHR.c
@@ -130,12 +130,11 @@ POname (clEnqueueCommandBufferKHR) (cl_uint num_queues,
     {
       _cl_command_node *cmd;
 
-      cl_event syncpoints[command_buffer->num_syncpoints];
-      memset (&syncpoints[0], 0,
-              sizeof (cl_event) * command_buffer->num_syncpoints);
+      cl_event *syncpoints
+          = alloca (command_buffer->num_syncpoints * sizeof (cl_event));
       cl_event *deps = (cl_event *)alloca (
-        sizeof (cl_event)
-        * (command_buffer->num_syncpoints + num_events_in_wait_list));
+          sizeof (cl_event)
+          * (command_buffer->num_syncpoints + num_events_in_wait_list));
 
       unsigned sync_id = 0;
       LL_FOREACH (command_buffer->cmds, cmd)

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -1989,10 +1989,12 @@ pocl_cuda_submit_kernel (CUstream stream, _cl_command_node *cmd,
   /* Prepare kernel arguments */
   void *null = NULL;
   unsigned sharedMemBytes = 0;
-  void *params[meta->num_args + meta->num_locals + 4];
-  unsigned sharedMemOffsets[meta->num_args + meta->num_locals];
+  void **params
+      = alloca (sizeof (void *) * (meta->num_args + meta->num_locals + 4));
+  unsigned *sharedMemOffsets
+      = alloca (sizeof (unsigned) * (meta->num_args + meta->num_locals));
   unsigned constantMemBytes = 0;
-  unsigned constantMemOffsets[meta->num_args];
+  unsigned *constantMemOffsets = alloca (sizeof (unsigned) * meta->num_args);
   unsigned globalOffsets[3];
 
   CUresult result;

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -262,8 +262,9 @@ work_group_scheduler (kernel_run_command *k,
 {
   pocl_kernel_metadata_t *meta = k->kernel->meta;
 
-  void *arguments[meta->num_args + meta->num_locals + 1];
-  void *arguments2[meta->num_args + meta->num_locals + 1];
+  const size_t num_args = meta->num_args + meta->num_locals + 1;
+  void *arguments = alloca (sizeof (void *) * num_args);
+  void *arguments2 = alloca (sizeof (void *) * num_args);
   struct pocl_context pc;
   unsigned i;
   unsigned start_index;
@@ -277,7 +278,7 @@ work_group_scheduler (kernel_run_command *k,
   assert (end_index >= start_index);
 
   pocl_setup_kernel_arg_array_with_locals (
-      (void **)&arguments, (void **)&arguments2, k, thread_data->local_mem,
+      (void **)arguments, (void **)arguments2, k, thread_data->local_mem,
       scheduler.local_mem_size);
   memcpy (&pc, &k->pc, sizeof (struct pocl_context));
 
@@ -333,8 +334,8 @@ work_group_scheduler (kernel_run_command *k,
   pocl_write_printf_buffer ((char *)pc.printf_buffer, position);
 #endif
 
-  pocl_free_kernel_arg_array_with_locals ((void **)&arguments, (void **)&arguments2,
-                                     k);
+  pocl_free_kernel_arg_array_with_locals ((void **)arguments,
+                                          (void **)arguments2, k);
 
   return 1;
 }
@@ -351,14 +352,15 @@ work_group_scheduler (kernel_run_command *k,
 
 #pragma omp parallel
   {
-    void *arguments[meta->num_args + meta->num_locals + 1];
-    void *arguments2[meta->num_args + meta->num_locals + 1];
+    const size_t num_args = meta->num_args + meta->num_locals + 1;
+    void *arguments = alloca (sizeof (void *) * num_args);
+    void *arguments2 = alloca (sizeof (void *) * num_args);
     struct pocl_context pc;
     void *local_mem = malloc (scheduler.local_mem_size);
 
-    pocl_setup_kernel_arg_array_with_locals ((void **)&arguments,
-                                        (void **)&arguments2, k, local_mem,
-                                        scheduler.local_mem_size);
+    pocl_setup_kernel_arg_array_with_locals ((void **)arguments,
+                                             (void **)arguments2, k, local_mem,
+                                             scheduler.local_mem_size);
     memcpy (&pc, &k->pc, sizeof (struct pocl_context));
 
     assert (pc.printf_buffer_capacity > 0);
@@ -389,8 +391,8 @@ work_group_scheduler (kernel_run_command *k,
     pocl_write_printf_buffer ((char *)pc.printf_buffer, position);
 #endif
 
-    pocl_free_kernel_arg_array_with_locals ((void **)&arguments,
-                                       (void **)&arguments2, k);
+    pocl_free_kernel_arg_array_with_locals ((void **)arguments,
+                                            (void **)arguments2, k);
 
     free (local_mem);
     free (pc.printf_buffer);

--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -332,7 +332,7 @@ writev_full (transport_info_t *connection,
              remote_server_data_t *sinfo)
 {
 
-  struct iovec ary[num];
+  struct iovec *ary = alloca (sizeof (struct iovec) * num);
   size_t total = 0;
   int res = 0;
   unsigned i;

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -842,14 +842,14 @@ pocl_remote_build_source (cl_program program, cl_uint device_i,
   unsigned num_relevant_devices = 0;
   unsigned num_devices = program->num_devices;
 
-  uint32_t relevant_devices[num_devices];
-  uint32_t relevant_platforms[num_devices];
+  uint32_t *relevant_devices = alloca (sizeof (uint32_t) * num_devices);
+  uint32_t *relevant_platforms = alloca (sizeof (uint32_t) * num_devices);
 
-  unsigned build_indexes[num_devices];
-  char *build_logs[num_devices];
+  unsigned *build_indexes = alloca (sizeof (unsigned) * num_devices);
+  char **build_logs = alloca (sizeof (char *) * num_devices);
 
-  char *binaries[num_devices];
-  size_t binary_sizes[num_devices];
+  char **binaries = alloca (sizeof (char *) * num_devices);
+  size_t *binary_sizes = alloca (sizeof (size_t) * num_devices);
 
   size_t total_binary_request_size = sizeof (uint32_t);
   int err;
@@ -942,14 +942,14 @@ pocl_remote_build_binary (cl_program program, cl_uint device_i,
   unsigned num_relevant_devices = 0;
   unsigned num_devices = program->num_devices;
 
-  uint32_t relevant_devices[num_devices];
-  uint32_t relevant_platforms[num_devices];
+  uint32_t *relevant_devices = alloca (sizeof (uint32_t) * num_devices);
+  uint32_t *relevant_platforms = alloca (sizeof (uint32_t) * num_devices);
 
-  unsigned build_indexes[num_devices];
-  char *build_logs[num_devices];
+  unsigned *build_indexes = alloca (sizeof (unsigned) * num_devices);
+  char **build_logs = alloca (sizeof (char *) * num_devices);
 
-  char *binaries[num_devices];
-  size_t binary_sizes[num_devices];
+  char **binaries = alloca (sizeof (char *) * num_devices);
+  size_t *binary_sizes = alloca (sizeof (size_t) * num_devices);
 
   size_t total_binary_request_size = sizeof (uint32_t);
   int err;
@@ -1111,14 +1111,14 @@ int pocl_remote_link_program (cl_program program, cl_uint device_i,
   unsigned num_relevant_devices = 0;
   unsigned num_devices = program->num_devices;
 
-  uint32_t relevant_devices[num_devices];
-  uint32_t relevant_platforms[num_devices];
+  uint32_t *relevant_devices = alloca (sizeof (uint32_t) * num_devices);
+  uint32_t *relevant_platforms = alloca (sizeof (uint32_t) * num_devices);
 
-  unsigned build_indexes[num_devices];
-  char *build_logs[num_devices];
+  unsigned *build_indexes = alloca (sizeof (unsigned) * num_devices);
+  char **build_logs = alloca (sizeof (char *) * num_devices);
 
-  char *binaries[num_devices];
-  size_t binary_sizes[num_devices];
+  char **binaries = alloca (sizeof (char *) * num_devices);
+  size_t *binary_sizes = alloca (sizeof (size_t) * num_devices);
 
   size_t total_binary_request_size = sizeof (uint32_t);
   int err;
@@ -1140,7 +1140,8 @@ int pocl_remote_link_program (cl_program program, cl_uint device_i,
   char *kernel_meta_bytes = NULL;
   size_t kernel_meta_size = 0;
 
-  uint32_t input_prog_ids[num_input_programs + 1];
+  uint32_t *input_prog_ids
+      = alloca (sizeof (uint32_t) * (num_input_programs + 1));
   input_prog_ids[0] = num_input_programs;
   for (i = 0; i < num_input_programs; ++i)
     input_prog_ids[i + 1] = input_programs[i]->id;

--- a/lib/CL/devices/vulkan/pocl-vulkan.c
+++ b/lib/CL/devices/vulkan/pocl-vulkan.c
@@ -4088,7 +4088,7 @@ pocl_vulkan_run (void *data, _cl_command_node *cmd)
   VkPipeline pipeline;
   VkShaderModule compute_shader = NULL;
   VkPushConstantRange pushc_range;
-  char pushc_data[d->max_pushc_size];
+  char *pushc_data = alloca (d->max_pushc_size);
   char *goffs_start = NULL;
 
   pocl_vulkan_setup_kernel_arguments (

--- a/lib/CL/pocl_cq_profiling.c
+++ b/lib/CL/pocl_cq_profiling.c
@@ -62,7 +62,8 @@ pocl_atexit ()
   unsigned long total_commands = 0;
   unsigned long different_kernels = 0;
 
-  struct kernel_stats kernel_statistics[cq_events_collected];
+  struct kernel_stats *kernel_statistics
+      = alloca (cq_events_collected * sizeof (struct kernel_stats));
   bzero_s (&kernel_statistics, sizeof (kernel_statistics));
 
   /* First statistics computation round. */

--- a/tests/runtime/test_clCreateSubDevices.c
+++ b/tests/runtime/test_clCreateSubDevices.c
@@ -46,12 +46,14 @@ static const char *prog_src_two = "kernel void\n"
 int test_context(cl_context ctx, const char *prog_src, int mul,
   int ndevs, cl_device_id *devs) {
   cl_int err;
-  cl_command_queue queue[ndevs];
   cl_program prog;
   cl_kernel krn;
   cl_mem buf;
-  cl_event evt[ndevs];
   cl_int i;
+
+  cl_command_queue *queue = malloc (ndevs * sizeof (cl_command_queue));
+  cl_event *evt = malloc (ndevs * sizeof (cl_event));
+  TEST_ASSERT (queue && evt);
 
   prog = clCreateProgramWithSource(ctx, 1, &prog_src, NULL, &err);
   CHECK_OPENCL_ERROR_IN("create program");
@@ -106,6 +108,8 @@ int test_context(cl_context ctx, const char *prog_src, int mul,
 
   CHECK_OPENCL_ERROR_IN("cleanup");
 
+  free (queue);
+  free (evt);
   return CL_SUCCESS;
 
 }

--- a/tests/runtime/test_clGetEventInfo.c
+++ b/tests/runtime/test_clGetEventInfo.c
@@ -5,7 +5,7 @@
 
 #define MAX_PLATFORMS 32
 #define MAX_DEVICES   32
-
+#define BUF_SIZE 1024
 int
 main(void)
 {
@@ -33,12 +33,13 @@ main(void)
           context = clCreateContext (NULL, 1, &devices[j], NULL, NULL, &err);
           queue = clCreateCommandQueue (context, devices[j], 0, &err);
 
-          const int buf_size = 1024;
-          cl_int host_buf[buf_size];
+          cl_int host_buf[BUF_SIZE];
 
           buf = clCreateBuffer (context, CL_MEM_READ_WRITE,
-                                sizeof (cl_int) * buf_size, NULL, &err);
-          CHECK_CL_ERROR(clEnqueueReadBuffer(queue, buf, CL_TRUE, 0, sizeof(cl_int) * buf_size, &host_buf, 0, NULL, &buf_event));
+                                sizeof (cl_int) * BUF_SIZE, NULL, &err);
+          CHECK_CL_ERROR (clEnqueueReadBuffer (
+              queue, buf, CL_TRUE, 0, sizeof (cl_int) * BUF_SIZE, &host_buf, 0,
+              NULL, &buf_event));
           CHECK_CL_ERROR(clFinish(queue));
           size_t param_val_size_ret;
           CHECK_CL_ERROR(clGetEventInfo(buf_event, CL_EVENT_COMMAND_QUEUE, sizeof(cl_command_queue), &event_command_queue, &param_val_size_ret));

--- a/tests/runtime/test_command_buffer.c
+++ b/tests/runtime/test_command_buffer.c
@@ -196,8 +196,8 @@ main (int _argc, char **_argv)
       sizeof (cl_command_buffer_state_khr), &cmdbuf_state, NULL));
   TEST_ASSERT (cmdbuf_state == CL_COMMAND_BUFFER_STATE_EXECUTABLE_KHR);
 
-  cl_int src1[frame_elements];
-  cl_int src2[frame_elements];
+  cl_int *src1 = malloc (frame_elements * sizeof (cl_int));
+  cl_int *src2 = malloc (frame_elements * sizeof (cl_int));
   for (size_t frame_index = 0; frame_index < frame_count; frame_index++)
     {
       for (size_t i = 0; i < frame_elements; ++i)
@@ -253,6 +253,8 @@ main (int _argc, char **_argv)
 
   CHECK_CL_ERROR (clUnloadPlatformCompiler (platform));
 
+  free (src1);
+  free (src2);
   printf ("OK\n");
   return EXIT_SUCCESS;
 #else

--- a/tests/runtime/test_command_buffer_images.c
+++ b/tests/runtime/test_command_buffer_images.c
@@ -163,7 +163,7 @@ main (int _argc, char **_argv)
 
   /*** Main test ***/
   {
-    uint8_t img_src[buf_size];
+    uint8_t *img_src = malloc (buf_size);
     for (size_t i = 0; i < img_npixels; ++i)
       {
         for (size_t j = 0; j < img_channels; ++j)
@@ -219,6 +219,7 @@ main (int _argc, char **_argv)
 
     CHECK_CL_ERROR (clReleaseEvent (write_src_event));
     CHECK_CL_ERROR (clReleaseEvent (command_buf_event));
+    free (img_src);
   }
 
   CHECK_CL_ERROR (ext.clReleaseCommandBufferKHR (command_buffer));

--- a/tests/runtime/test_command_buffer_multi_device.c
+++ b/tests/runtime/test_command_buffer_multi_device.c
@@ -114,8 +114,8 @@ main (int _argc, char **_argv)
           CHECK_CL_ERROR (clGetDeviceInfo (
             devices[j], CL_DEVICE_COMMAND_BUFFER_NUM_SYNC_DEVICES_KHR,
             sizeof (cl_uint), &num_sync_devices, NULL));
-          cl_device_id *sync_devices = (cl_device_id *)alloca (
-            sizeof (cl_device_id) * num_sync_devices);
+          cl_device_id *sync_devices
+              = malloc (sizeof (cl_device_id) * num_sync_devices);
           CHECK_CL_ERROR (clGetDeviceInfo (
             devices[j], CL_DEVICE_COMMAND_BUFFER_SYNC_DEVICES_KHR,
             sizeof (cl_device_id) * num_sync_devices, sync_devices, NULL));
@@ -139,6 +139,7 @@ main (int _argc, char **_argv)
                   return 77;
                 }
             }
+          free (sync_devices);
         }
     }
 
@@ -288,8 +289,8 @@ main (int _argc, char **_argv)
   TEST_ASSERT (cmdbuf_state == CL_COMMAND_BUFFER_STATE_EXECUTABLE_KHR);
 
   /* Enqueue N-queue buffer normally */
-  cl_int src1[frame_elements];
-  cl_int src2[frame_elements];
+  cl_int *src1 = malloc (sizeof (cl_int) * frame_elements);
+  cl_int *src2 = malloc (sizeof (cl_int) * frame_elements);
   for (size_t frame_index = 0; frame_index < frame_count; frame_index++)
     {
       for (size_t i = 0; i < frame_elements; ++i)
@@ -397,6 +398,8 @@ main (int _argc, char **_argv)
   CHECK_CL_ERROR (clReleaseContext (context));
 
   free (devices);
+  free (src1);
+  free (src2);
 
   printf ("OK\n");
   return EXIT_SUCCESS;

--- a/tests/spirv/printf.cc
+++ b/tests/spirv/printf.cc
@@ -41,8 +41,7 @@ std::vector<std::string> getKernelNames(cl_program Program) {
 			     0, NULL,
 			     &KernelNamesSize));
 
-
-  char Names[KernelNamesSize + 1];
+  std::vector<char> Names(KernelNamesSize + 1);
   CHECK_ERR(clGetProgramInfo(Program, CL_PROGRAM_KERNEL_NAMES,
 			     KernelNamesSize, &Names[0],
 			     &KernelNamesSize));
@@ -51,8 +50,8 @@ std::vector<std::string> getKernelNames(cl_program Program) {
   Names[KernelNamesSize] = 0;
 
   std::vector<std::string> KernelNames;
-  //Construct a stream from the string
-  std::stringstream StreamData(Names);
+  // Construct a stream from the string
+  std::stringstream StreamData(Names.data());
   std::string Kern;
   while (std::getline(StreamData, Kern, ';')) {
     KernelNames.push_back(Kern);

--- a/tests/workgroup/run_kernel.c
+++ b/tests/workgroup/run_kernel.c
@@ -126,9 +126,10 @@ main (int argc, char **argv)
                                 local_work_size, 0, NULL, NULL);
   CHECK_CL_ERROR2 (err);
 
+  cl_int *kern_output = NULL;
   if (num_args == 1)
     {
-      cl_int kern_output[grid_size];
+      kern_output = malloc (grid_size * sizeof (cl_int));
       err = clEnqueueReadBuffer (cmd_queue, outbuf, CL_TRUE, 0,
                                  grid_size * sizeof (cl_int), kern_output, 0,
                                  NULL, NULL);
@@ -157,6 +158,7 @@ ERROR:
 
   free (source);
   free (devices);
+  free (kern_output);
 
   if (err == CL_SUCCESS)
     {


### PR DESCRIPTION
Ban VLAs because MSVC does not support them - not even for C code because C99 is not supported where the VLA is a mandatory feature. This restriction is attempted to be enforced with -Werror=vla.

VLAs are replaced with malloc, std::vector or alloca.