### PR TITLE
Misc. fixes and cleanups

### DIFF
--- a/include/pocl_context.h
+++ b/include/pocl_context.h
@@ -70,24 +70,27 @@ struct pocl_context {
 
 
 /* Copy a 64b context struct to a 32b one. */
-#define POCL_CONTEXT_COPY64TO32(__DST, __SRC)				\
-  do {									\
-    struct pocl_context *__src = (struct pocl_context *)__SRC;		\
-    struct pocl_context32 *__dst = (struct pocl_context32 *)__DST;	\
-    __dst->work_dim = __src->work_dim;					\
-    __dst->num_groups[0] = __src->num_groups[0];			\
-    __dst->num_groups[1] = __src->num_groups[1];			\
-    __dst->num_groups[2] = __src->num_groups[2];			\
-    __dst->global_offset[0] = __src->global_offset[0];			\
-    __dst->global_offset[1] = __src->global_offset[1];			\
-    __dst->global_offset[2] = __src->global_offset[2];			\
-    __dst->local_size[0] = __src->local_size[0];			\
-    __dst->local_size[1] = __src->local_size[1];			\
-    __dst->local_size[2] = __src->local_size[2];			\
-    __dst->printf_buffer = __src->printf_buffer;			\
-    __dst->printf_buffer_position = __src->printf_buffer_position;	\
-    __dst->printf_buffer_capacity = __src->printf_buffer_capacity;	\
-  } while (0)
+#define POCL_CONTEXT_COPY64TO32(__DST, __SRC)                                 \
+  do                                                                          \
+    {                                                                         \
+      struct pocl_context *__src = (struct pocl_context *)__SRC;              \
+      struct pocl_context32 *__dst = (struct pocl_context32 *)__DST;          \
+      __dst->work_dim = __src->work_dim;                                      \
+      __dst->num_groups[0] = __src->num_groups[0];                            \
+      __dst->num_groups[1] = __src->num_groups[1];                            \
+      __dst->num_groups[2] = __src->num_groups[2];                            \
+      __dst->global_offset[0] = __src->global_offset[0];                      \
+      __dst->global_offset[1] = __src->global_offset[1];                      \
+      __dst->global_offset[2] = __src->global_offset[2];                      \
+      __dst->local_size[0] = __src->local_size[0];                            \
+      __dst->local_size[1] = __src->local_size[1];                            \
+      __dst->local_size[2] = __src->local_size[2];                            \
+      __dst->printf_buffer = (uintptr_t)__src->printf_buffer & 0xFFFFFFFF;    \
+      __dst->printf_buffer_position                                           \
+        = (uintptr_t)__src->printf_buffer_position & 0xFFFFFFFF;              \
+      __dst->printf_buffer_capacity = __src->printf_buffer_capacity;          \
+    }                                                                         \
+  while (0)
 
 #define POCL_CONTEXT_SIZE(__BITNESS)					\
   (__BITNESS == 64 ?							\

--- a/lib/CL/devices/bufalloc.c
+++ b/lib/CL/devices/bufalloc.c
@@ -179,11 +179,6 @@ append_new_chunk (memory_region_t *region,
   return new_chunk;
 }
 
-/**
- * Allocates a chunk of memory from the given memory region.
- *
- * @return The chunk, or NULL if no space available in the region.
- */
 chunk_info_t *
 pocl_alloc_buffer_from_region (memory_region_t *region, size_t size)
 {
@@ -240,12 +235,6 @@ pocl_alloc_buffer_from_region (memory_region_t *region, size_t size)
   return chunk;
 }
 
-/**
- * Allocates a chunk of memory from the given memory region and returns its
- * starting address.
- *
- * @return The address, or NULL if no space available in the region.
- */
 void *
 pocl_bufalloc (memory_region_t *region, size_t size)
 {
@@ -255,18 +244,6 @@ pocl_bufalloc (memory_region_t *region, size_t size)
   else
     return (void *)chunk->start_address;
 }
-
-/**
- * Allocates a chunk of memory from one of the given memory regions.
- *
- * The address ranges of the different regions must not overlap. Searches
- * through the regions in the order of the region pointer array.
- *
- * @param regions A linked list of region pointers.
- * @param size The size of the chunk to allocate.
- * @return The start address of the chunk, or 0 if no space available
- * in the buffer.
- */
 
 #ifndef BUFALLOC_NO_MULTIPLE_REGIONS 
 chunk_info_t *
@@ -284,12 +261,6 @@ pocl_alloc_buffer (memory_region_t *regions, size_t size)
 }
 #endif
 
-/**
- * Creates a reference to a part of a chunk.
- *
- * @todo Register to the parent also so it can free the
- * child references.
- */
 #ifndef BUFALLOC_NO_SUB_CHUNKS
 chunk_info_t *
 create_sub_chunk (chunk_info_t *parent, size_t offset, size_t size)
@@ -313,11 +284,9 @@ create_sub_chunk (chunk_info_t *parent, size_t offset, size_t size)
  * @return A pointer to the coalesced chunk, or the second chunk in case
  * coalsecing could not be done.
  */
-
 #ifndef BUFALLOC_NO_CHUNK_COALESCING
-static chunk_info_t * 
-coalesce_chunks (chunk_info_t* first, 
-                 chunk_info_t* second)
+static chunk_info_t *
+coalesce_chunks (chunk_info_t *first, chunk_info_t *second)
 {
   if (first == NULL) return second;
   if (second == NULL) return first;

--- a/lib/CL/devices/bufalloc.h
+++ b/lib/CL/devices/bufalloc.h
@@ -1,7 +1,7 @@
 /* OpenCL runtime/device driver library: custom buffer allocator
 
    Copyright (c) 2011 Tampere University of Technology
-                 2023 Pekka Jääskeläinen / Intel Finland Oy
+                 2023-2024 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to
@@ -47,8 +47,7 @@ typedef pocl_lock_t ba_lock_t;
 #define BA_UNLOCK(LOCK) POCL_UNLOCK(LOCK)
 #define BA_INIT_LOCK(LOCK) POCL_INIT_LOCK(LOCK)
 
-/* The qualifier to add in case using non-default
-   address space. */
+/* The qualifier to add in case using non-default address space. */
 #ifndef AS_QUALIFIER
 #define AS_QUALIFIER
 #endif
@@ -148,13 +147,35 @@ struct memory_region
   ba_lock_t lock;
 };
 
+/**
+ * Allocates a chunk of memory from the given memory region.
+ *
+ * \return The chunk, or NULL if no space available in the region.
+ */
 POCL_EXPORT
 chunk_info_t *pocl_alloc_buffer_from_region (memory_region_t *region,
                                              size_t size);
 
+/**
+ * Allocates a chunk of memory from the given memory region and returns its
+ * starting address.
+ *
+ * \return The address, or NULL if no space available in the region.
+ */
 POCL_EXPORT
 void *pocl_bufalloc (memory_region_t *region, size_t size);
 
+/**
+ * Allocates a chunk of memory from one of the given memory regions.
+ *
+ * The address ranges of the different regions must not overlap. Searches
+ * through the regions in the order of the region pointer array.
+ *
+ * \param regions A linked list of region pointers.
+ * \param size The size of the chunk to allocate.
+ * \return The start address of the chunk, or 0 if no space available
+ * in the buffer.
+ */
 POCL_EXPORT
 chunk_info_t *pocl_alloc_buffer(memory_region_t *regions, size_t size);
 
@@ -167,14 +188,17 @@ void pocl_free_chunk (chunk_info_t *chunk);
 /**
  * Initializes a memory allocation region (address space) with default
  * attributes.
- *
- * @param start The starting address.
- * @param size Size of the address space.
  */
 POCL_EXPORT
 void pocl_init_mem_region (
     memory_region_t *region, memory_address_t start, size_t size);
 
+/**
+ * Creates a reference to a part of a chunk.
+ *
+ * @todo Register to the parent also so it can free the
+ * child references.
+ */
 chunk_info_t *create_sub_chunk (chunk_info_t *parent, size_t offset, size_t size);
 
 void

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -193,8 +193,19 @@ llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
                           tmp_objfile, (size_t)objfile_size);
     }
 
