### PR TITLE
Fix few file handling issues

### DIFF
--- a/bin/poclcc.c
+++ b/bin/poclcc.c
@@ -406,7 +406,7 @@ main(int argc, char **argv)
   CHECK_CL_ERROR(clReleaseProgram(program));
   CHECK_CL_ERROR(clReleaseContext(context));
 
-  if (poclu_write_file(output_file, binary, binary_sizes))
+  if (poclu_write_binfile (output_file, binary, binary_sizes))
     ERRNO_EXIT(output_file);
 
   free(binary);

--- a/doc/sphinx/source/pocl_binary.rst
+++ b/doc/sphinx/source/pocl_binary.rst
@@ -54,7 +54,7 @@ Here is an example on how to create a program from a file:
    size_t binary_size;
    FILE *f;
 
-   f = fopen("youfile", "r"); // LLVM IR file or POCLCC binary file
+   f = fopen("youfile", "rb"); // LLVM IR file or POCLCC binary file
 
    fseek(f, 0, SEEK_END);
    binary_size = ftell(f);
@@ -62,7 +62,7 @@ Here is an example on how to create a program from a file:
 
    binary = malloc(binary_size);
    fread(binary, 1, binary_size, f);
-   
+
    fclose(f);
 
    cl_platform_id platform_id;

--- a/examples/accel/OpenCLcontext.cpp
+++ b/examples/accel/OpenCLcontext.cpp
@@ -355,7 +355,7 @@ bool OpenCL_Context::processCameraFrame(unsigned char* input, unsigned long *out
 #ifdef DUMP_FRAMES
     char filename[1024];
     std::snprintf(filename, 1024, "/tmp/carla_%u_%zu.raw", imgID, *output);
-    FILE* outfile = std::fopen(filename, "w");
+    FILE *outfile = std::fopen(filename, "wb");
     std::fwrite(input, 1, InputBufferSize, outfile);
     std::fclose(outfile);
     ++imgID;

--- a/examples/scalarwave/scalarwave.c
+++ b/examples/scalarwave/scalarwave.c
@@ -121,7 +121,8 @@ main(void)
       return 77;
     }
 
-  FILE *const source_file = fopen(SRCDIR "/examples/scalarwave/scalarwave.cl", "r");
+  FILE *const source_file
+      = fopen (SRCDIR "/examples/scalarwave/scalarwave.cl", "rb");
   TEST_ASSERT (source_file != NULL && "scalarwave.cl not found!");
   
   fseek(source_file, 0, SEEK_END);

--- a/poclu/misc.c
+++ b/poclu/misc.c
@@ -251,7 +251,7 @@ poclu_read_file (const char *filename)
   return res;
 }
 
-static int
+int
 poclu_write_file_in_mode (const char *filename, char *content, size_t size,
                           const char *mode)
 {
@@ -274,15 +274,9 @@ poclu_write_file_in_mode (const char *filename, char *content, size_t size,
 }
 
 int
-poclu_write_file (const char *filename, char *content, size_t size)
+poclu_write_binfile (const char *file, char *content, size_t size)
 {
-  return poclu_write_file_in_mode (filename, content, size, "w");
-}
-
-int
-poclu_write_binfile (const char *filename, char *content, size_t size)
-{
-  return poclu_write_file_in_mode (filename, content, size, "wb");
+  return poclu_write_file_in_mode (file, content, size, "wb");
 }
 
 int

--- a/poclu/misc.c
+++ b/poclu/misc.c
@@ -251,12 +251,13 @@ poclu_read_file (const char *filename)
   return res;
 }
 
-int
-poclu_write_file (const char *filename, char *content, size_t size)
+static int
+poclu_write_file_in_mode (const char *filename, char *content, size_t size,
+                          const char *mode)
 {
   FILE *file;
 
-  file = fopen (filename, "w");
+  file = fopen (filename, mode);
   if (file == NULL)
     return -1;
 
@@ -270,6 +271,18 @@ poclu_write_file (const char *filename, char *content, size_t size)
     return -1;
 
   return 0;
+}
+
+int
+poclu_write_file (const char *filename, char *content, size_t size)
+{
+  return poclu_write_file_in_mode (filename, content, size, "w");
+}
+
+int
+poclu_write_binfile (const char *filename, char *content, size_t size)
+{
+  return poclu_write_file_in_mode (filename, content, size, "wb");
 }
 
 int

