### PR TITLE
Fix off-by-one end iterator

### DIFF
--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -1046,7 +1046,7 @@ int pocl_invoke_clang(cl_device_id Device, const char** Args) {
                                   Device->llvm_target_triplet, Diags);
 
   const char **ArgsEnd = Args;
-  while (*ArgsEnd++ != nullptr) {}
+  while (*ArgsEnd != nullptr) { ArgsEnd++; }
   llvm::SmallVector<const char*, 0> ArgsArray(Args, ArgsEnd);
 
   int NumExtraArgs;


### PR DESCRIPTION
This error was mostly harmless as it added an extra array element (C string) which was nullptr. However, it caused a crash while attempting to print the element for debugging.