-  /* temporary filename for kernel.so */
-  if (pocl_cache_tempname (tmp_module, SHARED_LIB_EXT, NULL))
+  /* Temporary filename for kernel.so. Create it in the parallel.bc's
+     directory to enable a potential customized finalization step to
+     create multiple files next to it. */
+  char parallel_bc_dir[POCL_MAX_PATHNAME_LENGTH + 2];
+
+  pocl_cache_kernel_cachedir_path (parallel_bc_dir, program, device_i, kernel,
+                                   "", command, specialize);
+
+  size_t dir_len = strlen (parallel_bc_dir);
+  parallel_bc_dir[dir_len] = '/';
+  parallel_bc_dir[dir_len + 1] = 0;
+
+  if (pocl_mk_tempname (tmp_module, parallel_bc_dir, SHARED_LIB_EXT, NULL))
     {
       POCL_MSG_PRINT_LLVM ("Creating temporary kernel.so file"
                            " for kernel %s FAILED\n",

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -998,10 +998,11 @@ pocl_release_dlhandle_cache (void *dlhandle_cache_item)
  * if not, builds the kernel, caches it, and returns the file name of the
  * end result.
  *
- * @param command The kernel run command.
- * @param specialized 1 if should check the per-command specialized one instead
+ * \param module_fn [out] The file name of the final binary.
+ * \param command The kernel run command.
+ * \param specialized 1 if should check the per-command specialized one instead
  * of the generic one.
- * @returns The filename of the built binary in the disk.
+ * \returns The filename of the built binary in the disk.
  */
 int
 pocl_check_kernel_disk_cache (char *module_fn,

--- a/lib/CL/devices/common_driver.c
+++ b/lib/CL/devices/common_driver.c
@@ -487,8 +487,7 @@ pocl_driver_alloc_mem_obj (cl_device_id device, cl_mem mem, void *host_ptr)
   if (mem->has_device_address)
     p->is_pinned = 1;
 
-  POCL_MSG_PRINT_MEMORY ("Basic device ALLOC %p / size %zu \n", p->mem_ptr,
-                         mem->size);
+  POCL_MSG_PRINT_MEMORY ("ALLOC %p / size %zu \n", p->mem_ptr, mem->size);
 
   return CL_SUCCESS;
 }

--- a/lib/CL/pocl_file_util.c
+++ b/lib/CL/pocl_file_util.c
@@ -374,8 +374,6 @@ pocl_mk_tempdir (char *output, const char *prefix)
 #endif
 }
 
-/* write content[count] into a temporary file, and return the tempfile name in
- * output_path */
 int
 pocl_write_tempfile (char *output_path,
                      const char *prefix,

--- a/lib/CL/pocl_file_util.h
+++ b/lib/CL/pocl_file_util.h
@@ -72,6 +72,13 @@ POCL_EXPORT
 int pocl_write_file(const char* path, const char* content,
                     uint64_t count, int append);
 
+/** Write \param content with size \param count into a temporary file, and
+ * return the tempfile name in \param output_path.
+ *
+ * \param prefix Temp filename's prefix.
+ * \param suffix Temp filename's suffix.
+ */
+POCL_EXPORT
 int pocl_write_tempfile (char *output_path,
                          const char *prefix,
                          const char *suffix,

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -1717,7 +1717,9 @@ pocl_run_command_capture_output (char *capture_string,
       while ((r = read (out[0], buf, 4096)) > 0)
         {
           if (total_bytes + r > capture_limit)
-            break;
+            /* Read out the bytes even if they don't fit to the buffer to
+               not block the pipe. */
+            continue;
           memcpy (capture_string + total_bytes, buf, r);
           total_bytes += r;
         }

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -1389,6 +1389,14 @@ LLVMValueRef WorkgroupImpl::createArgBufferLoad(LLVMBuilderRef Builder,
                                                 LLVMContextRef Ctx,
                                                 LLVMValueRef F,
                                                 unsigned ParamIndex) {
+/// Creates a load to get an argument from an argument buffer.
+///
+/// \param Builder The LLVM IR builder to use.
+/// \param ArgBufferPtr The LLVM IR Value pointing to the arg buffer.
+/// \param ArgBufferOffsets The offsets of arguments in the buffer.
+/// \param Ctx LLVM Context to use.
+/// \param F The function with the arguments.
+/// \param ParamIndex The index of the argument.
 
   LLVMValueRef Param = LLVMGetParam(F, ParamIndex);
   LLVMTypeRef ParamType = LLVMTypeOf(Param);
@@ -1436,15 +1444,17 @@ LLVMValueRef WorkgroupImpl::createArgBufferLoad(LLVMBuilderRef Builder,
   }
 }
 
-/**
- * Creates a work group launcher with all the argument data passed
- * in a single argument buffer.
- *
- * All argument values, including pointers are stored directly in the
- * argument buffer with natural alignment. The rules for populating the
- * buffer are those of the HSA kernel calling convention. The name of
- * the generated function is KERNELNAME_workgroup_argbuffer.
- */
+/// Creates a work group launcher with all the argument data passed
+/// in a single argument buffer.
+///
+/// All argument values, including pointers are stored directly in the
+/// argument buffer with natural alignment. The rules for populating the
+/// buffer are those of the HSA kernel calling convention. The name of
+/// the generated function is KERNELNAME_workgroup_argbuffer.
+///
+/// \param Func The kernel to generate the launcher for.
+/// \param KernName The prefix for the launcher function's name, which will
+/// be called 'KernName_workgroup_argbuffer'.
 Function *
 WorkgroupImpl::createArgBufferWorkgroupLauncher(Function *Func,
                                                 std::string KernName) {


### PR DESCRIPTION
* Fix POCL_CONTEXT_COPY64TO32: There was an error due to the truncating conversion.
* Create the parallel.so temp to the parallel.bc dir to enable a potential customized finalization step to create multiple files next to it. It used to be created to the root of the temp.
* Still more argbuffer WG function fixing. Also make the output a bit more readable by naming the argument loads a bit better.
* pocl_run_command_capture_output to drain the pipe.
