### PR TITLE
Replace __attribute__((aligned(...)))

### DIFF
--- a/include/messages.h
+++ b/include/messages.h
@@ -199,43 +199,48 @@ extern "C"
     MessageType_Failure
   };
 
-  typedef struct __attribute__ ((packed, aligned (8))) ImgFormatType_s
+  typedef struct __attribute__ ((packed)) ImgFormatType_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint32_t channel_order;
     uint32_t channel_data_type;
   } ImgFormatType_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) ImgFormatInfo_s
+  typedef struct __attribute__ ((packed)) ImgFormatInfo_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint32_t memobj_type;
     uint32_t num_formats;
     ImgFormatType_t formats[MAX_IMAGE_FORMAT_TYPES];
   } ImgFormatInfo_t;
 
-  typedef struct __attribute__ ((packed, aligned (8)))
+  typedef struct __attribute__ ((packed))
   CreateOrAttachSessionMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t peer_id;
     uint16_t peer_port;
     uint8_t use_rdma;
     uint8_t fast_socket;
   } CreateOrAttachSessionMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8)))
+  typedef struct __attribute__ ((packed))
   CreateOrAttachSessionReply_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t session;
     uint8_t authkey[AUTHKEY_LENGTH];
     uint16_t peer_port;
     uint8_t use_rdma;
   } CreateOrAttachSessionReply_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) DeviceInfo_s
+  typedef struct __attribute__ ((packed)) DeviceInfo_s
   {
 
     /* ######## device properties ############## */
 
     /* Offsets to the strings-section. */
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t name;
     uint64_t opencl_c_version;
     uint64_t device_version;
@@ -351,8 +356,9 @@ extern "C"
     uint32_t specific_info_size;
   } DeviceInfo_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) ConnectPeerMsg_s
+  typedef struct __attribute__ ((packed)) ConnectPeerMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint16_t port;
     uint64_t session;
     uint8_t authkey[AUTHKEY_LENGTH];
@@ -366,8 +372,9 @@ extern "C"
   /* ########################## */
   /* ########################## */
 
-  typedef struct __attribute__ ((packed, aligned (8))) MigrateD2DMsg_s
+  typedef struct __attribute__ ((packed)) MigrateD2DMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t size;
     uint32_t source_pid;
     uint32_t source_did;
@@ -381,8 +388,9 @@ extern "C"
     uint32_t depth;
   } MigrateD2DMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) CreateBufferMsg_s
+  typedef struct __attribute__ ((packed)) CreateBufferMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t size;
     uint32_t flags;
     /* If non-zero, a previously allocated SVM pointer to be wrapped as
@@ -396,29 +404,33 @@ extern "C"
     uint64_t origin;
   } CreateBufferMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) CreateBufferReply_s
+  typedef struct __attribute__ ((packed)) CreateBufferReply_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t device_addr;
   } CreateBufferReply_t;
 
 #ifdef ENABLE_RDMA
-  typedef struct __attribute__ ((packed, aligned (8))) CreateRdmaBufferReply_s
+  typedef struct __attribute__ ((packed)) CreateRdmaBufferReply_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t server_vaddr;
     uint32_t server_rkey;
   } CreateRdmaBufferReply_t;
 #endif
 
-  typedef struct __attribute__ ((packed, aligned (8))) FreeBufferMsg_s
+  typedef struct __attribute__ ((packed)) FreeBufferMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t padding;
     /* If set to 1, the id of the buffer is the device side SVM allocation
        address to free, otherwise a cl_mem id.*/
     unsigned char is_svm;
   } FreeBufferMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) ReadBufferMsg_s
+  typedef struct __attribute__ ((packed)) ReadBufferMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t src_offset;
     uint64_t size;
     uint64_t content_size;
@@ -433,8 +445,9 @@ extern "C"
     unsigned char is_svm;
   } ReadBufferMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) WriteBufferMsg_s
+  typedef struct __attribute__ ((packed)) WriteBufferMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t dst_offset;
     uint64_t size;
     uint64_t content_size;
@@ -444,8 +457,9 @@ extern "C"
     unsigned char is_svm;
   } WriteBufferMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) CopyBufferMsg_s
