### PR TITLE
Use interprocess mutex for llvm_codegen() on Windows

### DIFF
--- a/lib/CL/CMakeLists.txt
+++ b/lib/CL/CMakeLists.txt
@@ -224,6 +224,10 @@ if(APPLE)
   list(APPEND POCL_LIB_SOURCES "pthread_barrier.c")
 endif()
 
+if(WIN32)
+  list(APPEND POCL_LIB_SOURCES "pocl_ipc_mutex_win.cc")
+endif()
+
 set(LIBPOCL_OBJS "$<TARGET_OBJECTS:libpocl_unlinked_objs>"
                  "$<TARGET_OBJECTS:pocl_cache>")
 

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -39,6 +39,7 @@
 #include <utlist.h>
 
 #ifdef _WIN32
+#include "pocl_ipc_mutex.h"
 #include "vccompat.hpp"
 #endif
 
@@ -124,6 +125,19 @@ llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
   char final_binary_path[POCL_MAX_PATHNAME_LENGTH];
   pocl_cache_final_binary_path (final_binary_path, program, device_i, kernel,
                                 command, specialize);
+
+#ifdef _WIN32
+  // Avoid race condition of multiple processes accessing same files.
+  char MtxName[MAX_PATH];
+  strncpy (MtxName, program->build_hash[device_i], MAX_PATH);
+  MtxName[MAX_PATH - 1] = '\0';
+  pocl_ipc_mutex_t ipc_mtx;
+  error = pocl_ipc_mutex_create_and_lock (MtxName, &ipc_mtx);
+  assert (!error && "IPC mutex lock failure!");
+  // For release builds, continue despite not having the mutex - maybe we are
+  // in luck not having a race condition.
+  int have_locked_mutex = !error;
+#endif
 
   if (pocl_exists (final_binary_path))
     goto FINISH;
@@ -251,6 +265,7 @@ llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
 
   /* rename temporary kernel.so */
   error = pocl_rename (tmp_module, final_binary_path);
+
   if (error)
     {
       POCL_MSG_PRINT_LLVM (
@@ -279,6 +294,10 @@ llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
     }
 
 FINISH:
+#ifdef _WIN32
+  if (have_locked_mutex)
+    pocl_ipc_mutex_unlock_and_release (&ipc_mtx);
+#endif
   pocl_destroy_llvm_module (llvm_module, kernel->context);
   POCL_MEM_FREE (objfile);
   POCL_MEASURE_FINISH (llvm_codegen);

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -127,8 +127,8 @@ llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
                                 command, specialize);
 
 #ifdef _WIN32
-  // Avoid race condition of multiple processes accessing same files.
-  char MtxName[MAX_PATH];
+  /* Avoid race condition of multiple processes accessing same files. */
+  char MtxName[MAX_PATH];  /* MAX_PATH is defined by Windows API.  */
   strncpy (MtxName, program->build_hash[device_i], MAX_PATH);
   MtxName[MAX_PATH - 1] = '\0';
   pocl_ipc_mutex_t ipc_mtx;

--- a/lib/CL/pocl_ipc_mutex.h
+++ b/lib/CL/pocl_ipc_mutex.h
@@ -50,7 +50,7 @@ int pocl_ipc_mutex_create (const char *name, pocl_ipc_mutex_t *ipc_mtx);
  * has locked the mutex. The mutex is unlocked in case the process
  * holding the lock terminates without unlocking first.
  *
- * The 'ípc_mtx' must be a valid object created by pocl_ipc_mutex_create().
+ * The 'ipc_mtx' must be a valid object created by pocl_ipc_mutex_create().
  *
  * If mutex is locked successfully, zero is returned. Otherwise, on an error,
  * non-zero is returned.  */
