### PR TITLE
pthread: clean-ups for MSVC toolchain

### DIFF
--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -27,8 +27,6 @@
 
 #include <assert.h>
 #include <errno.h>
-#include <pthread.h>
-#include <sched.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -27,10 +27,8 @@
 #include <sched.h>
 #endif
 
-#include <pthread.h>
 #include <string.h>
 #include <time.h>
-#include <unistd.h>
 
 #include "common.h"
 #include "common_driver.h"
@@ -714,7 +712,7 @@ pocl_pthread_driver_thread (void *p)
         {
           pocl_aligned_free (td->printf_buffer);
           pocl_aligned_free (td->local_mem);
-          pthread_exit (NULL);
+          return NULL;
         }
     }
 }


### PR DESCRIPTION
* Replace `pthread_exit(NULL)` with `return NULL`.

* Remove unused includes.