### PR TITLE
misc: fix warnings with -Wall and -Wextra

### DIFF
--- a/examples/example1/example1.c
+++ b/examples/example1/example1.c
@@ -49,7 +49,8 @@ main (int argc, char **argv)
   cl_float4 *srcA = NULL;
   cl_float4 *srcB = NULL;
   cl_float *dst = NULL;
-  int i, err, spirv, poclbin;
+  int err, spirv, poclbin;
+  cl_uint i;
 
   cl_context context = NULL;
   cl_platform_id platform = NULL;

--- a/lib/CL/clEnqueueUnmapMemObject.c
+++ b/lib/CL/clEnqueueUnmapMemObject.c
@@ -23,6 +23,7 @@
 */
 
 #include "pocl_cl.h"
+#include "pocl_compiler_macros.h"
 #include "pocl_mem_management.h"
 #include "pocl_util.h"
 #include "utlist.h"
@@ -97,6 +98,7 @@ POname(clEnqueueUnmapMemObject)(cl_command_queue command_queue,
 
   /* Release the "mapping reference" which keeps the buffer alive until the
      mapping is on. The command execution should also retain/release. */
+  POCL_UNUSED
   int newrefc;
   POCL_RELEASE_OBJECT (memobj, newrefc);
 

--- a/lib/CL/devices/cpu_dbk/pocl_dbk_khr_onnxrt_cpu.c
+++ b/lib/CL/devices/cpu_dbk/pocl_dbk_khr_onnxrt_cpu.c
@@ -249,7 +249,6 @@ pocl_destroy_ort_instance (onnxrt_instance_t **onnxrt)
   *onnxrt = NULL;
   free (ort);
 
-ERROR:
   return CL_SUCCESS;
 }
 

--- a/lib/CL/devices/printf_base.c
+++ b/lib/CL/devices/printf_base.c
@@ -24,8 +24,7 @@
 
 #include "printf_base.h"
 
-#include <stddef.h>
-#include <stdint.h>
+#include <limits.h>
 #include <stdio.h>
 
 void