@@ -58,7 +58,7 @@ int pocl_ipc_mutex_lock (pocl_ipc_mutex_t ipc_mtx);
 
 /** Combined variant of pocl_ipc_mutex_create() and pocl_ipc_mutex_lock().  */
 int pocl_ipc_mutex_create_and_lock (const char *name,
-                                      pocl_ipc_mutex_t *ipc_mtx);
+                                    pocl_ipc_mutex_t *ipc_mtx);
 
 /** Releases the mutex.
  *

--- a/lib/CL/pocl_ipc_mutex.h
+++ b/lib/CL/pocl_ipc_mutex.h
@@ -1,0 +1,77 @@
+/* pocl_ipc_mutex.h: Named interprocess mutex
+
+   Copyright (c) 2024 Henry Linjamäki / Intel Finland Oy
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+/* This header hosts API for named interprocess mutex that does not
+ * cause deadlock if a process dies or exits without unlocking
+ * first. Beware that deadlocks are still possible within process if a
+ * thread forgets to unlock the mutex.  */
+
+#ifndef POCL_IPC_MUTEX_H
+#define POCL_IPC_MUTEX_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct pocl_ipc_mutex_s
+{
+  void *handle;
+} pocl_ipc_mutex_t;
+
+/** Creates a mutex by 'name' or opens an existing one.
+ *
+ * On success, the return value is zero and a valid mutex object returned
+ * via 'ipc_mtx'.  */
+int pocl_ipc_mutex_create (const char *name, pocl_ipc_mutex_t *ipc_mtx);
+
+/** Lock the mutex.
+ *
+ * The call is blocked if another process or thread by the same name
+ * has locked the mutex. The mutex is unlocked in case the process
+ * holding the lock terminates without unlocking first.
+ *
+ * The 'ípc_mtx' must be a valid object created by pocl_ipc_mutex_create().
+ *
+ * If mutex is locked successfully, zero is returned. Otherwise, on an error,
+ * non-zero is returned.  */
+int pocl_ipc_mutex_lock (pocl_ipc_mutex_t ipc_mtx);
+
+/** Combined variant of pocl_ipc_mutex_create() and pocl_ipc_mutex_lock().  */
+int pocl_ipc_mutex_create_and_lock (const char *name,
+                                      pocl_ipc_mutex_t *ipc_mtx);
+
+/** Releases the mutex.
+ *
+ * The behavior is undefined if the mutex is still locked.  */
+void pocl_ipc_mutex_release (pocl_ipc_mutex_t *ipc_mtx);
+
+/** Unlocks the mutex and then releases the mutex object
+ *
+ * The behavior is undefined if the mutex has not been locked.  */
+void pocl_ipc_mutex_unlock_and_release (pocl_ipc_mutex_t *ipc_mtx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/CL/pocl_ipc_mutex.h
+++ b/lib/CL/pocl_ipc_mutex.h
@@ -42,7 +42,8 @@ typedef struct pocl_ipc_mutex_s
  *
  * On success, the return value is zero and a valid mutex object returned
  * via 'ipc_mtx'.  */
-int pocl_ipc_mutex_create (const char *name, pocl_ipc_mutex_t *ipc_mtx);
+int
+pocl_ipc_mutex_create (const char *name, pocl_ipc_mutex_t *ipc_mtx);
 
 /** Lock the mutex.
  *
@@ -54,21 +55,25 @@ int pocl_ipc_mutex_create (const char *name, pocl_ipc_mutex_t *ipc_mtx);
  *
  * If mutex is locked successfully, zero is returned. Otherwise, on an error,
  * non-zero is returned.  */
-int pocl_ipc_mutex_lock (pocl_ipc_mutex_t ipc_mtx);
+int
+pocl_ipc_mutex_lock (pocl_ipc_mutex_t ipc_mtx);
 
 /** Combined variant of pocl_ipc_mutex_create() and pocl_ipc_mutex_lock().  */
-int pocl_ipc_mutex_create_and_lock (const char *name,
-                                    pocl_ipc_mutex_t *ipc_mtx);
+int
+pocl_ipc_mutex_create_and_lock (const char *name,
+                                pocl_ipc_mutex_t *ipc_mtx);
 
 /** Releases the mutex.
  *
  * The behavior is undefined if the mutex is still locked.  */
-void pocl_ipc_mutex_release (pocl_ipc_mutex_t *ipc_mtx);
+void
+pocl_ipc_mutex_release (pocl_ipc_mutex_t *ipc_mtx);
 
 /** Unlocks the mutex and then releases the mutex object
  *
  * The behavior is undefined if the mutex has not been locked.  */
-void pocl_ipc_mutex_unlock_and_release (pocl_ipc_mutex_t *ipc_mtx);
+void
+pocl_ipc_mutex_unlock_and_release (pocl_ipc_mutex_t *ipc_mtx);
 
 #ifdef __cplusplus
 }

--- a/lib/CL/pocl_ipc_mutex.h
+++ b/lib/CL/pocl_ipc_mutex.h
@@ -1,6 +1,6 @@
 /* pocl_ipc_mutex.h: Named interprocess mutex
 
-   Copyright (c) 2024 Henry Linjam‰ki / Intel Finland Oy
+   Copyright (c) 2024 Henry Linjam√§ki / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to
@@ -20,7 +20,7 @@
    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
    IN THE SOFTWARE.
 */
