### PR TITLE
Grid launcher, a new bin finalization hook, cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 #   CMake build system files
 #
 #   Copyright (c) 2014-2024 pocl developers
+#                 2024 Pekka Jääskeläinen / Intel Finland Oy
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a copy
 #   of this software and associated documentation files (the "Software"), to deal
@@ -314,7 +315,7 @@ option(ENABLE_EXAMPLES "Build examples. Defaults to ON" ON)
 
 option(ENABLE_RDMA "Enable usage of RDMA libraries for memory allocations. Requires libRDMAcm and libverbs" OFF)
 
-option(RENAME_POCL "rename PoCL's ocl functions to PO<ocl_function>. Allows an user to call both PoCL and another ocl application" OFF)
+option(RENAME_POCL "Rename PoCL's OpenCL functions to PO<ocl_function>. Allows an user to call both PoCL and another OpenCL implementation." OFF)
 
 
 ##########################################################

--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -197,6 +197,8 @@
 
 #define CLANGXX "@CLANGXX@"
 
+#define CLANG_MARCH_FLAG "@CLANG_MARCH_FLAG@"
+
 #define LLVM_LLC "@LLVM_LLC@"
 
 #cmakedefine HAVE_LLVM_SPIRV

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -385,9 +385,6 @@ setup_kernellib_and_additional_extensions (cl_device_id dev,
   assert (data && "data must not be NULL!");
   assert (data->sm && data->ptx && "CUDA target must be known!");
 
-  dev->kernellib_fallback_name = NULL;
-  dev->kernellib_subdir = "cuda";
-
   int is_64bit_target = (sizeof (void *) == 8);
 
   int has_unified_addressing = 0;
@@ -518,6 +515,11 @@ pocl_cuda_init (unsigned j, cl_device_id dev, const char *parameters)
 
   assert (dev->data == NULL);
 
+  dev->llvm_target_triplet = (sizeof (void *) == 8) ? "nvptx64" : "nvptx";
+  dev->llvm_cpu = "generic";
+  dev->kernellib_fallback_name = NULL;
+  dev->kernellib_subdir = "cuda";
+
   pocl_init_default_device_infos (dev, CUDA_DEVICE_EXTENSIONS);
 
   SETUP_DEVICE_CL_VERSION (dev, CUDA_DEVICE_CL_VERSION_MAJOR,
@@ -529,7 +531,6 @@ pocl_cuda_init (unsigned j, cl_device_id dev, const char *parameters)
   dev->type = CL_DEVICE_TYPE_GPU;
   dev->address_bits = (sizeof (void *) * 8);
 
-  dev->llvm_target_triplet = (sizeof (void *) == 8) ? "nvptx64" : "nvptx";
   dev->llvm_fp_contract_mode = "fast";
 
   dev->spmd = CL_TRUE;

--- a/lib/CL/devices/prototypes.inc
+++ b/lib/CL/devices/prototypes.inc
@@ -88,6 +88,8 @@
   void pocl_##__DRV__##_compile_kernel (_cl_command_node *node,               \
                                          cl_kernel kernel,                    \
                                          cl_device_id device, int specialize);\
+  int pocl_##__DRV__##_finalize_binary (const char* final_binary,             \
+                                        const char *wg_func_obj);             \
   int pocl_##__DRV__##_init_queue (cl_device_id device,                       \
                                    cl_command_queue queue);                   \
   int pocl_##__DRV__##_free_queue (cl_device_id device,                       \

--- a/lib/CL/devices/prototypes.inc
+++ b/lib/CL/devices/prototypes.inc
@@ -86,8 +86,8 @@
       const size_t *region, size_t dst_row_pitch, size_t dst_slice_pitch,     \
       size_t src_row_pitch, size_t src_slice_pitch);                          \
   void pocl_##__DRV__##_compile_kernel (_cl_command_node *node,               \