--- a/poclu/poclu.h
+++ b/poclu/poclu.h
@@ -302,6 +302,13 @@ POCLU_API int POCLU_CALL poclu_write_file (const char *filename, char *content,
 int poclu_parse_version_string (const char *string);
 
 /**
+ * Same as poclu_write_file() but with contents written into the file in
+ * binary mode.
+ */
+POCLU_API int POCLU_CALL poclu_write_binfile (const char *filename,
+                                              char *content, size_t size);
+
+/**
  * \brief wrapper for poclu_load_program_multidev, see it for details.
  */
 int poclu_load_program (cl_platform_id platform,

--- a/poclu/poclu.h
+++ b/poclu/poclu.h
@@ -281,7 +281,7 @@ POCLU_API int POCLU_CALL poclu_supports_extension (cl_device_id dev,
 POCLU_API char *POCLU_CALL poclu_read_binfile (const char *filename,
                                                size_t *len);
 /**
- * \brief write content to a file.
+ * \brief write content to a file in text mode.
  *
  * filename can absolute or relative, according to the fopen
  * implementation on system.

--- a/poclu/poclu.h
+++ b/poclu/poclu.h
@@ -280,18 +280,20 @@ POCLU_API int POCLU_CALL poclu_supports_extension (cl_device_id dev,
  */
 POCLU_API char *POCLU_CALL poclu_read_binfile (const char *filename,
                                                size_t *len);
+
 /**
- * \brief write content to a file in text mode.
+ * Write content to a file in the given mode.
  *
- * filename can absolute or relative, according to the fopen
+ * The file can absolute or relative path, according to the fopen
  * implementation on system.
- * @param filename [in] string to the file.
- * @param content [in] string to be written.
- * @param size [in] size of the content.
- * @return -1 if there is any error otherwise 0.
+ *
+ * \param size The number of bytes to be written.
+ * \param mode The mode is in fopen().
+ * \return -1 if there is any error, otherwise 0.
  */
-POCLU_API int POCLU_CALL poclu_write_file (const char *filename, char *content,
-                                           size_t size);
+POCLU_API int POCLU_CALL poclu_write_file_in_mode (const char *file,
+                                                   char *content, size_t size,
+                                                   const char *mode);
 
 /**
  * Parse a platform or device version string.
@@ -302,11 +304,10 @@ POCLU_API int POCLU_CALL poclu_write_file (const char *filename, char *content,
 int poclu_parse_version_string (const char *string);
 
 /**
- * Same as poclu_write_file() but with contents written into the file in
- * binary mode.
+ * Same as poclu_write_file(file, content, size, "wb").
  */
-POCLU_API int POCLU_CALL poclu_write_binfile (const char *filename,
-                                              char *content, size_t size);
+POCLU_API int POCLU_CALL poclu_write_binfile (const char *file, char *content,
+                                              size_t size);
 
 /**
  * \brief wrapper for poclu_load_program_multidev, see it for details.

--- a/tests/runtime/test_dbk_jpeg.c
+++ b/tests/runtime/test_dbk_jpeg.c
@@ -189,7 +189,7 @@ main (int argc, char const *argv[])
   void *output_array = malloc (input_size);
   clEnqueueReadBuffer (queues[0], output_buf, CL_TRUE, 0, input_size,
                        output_array, 1, &size_read_event, NULL);
-  poclu_write_file (argv[4], output_array, input_size);
+  poclu_write_binfile (argv[4], output_array, input_size);
   free (output_array);
 #endif
 

--- a/tests/runtime/test_kernel_cache_includes.c
+++ b/tests/runtime/test_kernel_cache_includes.c
@@ -34,8 +34,9 @@ int main(int argc, char **argv)
   krn_src = poclu_read_file(SRCDIR "/tests/runtime/test_kernel_cache_includes.cl");
   TEST_ASSERT(krn_src);
 
-  err = poclu_write_file(BUILDDIR "/tests/runtime/test_include.h", first_include,
-                         sizeof(first_include)-1);
+  err = poclu_write_file_in_mode (BUILDDIR "/tests/runtime/test_include.h",
+                                  first_include, sizeof (first_include) - 1,
+                                  "w");
   TEST_ASSERT(err == 0);
 
   program = clCreateProgramWithSource(ctx, 1, &krn_src, NULL, &err);
@@ -61,8 +62,9 @@ int main(int argc, char **argv)
   program2 = clCreateProgramWithSource(ctx, 1, &krn_src, NULL, &err);
   CHECK_OPENCL_ERROR_IN("clCreateProgramWithSource 2");
 
-  err = poclu_write_file(BUILDDIR "/tests/runtime/test_include.h", second_include,
-                         sizeof(second_include)-1);
+  err = poclu_write_file_in_mode (BUILDDIR "/tests/runtime/test_include.h",
+                                  second_include, sizeof (second_include) - 1,
+                                  "w");
   TEST_ASSERT(err == 0);
 
   err = clBuildProgram(program2, 0, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
* Fix writing a binary to a file in *text mode* garbled the contents due to special handling of some characters on Windows.

* Fix kernel sources got truncated due to `ftell()` returning a value that does not match to the actual file size (on Windows) if the file is opened in text mode ("If the stream is open in text mode, the value returned by this function is unspecified and is only meaningful as the input to fseek()").

* Fix documentation sugggested use of `ftell()` on a file opened in text mode.