-/* This header hosts API for named interprocess mutex that does not
+/* \file pocl_ip_mutex.h named interprocess mutex that does not
  * cause deadlock if a process dies or exits without unlocking
  * first. Beware that deadlocks are still possible within process if a
  * thread forgets to unlock the mutex.  */
@@ -50,7 +50,7 @@ int pocl_ipc_mutex_create (const char *name, pocl_ipc_mutex_t *ipc_mtx);
  * has locked the mutex. The mutex is unlocked in case the process
  * holding the lock terminates without unlocking first.
  *
- * The 'Ìpc_mtx' must be a valid object created by pocl_ipc_mutex_create().
+ * The '√≠pc_mtx' must be a valid object created by pocl_ipc_mutex_create().
  *
  * If mutex is locked successfully, zero is returned. Otherwise, on an error,
  * non-zero is returned.  */

--- a/lib/CL/pocl_ipc_mutex_win.cc
+++ b/lib/CL/pocl_ipc_mutex_win.cc
@@ -1,7 +1,7 @@
 /* pocl_ipc_mutex.h: Named interprocess mutex that does not cause deadlock if a
    process dies or exits without unlocking.
 
-   Copyright (c) 2024 Henry Linjam‰ki / Intel Finland Oy
+   Copyright (c) 2024 Henry Linjam√§ki / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/lib/CL/pocl_ipc_mutex_win.cc
+++ b/lib/CL/pocl_ipc_mutex_win.cc
@@ -1,0 +1,111 @@
+/* pocl_ipc_mutex.h: Named interprocess mutex that does not cause deadlock if a
+   process dies or exits without unlocking.
+
+   Copyright (c) 2024 Henry Linjamäki / Intel Finland Oy
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+#include "pocl_debug.h"
+#include "pocl_ipc_mutex.h"
+
+#include <windows.h>
+
+#include <cassert>
+#include <string>
+
+extern "C" int pocl_ipc_mutex_create(const char *Name,
+                                     pocl_ipc_mutex_t *IpcMtx) {
+  assert(IpcMtx && "IpcMtx must not be nullptr!");
+  if (std::string(Name).size() > MAX_PATH) {
+    POCL_MSG_ERR("The mutex name exceeds an OS limit.");
+    return -1;
+  }
+
+  HANDLE MtxHandle = CreateMutexA(NULL, FALSE, Name);
+  if (MtxHandle == NULL) {
+    POCL_MSG_ERR("CreateMutexA returned an error. GetLastError()=%zu\n",
+                 static_cast<size_t>(GetLastError()));
+    return -1;
+  }
+  IpcMtx->handle = static_cast<void *>(MtxHandle);
+  return 0;
+}
+
+extern "C" int pocl_ipc_mutex_lock(pocl_ipc_mutex_t IpcMtx) {
+  assert(IpcMtx.handle && "pocl_ipc_mutex_create() must be called first!");
+  auto MtxHandle = static_cast<HANDLE>(IpcMtx.handle);
+  switch (WaitForSingleObject(MtxHandle, INFINITE)) {
+  case WAIT_ABANDONED:
+    POCL_MSG_WARN(
+        "Another thread/process terminated before unlocking this mutex.");
+    // FALL-THROUGH
+  case WAIT_OBJECT_0:
+    return 0;
+
+  case WAIT_FAILED:
+    POCL_MSG_WARN("Couldn't unlock an IPC mutex. GetLastError()=%zu\n",
+                  static_cast<size_t>(GetLastError()));
+    return -1;
+
+  case WAIT_TIMEOUT:
+  default:
+    assert(!"Unexpected wait state!");
+    return -1;
+  }
+
+  return 0;
+}
+
+extern "C" int pocl_ipc_mutex_create_and_lock(const char *Name,
+                                              pocl_ipc_mutex_t *IpcMtx) {
+  assert(IpcMtx && "IpcMtx must not be nullptr!");
+  if (int error = pocl_ipc_mutex_create(Name, IpcMtx))
+    return error;
+  if (int error = pocl_ipc_mutex_lock(*IpcMtx)) {
+    pocl_ipc_mutex_release(IpcMtx);
+    return error;
+  }
+  return 0;
+}
+
+extern "C" void pocl_ipc_mutex_release(pocl_ipc_mutex_t *IpcMtx) {
+  assert(IpcMtx && "Invalid pocl_ipc_mutex_t handle!");
+  auto MtxHandle = static_cast<HANDLE>(IpcMtx->handle);
+  if (!CloseHandle(MtxHandle)) {
+    POCL_MSG_WARN("CloseHandle returned an error. GetLastError()=%zu\n",
+                  static_cast<size_t>(GetLastError()));
+    assert(!"Failed to release an IPC mutex!");
+  }
+  IpcMtx->handle = NULL;
+}
+
+extern "C" void pocl_ipc_mutex_unlock_and_release(pocl_ipc_mutex_t *IpcMtx) {
+  assert(IpcMtx && "Invalid pocl_ipc_mutex_t handle!");
+  if (IpcMtx->handle == nullptr)
+    return;
+
+  auto MtxHandle = static_cast<HANDLE>(IpcMtx->handle);
+  if (!ReleaseMutex(MtxHandle)) {
+    POCL_MSG_WARN("ReleaseMutex returned an error. GetLastError()=%zu\n",
+                  static_cast<size_t>(GetLastError()));
+    assert(!"Failed to release an IPC mutex!");
+  }
+  pocl_ipc_mutex_release(IpcMtx);
+}

--- a/lib/CL/pocl_ipc_mutex_win.cc
+++ b/lib/CL/pocl_ipc_mutex_win.cc
@@ -30,8 +30,7 @@
 #include <cassert>
 #include <string>
 
-extern "C" int pocl_ipc_mutex_create(const char *Name,
-                                     pocl_ipc_mutex_t *IpcMtx) {
+int pocl_ipc_mutex_create(const char *Name, pocl_ipc_mutex_t *IpcMtx) {
   assert(IpcMtx && "IpcMtx must not be nullptr!");
   if (std::string(Name).size() > MAX_PATH) {
     POCL_MSG_ERR("The mutex name exceeds an OS limit.");
@@ -48,7 +47,7 @@ extern "C" int pocl_ipc_mutex_create(const char *Name,
   return 0;
 }
 
-extern "C" int pocl_ipc_mutex_lock(pocl_ipc_mutex_t IpcMtx) {
+int pocl_ipc_mutex_lock(pocl_ipc_mutex_t IpcMtx) {
   assert(IpcMtx.handle && "pocl_ipc_mutex_create() must be called first!");
   auto MtxHandle = static_cast<HANDLE>(IpcMtx.handle);
   switch (WaitForSingleObject(MtxHandle, INFINITE)) {
@@ -73,8 +72,7 @@ extern "C" int pocl_ipc_mutex_lock(pocl_ipc_mutex_t IpcMtx) {
   return 0;
 }
 
-extern "C" int pocl_ipc_mutex_create_and_lock(const char *Name,
-                                              pocl_ipc_mutex_t *IpcMtx) {
+int pocl_ipc_mutex_create_and_lock(const char *Name, pocl_ipc_mutex_t *IpcMtx) {
   assert(IpcMtx && "IpcMtx must not be nullptr!");
   if (int error = pocl_ipc_mutex_create(Name, IpcMtx))
     return error;
@@ -85,7 +83,7 @@ extern "C" int pocl_ipc_mutex_create_and_lock(const char *Name,
   return 0;
 }
 
-extern "C" void pocl_ipc_mutex_release(pocl_ipc_mutex_t *IpcMtx) {
+void pocl_ipc_mutex_release(pocl_ipc_mutex_t *IpcMtx) {
   assert(IpcMtx && "Invalid pocl_ipc_mutex_t handle!");
   auto MtxHandle = static_cast<HANDLE>(IpcMtx->handle);
   if (!CloseHandle(MtxHandle)) {
@@ -96,7 +94,7 @@ extern "C" void pocl_ipc_mutex_release(pocl_ipc_mutex_t *IpcMtx) {
   IpcMtx->handle = NULL;
 }
 
-extern "C" void pocl_ipc_mutex_unlock_and_release(pocl_ipc_mutex_t *IpcMtx) {
+void pocl_ipc_mutex_unlock_and_release(pocl_ipc_mutex_t *IpcMtx) {
   assert(IpcMtx && "Invalid pocl_ipc_mutex_t handle!");
   if (IpcMtx->handle == nullptr)
     return;


### PR DESCRIPTION
... to avoid race condition on `pocl_rename()` calls by multiple processes and threads targeting same files. File renaming and moving does not seems to be atomic operation on windows as `pocl_rename()` calls within the `llvm_codegen()` occationally fail while running internal tests parallel with kernel cache cleared.

Add an API for name interprocess mutex and implement it for Windows. Use it avoid the race condition.