+  typedef struct __attribute__ ((packed)) CopyBufferMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint32_t src_buffer_id;
     uint32_t dst_buffer_id;
     uint32_t size_buffer_id;
@@ -454,15 +468,17 @@ extern "C"
     uint64_t size;
   } CopyBufferMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) FillBufferMsg_s
+  typedef struct __attribute__ ((packed)) FillBufferMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t dst_offset;
     uint64_t size;
     uint64_t pattern_size;
   } FillBufferMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) ReadBufferRectMsg_s
+  typedef struct __attribute__ ((packed)) ReadBufferRectMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     vec3_t buffer_origin;
     vec3_t region;
 
@@ -476,8 +492,9 @@ extern "C"
 #endif
   } ReadBufferRectMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) WriteBufferRectMsg_s
+  typedef struct __attribute__ ((packed)) WriteBufferRectMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     vec3_t buffer_origin;
     vec3_t region;
 
@@ -487,8 +504,9 @@ extern "C"
     uint64_t host_bytes;
   } WriteBufferRectMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) CopyBufferRectMsg_s
+  typedef struct __attribute__ ((packed)) CopyBufferRectMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint32_t src_buffer_id;
     uint32_t dst_buffer_id;
 
@@ -503,8 +521,9 @@ extern "C"
 
   } CopyBufferRectMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) CreateImageMsg_s
+  typedef struct __attribute__ ((packed)) CreateImageMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint32_t flags;
     // format
     uint32_t channel_order;
@@ -521,15 +540,17 @@ extern "C"
     //    cl_uint                 num_samples;
   } CreateImageMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) CreateSamplerMsg_s
+  typedef struct __attribute__ ((packed)) CreateSamplerMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint32_t normalized;
     uint32_t address_mode;
     uint32_t filter_mode;
   } CreateSamplerMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) CopyImage2ImageMsg_s
+  typedef struct __attribute__ ((packed)) CopyImage2ImageMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint32_t src_image_id;
     uint32_t dst_image_id;
 
@@ -539,8 +560,9 @@ extern "C"
 
   } CopyImg2ImgMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) CopyBuf2ImgMsg_s
+  typedef struct __attribute__ ((packed)) CopyBuf2ImgMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     vec3_t origin;
     vec3_t region;
 
@@ -548,8 +570,9 @@ extern "C"
     uint64_t src_offset;
   } CopyBuf2ImgMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) CopyImg2BufMsg_s
+  typedef struct __attribute__ ((packed)) CopyImg2BufMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     vec3_t origin;
     vec3_t region;
 
@@ -557,8 +580,9 @@ extern "C"
     uint64_t dst_offset;
   } CopyImg2BufMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) ReadImageRectMsg_s
+  typedef struct __attribute__ ((packed)) ReadImageRectMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     vec3_t origin;
     vec3_t region;
 
@@ -569,23 +593,26 @@ extern "C"
 #endif
   } ReadImageRectMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) WriteImageRectMsg_s
+  typedef struct __attribute__ ((packed)) WriteImageRectMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     vec3_t origin;
     vec3_t region;
 
     uint64_t host_bytes;
   } WriteImageRectMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) FillImageRectMsg_s
+  typedef struct __attribute__ ((packed)) FillImageRectMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     vec3_t origin;
     vec3_t region;
 
   } FillImageRectMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) BuildProgramMsg_s
+  typedef struct __attribute__ ((packed)) BuildProgramMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t payload_size;
     uint64_t options_len;
     // nonzero, if the program's memory accesses should be offset-adjusted
@@ -598,19 +625,22 @@ extern "C"
     // options: char*
   } BuildProgramMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) CreateKernelMsg_s
+  typedef struct __attribute__ ((packed)) CreateKernelMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t name_len;
     uint32_t prog_id;
   } CreateKernelMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) FreeKernelMsg_s
+  typedef struct __attribute__ ((packed)) FreeKernelMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint32_t prog_id;
   } FreeKernelMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) RunKernelMsg_s
+  typedef struct __attribute__ ((packed)) RunKernelMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     vec3_t global;
     vec3_t local;
     vec3_t offset;