-                                        cl_kernel kernel,                     \
-                                        cl_device_id device, int specialize); \
+                                         cl_kernel kernel,                    \
+                                         cl_device_id device, int specialize);\
   int pocl_##__DRV__##_init_queue (cl_device_id device,                       \
                                    cl_command_queue queue);                   \
   int pocl_##__DRV__##_free_queue (cl_device_id device,                       \

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -756,6 +756,16 @@ struct pocl_device_ops {
   void (*compile_kernel) (_cl_command_node *cmd, cl_kernel kernel,
                           cl_device_id device, int specialize);
 
+  /** Optional: If the target can utilize the basic Clang-driven steps for
+   * other compilation steps, but the final linkage step, this function can be
+   * used to define them.
+   *
+   * \param final_binary The target filename for the finalized binary.
+   * \param wg_func_obj The binary for the generated work-group function.
+   * \return Non-zero on error.
+   */
+  int (*finalize_binary) (const char *final_binary, const char *wg_func_obj);
+
   /** Optional: The driver should free the content of "program->data" here,
    * if it fills it. */
   int (*free_program) (cl_device_id device, cl_program program,

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -1073,11 +1073,19 @@ struct _cl_device_id {
      we need to generate work-item loops to execute all the work-items
      in the WG. For SPMD machines, the hardware spawns the WIs. */
   cl_bool spmd;
-  /* The device uses an HSA-like kernel ABI with a single argument buffer as
-     an input. */
+
+  /**
+   * The device uses an HSA-like kernel ABI with a single argument buffer as
+   * an input.
+   */
   cl_bool arg_buffer_launcher;
-  /* The device uses a GRID launcher */
+
+  /**
+   * The device uses a grid launcher which iterates through the whole
+   * index space.
+   */
   cl_bool grid_launcher;
+
   /* The Workgroup pass creates launcher functions and replaces work-item
      placeholder global variables (e.g. _local_size_, _global_offset_ etc) with
      loads from the context struct passed as a kernel argument. This flag

--- a/lib/CL/pocl_llvm.h
+++ b/lib/CL/pocl_llvm.h
@@ -35,7 +35,7 @@ extern "C" {
   void InitializeLLVM ();
   void UnInitializeLLVM ();
 
-  /* Returns the cpu name as reported by LLVM. */
+  /* Returns the host cpu name as reported by LLVM. */
   POCL_EXPORT
   char *pocl_get_llvm_cpu_name ();
 

--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -154,20 +154,20 @@ static llvm::Module *getKernelLibrary(cl_device_id device,
                                       PoclLLVMContextData *llvm_ctx);
 
 /**
-* \brief  This function runs various LLVM "passes" on the program.bc LLVM module;
-* the passes are not real LLVM passes, but perhaps it will make sense
-* to convert at some point. Note that this should only run passes which
-* for some reason must be run at program.bc stage rather than parallel.bc
-*
-* \param [in] Context the pocl LLVM context
-* \param [in] Mod is the LLVM module
-* \param [in] Program the cl_program corresponding to Mod
-* \param [in] Device the device used for the LLVM passes
-* \param [in] device_i index into program->devices[] corresponding to Device
-* \param [out] Log a std::string containing the error/warning log
-* \returns true if there is an error
-*
-*/
+ * Runs various LLVM "passes" on the program.bc LLVM module;
+ * the passes are not real LLVM passes, but perhaps it will make sense
+ * to convert at some point. Note that this should only run passes which
+ * for some reason must be run at program.bc stage rather than parallel.bc
+ *
+ * \param [in] Context the pocl LLVM context
+ * \param [in] Mod is the LLVM module
+ * \param [in] Program the cl_program corresponding to Mod
+ * \param [in] Device the device used for the LLVM passes
+ * \param [in] device_i index into program->devices[] corresponding to Device
+ * \param [out] Log a std::string containing the error/warning log
+ * \returns true if there is an error
+ *
+ */
 static bool generateProgramBC(PoclLLVMContextData *Context, llvm::Module *Mod,
                              cl_program Program, cl_device_id Device,
                              unsigned device_i, std::string &Log) {
@@ -293,7 +293,7 @@ int pocl_llvm_build_program(cl_program program,
   if (device->has_64bit_long)
     ss << "-Dcl_khr_int64 ";
 
-  if (device->use_only_clang_opencl_headers == CL_FALSE) {
+  if (!device->use_only_clang_opencl_headers) {
     ss << "-DPOCL_DEVICE_ADDRESS_BITS=" << device->address_bits << " ";
     ss << "-D__USE_CLANG_OPENCL_C_H ";
   }
@@ -875,7 +875,7 @@ int pocl_llvm_link_program(cl_program program, unsigned device_i,
     error = pocl_convert_spir_bitcode_to_target(TempModule.get(), libmodule,
                                                 device);
     POCL_RETURN_ERROR_ON((error != CL_SUCCESS), CL_LINK_PROGRAM_FAILURE,
-                         "could connvert SPIR to Target\n");
+                         "could not convert SPIR to Target\n");
 
     if (Linker::linkModules(*mod, std::move(TempModule))) {
       std::string msg = getDiagString(ctx);

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -1731,20 +1731,6 @@ pocl_command_to_str (cl_command_type cmd)
   return "unknown";
 }
 
-/*
- * This replaces a simple system(), because:
- *
- * 1) system() was causing issues (gpu lockups) with HSA when
- * compiling code (via compile_parallel_bc_to_brig)
- * with OpenCL 2.0 atomics (like CalcPie from AMD SDK).
- * The reason of lockups is unknown (yet).
- *
- * 2) system() uses fork() which copies page table maps, and runs
- * out of AS when pocl has already allocated huge buffers in memory.
- * this happened in llvm_codegen()
- *
- * vfork() does not copy pagetables.
- */
 int
 pocl_run_command (const char **args)
 {

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -327,10 +327,28 @@ POCL_EXPORT
 const char *
 pocl_command_to_str (cl_command_type cmd);
 
+/**
+ * Wrapper for running commands.
+ *
+ * \param args The list of arguments, including the executed program.
+ * \return The return value from the executed command.
+ */
 POCL_EXPORT
 int pocl_run_command (const char **args);
 
 #if defined(HAVE_FORK)
+ /**
+ * Wrapper for running commands with their output captured to a buffer.
+ *
+ * \todo This currently might block forever if capture_string is too small
+ * for all the output.
+ *
+ * \param capture_string The target for storing the stdout and stderr.
+ * \param captured_bytes [in/out] Input the number of bytes allocated in
+ * capture_string, outputs the number of bytes written there.
+ * \param args The list of arguments, including the executed program.
+ * \return The return value from the executed command.
+ */
 POCL_EXPORT
 int pocl_run_command_capture_output (char *capture_string,
                                      size_t *captured_bytes,

--- a/lib/kernel/pocl_run_all_wgs.c
+++ b/lib/kernel/pocl_run_all_wgs.c
@@ -34,21 +34,26 @@ _pocl_spawn_wg (void *restrict wg_func_ptr, uchar *restrict args,
 		uchar *restrict ctx,
 		size_t group_x, size_t group_y, size_t group_z);
 
-/* Launches all the work-groups in the grid using the given work group function.
-   Blocks until all WGs have been executed to the end.
-
-   @param wg_func_ptr Pointer to the pocl-generated WG function for the kernel.
-   @param args The flat argument buffer.
-   @param pc The context struct for getting the dimensions etc.  */
+/** Launches all the work-groups in the grid using the given work group
+ * function.
+ *
+ * Blocks until all WGs have been executed to the end.
+ *
+ * \param wg_func_ptr Pointer to the pocl-generated WG function for the kernel.
+ * \param args The flat argument buffer.
+ * \param pc Pointer to the context struct for getting the dimensions etc.
+ */
 void
-_pocl_run_all_wgs (void *restrict wg_func_ptr, uchar *restrict args,
-                   uchar *restrict pcptr, void *d)
+_pocl_run_all_wgs (void *restrict wg_func_ptr,
+                   uchar *restrict args,
+                   uchar *restrict pc,
+                   void *d)
 {
-  struct pocl_context *pc = (struct pocl_context*)pcptr;
-  for (size_t gz = 0; gz < pc->num_groups[2]; ++gz)
-    for (size_t gy = 0; gy < pc->num_groups[1]; ++gy)
-      for (size_t gx = 0; gx < pc->num_groups[0]; ++gx)
-	_pocl_spawn_wg (wg_func_ptr, args, pcptr, gx, gy, gz);
+  struct pocl_context *pc_ = (struct pocl_context *)pc;
+  for (size_t gz = 0; gz < pc_->num_groups[2]; ++gz)
+    for (size_t gy = 0; gy < pc_->num_groups[1]; ++gy)
+      for (size_t gx = 0; gx < pc_->num_groups[0]; ++gx)
+        _pocl_spawn_wg (wg_func_ptr, args, pc, gx, gy, gz);
 
-  _pocl_finish_all_wgs (pcptr);
+  _pocl_finish_all_wgs (pc);
 }

--- a/lib/llvmopencl/DebugHelpers.h
+++ b/lib/llvmopencl/DebugHelpers.h
@@ -78,6 +78,9 @@ bool chopBBs (llvm::Function &F, llvm::Pass &P);
 // Controls the debug output from ImplicitConditionalBarriers.cc:
 //#define DEBUG_COND_BARRIERS
 
+// Controls the debug output from Workgroup.cc
+// #define DEBUG_WORK_GROUP_GEN
+
 // Controls the debug output from PHIsToAllocas.cc
 //#define DEBUG_PHIS_TO_ALLOCAS
 

--- a/lib/llvmopencl/Flatten.cc
+++ b/lib/llvmopencl/Flatten.cc
@@ -105,7 +105,10 @@ static bool flattenAll(Module &M) {
 
     OnlyDynamicWIFuncCallsFound = IsStaticWIFuncCall && UI == UE;
 
-    if (pocl::isKernelToProcess(*F) || OnlyDynamicWIFuncCallsFound) {
+    if (pocl::isKernelToProcess(*F) || OnlyDynamicWIFuncCallsFound ||
+        // If the target defines a main for the kernel command, we should keep
+        // it globally accessible.
+        F->getName() == "main") {
       replaceThisAttr = Attribute::AlwaysInline;
       replacementAttr = Attribute::NoInline;
       linkage = llvm::GlobalValue::ExternalLinkage;

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -1476,14 +1476,16 @@ WorkgroupImpl::createArgBufferWorkgroupLauncher(Function *Func,
   return llvm::dyn_cast<llvm::Function>(llvm::unwrap(WrapperKernel));
 }
 
-/**
- * Creates a launcher function that executes all work-items in the grid by
- * launching a given work-group function for all work-group ids.
- *
- * The function adheres to the PHSA calling convention where the first two
- * arguments are for PHSA's context data, and the third one is the argument
- * buffer. The name will be phsa_kernel.KERNELNAME_grid_launcher.
- */
+/// Creates a launcher function that executes all work-items in the grid by
+/// launching a given work-group function for all work-group ids.
+///
+/// The function adheres to the PHSA calling convention where the first two
+/// arguments are for PHSA's context data, and the third one is the argument
+/// buffer. The name will be phsa_kernel.KERNELNAME_grid_launcher.
+///
+/// \param KernFunc The kernel function to generate the launcher for.
+/// \param WGFunc The work-group function.
+/// \param KernName The (original) name of the kernel.
 void WorkgroupImpl::createGridLauncher(Function *KernFunc, Function *WGFunc,
                                        std::string KernName) {
 
@@ -1725,6 +1727,11 @@ llvm::PreservedAnalyses Workgroup::run(llvm::Module &M,
   for (llvm::GlobalVariable *GVar : GVarsToDelete) {
     GVar->eraseFromParent();
   }
+
+#ifdef DEBUG_WORK_GROUP_GEN
+  std::cerr << "### After Workgroup:\n";
+  M.dump();
+#endif
 
   return Ret ? PAChanged : PreservedAnalyses::all();
 }

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -251,7 +251,10 @@ bool WorkgroupImpl::runOnModule(Module &M, FunctionVec &OldKernels) {
     // linker's switch --wrap=symbol, where calls to the "symbol" are replaced
     // with "__wrap_symbol" at link time.  These functions may not be referenced
     // until final link and being deleted by LLVM optimizations before it.
-    if (!i->isDeclaration() && !i->getName().starts_with("__wrap_"))
+    // Also, if there's a main aux function, we want to keep it as it will be
+    // likely used in the kernel command functionality for the device.
+    if (!i->isDeclaration() && !i->getName().starts_with("__wrap_") &&
+        i->getName() != "main")
       i->setLinkage(Function::InternalLinkage);
   }
 

--- a/lib/llvmopencl/linker.cpp
+++ b/lib/llvmopencl/linker.cpp
@@ -2,6 +2,7 @@
 //
 // Copyright (c) 2014 Kalle Raiskila
 //               2016-2022 Pekka Jääskeläinen
+//               2023-2024 Pekka Jääskeläinen / Intel Finland Oy
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
* Enable including a device-main in the bitcode library. Device mains can have the kernel command handling and launch the work-groups via grid launcher.
* Fix grid launcher generation. It rots because phsa is not tested anymore, but is useful for some targets.
* Allow overriding the final linkage step via a new finalize_binary() hook.
* Cleanups, documentation, minor internal convenience. pocl_init_default_device_infos() now lets setting triplet etc. beforehand and it doesn't overwrite with the 'host' defaults. This enables generating the built-in lib pathnames with the helper with more flexibility.
