### PR TITLE
Allow override of platform name with POCL_PLATFORM_OVERRIDE

### DIFF
--- a/doc/sphinx/source/using.rst
+++ b/doc/sphinx/source/using.rst
@@ -327,6 +327,11 @@ pocl.
 
   * **POCL_ARGS_CLANG** -- Additional arguments to pass to clang.
 
+- **POCL_PLATFORM_NAME_OVERRIDE**
+
+ Overrides the platform name reported by PoCL. For example, setting the platform
+ "PoCL (Intel OpenCL compat)" will allow running OneDNN applications, which will
+ fail to create a device if 'Intel' and 'OpenCL' are not in the platform string.
 
 - **POCL_SIGFPE_HANDLER**
 

--- a/lib/CL/clGetPlatformInfo.c
+++ b/lib/CL/clGetPlatformInfo.c
@@ -218,7 +218,8 @@ POname(clGetPlatformInfo)(cl_platform_id   platform,
       POCL_RETURN_GETINFO (cl_version, pocl_numeric_version);
 
     case CL_PLATFORM_NAME:
-      POCL_RETURN_GETINFO_STR("Portable Computing Language");
+      POCL_RETURN_GETINFO_STR (pocl_get_string_option (
+        "POCL_PLATFORM_NAME_OVERRIDE", "Portable Computing Language"));
 
     case CL_PLATFORM_VENDOR:
       POCL_RETURN_GETINFO_STR("The pocl project");


### PR DESCRIPTION
OneDNN does not work if `Intel` or `OpenCL` are not part of the platform string.

https://github.com/oneapi-src/oneDNN/blob/rls-v3.6/src/xpu/sycl/utils.cpp#L96-L113