@@ -622,8 +652,9 @@ extern "C"
     uint64_t pod_arg_size;
   } RunKernelMsg_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) DeviceInfoMsg_s
+  typedef struct __attribute__ ((packed)) DeviceInfoMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     /* If non-zero, the client has requested a specific device info
        instead of all standard ones at once. */
     cl_device_info id;
@@ -631,15 +662,17 @@ extern "C"
 
   /* ########################## */
 
-  typedef struct __attribute__ ((packed, aligned (8))) PeerHandshake_s
+  typedef struct __attribute__ ((packed)) PeerHandshake_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t peer_id;
   } PeerHandshake_t;
 
   /* ########################## */
 
-  typedef struct __attribute__ ((packed, aligned (8))) RequestMsg_s
+  typedef struct __attribute__ ((packed)) RequestMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t session;
     uint8_t authkey[AUTHKEY_LENGTH];
     uint64_t msg_id;
@@ -708,8 +741,9 @@ extern "C"
     Local
   } PoclRemoteArgType;
 
-  typedef struct __attribute__ ((packed, aligned (8))) ArgumentInfo_s
+  typedef struct __attribute__ ((packed)) ArgumentInfo_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     STRING_TYPE (name);
     STRING_TYPE (type_name);
     uint32_t address_qualifier;
@@ -743,8 +777,9 @@ extern "C"
     uint64_t completed;
   } EventTiming_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) KernelMetaInfo_s
+  typedef struct __attribute__ ((packed)) KernelMetaInfo_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     STRING_TYPE (name);
     STRING_TYPE (attributes);
     vec3_t reqd_wg_size;
@@ -752,8 +787,9 @@ extern "C"
     uint32_t num_args;
   } KernelMetaInfo_t;
 
-  typedef struct __attribute__ ((packed, aligned (8))) ReplyMsg_s
+  typedef struct __attribute__ ((packed)) ReplyMsg_s
   {
+    POCL_ALIGNAS(8) // Meant for aligning the structure, not the members.
     uint64_t msg_id;
     // this is the Platform ID on remote side
     uint32_t pid;

--- a/include/pocl.h
+++ b/include/pocl.h
@@ -67,6 +67,19 @@ typedef uint64_t pocl_obj_id_t;
 #define CL_KHRONOS_VENDOR_ID_POCL 0x10006
 #endif
 
+#if __cplusplus >= 201103L
+#  define POCL_ALIGNAS(x) alignas(x)
+#elif __STDC_VERSION__ >= 201112L /* C11 */
+#  define POCL_ALIGNAS(x) _Alignas(x)
+#elif defined(_MSC_VER)
+#  define POCL_ALIGNAS(x) __declspec(align(x))
+#elif defined(__clang__) || defined(__GNUC__)
+#  define POCL_ALIGNAS(x) __attribute__ ((aligned (x)))
+#else
+/* Emit an error for potential correctness issues if alignas() is ignored. */
+#  error "Don't know alignas() counterpart for this compiler!"
+#endif
+
 /* represents a single buffer to host memory mapping */
 typedef struct mem_mapping
 {

--- a/lib/CL/devices/almaif/openasip/AlmaifCompileOpenasip.cc
+++ b/lib/CL/devices/almaif/openasip/AlmaifCompileOpenasip.cc
@@ -522,6 +522,7 @@ void pocl_almaif_openasip_produce_standalone_program(AlmaifData *D,
   out << "#include \"almaif-tce-device-defs.h\"" << std::endl << std::endl;
 
   out << "#undef ALIGN4" << std::endl;
+  // Using __attribute__ is fine here as the code is passed to clang.
   out << "#define ALIGN4 __attribute__ ((aligned (4)))" << std::endl;
 
   /* The standalone binary shall have the same input data as in the original

--- a/lib/CL/devices/almaif/openasip/AlmaifCompileOpenasip.hh
+++ b/lib/CL/devices/almaif/openasip/AlmaifCompileOpenasip.hh
@@ -42,8 +42,7 @@ void pocl_almaif_openasip_produce_standalone_program(AlmaifData *D,
 char *pocl_almaif_openasip_init_build(void *data);
 
 typedef struct openasip_backend_data_s {
-  pocl_lock_t openasip_compile_lock
-      __attribute__((aligned(HOST_CPU_CACHELINE_SIZE)));
+  POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) pocl_lock_t openasip_compile_lock;
   std::string machine_file;
   int core_count;
 } openasip_backend_data_t;

--- a/lib/CL/devices/common_utils.h
+++ b/lib/CL/devices/common_utils.h
@@ -40,11 +40,11 @@
 typedef struct kernel_run_command kernel_run_command;
 struct kernel_run_command
 {
-  pocl_lock_t lock __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+  POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) pocl_lock_t lock;
   void *data;
   cl_kernel kernel;
   cl_device_id device;
-  struct pocl_context pc __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+  POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) struct pocl_context pc;
   _cl_command_node *cmd;
   pocl_workgroup_func workgroup;
   struct pocl_argument *kernel_args;
@@ -60,7 +60,7 @@ struct kernel_run_command
 
   size_t remaining_wgs;
   size_t wgs_dealt;
-} __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+};
 
 #ifdef __cplusplus
 extern "C"

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -50,7 +50,7 @@ static void* pocl_pthread_driver_thread (void *p);
 
 struct pool_thread_data
 {
-  pocl_thread_t thread __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+  POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) pocl_thread_t thread;
 
   unsigned long executed_commands;
   /* per-CU (= per-thread) local memory */
@@ -64,14 +64,13 @@ struct pool_thread_data
   unsigned index;
   /* printf buffer*/
   void *printf_buffer;
-} __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+};
 
 typedef struct scheduler_data_
 {
-  pocl_cond_t wake_pool __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
-  pocl_lock_t wq_lock_fast __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
-  _cl_command_node *work_queue
-      __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+  POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) pocl_cond_t wake_pool;
+  POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) pocl_lock_t wq_lock_fast;
+  POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) _cl_command_node *work_queue;
 
   unsigned num_threads;
   unsigned printf_buf_size;