@@ -51,7 +50,7 @@ void
 __pocl_printf_ul_base (param_t *p, UINT_T num)
 {
   char temp[SMALL_BUF_SIZE];
-  unsigned i = 0, j = 0;
+  int i = 0, j = 0;
   unsigned digit;
   unsigned base = p->base;
   while (num > 0)
@@ -78,7 +77,7 @@ void
 __pocl_printf_ul16 (param_t *p, UINT_T num)
 {
   char temp[SMALL_BUF_SIZE];
-  unsigned i = 0, j = 0;
+  int i = 0, j = 0;
   unsigned digit;
   const unsigned base = 16;
   char digit_offset = (p->flags.uc ? 'A' : 'a');
@@ -432,17 +431,17 @@ __pocl_printf_puts_ljust (param_t *p,
 {
   char c;
   unsigned written = 0;
-  if (max_width < 0)
-    max_width = INT32_MAX;
+  unsigned max_width_u = max_width >= 0 ? max_width : UINT_MAX;
+
   while ((c = *string++))
     {
-      if (written < max_width)
+      if (written < max_width_u)
         __pocl_printf_putcf (p, c);
       ++written;
     }
   while (written < width)
     {
-      if (written < max_width)
+      if (written < max_width_u)
         __pocl_printf_putcf (p, ' ');
       ++written;
     }
@@ -457,8 +456,7 @@ __pocl_printf_puts_rjust (param_t *p,
 {
   char c;
   unsigned i, strleng = 0, written = 0;
-  if (max_width < 0)
-    max_width = INT32_MAX;
+  unsigned max_width_u = max_width >= 0 ? max_width : UINT_MAX;
 
   const char *tmp = string;
   while ((c = *tmp++))
@@ -466,14 +464,14 @@ __pocl_printf_puts_rjust (param_t *p,
 
   for (i = strleng; i < width; ++i)
     {
-      if (written < max_width)
+      if (written < max_width_u)
         __pocl_printf_putcf (p, ' ');
       ++written;
     }
 
   while ((c = *string++))
     {
-      if (written < max_width)
+      if (written < max_width_u)
         __pocl_printf_putcf (p, c);
       ++written;
     }

--- a/lib/CL/devices/printf_buffer.c
+++ b/lib/CL/devices/printf_buffer.c
@@ -26,6 +26,7 @@
 
 #include "printf_buffer.h"
 #include "common.h"
+#include "pocl_compiler_macros.h"
 #include "pocl_debug.h"
 #include "printf_base.h"
 
@@ -559,6 +560,7 @@ __pocl_printf_format_full (param_t *p, char *buffer, uint32_t buffer_size)
                           {
                             /* .. else fallthrough to double */
                             alloca_length = 8;
+                            POCL_FALLTHROUGH;
                           }
                       case 8:
                         __pocl_print_floats_double (p, buffer, vector_length);

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -1017,7 +1017,7 @@ pocl_remote_build_binary (cl_program program, cl_uint device_i,
 
       program->data[real_i] = pd;
       assert ((!spirv_build && program->binary_sizes[real_i] > 0)
-              || spirv_build && program->program_il_size > 0);
+              || (spirv_build && program->program_il_size > 0));
       assert ((!spirv_build && program->binaries[real_i] != NULL)
               || (spirv_build && program->program_il != NULL));
 
@@ -2736,7 +2736,7 @@ pocl_remote_set_kernel_exec_info_ext (cl_device_id dev,
     case CL_KERNEL_EXEC_INFO_SVM_PTRS:
     case CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL:
       {
-        for (int i = 0; i < param_value_size / sizeof (void *); ++i)
+        for (size_t i = 0; i < param_value_size / sizeof (void *); ++i)
           {
             struct _pocl_ptr_list_node *n
                 = malloc (sizeof (struct _pocl_ptr_list_node));

--- a/lib/CL/pocl_binary.c
+++ b/lib/CL/pocl_binary.c
@@ -874,7 +874,7 @@ pocl_binary_get_kernels_metadata (cl_program program, unsigned device_i)
       BUFFER_READ(len, uint64_t);
       assert (len > 0);
       buffer += len;
-      assert (buffer - start <= max_len);
+      assert ((size_t) (buffer - start) <= max_len);
     }
 
   unsigned j;

--- a/lib/CL/pocl_builtin_kernels.c
+++ b/lib/CL/pocl_builtin_kernels.c
@@ -886,9 +886,14 @@ pocl_copy_defined_builtin_attributes (BuiltinKernelId kernel_id,
           = (cl_dbk_attributes_exp_gemm *)kernel_attributes;
         memcpy (attrs, src, sizeof (cl_dbk_attributes_exp_gemm));
         err = pocl_copy_tensor_desc_layout (&attrs->a, &src->a);
-        err = pocl_copy_tensor_desc_layout (&attrs->b, &src->b);
-        err = pocl_copy_tensor_desc_layout (&attrs->c_in, &src->c_in);
-        err = pocl_copy_tensor_desc_layout (&attrs->c_out, &src->c_out);
+        err |= pocl_copy_tensor_desc_layout(&attrs->b, &src->b);
+        err |= pocl_copy_tensor_desc_layout(&attrs->c_in, &src->c_in);
+        err |= pocl_copy_tensor_desc_layout(&attrs->c_out, &src->c_out);
+        if (err != CL_SUCCESS) {
+          POCL_MSG_WARN("Could not copy POCL_CDBI_DBK_EXP_GEMM attributes (err: %d).\n", err);
+          free(attrs);
+          return NULL;
+        }
 
         return attrs;
       }
@@ -903,9 +908,13 @@ pocl_copy_defined_builtin_attributes (BuiltinKernelId kernel_id,
         memcpy (attrs, src, sizeof (cl_dbk_attributes_exp_matmul));
 
         err = pocl_copy_tensor_desc_layout (&attrs->a, &src->a);
-        err = pocl_copy_tensor_desc_layout (&attrs->b, &src->b);
-        err = pocl_copy_tensor_desc_layout (&attrs->c, &src->c);
-
+        err |= pocl_copy_tensor_desc_layout (&attrs->b, &src->b);
+        err |= pocl_copy_tensor_desc_layout (&attrs->c, &src->c);
+        if (err != CL_SUCCESS) {
+          POCL_MSG_WARN("Could not copy POCL_CDBI_DBK_EXP_MATMUL attributes (err: %d).\n", err);
+          free(attrs);
+          return NULL;
+        }
         return attrs;
       }
     case POCL_CDBI_DBK_EXP_JPEG_ENCODE:

--- a/lib/CL/pocl_compiler_macros.h
+++ b/lib/CL/pocl_compiler_macros.h
@@ -1,0 +1,40 @@
+/* pocl_compiler_macros.h - collection of macros to tell the compiler that a
+   warning for a piece of code is deliberate.
+
+   Copyright (c) 2024 Robin Bijl / Tampere University
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#ifndef POCL_POCL_COMPILER_MACROS_H
+#define POCL_POCL_COMPILER_MACROS_H
+
+#if (defined(__GNUC__) && (__GNUC__ > 6)) || (defined(__clang__) && __clang_major__ >= 12)
+#define POCL_FALLTHROUGH __attribute__((fallthrough))
+#else
+#define POCL_FALLTHROUGH
+#endif
+
+#if defined(__GNUC__)
+#define POCL_UNUSED __attribute__((unused))
+#else
+#define POCL_UNUSED
+#endif
+
+#endif //POCL_POCL_COMPILER_MACROS_H

--- a/lib/CL/pocl_tensor_util.c
+++ b/lib/CL/pocl_tensor_util.c
@@ -346,9 +346,9 @@ pocl_tensor_dtype_value_equals (const cl_tensor_datatype DType,
     case CL_TENSOR_DTYPE_INT64:
       return (Value->l == longConst);
     case CL_TENSOR_DTYPE_UINT64:
-      return (Value->l == ulongConst);
+      return ((cl_ulong)Value->l == ulongConst);
     case CL_TENSOR_DTYPE_INT32:
-      return ((cl_long)Value->l == longConst);
+      return (Value->l == longConst);
     case CL_TENSOR_DTYPE_UINT32:
       return ((cl_ulong)Value->i == ulongConst);
     case CL_TENSOR_DTYPE_INT16:

--- a/tests/runtime/test_dbk_jpeg.c
+++ b/tests/runtime/test_dbk_jpeg.c
@@ -201,7 +201,7 @@ main (int argc, char const *argv[])
                             write_event, decode_event };
   size_t all_events_size = sizeof (all_events) / sizeof (all_events[0]);
   clWaitForEvents (all_events_size, all_events);
-  for (int i = 0; i < all_events_size; i++)
+  for (size_t i = 0; i < all_events_size; i++)
     clReleaseEvent (all_events[i]);
 
   TEST_ASSERT (jpeg_size_value > 0);
@@ -220,7 +220,7 @@ main (int argc, char const *argv[])
   clReleaseKernel (decode_kernel);
   clReleaseProgram (program);
   clReleaseContext (context);
-  for (int i = 0; i < num_devices; i++)
+  for (cl_uint i = 0; i < num_devices; i++)
     {
       clReleaseDevice (devices[i]);
       clReleaseCommandQueue (queues[i]);

--- a/tests/runtime/test_event_free.c
+++ b/tests/runtime/test_event_free.c
@@ -144,7 +144,7 @@ int main(int argc, char **argv)
    */
 
   if (has_img) {
-    cl_uint4 color = {0,0,0,0};
+    cl_uint4 color = {{0,0,0,0}};
     const size_t origin[] = {0, 0, 0};
     const size_t region[] = {1, 1, 1};
 

--- a/tests/runtime/test_fill-buffer.c
+++ b/tests/runtime/test_fill-buffer.c
@@ -107,35 +107,35 @@ main (void)
                                                    NULL, NULL));
 
               CHECK_CL_ERROR (clFinish (queue));
-              for (int i = 0; i < pattern_size * 2; i++)
+              for (int k = 0; k < pattern_size * 2; k++)
                 {
-                  if (host_buf1[i] != 1)
+                  if (host_buf1[k] != 1)
                     {
-                      printf ("Expected value at %d: 1, actual value: %d\n", i,
-                              host_buf1[i]);
+                      printf ("Expected value at %d: 1, actual value: %d\n", k,
+                              host_buf1[k]);
                       return EXIT_FAILURE;
                     }
                 }
-              for (int i = buf_size - pattern_size; i < buf_size; i++)
+              for (size_t k = buf_size - pattern_size; k < buf_size; k++)
                 {
-                  if (host_buf1[i] != 1)
+                  if (host_buf1[k] != 1)
                     {
-                      printf ("Expected value at %d: 1, actual value: %d\n", i,
-                              host_buf1[i]);
+                      printf ("Expected value at %zu: 1, actual value: %d\n",
+                              k, host_buf1[k]);
                       return EXIT_FAILURE;
                     }
                 }
-              for (int i = pattern_size * 2; i < buf_size - pattern_size;
-                   i += pattern_size)
+              for (size_t k = pattern_size * 2; k < buf_size - pattern_size;
+                   k += pattern_size)
                 {
-                  for (int j = 0; j < pattern_size; j++)
+                  for (int l = 0; l < pattern_size; l++)
                     {
-                      cl_char expected_value = *((char *)&(pattern) + j);
-                      if (host_buf1[i + j] != expected_value)
+                      cl_char expected_value = *((char *)&(pattern) + l);
+                      if (host_buf1[k + l] != expected_value)
                         {
                           printf (
-                              "Expected value at %d: %d, actual value: %d\n",
-                              i + j, expected_value, host_buf1[i + j]);
+                            "Expected value at %zu: %d, actual value: %d\n",
+                            k + l, expected_value, host_buf1[k + l]);
                           return EXIT_FAILURE;
                         }
                     }


### PR DESCRIPTION
A WIP fixing warnings that `-Wall -Wextra` show so that in the future it would be possible to compile locally and see warnings introduced by new code.
As a side note, the CI could probably also use the `-Wno-unused-function` flag.

Some things being fixed:
* signed compare warnings
* set but unused variables
* bracket warnings