@@ -85,9 +84,8 @@ typedef struct scheduler_data_
   kernel_run_command *kernel_queue;
 #endif
 
-  pocl_barrier_t init_barrier
-    __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
-} scheduler_data __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+  POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) pocl_barrier_t init_barrier;
+} scheduler_data;
 
 static scheduler_data scheduler;
 

--- a/lib/CL/devices/tbb/tbb_scheduler.h
+++ b/lib/CL/devices/tbb/tbb_scheduler.h
@@ -51,13 +51,11 @@ extern "C"
 
   typedef struct
   {
-    pocl_cond_t wake_meta_thread
-      __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
-    pocl_lock_t wq_lock_fast
-      __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+    POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) pocl_cond_t wake_meta_thread;
+    POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) pocl_lock_t wq_lock_fast;
     _cl_command_node *work_queue;
 
-    size_t local_mem_size __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+    POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) size_t local_mem_size;
     char *local_mem_global_ptr;
 
     uchar *printf_buf_global_ptr;
@@ -71,8 +69,7 @@ extern "C"
 
     pocl_thread_t meta_thread;
     int meta_thread_shutdown_requested;
-  } pocl_tbb_scheduler_data
-      __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+  } pocl_tbb_scheduler_data;
 
   size_t tbb_get_numa_nodes ();
 

--- a/lib/CL/devices/tce/ttasim/ttasim.cc
+++ b/lib/CL/devices/tce/ttasim/ttasim.cc
@@ -347,6 +347,7 @@ public:
     out << "#include <pocl_device.h>" << std::endl << std::endl;
 
     out << "#undef ALIGN4" << std::endl;
+    // The __attribute__s are fine here as the code is passed to clang.
     out << "#define ALIGN4 __attribute__ ((aligned (4)))" << std::endl;
     out << "#define __local__ __attribute__((address_space(" <<  TTA_ASID_LOCAL<< ")))" << std::endl;
     out << "#define __global__ __attribute__((address_space(" << TTA_ASID_GLOBAL << ")))" << std::endl;

--- a/lib/CL/devices/vulkan/pocl-vulkan.c
+++ b/lib/CL/devices/vulkan/pocl-vulkan.c
@@ -313,12 +313,10 @@ typedef struct pocl_vulkan_device_data_s
   _cl_command_node *work_queue;
 
   /* driver wake + lock */
-  pthread_cond_t wakeup_cond
-      __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
-  pocl_lock_t wq_lock_fast __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+  POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) pthread_cond_t wakeup_cond;
+  POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) pocl_lock_t wq_lock_fast;
 
-  size_t driver_thread_exit_requested
-      __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+  POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) size_t driver_thread_exit_requested;
   /* device pthread */
   pthread_t driver_pthread_id;
 

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -100,7 +100,7 @@
 #endif
 
 #ifdef __linux__
-#define ALIGN_CACHE(x) x __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)))
+#define ALIGN_CACHE(x) POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) x
 #else
 #define ALIGN_CACHE(x) x
 #endif

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -2679,10 +2679,8 @@ struct _pocl_async_callback_item
 };
 
 static pocl_async_callback_item *async_callback_list = NULL;
-static pocl_cond_t async_cb_wake_cond
-  __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
-static pocl_lock_t async_cb_lock
-  __attribute__ ((aligned (HOST_CPU_CACHELINE_SIZE)));
+POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) static pocl_cond_t async_cb_wake_cond;
+POCL_ALIGNAS(HOST_CPU_CACHELINE_SIZE) static pocl_lock_t async_cb_lock;
 static int exit_pocl_async_callback_thread = CL_FALSE;
 static pocl_thread_t async_callback_thread_id = 0;
 

--- a/poclu/poclu.h
+++ b/poclu/poclu.h
@@ -41,6 +41,18 @@
 extern "C" {
 #endif
 
+#if __cplusplus >= 201103L
+#  define POCLU_ALIGNAS(x) alignas(x)
+#elif __STDC_VERSION__ >= 201112L /* C11 */
+#  define POCLU_ALIGNAS(x) _Alignas(x)
+#elif defined(_MSC_VER)
+#  define POCLU_ALIGNAS(x) __declspec(align(x))
+#elif defined(__clang__) || defined(__GNUC__)
+#  define POCLU_ALIGNAS(x) __attribute__ ((aligned (x)))
+#else
+#  error "Don't know alignas/aligned/align counterpart for this compiler!"
+#endif
+
 /**
 * \brief Byte swap functions for endianness swapping between the host
 * (current CPU) and a target device.

--- a/tests/kernel/test_shuffle.cc
+++ b/tests/kernel/test_shuffle.cc
@@ -44,11 +44,11 @@ class TestShuffle {
 
   cl_program prog;
 
-  D in1 [16] __attribute__ ((aligned (128)));
-  D in2 [16] __attribute__ ((aligned (128)));
-  D out [16] __attribute__ ((aligned (128)));
-  M mask1 [16] __attribute__ ((aligned (128)));
-  M mask2 [16] __attribute__ ((aligned (128)));
+  POCLU_ALIGNAS(128) D in1 [16];
+  POCLU_ALIGNAS(128) D in2 [16];
+  POCLU_ALIGNAS(128) D out [16];
+  POCLU_ALIGNAS(128) M mask1 [16];
+  POCLU_ALIGNAS(128) M mask2 [16];
   const char* ocl_type;
   unsigned size;
   cl_int errcode;

--- a/tests/regression/test_structs_as_args.cpp
+++ b/tests/regression/test_structs_as_args.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "pocl_opencl.h"
+#include "poclu.h"
 
 // Enable OpenCL C++ exceptions
 #define CL_HPP_ENABLE_EXCEPTIONS
@@ -55,7 +56,7 @@ struct int_pair {
 
 // i386 has a default alignment of 4 even for 64-bit types
 #ifdef __i386__
-#define CL_LONG_ALIGNMENT __attribute__((aligned(8)))
+#define CL_LONG_ALIGNMENT POCLU_ALIGNAS(8)
 #else
 #define CL_LONG_ALIGNMENT
 #endif


### PR DESCRIPTION
... with `POCL_ALIGNAS(...)` and `POCLU_ALIGNAS(...)` and map them to `_Alignas()`, `alignas()` or corresponding supported compiler extension (e.g. `__declspec(align(...))` on MSVC).