### PR TITLE
Update to match current tensor & DBK spec draft

### DIFF
--- a/examples/accel/firmware.c
+++ b/examples/accel/firmware.c
@@ -56,7 +56,7 @@
 
 // NOTE: This enum contains highly experimental built-in kernel IDs, that are
 // subject to change in future PoCL releases without any deprecation period.
-enum BuiltinKernelId : uint16_t
+enum cl_dbk_id_exp : uint16_t
 {
   // CD = custom device, BI = built-in
   // 1D array byte copy, get_global_size(0) defines the size of data to copy

--- a/lib/CL/clCreateBuffer.c
+++ b/lib/CL/clCreateBuffer.c
@@ -352,11 +352,9 @@ ERROR:
 }
 POsym (clCreateBuffer);
 
-
-
 static cl_int
 pocl_parse_cl_mem_properties (const cl_mem_properties *prop_ptr,
-                              const cl_tensor_desc **tdesc)
+                              const cl_tensor_desc_exp **tdesc)
 {
 
   if (!prop_ptr)
@@ -373,9 +371,9 @@ pocl_parse_cl_mem_properties (const cl_mem_properties *prop_ptr,
     {
       switch (*prop_ptr)
         {
-        case CL_MEM_TENSOR:
+        case CL_MEM_TENSOR_EXP:
           {
-            *tdesc = (const cl_tensor_desc *)prop_ptr[1];
+            *tdesc = (const cl_tensor_desc_exp *)prop_ptr[1];
             prop_ptr += 2; /* = CL_MEM_TENSOR and its value. */
 
             POCL_RETURN_ERROR_ON ((pocl_check_tensor_desc (*tdesc)),
@@ -401,7 +399,7 @@ CL_API_ENTRY cl_mem CL_API_CALL POname (clCreateBufferWithProperties)(
 CL_API_SUFFIX__VERSION_3_0
 {
   int errcode;
-  const cl_tensor_desc *tdesc = NULL;
+  const cl_tensor_desc_exp *tdesc = NULL;
 
   errcode = pocl_parse_cl_mem_properties (properties, &tdesc);
   if (errcode != CL_SUCCESS)
@@ -423,7 +421,7 @@ CL_API_SUFFIX__VERSION_3_0
   if (tdesc)
     {
       mem->num_properties = 1;
-      mem->properties[0] = CL_MEM_TENSOR;
+      mem->properties[0] = CL_MEM_TENSOR_EXP;
       POCL_GOTO_ERROR_ON ((pocl_copy_tensor_desc2mem (mem, tdesc)),
                           CL_OUT_OF_HOST_MEMORY,
                           "Couldn't allocate space for tensor description.");

--- a/lib/CL/clCreateProgramWithDefinedBuiltInKernels.c
+++ b/lib/CL/clCreateProgramWithDefinedBuiltInKernels.c
@@ -30,7 +30,7 @@
 
 /*
  * num_kernel - number of kernels (K)
- * kernel_ids - array of K enum values, must be valid BuiltinKernelId
+ * kernel_ids - array of K enum values, must be valid cl_dbk_id_exp
  * kernel_names - array of K strings, these are user-chosen kernel names for
  * each kernel, must be unique within program
  * kernel_attributes - array of K structs that contain attrs
@@ -38,12 +38,12 @@
  */
 
 CL_API_ENTRY cl_program CL_API_CALL
-POname (clCreateProgramWithDefinedBuiltInKernels) (
+POname (clCreateProgramWithDefinedBuiltInKernelsEXP) (
   cl_context context,
   cl_uint num_devices,
   const cl_device_id *device_list,
   cl_uint num_kernels,
-  const BuiltinKernelId *kernel_ids,
+  const cl_dbk_id_exp *kernel_ids,
   const char **kernel_names,
   const void **kernel_attributes,
   cl_int *device_support,
@@ -55,7 +55,7 @@ POname (clCreateProgramWithDefinedBuiltInKernels) (
   char **builtin_names = NULL;
   size_t concated_kernel_names_size = 0;
   char *concated_kernel_names = NULL;
-  BuiltinKernelId *builtin_kernel_ids = NULL;
+  cl_dbk_id_exp *builtin_kernel_ids = NULL;
   void **builtin_kernel_attrs = NULL;
 
   POCL_GOTO_ERROR_COND ((!IS_CL_OBJECT_VALID (context)), CL_INVALID_CONTEXT);
@@ -87,7 +87,7 @@ POname (clCreateProgramWithDefinedBuiltInKernels) (
                         CL_OUT_OF_HOST_MEMORY);
 
   builtin_kernel_ids
-    = (BuiltinKernelId *)calloc (num_kernels, sizeof (BuiltinKernelId));
+    = (cl_dbk_id_exp *)calloc (num_kernels, sizeof (cl_dbk_id_exp));
   POCL_GOTO_ERROR_COND ((builtin_kernel_ids == NULL), CL_OUT_OF_HOST_MEMORY);
 
   builtin_kernel_attrs = (void **)calloc (num_kernels, sizeof (void *));
@@ -194,4 +194,4 @@ ERROR:
     *errcode_ret = errcode;
   return NULL;
 }
-POsym (clCreateProgramWithDefinedBuiltInKernels)
+POsym (clCreateProgramWithDefinedBuiltInKernelsEXP)

--- a/lib/CL/clGetExtensionFunctionAddressForPlatform.c
+++ b/lib/CL/clGetExtensionFunctionAddressForPlatform.c
@@ -224,8 +224,8 @@ CL_API_SUFFIX__VERSION_1_2
     return (void *)&POname (clGetMutableCommandInfoKHR);
 #endif
 
-  if (strcmp (func_name, "clCreateProgramWithDefinedBuiltInKernels") == 0)
-    return (void *)&POname (clCreateProgramWithDefinedBuiltInKernels);
+  if (strcmp (func_name, "clCreateProgramWithDefinedBuiltInKernelsEXP") == 0)
+    return (void *)&POname (clCreateProgramWithDefinedBuiltInKernelsEXP);
 
   POCL_MSG_ERR ("unknown platform extension requested: %s\n", func_name);
   return NULL;

--- a/lib/CL/clSetKernelArg.c
+++ b/lib/CL/clSetKernelArg.c
@@ -53,32 +53,32 @@ dump_hex (const char *data, size_t size, char *buffer)
 }
 
 static int
-pocl_verify_dbk_kernel_arg (cl_mem buf, const cl_tensor_desc *desc)
+pocl_verify_dbk_kernel_arg (cl_mem buf, const cl_tensor_desc_exp *desc)
 {
   POCL_RETURN_ERROR_ON ((buf->is_tensor == CL_FALSE), CL_INVALID_ARG_VALUE,
                         "the cl_mem argument must be a tensor\n");
 
-  const cl_tensor_properties *P = desc->properties;
+  const cl_tensor_properties_exp *props = desc->properties;
   char tensor_mutable_layout = 0;
   char tensor_mutable_shape = 0;
   char tensor_mutable_dtype = 0;
-  while (*P)
+  while (*props)
     {
-      switch (*P)
+      switch (*props)
         {
-        case CL_TENSOR_PROPERTY_MUTABLE_SHAPE:
+        case CL_TENSOR_PROPERTY_MUTABLE_SHAPE_EXP:
           tensor_mutable_shape = 1;
           break;
-        case CL_TENSOR_PROPERTY_MUTABLE_DTYPE:
+        case CL_TENSOR_PROPERTY_MUTABLE_DTYPE_EXP:
           tensor_mutable_dtype = 1;
           break;
-        case CL_TENSOR_PROPERTY_MUTABLE_LAYOUT:
+        case CL_TENSOR_PROPERTY_MUTABLE_LAYOUT_EXP:
           tensor_mutable_layout = 1;
           break;
         default:
           break;
         }
-      ++P;
+      ++props;
     }
 
   POCL_RETURN_ERROR_ON ((buf->tensor_rank != desc->rank), CL_INVALID_ARG_VALUE,
@@ -97,13 +97,17 @@ pocl_verify_dbk_kernel_arg (cl_mem buf, const cl_tensor_desc *desc)
   int cmp = 0;
   switch (desc->layout_type)
     {
-    case CL_TENSOR_LAYOUT_ML:
+    case CL_TENSOR_LAYOUT_ML_EXP:
       cmp = memcmp (buf->tensor_layout, desc->layout,
-                    sizeof (cl_tensor_layout_ml));
+                    sizeof (cl_tensor_layout_ml_exp));
       break;
-    case CL_TENSOR_LAYOUT_BLAS:
+    case CL_TENSOR_LAYOUT_BLAS_EXP:
       cmp = memcmp (buf->tensor_layout, desc->layout,
-                    sizeof (cl_tensor_layout_blas));
+                    sizeof (cl_tensor_layout_blas_exp));
+      break;
+    case CL_TENSOR_LAYOUT_BLAS_PITCHED_EXP:
+      cmp = memcmp (buf->tensor_layout, desc->layout,
+                    sizeof (cl_tensor_layout_blas_pitched_exp));
       break;
     default:
       break;
@@ -128,10 +132,10 @@ pocl_verify_dbk_kernel_args (cl_mem buf,
 {
   switch (meta->builtin_kernel_id)
     {
-    case POCL_CDBI_DBK_EXP_GEMM:
+    case CL_DBK_GEMM_EXP:
       {
-        const cl_dbk_attributes_exp_gemm *Attrs
-          = (cl_dbk_attributes_exp_gemm *)meta->builtin_kernel_attrs;
+        const cl_dbk_attributes_gemm_exp *Attrs
+          = (cl_dbk_attributes_gemm_exp *)meta->builtin_kernel_attrs;
         if (arg_index == 0)
           return pocl_verify_dbk_kernel_arg (buf, &Attrs->a);
         if (arg_index == 1)
@@ -143,10 +147,10 @@ pocl_verify_dbk_kernel_args (cl_mem buf,
         POCL_RETURN_ERROR (CL_INVALID_ARG_INDEX, "invalid arg index to "
                                                  "POCL_CDBI_DBK_EXP_GEMM");
       }
-    case POCL_CDBI_DBK_EXP_MATMUL:
+    case CL_DBK_MATMUL_EXP:
       {
-        const cl_dbk_attributes_exp_matmul *Attrs
-          = (const cl_dbk_attributes_exp_matmul *)meta->builtin_kernel_attrs;
+        const cl_dbk_attributes_matmul_exp *Attrs
+          = (const cl_dbk_attributes_matmul_exp *)meta->builtin_kernel_attrs;
         if (arg_index == 0)
           return pocl_verify_dbk_kernel_arg (buf, &Attrs->a);
         if (arg_index == 1)
@@ -156,13 +160,13 @@ pocl_verify_dbk_kernel_args (cl_mem buf,
         POCL_RETURN_ERROR (CL_INVALID_ARG_INDEX, "invalid arg index to "
                                                  "POCL_CDBI_DBK_EXP_MATMUL");
       }
-    case POCL_CDBI_DBK_EXP_JPEG_ENCODE:
-    case POCL_CDBI_DBK_EXP_JPEG_DECODE:
+    case CL_DBK_JPEG_ENCODE_EXP:
+    case CL_DBK_JPEG_DECODE_EXP:
       return CL_SUCCESS;
-    case POCL_CDBI_DBK_EXP_ONNX_INFERENCE:
+    case CL_DBK_ONNX_INFERENCE_EXP:
       {
-        const cl_dbk_attributes_exp_onnx_inference *attrs
-          = (const cl_dbk_attributes_exp_onnx_inference *)
+        const cl_dbk_attributes_onnx_inference_exp *attrs
+          = (const cl_dbk_attributes_onnx_inference_exp *)
               meta->builtin_kernel_attrs;
 
         /* Input offsets */

--- a/lib/CL/dbk/pocl_dbk_khr_jpeg_shared.c
+++ b/lib/CL/dbk/pocl_dbk_khr_jpeg_shared.c
@@ -24,31 +24,30 @@
 #include "pocl_dbk_khr_jpeg_shared.h"
 
 int
-pocl_validate_khr_jpeg (BuiltinKernelId kernel_id,
-                        const void *kernel_attributes)
+pocl_validate_khr_jpeg (cl_dbk_id_exp kernel_id, const void *kernel_attributes)
 {
 
   switch (kernel_id)
     {
-    case POCL_CDBI_DBK_EXP_JPEG_ENCODE:
+    case CL_DBK_JPEG_ENCODE_EXP:
       {
-        cl_dbk_attributes_exp_jpeg_encode *attrs
-          = (cl_dbk_attributes_exp_jpeg_encode *)kernel_attributes;
+        cl_dbk_attributes_jpeg_encode_exp *attrs
+          = (cl_dbk_attributes_jpeg_encode_exp *)kernel_attributes;
         POCL_RETURN_ERROR_ON ((1 > attrs->height || attrs->height > 65535),
-                              CL_INVALID_DBK_ATTRIBUTE,
+                              CL_DBK_INVALID_ATTRIBUTE_EXP,
                               "Height not between (0, 65535].\n");
         POCL_RETURN_ERROR_ON ((1 > attrs->width || attrs->width > 65535),
-                              CL_INVALID_DBK_ATTRIBUTE,
+                              CL_DBK_INVALID_ATTRIBUTE_EXP,
                               "Width not between (0, 65535].\n");
         POCL_RETURN_ERROR_ON ((0 > attrs->quality || attrs->quality > 100),
-                              CL_INVALID_DBK_ATTRIBUTE,
+                              CL_DBK_INVALID_ATTRIBUTE_EXP,
                               "Quality not between [0, 100].\n");
         return CL_SUCCESS;
       }
-    case POCL_CDBI_DBK_EXP_JPEG_DECODE:
+    case CL_DBK_JPEG_DECODE_EXP:
       {
         POCL_RETURN_ERROR_ON (kernel_attributes != NULL,
-                              CL_INVALID_DBK_ATTRIBUTE,
+                              CL_DBK_INVALID_ATTRIBUTE_EXP,
                               "decode attributes should be null. \n");
         return CL_SUCCESS;
       }
@@ -60,20 +59,20 @@ pocl_validate_khr_jpeg (BuiltinKernelId kernel_id,
 }
 
 void *
-pocl_copy_dbk_attributes_khr_jpeg (BuiltinKernelId kernel_id,
+pocl_copy_dbk_attributes_khr_jpeg (cl_dbk_id_exp kernel_id,
                                    const void *kernel_attributes)
 {
 
   switch (kernel_id)
     {
-    case POCL_CDBI_DBK_EXP_JPEG_ENCODE:
+    case CL_DBK_JPEG_ENCODE_EXP:
       {
-        void *ret = malloc (sizeof (cl_dbk_attributes_exp_jpeg_encode));
+        void *ret = malloc (sizeof (cl_dbk_attributes_jpeg_encode_exp));
         memcpy (ret, kernel_attributes,
-                sizeof (cl_dbk_attributes_exp_jpeg_encode));
+                sizeof (cl_dbk_attributes_jpeg_encode_exp));
         return ret;
       }
-    case POCL_CDBI_DBK_EXP_JPEG_DECODE:
+    case CL_DBK_JPEG_DECODE_EXP:
       return NULL;
     default:
       POCL_MSG_ERR ("pocl_copy_dbk_attributes_khr_jpeg called with "
@@ -83,25 +82,27 @@ pocl_copy_dbk_attributes_khr_jpeg (BuiltinKernelId kernel_id,
 }
 
 int
-pocl_release_dbk_attributes_khr_jpeg (BuiltinKernelId kernel_id,
+pocl_release_dbk_attributes_khr_jpeg (cl_dbk_id_exp kernel_id,
                                       void *kernel_attributes)
 {
 
   switch (kernel_id)
     {
-    case POCL_CDBI_DBK_EXP_JPEG_ENCODE:
+    case CL_DBK_JPEG_ENCODE_EXP:
       {
         POCL_MEM_FREE (kernel_attributes);
         return CL_SUCCESS;
       }
-    case POCL_CDBI_DBK_EXP_JPEG_DECODE:
+    case CL_DBK_JPEG_DECODE_EXP:
       {
         POCL_MEM_FREE (kernel_attributes);
         return CL_SUCCESS;
       }
     default:
-      POCL_RETURN_ERROR (CL_INVALID_DBK_ID,
+      POCL_RETURN_ERROR (CL_DBK_INVALID_ID_EXP,
                          "pocl_copy_dbk_attributes_khr_jpeg called with "
                          "wrong kernel_id.\n");
     }
+  assert (!"UNREACHABLE");
+  return CL_DBK_INVALID_ID_EXP;
 }

--- a/lib/CL/dbk/pocl_dbk_khr_jpeg_shared.h
+++ b/lib/CL/dbk/pocl_dbk_khr_jpeg_shared.h
@@ -26,13 +26,13 @@
 
 #include "pocl_builtin_kernels.h"
 
-int pocl_validate_khr_jpeg (BuiltinKernelId kernel_id,
+int pocl_validate_khr_jpeg (cl_dbk_id_exp kernel_id,
                             const void *kernel_attributes);
 
-int pocl_release_dbk_attributes_khr_jpeg (BuiltinKernelId kernel_id,
+int pocl_release_dbk_attributes_khr_jpeg (cl_dbk_id_exp kernel_id,
                                           void *kernel_attributes);
 
-void *pocl_copy_dbk_attributes_khr_jpeg (BuiltinKernelId kernel_id,
+void *pocl_copy_dbk_attributes_khr_jpeg (cl_dbk_id_exp kernel_id,
                                          const void *kernel_attributes);
 
 #endif //_POCL_DBK_KHR_JPEG_SHARED_H_

--- a/lib/CL/dbk/pocl_dbk_khr_onnxrt_shared.c
+++ b/lib/CL/dbk/pocl_dbk_khr_onnxrt_shared.c
@@ -24,13 +24,13 @@
 #include "pocl_tensor_util.h"
 
 /** Construct a deep copy of the given attributes */
-cl_dbk_attributes_exp_onnx_inference *
+cl_dbk_attributes_onnx_inference_exp *
 pocl_copy_onnx_inference_dbk_attributes (
-  const cl_dbk_attributes_exp_onnx_inference *src)
+  const cl_dbk_attributes_onnx_inference_exp *src)
 {
   int err;
-  cl_dbk_attributes_exp_onnx_inference *attrs
-    = malloc (sizeof (cl_dbk_attributes_exp_onnx_inference));
+  cl_dbk_attributes_onnx_inference_exp *attrs
+    = malloc (sizeof (cl_dbk_attributes_onnx_inference_exp));
   if (attrs == NULL)
     return NULL;
   attrs->model_size = src->model_size;
@@ -47,7 +47,7 @@ pocl_copy_onnx_inference_dbk_attributes (
   if (attrs->input_tensor_names == NULL)
     goto ERROR;
   attrs->input_tensor_descs
-      = calloc (attrs->num_inputs, sizeof (cl_tensor_desc));
+    = calloc (attrs->num_inputs, sizeof (cl_tensor_desc_exp));
   if (attrs->input_tensor_descs == NULL)
     goto ERROR;
   for (size_t i = 0; i < attrs->num_inputs; ++i)
@@ -55,10 +55,10 @@ pocl_copy_onnx_inference_dbk_attributes (
       attrs->input_tensor_names[i] = strdup (src->input_tensor_names[i]);
       if (attrs->input_tensor_names[i] == NULL)
         goto ERROR;
-      memcpy ((cl_tensor_desc *)&attrs->input_tensor_descs[i],
-              &src->input_tensor_descs[i], sizeof (cl_tensor_desc));
+      memcpy ((cl_tensor_desc_exp *)&attrs->input_tensor_descs[i],
+              &src->input_tensor_descs[i], sizeof (cl_tensor_desc_exp));
       err = pocl_copy_tensor_desc_layout (
-        (cl_tensor_desc *)&attrs->input_tensor_descs[i],
+        (cl_tensor_desc_exp *)&attrs->input_tensor_descs[i],
         &src->input_tensor_descs[i]);
       if (err != CL_SUCCESS)
         goto ERROR;
@@ -69,7 +69,7 @@ pocl_copy_onnx_inference_dbk_attributes (
   if (attrs->output_tensor_names == NULL)
     goto ERROR;
   attrs->output_tensor_descs
-      = calloc (attrs->num_outputs, sizeof (cl_tensor_desc));
+    = calloc (attrs->num_outputs, sizeof (cl_tensor_desc_exp));
   if (attrs->output_tensor_descs == NULL)
     goto ERROR;
   for (size_t i = 0; i < attrs->num_outputs; ++i)
@@ -77,10 +77,10 @@ pocl_copy_onnx_inference_dbk_attributes (
       attrs->output_tensor_names[i] = strdup (src->output_tensor_names[i]);
       if (attrs->output_tensor_names[i] == NULL)
         goto ERROR;
-      memcpy ((cl_tensor_desc *)&attrs->output_tensor_descs[i],
-              &src->output_tensor_descs[i], sizeof (cl_tensor_desc));
+      memcpy ((cl_tensor_desc_exp *)&attrs->output_tensor_descs[i],
+              &src->output_tensor_descs[i], sizeof (cl_tensor_desc_exp));
       err = pocl_copy_tensor_desc_layout (
-        (cl_tensor_desc *)&attrs->output_tensor_descs[i],
+        (cl_tensor_desc_exp *)&attrs->output_tensor_descs[i],
         &src->output_tensor_descs[i]);
       if (err != CL_SUCCESS)
         goto ERROR;
@@ -98,7 +98,7 @@ pocl_copy_onnx_inference_dbk_attributes (
       if (attrs->initializer_data == NULL)
         goto ERROR;
       attrs->initializer_tensor_descs
-          = calloc (attrs->num_initializers, sizeof (cl_tensor_desc));
+        = calloc (attrs->num_initializers, sizeof (cl_tensor_desc_exp));
       if (attrs->initializer_tensor_descs == NULL)
         goto ERROR;
       for (size_t i = 0; i < attrs->num_initializers; ++i)
@@ -106,10 +106,11 @@ pocl_copy_onnx_inference_dbk_attributes (
           attrs->initializer_names[i] = strdup (src->initializer_names[i]);
           if (attrs->initializer_names[i] == NULL)
             goto ERROR;
-          memcpy ((cl_tensor_desc *)&attrs->initializer_tensor_descs[i],
-                  &src->initializer_tensor_descs[i], sizeof (cl_tensor_desc));
+          memcpy ((cl_tensor_desc_exp *)&attrs->initializer_tensor_descs[i],
+                  &src->initializer_tensor_descs[i],
+                  sizeof (cl_tensor_desc_exp));
           err = pocl_copy_tensor_desc_layout (
-            (cl_tensor_desc *)&attrs->initializer_tensor_descs[i],
+            (cl_tensor_desc_exp *)&attrs->initializer_tensor_descs[i],
             &src->initializer_tensor_descs[i]);
           if (err != CL_SUCCESS)
             goto ERROR;
@@ -139,7 +140,7 @@ pocl_copy_onnx_inference_dbk_attributes (
  * or string literals. */
 void
 pocl_release_onnx_inference_dbk_attributes (
-  cl_dbk_attributes_exp_onnx_inference *attrs)
+  cl_dbk_attributes_onnx_inference_exp *attrs)
 {
   free ((char *)attrs->model_data);
 
@@ -147,9 +148,9 @@ pocl_release_onnx_inference_dbk_attributes (
     {
       if (attrs->input_tensor_descs)
         {
-          free (attrs->input_tensor_descs[i].layout);
-          memset ((cl_tensor_desc *)&(attrs->input_tensor_descs[i]), 0,
-                  sizeof (cl_tensor_desc));
+          free ((void *)attrs->input_tensor_descs[i].layout);
+          memset ((cl_tensor_desc_exp *)&(attrs->input_tensor_descs[i]), 0,
+                  sizeof (cl_tensor_desc_exp));
         }
 
       if (attrs->input_tensor_names)
@@ -158,16 +159,16 @@ pocl_release_onnx_inference_dbk_attributes (
           memset (&attrs->input_tensor_names[i], 0, sizeof (char *));
         }
     }
-  free ((cl_tensor_desc *)attrs->input_tensor_descs);
+  free ((cl_tensor_desc_exp *)attrs->input_tensor_descs);
   POCL_MEM_FREE (attrs->input_tensor_names);
 
   for (size_t i = 0; i < attrs->num_outputs; ++i)
     {
       if (attrs->output_tensor_descs)
         {
-          free (attrs->output_tensor_descs[i].layout);
-          memset ((cl_tensor_desc *)&(attrs->output_tensor_descs[i]), 0,
-                  sizeof (cl_tensor_desc));
+          free ((void *)attrs->output_tensor_descs[i].layout);
+          memset ((cl_tensor_desc_exp *)&(attrs->output_tensor_descs[i]), 0,
+                  sizeof (cl_tensor_desc_exp));
         }
 
       if (attrs->output_tensor_names)
@@ -176,7 +177,7 @@ pocl_release_onnx_inference_dbk_attributes (
           memset (&attrs->output_tensor_names[i], 0, sizeof (char *));
         }
     }
-  free ((cl_tensor_desc *)attrs->output_tensor_descs);
+  free ((cl_tensor_desc_exp *)attrs->output_tensor_descs);
   POCL_MEM_FREE (attrs->output_tensor_names);
 
   if (attrs->num_initializers != 0)
@@ -186,18 +187,18 @@ pocl_release_onnx_inference_dbk_attributes (
           free ((char *)attrs->initializer_names[i]);
           memset (&attrs->initializer_names[i], 0, sizeof (char *));
 
-          free (attrs->initializer_tensor_descs[i].layout);
-          memset ((cl_tensor_desc *)&(attrs->initializer_tensor_descs[i]), 0,
-                  sizeof (cl_tensor_desc));
+          free ((void *)attrs->initializer_tensor_descs[i].layout);
+          memset ((cl_tensor_desc_exp *)&(attrs->initializer_tensor_descs[i]),
+                  0, sizeof (cl_tensor_desc_exp));
 
           free ((char *)attrs->initializer_data[i]);
           memset (&attrs->initializer_data[i], 0, sizeof (char *));
         }
     }
   POCL_MEM_FREE (attrs->initializer_names);
-  free ((cl_tensor_desc *)attrs->initializer_tensor_descs);
+  free ((cl_tensor_desc_exp *)attrs->initializer_tensor_descs);
   POCL_MEM_FREE (attrs->initializer_data);
 
-  memset (attrs, 0, sizeof (cl_dbk_attributes_exp_onnx_inference));
+  memset (attrs, 0, sizeof (cl_dbk_attributes_onnx_inference_exp));
   POCL_MEM_FREE (attrs);
 }

--- a/lib/CL/dbk/pocl_dbk_khr_onnxrt_shared.h
+++ b/lib/CL/dbk/pocl_dbk_khr_onnxrt_shared.h
@@ -30,11 +30,11 @@
 #include "pocl_export.h"
 
 POCL_EXPORT
-cl_dbk_attributes_exp_onnx_inference *pocl_copy_onnx_inference_dbk_attributes (
-  const cl_dbk_attributes_exp_onnx_inference *src);
+cl_dbk_attributes_onnx_inference_exp *pocl_copy_onnx_inference_dbk_attributes (
+  const cl_dbk_attributes_onnx_inference_exp *src);
 
 POCL_EXPORT
 void pocl_release_onnx_inference_dbk_attributes (
-  cl_dbk_attributes_exp_onnx_inference *attrs);
+  cl_dbk_attributes_onnx_inference_exp *attrs);
 
 #endif //_POCL_DBK_KHR_ONNXRT_SHARED_H_

--- a/lib/CL/devices/almaif/AlmaifDB/AlmaIFBitstreamDatabaseManager.cc
+++ b/lib/CL/devices/almaif/AlmaifDB/AlmaIFBitstreamDatabaseManager.cc
@@ -166,7 +166,7 @@ void AlmaIFBitstreamDatabaseManager::parseBIKernels(
   int64_t BikIDLong = json_getInteger(Bik);
   assert(BikIDLong < 0xFFFF);
 
-  BuiltinKernelId BikID = (BuiltinKernelId)BikIDLong;
+  cl_dbk_id_exp BikID = (cl_dbk_id_exp)BikIDLong;
   SupportedBIKernels_[ProgFilesInfo.FpgaType].push_back(
       {BikID, ProgFilesInfo.FpgaType, ProgFilesInfo.BitstreamPath,
        ProgFilesInfo.FirmwarePath, ProgFilesInfo.KernelName});
@@ -249,7 +249,7 @@ AlmaIFBitstreamDatabaseManager::deviceTypeEnum2String(DEVICE_TYPE DeviceType) {
 }
 
 const AlmaIFBitstreamDatabaseManager::ProgrammingFiles &
-AlmaIFBitstreamDatabaseManager::getBitstreamFile(BuiltinKernelId BikID,
+AlmaIFBitstreamDatabaseManager::getBitstreamFile(cl_dbk_id_exp BikID,
                                                  DEVICE_TYPE UsedDeviceType) {
 
   for (const ProgrammingFiles &Iter : SupportedBIKernels_[UsedDeviceType]) {
@@ -261,7 +261,7 @@ AlmaIFBitstreamDatabaseManager::getBitstreamFile(BuiltinKernelId BikID,
 }
 
 const AlmaIFBitstreamDatabaseManager::ProgrammingFiles &
-AlmaIFBitstreamDatabaseManager::getFirmwareFile(BuiltinKernelId BikID,
+AlmaIFBitstreamDatabaseManager::getFirmwareFile(cl_dbk_id_exp BikID,
                                                 DEVICE_TYPE UsedDeviceType) {
 
   for (const ProgrammingFiles &Iter : SupportedBIKernels_[UsedDeviceType]) {
@@ -272,13 +272,13 @@ AlmaIFBitstreamDatabaseManager::getFirmwareFile(BuiltinKernelId BikID,
   POCL_ABORT("Built in kernel %d firmware not found\n", BikID);
 }
 
-std::vector<BuiltinKernelId>
+std::vector<cl_dbk_id_exp>
 AlmaIFBitstreamDatabaseManager::supportedBuiltinKernels(
     DEVICE_TYPE UsedDeviceType) {
 
-  std::vector<BuiltinKernelId> Output;
+  std::vector<cl_dbk_id_exp> Output;
   for (const ProgrammingFiles &Iter : SupportedBIKernels_[UsedDeviceType]) {
-    Output.push_back((BuiltinKernelId)Iter.BikID);
+    Output.push_back((cl_dbk_id_exp)Iter.BikID);
   }
   return Output;
 }

--- a/lib/CL/devices/almaif/AlmaifDB/DBDevice.cc
+++ b/lib/CL/devices/almaif/AlmaifDB/DBDevice.cc
@@ -74,7 +74,7 @@ DBDevice::DBDevice(const std::string &DBPath) : DB_(DBPath) {
 
 DBDevice::~DBDevice() { delete Dev_; }
 
-void DBDevice::programBIKernelBitstream(BuiltinKernelId BikID) {
+void DBDevice::programBIKernelBitstream(cl_dbk_id_exp BikID) {
 
   const AlmaIFBitstreamDatabaseManager::ProgrammingFiles &BitstreamToProgram =
       DB_.getBitstreamFile(BikID, UsedDeviceType_);
@@ -101,7 +101,7 @@ void DBDevice::programBIKernelBitstream(BuiltinKernelId BikID) {
   LoadedBitstreamPath_ = BitstreamPath;
 }
 
-void DBDevice::programBIKernelFirmware(BuiltinKernelId BikID) {
+void DBDevice::programBIKernelFirmware(cl_dbk_id_exp BikID) {
 
   const AlmaIFBitstreamDatabaseManager::ProgrammingFiles &BitstreamToProgram =
       DB_.getFirmwareFile(BikID, UsedDeviceType_);
@@ -169,6 +169,6 @@ size_t DBDevice::pointerDeviceOffset(pocl_mem_identifier *P) {
 
 void DBDevice::discoverDeviceParameters() { Dev_->discoverDeviceParameters(); }
 
-std::vector<BuiltinKernelId> DBDevice::supportedBuiltinKernels() {
+std::vector<cl_dbk_id_exp> DBDevice::supportedBuiltinKernels() {
   return DB_.supportedBuiltinKernels(UsedDeviceType_);
 }

--- a/lib/CL/devices/almaif/AlmaifDB/DBDevice.hh
+++ b/lib/CL/devices/almaif/AlmaifDB/DBDevice.hh
@@ -60,10 +60,10 @@ public:
   void freePipe(pocl_mem_identifier *P) override;
   size_t pointerDeviceOffset(pocl_mem_identifier *P) override;
 
-  virtual void programBIKernelFirmware(BuiltinKernelId BikID);
-  virtual void programBIKernelBitstream(BuiltinKernelId BikID);
+  virtual void programBIKernelFirmware(cl_dbk_id_exp BikID);
+  virtual void programBIKernelBitstream(cl_dbk_id_exp BikID);
 
-  virtual std::vector<BuiltinKernelId> supportedBuiltinKernels();
+  virtual std::vector<cl_dbk_id_exp> supportedBuiltinKernels();
   virtual void discoverDeviceParameters();
   int pipeCount() override;
 

--- a/lib/CL/devices/almaif/almaif.cc
+++ b/lib/CL/devices/almaif/almaif.cc
@@ -403,10 +403,10 @@ cl_int pocl_almaif_init(unsigned j, cl_device_id dev, const char *parameters) {
 
   if (D->Dev->isDBDevice()) {
 #ifdef HAVE_DBDEVICE
-    std::vector<BuiltinKernelId> bik_list =
+    std::vector<cl_dbk_id_exp> bik_list =
         ((DBDevice *)(D->Dev))->supportedBuiltinKernels();
 
-    for (const BuiltinKernelId &kernelId : bik_list) {
+    for (const cl_dbk_id_exp &kernelId : bik_list) {
 
       bool found = false;
       for (size_t i = 0; i < BIKERNELS; ++i) {
@@ -430,7 +430,7 @@ cl_int pocl_almaif_init(unsigned j, cl_device_id dev, const char *parameters) {
   } else {
     while ((paramToken = strtok_r(NULL, ",", &savePtr))) {
       auto token = strtoul(paramToken, NULL, 0);
-      BuiltinKernelId kernelId = static_cast<BuiltinKernelId>(token);
+      cl_dbk_id_exp kernelId = static_cast<cl_dbk_id_exp>(token);
 
       bool found = false;
       for (size_t i = 0; i < BIKERNELS; ++i) {
@@ -858,9 +858,9 @@ void scheduleNDRange(AlmaifData *data, _cl_command_node *cmd, size_t arg_size,
 #ifdef HAVE_DBDEVICE
   if (data->Dev->isDBDevice()) {
     ((DBDevice *)(data->Dev))
-        ->programBIKernelBitstream((BuiltinKernelId)kernelID);
+        ->programBIKernelBitstream((cl_dbk_id_exp)kernelID);
     ((DBDevice *)(data->Dev))
-        ->programBIKernelFirmware((BuiltinKernelId)kernelID);
+        ->programBIKernelFirmware((cl_dbk_id_exp)kernelID);
   }
 #endif
 

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -1009,22 +1009,22 @@ pocl_basic_create_kernel (cl_device_id device,
     return CL_INVALID_KERNEL_NAME;
 
   int status = CL_SUCCESS;
-  BuiltinKernelId dbk_id = p->builtin_kernel_ids[dbk_index];
+  cl_dbk_id_exp dbk_id = p->builtin_kernel_ids[dbk_index];
   switch (dbk_id)
     {
 #ifdef HAVE_LIBXSMM
-    case POCL_CDBI_DBK_EXP_GEMM:
-    case POCL_CDBI_DBK_EXP_MATMUL:
+    case CL_DBK_GEMM_EXP:
+    case CL_DBK_MATMUL_EXP:
       return status;
 #endif
 #ifdef HAVE_LIBJPEG_TURBO
-    case POCL_CDBI_DBK_EXP_JPEG_ENCODE:
+    case CL_DBK_JPEG_ENCODE_EXP:
       {
         k->data[device_i] = pocl_cpu_init_dbk_khr_jpeg_encode (
           p->builtin_kernel_attributes[dbk_index], &status);
         return status;
       }
-    case POCL_CDBI_DBK_EXP_JPEG_DECODE:
+    case CL_DBK_JPEG_DECODE_EXP:
       {
         k->data[device_i] = pocl_cpu_init_dbk_khr_jpeg_decode (
           p->builtin_kernel_attributes[dbk_index], &status);
@@ -1041,11 +1041,13 @@ pocl_basic_create_kernel (cl_device_id device,
       }
 #endif
     default:
-      POCL_RETURN_ERROR (CL_INVALID_DBK_ID,
+      POCL_RETURN_ERROR (CL_DBK_INVALID_ID_EXP,
                          "pocl_basic_create_kernel called with "
                          "unknown/unimplemented "
                          "DBK kernel.\n");
     }
+  assert (!"UNREACHABLE!");
+  return CL_DBK_INVALID_ID_EXP;
 }
 
 int
@@ -1064,21 +1066,21 @@ pocl_basic_free_kernel (cl_device_id device,
     return CL_INVALID_KERNEL_NAME;
 
   int status = CL_SUCCESS;
-  BuiltinKernelId dbk_id = p->builtin_kernel_ids[dbk_index];
+  cl_dbk_id_exp dbk_id = p->builtin_kernel_ids[dbk_index];
   switch (dbk_id)
     {
 #ifdef HAVE_LIBXSMM
-    case POCL_CDBI_DBK_EXP_GEMM:
-    case POCL_CDBI_DBK_EXP_MATMUL:
+    case CL_DBK_GEMM_EXP:
+    case CL_DBK_MATMUL_EXP:
       return status;
 #endif
 #ifdef HAVE_LIBJPEG_TURBO
-    case POCL_CDBI_DBK_EXP_JPEG_ENCODE:
+    case CL_DBK_JPEG_ENCODE_EXP:
       {
         status = pocl_cpu_destroy_dbk_khr_jpeg_encode (&(k->data[device_i]));
         return status;
       }
-    case POCL_CDBI_DBK_EXP_JPEG_DECODE:
+    case CL_DBK_JPEG_DECODE_EXP:
       {
         status = pocl_cpu_destroy_dbk_khr_jpeg_decode (&(k->data[device_i]));
         return status;
@@ -1093,8 +1095,10 @@ pocl_basic_free_kernel (cl_device_id device,
       }
 #endif
     default:
-      POCL_RETURN_ERROR (CL_INVALID_DBK_ID,
+      POCL_RETURN_ERROR (CL_DBK_INVALID_ID_EXP,
                          "pocl_basic_free_kernel called with "
                          "unknown/unimplemented DBK kernel.\n");
     }
+  assert (!"UNREACHABLE");
+  return CL_DBK_INVALID_ID_EXP;
 }

--- a/lib/CL/devices/common_utils.h
+++ b/lib/CL/devices/common_utils.h
@@ -88,7 +88,7 @@ cl_int pocl_cpu_init_common (cl_device_id device);
 
 POCL_EXPORT
 int pocl_cpu_supports_dbk (cl_device_id device,
-                           BuiltinKernelId kernel_id,
+                           cl_dbk_id_exp kernel_id,
                            const void *kernel_attributes);
 POCL_EXPORT
 int pocl_cpu_build_defined_builtin (cl_program program, cl_uint device_i);
@@ -114,10 +114,10 @@ int pocl_setup_kernel_arg_array_with_locals (void **arguments,
                                              size_t local_mem_size);
 
 POCL_EXPORT
-int pocl_tensor_type_size (cl_tensor_datatype T);
+int pocl_tensor_type_size (cl_tensor_datatype_exp dtype);
 
 POCL_EXPORT
-int pocl_tensor_type_is_int (cl_tensor_datatype T);
+int pocl_tensor_type_is_int (cl_tensor_datatype_exp dtype);
 
 POCL_EXPORT
 void pocl_free_kernel_arg_array (kernel_run_command *k);

--- a/lib/CL/devices/cpu_dbk/pocl_dbk_khr_jpeg_cpu.c
+++ b/lib/CL/devices/cpu_dbk/pocl_dbk_khr_jpeg_cpu.c
@@ -51,8 +51,8 @@ pocl_cpu_execute_dbk_khr_jpeg_encode (cl_program program,
                                       struct pocl_argument *arguments)
 {
   cl_device_id dev = program->devices[dev_i];
-  cl_dbk_attributes_exp_jpeg_encode *attributes
-    = (cl_dbk_attributes_exp_jpeg_encode *)meta->builtin_kernel_attrs;
+  cl_dbk_attributes_jpeg_encode_exp *attributes
+    = (cl_dbk_attributes_jpeg_encode_exp *)meta->builtin_kernel_attrs;
   unsigned mem_id = dev->global_mem_id;
   void *image = pocl_cpu_get_ptr (&arguments[0], mem_id);
   void *jpeg = pocl_cpu_get_ptr (&arguments[1], mem_id);
@@ -102,8 +102,8 @@ pocl_cpu_init_dbk_khr_jpeg_encode (void const *attributes, int *status)
     }
 
   int jpeg_status;
-  cl_dbk_attributes_exp_jpeg_encode *jpeg_attr
-    = (cl_dbk_attributes_exp_jpeg_encode *)attributes;
+  cl_dbk_attributes_jpeg_encode_exp *jpeg_attr
+    = (cl_dbk_attributes_jpeg_encode_exp *)attributes;
   jpeg_status = tj3Set (state->tj_handle, TJPARAM_QUALITY, jpeg_attr->quality);
   if (jpeg_status != 0)
     {

--- a/lib/CL/devices/cpu_dbk/pocl_dbk_khr_onnxrt_cpu.c
+++ b/lib/CL/devices/cpu_dbk/pocl_dbk_khr_onnxrt_cpu.c
@@ -47,7 +47,7 @@ typedef struct onnxrt_instance
   OrtMemoryInfo *mem_info;
   OrtSession *session;
   OrtSessionOptions *session_options;
-  const cl_dbk_attributes_exp_onnx_inference *attributes;
+  const cl_dbk_attributes_onnx_inference_exp *attributes;
 } onnxrt_instance_t;
 
 static void
@@ -158,7 +158,7 @@ cl_to_onnxrt_tensor_element_type (cl_tensor_datatype dtype)
   while (0)
 
 cl_int
-pocl_create_ort_instance (const cl_dbk_attributes_exp_onnx_inference *attrs,
+pocl_create_ort_instance (const cl_dbk_attributes_onnx_inference_exp *attrs,
                           onnxrt_instance_t **onnxrt)
 {
   cl_int err = CL_SUCCESS;

--- a/lib/CL/devices/prototypes.inc
+++ b/lib/CL/devices/prototypes.inc
@@ -42,7 +42,8 @@
   unsigned int pocl_##__DRV__##_probe (struct pocl_device_ops *ops);          \
   cl_int pocl_##__DRV__##_alloc_mem_obj (cl_device_id device, cl_mem mem_obj, \
                                          void *host_ptr);                     \
-  cl_int pocl_##__DRV__##_alloc_subbuffer (cl_device_id device, cl_mem sub_buf); \
+  cl_int pocl_##__DRV__##_alloc_subbuffer (cl_device_id device,               \
+                                           cl_mem sub_buf);                   \
   void pocl_##__DRV__##_free (cl_device_id device, cl_mem mem_obj);           \
   int pocl_##__DRV__##_can_migrate_d2d (cl_device_id dest,                    \
                                         cl_device_id source);                 \
@@ -72,8 +73,8 @@
       size_t host_slice_pitch);                                               \
   void pocl_##__DRV__##_copy (                                                \
       void *data, pocl_mem_identifier *dst_mem_id, cl_mem dst_buf,            \
-      pocl_mem_identifier *src_mem_id, cl_mem src_buf,                        \
-      size_t dst_offset, size_t src_offset, size_t size);                     \
+      pocl_mem_identifier *src_mem_id, cl_mem src_buf, size_t dst_offset,     \
+      size_t src_offset, size_t size);                                        \
   void pocl_##__DRV__##_copy_with_size (                                      \
       void *data, pocl_mem_identifier *dst_mem_id, cl_mem dst_buf,            \
       pocl_mem_identifier *src_mem_id, cl_mem src_buf,                        \
@@ -106,10 +107,11 @@
       cl_program program, cl_uint device_i, cl_uint num_input_headers,        \
       const cl_program *input_headers, const char **header_include_names,     \
       int link_program);                                                      \
-  int pocl_##__DRV__##_build_binary ( cl_program program,                     \
-      cl_uint device_i, int link_program, int spir_build);                    \
+  int pocl_##__DRV__##_build_binary (cl_program program, cl_uint device_i,    \
+                                     int link_program, int spir_build);       \
   int pocl_##__DRV__##_build_builtin (cl_program program, cl_uint device_i);  \
-  int pocl_##__DRV__##_build_defined_builtin (cl_program program, cl_uint device_i);  \
+  int pocl_##__DRV__##_build_defined_builtin (cl_program program,             \
+                                              cl_uint device_i);              \
   int pocl_##__DRV__##_link_program (                                         \
       cl_program program, cl_uint device_i, cl_uint num_input_programs,       \
       const cl_program *input_programs, int create_library);                  \
@@ -121,10 +123,10 @@
                                      unsigned program_device_i);              \
   int pocl_##__DRV__##_setup_metadata (                                       \
       cl_device_id device, cl_program program, unsigned program_device_i);    \
-  int pocl_##__DRV__##_supports_binary (                                      \
-      cl_device_id device, size_t length, const char *binary);                \
+  int pocl_##__DRV__##_supports_binary (cl_device_id device, size_t length,   \
+                                        const char *binary);                  \
   int pocl_##__DRV__##_supports_dbk (cl_device_id device,                     \
-                                     BuiltinKernelId kernel_id,               \
+                                     cl_dbk_id_exp kernel_id,                 \
                                      const void *kernel_attributes);          \
   void pocl_##__DRV__##_memfill (void *data, pocl_mem_identifier *dst_mem_id, \
                                  cl_mem dst_buf, size_t size, size_t offset,  \
@@ -139,11 +141,11 @@
                                      pocl_mem_identifier *dst_mem_id,         \
                                      cl_mem dst_buf, mem_mapping_t *map);     \
   cl_int pocl_##__DRV__##_get_mapping_ptr (void *data,                        \
-                            pocl_mem_identifier *mem_id,                      \
-                            cl_mem mem, mem_mapping_t *map);                  \
+                                           pocl_mem_identifier *mem_id,       \
+                                           cl_mem mem, mem_mapping_t *map);   \
   cl_int pocl_##__DRV__##_free_mapping_ptr (void *data,                       \
-                            pocl_mem_identifier *mem_id,                      \
-                            cl_mem mem, mem_mapping_t *map);                  \
+                                            pocl_mem_identifier *mem_id,      \
+                                            cl_mem mem, mem_mapping_t *map);  \
   char *pocl_##__DRV__##_init_build (void *data);                             \
   char *pocl_##__DRV__##_build_hash (cl_device_id device);                    \
   void pocl_##__DRV__##_init_target_machine (void *data,                      \
@@ -174,12 +176,11 @@
                                        cl_mem dst_image, mem_mapping_t *map); \
   cl_int pocl_##__DRV__##_fill_image (                                        \
       void *data, cl_mem image, pocl_mem_identifier *mem_id,                  \
-      const size_t *origin, const size_t *region,                             \
-      cl_uint4 orig_pixel, pixel_t fill_pixel,  size_t pixel_size);           \
-  cl_int pocl_##__DRV__##_get_gl_context_assoc                                \
-         (cl_device_id device,              \
-          cl_gl_context_info type,                  \
-          const cl_context_properties *properties);      \
+      const size_t *origin, const size_t *region, cl_uint4 orig_pixel,        \
+      pixel_t fill_pixel, size_t pixel_size);                                 \
+  cl_int pocl_##__DRV__##_get_gl_context_assoc (                              \
+      cl_device_id device, cl_gl_context_info type,                           \
+      const cl_context_properties *properties);                               \
   void pocl_##__DRV__##_svm_free (cl_device_id dev, void *svm_ptr);           \
   void *pocl_##__DRV__##_svm_alloc (cl_device_id dev, cl_svm_mem_flags flags, \
                                     size_t size);                             \
@@ -190,57 +191,39 @@
   void pocl_##__DRV__##_svm_fill (                                            \
       cl_device_id dev, void *__restrict__ svm_ptr, size_t size,              \
       void *__restrict__ pattern, size_t pattern_size);                       \
-  void pocl_##__DRV__##_svm_migrate (cl_device_id dev,                        \
-        size_t num_svm_pointers,                                              \
-                       void *__restrict__ svm_pointers,    \
-                       size_t *__restrict__ sizes); \
-  void pocl_##__DRV__##_svm_register (cl_device_id dev, void *host_ptr, size_t size);      \
-  void pocl_##__DRV__##_svm_unregister (cl_device_id dev, void *host_ptr, size_t size);    \
-  void pocl_##__DRV__##_svm_copy_rect (cl_device_id dev, \
-                                       void *__restrict__ dst,  \
-                                       const void *__restrict__ src,  \
-                                       const size_t *dst_origin, \
-                                       const size_t *src_origin, \
-                                       const size_t *region, \
-                                       size_t dst_row_pitch, \
-                                       size_t dst_slice_pitch,  \
-                                       size_t src_row_pitch,\
-                                       size_t src_slice_pitch); \
-  void pocl_##__DRV__##_svm_fill_rect (cl_device_id dev, \
-                                       void *__restrict__ svm_ptr, \
-                                       const size_t *origin, \
-                                       const size_t *region, \
-                                       size_t row_pitch, \
-                                       size_t slice_pitch, \
-                                       void *__restrict__ pattern, \
-                                       size_t pattern_size); \
+  void pocl_##__DRV__##_svm_migrate (                                         \
+      cl_device_id dev, size_t num_svm_pointers,                              \
+      void *__restrict__ svm_pointers, size_t *__restrict__ sizes);           \
+  void pocl_##__DRV__##_svm_register (cl_device_id dev, void *host_ptr,       \
+                                      size_t size);                           \
+  void pocl_##__DRV__##_svm_unregister (cl_device_id dev, void *host_ptr,     \
+                                        size_t size);                         \
+  void pocl_##__DRV__##_svm_copy_rect (                                       \
+      cl_device_id dev, void *__restrict__ dst, const void *__restrict__ src, \
+      const size_t *dst_origin, const size_t *src_origin,                     \
+      const size_t *region, size_t dst_row_pitch, size_t dst_slice_pitch,     \
+      size_t src_row_pitch, size_t src_slice_pitch);                          \
+  void pocl_##__DRV__##_svm_fill_rect (                                       \
+      cl_device_id dev, void *__restrict__ svm_ptr, const size_t *origin,     \
+      const size_t *region, size_t row_pitch, size_t slice_pitch,             \
+      void *__restrict__ pattern, size_t pattern_size);                       \
   void pocl_##__DRV__##_notify_cmdq_finished (cl_command_queue cq);           \
   void pocl_##__DRV__##_notify_event_finished (cl_event event);               \
-  cl_int pocl_##__DRV__##_get_device_info_ext(cl_device_id dev,               \
-                                         cl_device_info param_name,           \
-                                         size_t param_value_size,             \
-                                         void * param_value,                  \
-                                         size_t * param_value_size_ret);      \
-  cl_int pocl_##__DRV__##_get_subgroup_info_ext (cl_device_id dev, cl_kernel kernel, \
-                                         unsigned program_device_i, \
-                                         cl_kernel_sub_group_info param_name, \
-                                         size_t input_value_size, const void *input_value, \
-                                         size_t param_value_size, void *param_value, \
-                                         size_t *param_value_size_ret); \
-cl_int pocl_##__DRV__##_set_kernel_exec_info_ext (cl_device_id dev,          \
-                                      unsigned program_device_i, \
-                                      cl_kernel kernel,   \
-                                      cl_uint param_name,  \
-                                      size_t param_value_size,  \
-                                      const void * param_value);  \
-  cl_int pocl_##__DRV__##_get_synchronized_timestamps (cl_device_id dev,     \
-                                         cl_ulong *dev_timestamp,            \
-                                         cl_ulong *host_timestamp);          \
-  void pocl_##__DRV__##_usm_free (cl_device_id dev, \
-                                  void *svm_ptr); \
-  void pocl_##__DRV__##_usm_free_blocking (cl_device_id dev, \
-                                           void *svm_ptr); \
-  void * pocl_##__DRV__##_usm_alloc (cl_device_id dev, unsigned alloc_type, \
-                                     cl_mem_alloc_flags_intel flags, size_t size, \
-                                     cl_int *errcode);
-
+  cl_int pocl_##__DRV__##_get_device_info_ext (                               \
+      cl_device_id dev, cl_device_info param_name, size_t param_value_size,   \
+      void *param_value, size_t *param_value_size_ret);                       \
+  cl_int pocl_##__DRV__##_get_subgroup_info_ext (                             \
+      cl_device_id dev, cl_kernel kernel, unsigned program_device_i,          \
+      cl_kernel_sub_group_info param_name, size_t input_value_size,           \
+      const void *input_value, size_t param_value_size, void *param_value,    \
+      size_t *param_value_size_ret);                                          \
+  cl_int pocl_##__DRV__##_set_kernel_exec_info_ext (                          \
+      cl_device_id dev, unsigned program_device_i, cl_kernel kernel,          \
+      cl_uint param_name, size_t param_value_size, const void *param_value);  \
+  cl_int pocl_##__DRV__##_get_synchronized_timestamps (                       \
+      cl_device_id dev, cl_ulong *dev_timestamp, cl_ulong *host_timestamp);   \
+  void pocl_##__DRV__##_usm_free (cl_device_id dev, void *svm_ptr);           \
+  void pocl_##__DRV__##_usm_free_blocking (cl_device_id dev, void *svm_ptr);  \
+  void *pocl_##__DRV__##_usm_alloc (cl_device_id dev, unsigned alloc_type,    \
+                                    cl_mem_alloc_flags_intel flags,           \
+                                    size_t size, cl_int *errcode);

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -1299,7 +1299,7 @@ extern pocl_kernel_metadata_t pocl_BIDescriptors[BIKERNELS];
 
 int
 pocl_remote_supports_dbk (cl_device_id device,
-                          BuiltinKernelId kernel_id,
+                          cl_dbk_id_exp kernel_id,
                           const void *kernel_attributes)
 {
   if (strstr (device->extensions, "cl_exp_defined_builtin_kernels") != NULL)

--- a/lib/CL/pocl_builtin_kernels.c
+++ b/lib/CL/pocl_builtin_kernels.c
@@ -33,15 +33,15 @@
 /*
   steps to add a new builtin kernel:
 
-  1) add it to the end of BuiltinKernelId enum in the
+  1) add it to the end of cl_dbk_id_exp enum in the
      cl_exp_defined_builtin_kernels.h header, before
      POCL_CDBI_LAST
 
   2) open builtin_kernels.c and edit pocl_BIDescriptors, add a new struct
      for the new kernel, with argument metadata
 
-  2.5)if adding a Defined Built-in Kernel (DBK) add code specific to that kernel
-     to:
+  2.5)if adding a Defined Built-in Kernel (DBK) add code specific to that
+  kernel to:
        * pocl_validate_dbk_attributes
        * pocl_copy_defined_builtin_attributes
        * pocl_release_defined_builtin_attributes
@@ -65,8 +65,8 @@
          lib/CL/devices/almaif/tce_builtins.cl
        * almaif driver with other backends has builtin kernels in binary format
   (bitstream)
-  4.5) to add DBK kernels to cpu devices, add your specific code to the following
-  functions:
+  4.5) to add DBK kernels to cpu devices, add your specific code to the
+  following functions:
        * pocl_basic_create_kernel
        * pocl_basic_free_kernel
        * pocl_cpu_init_common
@@ -178,35 +178,38 @@ pocl_init_builtin_kernel_metadata ()
     BIKD (POCL_CDBI_COPY_I8, "pocl.copy.i8", 2,
           BI_ARG_READ_BUF ("char*", "input"),
           BI_ARG_WRITE_BUF ("char*", "output")),
-    BIKD (
-      POCL_CDBI_ADD_I32, "pocl.add.i32", 3, BI_ARG_READ_BUF ("int*", "input1"),
-      BI_ARG_READ_BUF ("int*", "input2"), BI_ARG_WRITE_BUF ("int*", "output")),
-    BIKD (
-      POCL_CDBI_MUL_I32, "pocl.mul.i32", 3, BI_ARG_READ_BUF ("int*", "input1"),
-      BI_ARG_READ_BUF ("int*", "input2"), BI_ARG_WRITE_BUF ("int*", "output")),
+    BIKD (POCL_CDBI_ADD_I32, "pocl.add.i32", 3,
+          BI_ARG_READ_BUF ("int*", "input1"),
+          BI_ARG_READ_BUF ("int*", "input2"),
+          BI_ARG_WRITE_BUF ("int*", "output")),
+    BIKD (POCL_CDBI_MUL_I32, "pocl.mul.i32", 3,
+          BI_ARG_READ_BUF ("int*", "input1"),
+          BI_ARG_READ_BUF ("int*", "input2"),
+          BI_ARG_WRITE_BUF ("int*", "output")),
     BIKD (POCL_CDBI_LEDBLINK, "pocl.ledblink", 2,
           BI_ARG_READ_BUF ("int*", "input1"),
           BI_ARG_READ_BUF ("int*", "input2")),
     BIKD (POCL_CDBI_COUNTRED, "pocl.countred", 2,
           BI_ARG_READ_BUF ("int*", "input"),
           BI_ARG_WRITE_BUF ("int*", "output")),
-    BIKD (
-      POCL_CDBI_DNN_CONV2D_RELU_I8, "pocl.dnn.conv2d.relu.i8", 12,
-      BI_ARG_READ_BUF ("char*", "input"), BI_ARG_READ_BUF ("char*", "weights"),
-      BI_ARG_WRITE_BUF ("char*", "output"), BI_ARG_READ_BUF ("int*", "bias"),
-      BI_ARG_READ_BUF ("int*", "scale"), BI_ARG_READ_BUF ("int*", "shift"),
-      BI_ARG_READ_BUF ("char*", "zero_point"),
-      BI_ARG_POD_32b ("unsigned", "window_size_x"),
-      BI_ARG_POD_32b ("unsigned", "window_size_y"),
-      BI_ARG_POD_32b ("unsigned", "stride_x"),
-      BI_ARG_POD_32b ("unsigned", "stride_y"),
-      BI_ARG_POD_32b ("unsigned", "input_depth")),
+    BIKD (POCL_CDBI_DNN_CONV2D_RELU_I8, "pocl.dnn.conv2d.relu.i8", 12,
+          BI_ARG_READ_BUF ("char*", "input"),
+          BI_ARG_READ_BUF ("char*", "weights"),
+          BI_ARG_WRITE_BUF ("char*", "output"),
+          BI_ARG_READ_BUF ("int*", "bias"), BI_ARG_READ_BUF ("int*", "scale"),
+          BI_ARG_READ_BUF ("int*", "shift"),
+          BI_ARG_READ_BUF ("char*", "zero_point"),
+          BI_ARG_POD_32b ("unsigned", "window_size_x"),
+          BI_ARG_POD_32b ("unsigned", "window_size_y"),
+          BI_ARG_POD_32b ("unsigned", "stride_x"),
+          BI_ARG_POD_32b ("unsigned", "stride_y"),
+          BI_ARG_POD_32b ("unsigned", "input_depth")),
     BIKD_LOCAL (
-      POCL_CDBI_SGEMM_LOCAL_F32, "pocl.sgemm.local.f32", 6,
-      (2 * 16 * 16 * 4), // local mem size, 2 float arrays 16x16
-      BI_ARG_READ_BUF ("float*", "A"), BI_ARG_READ_BUF ("float*", "B"),
-      BI_ARG_WRITE_BUF ("float*", "C"), BI_ARG_POD_32b ("unsigned", "M"),
-      BI_ARG_POD_32b ("unsigned", "N"), BI_ARG_POD_32b ("unsigned", "K"), ),
+        POCL_CDBI_SGEMM_LOCAL_F32, "pocl.sgemm.local.f32", 6,
+        (2 * 16 * 16 * 4), // local mem size, 2 float arrays 16x16
+        BI_ARG_READ_BUF ("float*", "A"), BI_ARG_READ_BUF ("float*", "B"),
+        BI_ARG_WRITE_BUF ("float*", "C"), BI_ARG_POD_32b ("unsigned", "M"),
+        BI_ARG_POD_32b ("unsigned", "N"), BI_ARG_POD_32b ("unsigned", "K"), ),
     BIKD (POCL_CDBI_SGEMM_TENSOR_F16F16F32_SCALE,
           "pocl.sgemm.scale.tensor.f16f16f32", 8,
           BI_ARG_READ_BUF ("half*", "A"), BI_ARG_READ_BUF ("half*", "B"),
@@ -223,16 +226,17 @@ pocl_init_builtin_kernel_metadata ()
 
           BI_ARG_READ_BUF ("float*", "input"),
           BI_ARG_WRITE_BUF ("float*", "output"), ),
-    BIKD (
-      POCL_CDBI_DNN_DENSE_RELU_I8, "pocl.dnn.dense.relu.i8", 9,
+    BIKD (POCL_CDBI_DNN_DENSE_RELU_I8, "pocl.dnn.dense.relu.i8", 9,
 
-      BI_ARG_READ_BUF ("char*", "input"), BI_ARG_READ_BUF ("char*", "weights"),
-      BI_ARG_WRITE_BUF ("char*", "output"), BI_ARG_READ_BUF ("int*", "bias"),
-      BI_ARG_POD_32b ("unsigned", "scale"),
-      BI_ARG_POD_32b ("unsigned", "shift"),
-      BI_ARG_POD_32b ("unsigned", "zero_point"),
-      BI_ARG_POD_32b ("unsigned", "output_minus"),
-      BI_ARG_POD_32b ("unsigned", "input_size"), ),
+          BI_ARG_READ_BUF ("char*", "input"),
+          BI_ARG_READ_BUF ("char*", "weights"),
+          BI_ARG_WRITE_BUF ("char*", "output"),
+          BI_ARG_READ_BUF ("int*", "bias"),
+          BI_ARG_POD_32b ("unsigned", "scale"),
+          BI_ARG_POD_32b ("unsigned", "shift"),
+          BI_ARG_POD_32b ("unsigned", "zero_point"),
+          BI_ARG_POD_32b ("unsigned", "output_minus"),
+          BI_ARG_POD_32b ("unsigned", "input_size"), ),
     BIKD (POCL_CDBI_MAXPOOL_I8, "pocl.maxpool.i8", 6,
 
           BI_ARG_READ_BUF ("char*", "input"),
@@ -266,38 +270,41 @@ pocl_init_builtin_kernel_metadata ()
     BIKD (POCL_CDBI_STREAMIN_I32, "pocl.streamin.i32", 1,
           BI_ARG_WRITE_BUF ("int*", "output")),
     BIKD (
-      POCL_CDBI_VOTE_U32, "pocl.vote.u32", 10,
-      BI_ARG_READ_BUF ("int*", "output"),
-      BI_ARG_POD_32b ("unsigned", "num_inputs"),
-      BI_ARG_READ_BUF ("int*", "input0"), BI_ARG_READ_BUF ("int*", "input1"),
-      BI_ARG_READ_BUF ("int*", "input2"), BI_ARG_READ_BUF ("int*", "input3"),
-      BI_ARG_READ_BUF ("int*", "input4"), BI_ARG_READ_BUF ("int*", "input5"),
-      BI_ARG_READ_BUF ("int*", "input6"),
-      BI_ARG_READ_BUF ("int*", "input7"), ),
+        POCL_CDBI_VOTE_U32, "pocl.vote.u32", 10,
+        BI_ARG_READ_BUF ("int*", "output"),
+        BI_ARG_POD_32b ("unsigned", "num_inputs"),
+        BI_ARG_READ_BUF ("int*", "input0"), BI_ARG_READ_BUF ("int*", "input1"),
+        BI_ARG_READ_BUF ("int*", "input2"), BI_ARG_READ_BUF ("int*", "input3"),
+        BI_ARG_READ_BUF ("int*", "input4"), BI_ARG_READ_BUF ("int*", "input5"),
+        BI_ARG_READ_BUF ("int*", "input6"),
+        BI_ARG_READ_BUF ("int*", "input7"), ),
+    BIKD (POCL_CDBI_VOTE_U8, "pocl.vote.u8", 10,
+          BI_ARG_READ_BUF ("char*", "output"),
+          BI_ARG_POD_32b ("unsigned", "num_inputs"),
+          BI_ARG_READ_BUF ("char*", "input0"),
+          BI_ARG_READ_BUF ("char*", "input1"),
+          BI_ARG_READ_BUF ("char*", "input2"),
+          BI_ARG_READ_BUF ("char*", "input3"),
+          BI_ARG_READ_BUF ("char*", "input4"),
+          BI_ARG_READ_BUF ("char*", "input5"),
+          BI_ARG_READ_BUF ("char*", "input6"),
+          BI_ARG_READ_BUF ("char*", "input7"), ),
     BIKD (
-      POCL_CDBI_VOTE_U8, "pocl.vote.u8", 10,
-      BI_ARG_READ_BUF ("char*", "output"),
-      BI_ARG_POD_32b ("unsigned", "num_inputs"),
-      BI_ARG_READ_BUF ("char*", "input0"), BI_ARG_READ_BUF ("char*", "input1"),
-      BI_ARG_READ_BUF ("char*", "input2"), BI_ARG_READ_BUF ("char*", "input3"),
-      BI_ARG_READ_BUF ("char*", "input4"), BI_ARG_READ_BUF ("char*", "input5"),
-      BI_ARG_READ_BUF ("char*", "input6"),
-      BI_ARG_READ_BUF ("char*", "input7"), ),
-    BIKD (
-      POCL_CDBI_DNN_CONV2D_NCHW_F32, "pocl.dnn.conv2d.nchw.f32", 20,
+        POCL_CDBI_DNN_CONV2D_NCHW_F32, "pocl.dnn.conv2d.nchw.f32", 20,
 
-      BI_ARG_READ_BUF ("float*", "input"),
-      BI_ARG_READ_BUF ("float*", "weights"),
-      BI_ARG_WRITE_BUF ("float*", "output"), BI_ARG_POD_32b ("int", "input_n"),
-      BI_ARG_POD_32b ("int", "input_c"), BI_ARG_POD_32b ("int", "input_h"),
-      BI_ARG_POD_32b ("int", "input_w"), BI_ARG_POD_32b ("int", "filt_k"),
-      BI_ARG_POD_32b ("int", "filt_c"), BI_ARG_POD_32b ("int", "filt_h"),
-      BI_ARG_POD_32b ("int", "filt_w"), BI_ARG_POD_32b ("int", "stride_h"),
-      BI_ARG_POD_32b ("int", "stride_w"), BI_ARG_POD_32b ("int", "dilation_h"),
-      BI_ARG_POD_32b ("int", "dilation_w"),
-      BI_ARG_POD_32b ("int", "padding_h"), BI_ARG_POD_32b ("int", "padding_w"),
-      BI_ARG_POD_32b ("int", "groups"), BI_ARG_POD_32b ("float", "alpha"),
-      BI_ARG_POD_32b ("float", "beta"), ),
+        BI_ARG_READ_BUF ("float*", "input"),
+        BI_ARG_READ_BUF ("float*", "weights"),
+        BI_ARG_WRITE_BUF ("float*", "output"),
+        BI_ARG_POD_32b ("int", "input_n"), BI_ARG_POD_32b ("int", "input_c"),
+        BI_ARG_POD_32b ("int", "input_h"), BI_ARG_POD_32b ("int", "input_w"),
+        BI_ARG_POD_32b ("int", "filt_k"), BI_ARG_POD_32b ("int", "filt_c"),
+        BI_ARG_POD_32b ("int", "filt_h"), BI_ARG_POD_32b ("int", "filt_w"),
+        BI_ARG_POD_32b ("int", "stride_h"), BI_ARG_POD_32b ("int", "stride_w"),
+        BI_ARG_POD_32b ("int", "dilation_h"),
+        BI_ARG_POD_32b ("int", "dilation_w"),
+        BI_ARG_POD_32b ("int", "padding_h"),
+        BI_ARG_POD_32b ("int", "padding_w"), BI_ARG_POD_32b ("int", "groups"),
+        BI_ARG_POD_32b ("float", "alpha"), BI_ARG_POD_32b ("float", "beta"), ),
     BIKD (POCL_CDBI_OPENVX_SCALEIMAGE_NN_U8,
           "org.khronos.openvx.scale_image.nn.u8", 6,
 
@@ -399,7 +406,7 @@ pocl_init_builtin_kernel_metadata ()
     BIKD (POCL_CDBI_GAUSSIAN3X3_P512, "pocl.gaussian3x3.p512", 2,
           BI_ARG_READ_PIPE ("uchar64", "in"),
           BI_ARG_WRITE_PIPE ("uchar64", "out"), ),
-    BIKD_DBK (POCL_CDBI_DBK_EXP_GEMM, "exp_gemm", 6,
+    BIKD_DBK (CL_DBK_GEMM_EXP, "gemm_exp", 6,
               // The types are placeholders
               BI_ARG_READ_BUF ("unsigned char*", "a"),
               BI_ARG_READ_BUF ("unsigned char*", "b"),
@@ -410,19 +417,19 @@ pocl_init_builtin_kernel_metadata ()
               // given to clCreateProgramWithDefinedBuiltinKernels
               BI_ARG_POD_MUTABLE ("mutable", "alpha"),
               BI_ARG_POD_MUTABLE ("mutable", "beta"), ),
-    BIKD_DBK (POCL_CDBI_DBK_EXP_MATMUL, "exp_matmul", 3,
+    BIKD_DBK (CL_DBK_MATMUL_EXP, "matmul_exp", 3,
               BI_ARG_READ_BUF ("unsigned char*", "a"),
               BI_ARG_READ_BUF ("unsigned char*", "b"),
               BI_ARG_WRITE_BUF ("unsigned char*", "c"), ),
-    BIKD_DBK (POCL_CDBI_DBK_EXP_JPEG_ENCODE, "exp_jpeg_encode", 3,
+    BIKD_DBK (CL_DBK_JPEG_ENCODE_EXP, "jpeg_encode_exp", 3,
               BI_ARG_READ_BUF ("uint8_t*", "image"),
               BI_ARG_WRITE_BUF ("uint8_t*", "jpeg"),
               BI_ARG_WRITE_BUF ("int64_t*", "jpeg_size"), ),
-    BIKD_DBK (POCL_CDBI_DBK_EXP_JPEG_DECODE, "exp_jpeg_decode", 3,
+    BIKD_DBK (CL_DBK_JPEG_DECODE_EXP, "jpeg_decode_exp", 3,
               BI_ARG_READ_BUF ("uint8_t*", "jpeg"),
               BI_ARG_READ_BUF ("int64_t*", "jpeg_size"),
               BI_ARG_WRITE_BUF ("uint8_t*", "image"), ),
-    BIKD_DBK (POCL_CDBI_DBK_EXP_ONNX_INFERENCE, "exp_onnx_inference", 4,
+    BIKD_DBK (CL_DBK_ONNX_INFERENCE_EXP, "onnx_inference_exp", 4,
               BI_ARG_READ_BUF ("unsigned long*", "input_offsets"),
               BI_ARG_READ_BUF ("unsigned char*", "inputs"),
               BI_ARG_READ_BUF ("unsigned long*", "output_offsets"),
@@ -502,57 +509,57 @@ pocl_clone_builtin_kernel_metadata_by_name (cl_device_id dev,
 static void
 pocl_set_defined_arg_info (pocl_argument_info *DstArg,
                            pocl_argument_info *SrcArg,
-                           cl_tensor_datatype dtype)
+                           cl_tensor_datatype_exp dtype)
 {
   memcpy (DstArg, SrcArg, sizeof (pocl_argument_info));
   DstArg->type = POCL_ARG_TYPE_NONE;
   switch (dtype)
     {
-    case CL_TENSOR_DTYPE_FP16:
+    case CL_TENSOR_DTYPE_FP16_EXP:
       DstArg->type_name = "half";
       DstArg->type_size = 2;
       break;
-    case CL_TENSOR_DTYPE_FP32:
+    case CL_TENSOR_DTYPE_FP32_EXP:
       DstArg->type_name = "float";
       DstArg->type_size = 4;
       break;
-    case CL_TENSOR_DTYPE_FP64:
+    case CL_TENSOR_DTYPE_FP64_EXP:
       DstArg->type_name = "double";
       DstArg->type_size = 8;
       break;
     // case CL_TENSOR_FP8: DstArg->type_name = "fp8"; DstArg->type_size = 1;
     // break;
-    case CL_TENSOR_DTYPE_INT64:
+    case CL_TENSOR_DTYPE_INT64_EXP:
       DstArg->type_name = "long";
       DstArg->type_size = 8;
       break;
-    case CL_TENSOR_DTYPE_INT32:
+    case CL_TENSOR_DTYPE_INT32_EXP:
       DstArg->type_name = "int";
       DstArg->type_size = 4;
       break;
-    case CL_TENSOR_DTYPE_INT16:
+    case CL_TENSOR_DTYPE_INT16_EXP:
       DstArg->type_name = "short";
       DstArg->type_size = 2;
       break;
-    case CL_TENSOR_DTYPE_INT8:
+    case CL_TENSOR_DTYPE_INT8_EXP:
       DstArg->type_name = "char";
       DstArg->type_size = 1;
       break;
     // case CL_TENSOR_INT4: DstArg->type_name = "int4_t"; DstArg->type_size =
     // 1; break;
-    case CL_TENSOR_DTYPE_UINT64:
+    case CL_TENSOR_DTYPE_UINT64_EXP:
       DstArg->type_name = "ulong";
       DstArg->type_size = 8;
       break;
-    case CL_TENSOR_DTYPE_UINT32:
+    case CL_TENSOR_DTYPE_UINT32_EXP:
       DstArg->type_name = "uint";
       DstArg->type_size = 4;
       break;
-    case CL_TENSOR_DTYPE_UINT16:
+    case CL_TENSOR_DTYPE_UINT16_EXP:
       DstArg->type_name = "ushort";
       DstArg->type_size = 2;
       break;
-    case CL_TENSOR_DTYPE_UINT8:
+    case CL_TENSOR_DTYPE_UINT8_EXP:
       DstArg->type_name = "uchar";
       DstArg->type_size = 1;
       break;
@@ -570,7 +577,7 @@ pocl_set_defined_arg_info (pocl_argument_info *DstArg,
  * (that should be in the kernel metadata) depends on the builtin kernel
  * attributes. This functions sets up the actual metadata types. */
 static void
-pocl_generate_dbk_defined_arg_info (BuiltinKernelId kernel_id,
+pocl_generate_dbk_defined_arg_info (cl_dbk_id_exp kernel_id,
                                     pocl_kernel_metadata_t *desc,
                                     pocl_argument_info *extra,
                                     void *attrs)
@@ -578,10 +585,10 @@ pocl_generate_dbk_defined_arg_info (BuiltinKernelId kernel_id,
   switch (kernel_id)
     {
     // currently only GEMM has mutable POD arguments
-    case POCL_CDBI_DBK_EXP_GEMM:
+    case CL_DBK_GEMM_EXP:
       {
-        const cl_dbk_attributes_exp_gemm *gemm_attrs
-          = (const cl_dbk_attributes_exp_gemm *)attrs;
+        const cl_dbk_attributes_gemm_exp *gemm_attrs
+          = (const cl_dbk_attributes_gemm_exp *)attrs;
         // BI_ARG_POD_MUTABLE("mutable", "alpha"),
         // BI_ARG_POD_MUTABLE("mutable", "beta"),
         //  TODO should we support separate datatypes for alpha/beta ?
@@ -598,7 +605,7 @@ pocl_generate_dbk_defined_arg_info (BuiltinKernelId kernel_id,
 /* creates a deep copy of pocl_kernel_metadata_t in 'target' */
 static cl_int
 pocl_clone_builtin_kernel_metadata_by_id (cl_device_id dev,
-                                          BuiltinKernelId id,
+                                          cl_dbk_id_exp id,
                                           pocl_kernel_metadata_t *target,
                                           void *attrs)
 {
@@ -695,7 +702,8 @@ pocl_restore_builtin_kernel_name (cl_kernel kernel, char *saved_name)
 }
 
 static cl_bool
-pocl_tensor_shape_equals (const cl_tensor_desc *A, const cl_tensor_desc *B)
+pocl_tensor_shape_equals (const cl_tensor_desc_exp *A,
+                          const cl_tensor_desc_exp *B)
 {
   assert (A);
   assert (B);
@@ -713,42 +721,46 @@ pocl_tensor_shape_equals (const cl_tensor_desc *A, const cl_tensor_desc *B)
 static int
 pocl_validate_khr_gemm (cl_bool TransA,
                         cl_bool TransB,
-                        const cl_tensor_desc *TenA,
-                        const cl_tensor_desc *TenB,
-                        const cl_tensor_desc *TenCIOpt,
-                        const cl_tensor_desc *TenCOut,
-                        const cl_tensor_datatype_value *Alpha,
-                        const cl_tensor_datatype_value *Beta)
+                        const cl_tensor_desc_exp *TenA,
+                        const cl_tensor_desc_exp *TenB,
+                        const cl_tensor_desc_exp *TenCIOpt,
+                        const cl_tensor_desc_exp *TenCOut,
+                        const cl_tensor_datatype_value_exp *Alpha,
+                        const cl_tensor_datatype_value_exp *Beta)
 {
-  POCL_RETURN_ERROR_COND ((TenA == NULL), CL_INVALID_DBK_ATTRIBUTE);
-  POCL_RETURN_ERROR_COND ((TenB == NULL), CL_INVALID_DBK_ATTRIBUTE);
-  POCL_RETURN_ERROR_COND ((TenCOut == NULL), CL_INVALID_DBK_ATTRIBUTE);
+  POCL_RETURN_ERROR_COND ((TenA == NULL), CL_DBK_INVALID_ATTRIBUTE_EXP);
+  POCL_RETURN_ERROR_COND ((TenB == NULL), CL_DBK_INVALID_ATTRIBUTE_EXP);
+  POCL_RETURN_ERROR_COND ((TenCOut == NULL), CL_DBK_INVALID_ATTRIBUTE_EXP);
 
   if (Alpha)
     {
-      POCL_RETURN_ERROR_COND (Alpha->l == 0, CL_INVALID_DBK_ATTRIBUTE);
+      /* FIXME: potential non-conformant C type punning here. Also, -0.0f is
+       * not handled correctly. */
+      POCL_RETURN_ERROR_COND (Alpha->ul == 0, CL_DBK_INVALID_ATTRIBUTE_EXP);
     }
   // beta can be 0
-  // POCL_RETURN_ERROR_COND (Beta->l == 0, CL_INVALID_DBK_ATTRIBUTE);
+  // POCL_RETURN_ERROR_COND (Beta->ul == 0, CL_DBK_INVALID_ATTRIBUTE_EXP);
 
   // TBC: 4D+ tensor could be supported by treating the additional
   //      dimensions as batch dimensions - but it might not be
   //      worthwhile due the extra work to support them and processing
   //      overhead they may impose.
-  POCL_RETURN_ERROR_ON ((TenA->rank > 3), CL_INVALID_TENSOR_RANK,
+  POCL_RETURN_ERROR_ON ((TenA->rank > 3), CL_INVALID_TENSOR_RANK_EXP,
                         "Unsupported high-degree tensors.\n");
-  POCL_RETURN_ERROR_ON ((TenA->rank < 2), CL_INVALID_TENSOR_RANK,
+  POCL_RETURN_ERROR_ON ((TenA->rank < 2), CL_INVALID_TENSOR_RANK_EXP,
                         "Rank of A/B tensors must be in {2,3}.\n");
 
-  POCL_RETURN_ERROR_ON ((TenA->rank != TenB->rank), CL_INVALID_TENSOR_RANK,
+  POCL_RETURN_ERROR_ON ((TenA->rank != TenB->rank), CL_INVALID_TENSOR_RANK_EXP,
                         "Rank mismatch between A and B\n");
-  POCL_RETURN_ERROR_ON ((TenB->rank != TenCOut->rank), CL_INVALID_TENSOR_RANK,
+  POCL_RETURN_ERROR_ON ((TenB->rank != TenCOut->rank),
+                        CL_INVALID_TENSOR_RANK_EXP,
                         "Rank mismatch between A/B and COut\n");
 
   POCL_RETURN_ERROR_ON (
     (TenCIOpt != NULL
      && pocl_tensor_shape_equals (TenCIOpt, TenCOut) == CL_FALSE),
-    CL_INVALID_TENSOR_SHAPE, "Tensor shape mismatch between C_in and C_out.");
+    CL_INVALID_TENSOR_SHAPE_EXP,
+    "Tensor shape mismatch between C_in and C_out.");
 
   size_t BatchDims = TenA->rank - 2;
 
@@ -775,9 +787,9 @@ pocl_validate_khr_gemm (cl_bool TransA,
   size_t COm = TenCOut->shape[BatchDims + 0];
   size_t COn = TenCOut->shape[BatchDims + 1];
 
-  POCL_RETURN_ERROR_COND ((Ak != Bk), CL_INVALID_DBK_ATTRIBUTE);
-  POCL_RETURN_ERROR_COND ((Am != COm), CL_INVALID_DBK_ATTRIBUTE);
-  POCL_RETURN_ERROR_COND ((Bn != COn), CL_INVALID_DBK_ATTRIBUTE);
+  POCL_RETURN_ERROR_COND ((Ak != Bk), CL_DBK_INVALID_ATTRIBUTE_EXP);
+  POCL_RETURN_ERROR_COND ((Am != COm), CL_DBK_INVALID_ATTRIBUTE_EXP);
+  POCL_RETURN_ERROR_COND ((Bn != COn), CL_DBK_INVALID_ATTRIBUTE_EXP);
 
   // Check batch dimensions match.
   if (TenA->rank == 3)
@@ -786,24 +798,26 @@ pocl_validate_khr_gemm (cl_bool TransA,
       POCL_RETURN_ERROR_ON ((BatchSize > 1
                              && (BatchSize != TenB->shape[0]
                                  || TenB->shape[0] != TenCOut->shape[0])),
-                            CL_INVALID_TENSOR_SHAPE, "Batch size mismatch.\n");
+                            CL_INVALID_TENSOR_SHAPE_EXP,
+                            "Batch size mismatch.\n");
 
       POCL_RETURN_ERROR_ON (
         (BatchSize > 1 && TenCIOpt && TenCIOpt->shape[0] != TenCOut->shape[0]),
-        CL_INVALID_TENSOR_SHAPE, "Batch size mismatch.\n");
+        CL_INVALID_TENSOR_SHAPE_EXP, "Batch size mismatch.\n");
     }
 
   // Check datatypes
   POCL_RETURN_ERROR_ON (
     (TenA->dtype >= CL_TENSOR_DTYPE_LAST || TenB->dtype >= CL_TENSOR_DTYPE_LAST
      || TenCOut->dtype >= CL_TENSOR_DTYPE_LAST),
-    CL_INVALID_TENSOR_DATATYPE, "Unknown data type in input Tensors");
+    CL_INVALID_TENSOR_DATATYPE_EXP, "Unknown data type in input Tensors");
 
-  POCL_RETURN_ERROR_ON ((TenA->dtype != TenB->dtype), CL_INVALID_TENSOR_DATATYPE,
+  POCL_RETURN_ERROR_ON ((TenA->dtype != TenB->dtype),
+                        CL_INVALID_TENSOR_DATATYPE_EXP,
                         "datatype mismatch between A and B.\n");
 
   POCL_RETURN_ERROR_ON (TenCIOpt && (TenCIOpt->dtype != TenCOut->dtype),
-                        CL_INVALID_TENSOR_DATATYPE,
+                        CL_INVALID_TENSOR_DATATYPE_EXP,
                         "datatype mismatch between C_ind and C_out\n");
 
   // TODO: check validity of data layouts of the tensors. Now assumes they're
@@ -813,7 +827,7 @@ pocl_validate_khr_gemm (cl_bool TransA,
 }
 
 int
-pocl_validate_dbk_attributes (BuiltinKernelId kernel_id,
+pocl_validate_dbk_attributes (cl_dbk_id_exp kernel_id,
                               const void *kernel_attributes,
                               pocl_validate_khr_gemm_callback_t GemmCB)
 {
@@ -821,32 +835,32 @@ pocl_validate_dbk_attributes (BuiltinKernelId kernel_id,
     GemmCB = pocl_validate_khr_gemm;
   switch (kernel_id)
     {
-    case POCL_CDBI_DBK_EXP_GEMM:
+    case CL_DBK_GEMM_EXP:
       {
-        const cl_dbk_attributes_exp_gemm *Attrs
-          = (const cl_dbk_attributes_exp_gemm *)kernel_attributes;
+        const cl_dbk_attributes_gemm_exp *Attrs
+          = (const cl_dbk_attributes_gemm_exp *)kernel_attributes;
 
         return GemmCB (Attrs->trans_a, Attrs->trans_b, &Attrs->a, &Attrs->b,
                        &Attrs->c_in, &Attrs->c_out, &Attrs->alpha,
                        &Attrs->beta);
       }
-    case POCL_CDBI_DBK_EXP_MATMUL:
+    case CL_DBK_MATMUL_EXP:
       {
-        const cl_dbk_attributes_exp_matmul *Attrs
-          = (const cl_dbk_attributes_exp_matmul *)kernel_attributes;
+        const cl_dbk_attributes_matmul_exp *Attrs
+          = (const cl_dbk_attributes_matmul_exp *)kernel_attributes;
 
         return GemmCB (Attrs->trans_a, Attrs->trans_b, &Attrs->a, &Attrs->b,
                        NULL, &Attrs->c, NULL, NULL);
       }
-    case POCL_CDBI_DBK_EXP_JPEG_DECODE:
-    case POCL_CDBI_DBK_EXP_JPEG_ENCODE:
+    case CL_DBK_JPEG_DECODE_EXP:
+    case CL_DBK_JPEG_ENCODE_EXP:
       return pocl_validate_khr_jpeg (kernel_id, kernel_attributes);
 #ifdef HAVE_ONNXRT
-    case POCL_CDBI_DBK_EXP_ONNX_INFERENCE:
+    case CL_DBK_ONNX_INFERENCE_EXP:
       {
         /* TODO: validate I/O tensor list */
-        const cl_dbk_attributes_exp_onnx_inference *attrs
-          = (cl_dbk_attributes_exp_onnx_inference *)kernel_attributes;
+        const cl_dbk_attributes_onnx_inference_exp *attrs
+          = (cl_dbk_attributes_onnx_inference_exp *)kernel_attributes;
 
         if (attrs->num_initializers == 0
             && (attrs->initializer_names != NULL
@@ -865,63 +879,66 @@ pocl_validate_dbk_attributes (BuiltinKernelId kernel_id,
   default:
       break;
     }
-  POCL_RETURN_ERROR (CL_INVALID_DBK_ID, "Unknown builtin kernel ID: %u.\n",
+  POCL_RETURN_ERROR (CL_DBK_INVALID_ID_EXP, "Unknown builtin kernel ID: %u.\n",
                      kernel_id);
 }
 
 void *
-pocl_copy_defined_builtin_attributes (BuiltinKernelId kernel_id,
+pocl_copy_defined_builtin_attributes (cl_dbk_id_exp kernel_id,
                                       const void *kernel_attributes)
 {
   int err = CL_SUCCESS;
   switch (kernel_id)
     {
-    case POCL_CDBI_DBK_EXP_GEMM:
+    case CL_DBK_GEMM_EXP:
       {
-        cl_dbk_attributes_exp_gemm *attrs
-          = malloc (sizeof (cl_dbk_attributes_exp_gemm));
+        cl_dbk_attributes_gemm_exp *attrs
+          = malloc (sizeof (cl_dbk_attributes_gemm_exp));
         if (attrs == NULL)
           return NULL;
-        cl_dbk_attributes_exp_gemm *src
-          = (cl_dbk_attributes_exp_gemm *)kernel_attributes;
-        memcpy (attrs, src, sizeof (cl_dbk_attributes_exp_gemm));
+        cl_dbk_attributes_gemm_exp *src
+          = (cl_dbk_attributes_gemm_exp *)kernel_attributes;
+        memcpy (attrs, src, sizeof (cl_dbk_attributes_gemm_exp));
         err = pocl_copy_tensor_desc_layout (&attrs->a, &src->a);
         err |= pocl_copy_tensor_desc_layout(&attrs->b, &src->b);
         err |= pocl_copy_tensor_desc_layout(&attrs->c_in, &src->c_in);
         err |= pocl_copy_tensor_desc_layout(&attrs->c_out, &src->c_out);
-        if (err != CL_SUCCESS) {
-          POCL_MSG_WARN("Could not copy POCL_CDBI_DBK_EXP_GEMM attributes (err: %d).\n", err);
-          free(attrs);
-          return NULL;
-        }
+        if (err != CL_SUCCESS)
+          {
+            POCL_MSG_WARN (
+              "Could not copy CL_DBK_GEMM_EXP attributes (err: %d).\n", err);
+            free (attrs);
+            return NULL;
+          }
 
         return attrs;
       }
-    case POCL_CDBI_DBK_EXP_MATMUL:
+    case CL_DBK_MATMUL_EXP:
       {
-        cl_dbk_attributes_exp_matmul *attrs
-          = malloc (sizeof (cl_dbk_attributes_exp_matmul));
+        cl_dbk_attributes_matmul_exp *attrs
+          = malloc (sizeof (cl_dbk_attributes_matmul_exp));
         if (attrs == NULL)
           return NULL;
-        cl_dbk_attributes_exp_matmul *src
-          = (cl_dbk_attributes_exp_matmul *)kernel_attributes;
-        memcpy (attrs, src, sizeof (cl_dbk_attributes_exp_matmul));
+        cl_dbk_attributes_matmul_exp *src
+          = (cl_dbk_attributes_matmul_exp *)kernel_attributes;
+        memcpy (attrs, src, sizeof (cl_dbk_attributes_matmul_exp));
 
         err = pocl_copy_tensor_desc_layout (&attrs->a, &src->a);
         err |= pocl_copy_tensor_desc_layout (&attrs->b, &src->b);
         err |= pocl_copy_tensor_desc_layout (&attrs->c, &src->c);
         if (err != CL_SUCCESS) {
-          POCL_MSG_WARN("Could not copy POCL_CDBI_DBK_EXP_MATMUL attributes (err: %d).\n", err);
-          free(attrs);
-          return NULL;
+            POCL_MSG_WARN (
+              "Could not copy CL_DBK_MATMUL_EXP attributes (err: %d).\n", err);
+            free (attrs);
+            return NULL;
         }
         return attrs;
       }
-    case POCL_CDBI_DBK_EXP_JPEG_ENCODE:
-    case POCL_CDBI_DBK_EXP_JPEG_DECODE:
+    case CL_DBK_JPEG_ENCODE_EXP:
+    case CL_DBK_JPEG_DECODE_EXP:
       return pocl_copy_dbk_attributes_khr_jpeg (kernel_id, kernel_attributes);
 #ifdef HAVE_ONNXRT
-    case POCL_CDBI_DBK_EXP_ONNX_INFERENCE:
+    case CL_DBK_ONNX_INFERENCE_EXP:
       return pocl_copy_onnx_inference_dbk_attributes (kernel_attributes);
 #endif
   default:
@@ -932,38 +949,38 @@ pocl_copy_defined_builtin_attributes (BuiltinKernelId kernel_id,
 }
 
 int
-pocl_release_defined_builtin_attributes (BuiltinKernelId kernel_id,
+pocl_release_defined_builtin_attributes (cl_dbk_id_exp kernel_id,
                                          void *kernel_attributes)
 {
   switch (kernel_id)
     {
-    case POCL_CDBI_DBK_EXP_GEMM:
+    case CL_DBK_GEMM_EXP:
       {
-        cl_dbk_attributes_exp_gemm *attrs
-          = (cl_dbk_attributes_exp_gemm *)kernel_attributes;
-        POCL_MEM_FREE (attrs->a.layout);
-        POCL_MEM_FREE (attrs->b.layout);
-        POCL_MEM_FREE (attrs->c_in.layout);
-        POCL_MEM_FREE (attrs->c_out.layout);
-        POCL_MEM_FREE (attrs);
+        cl_dbk_attributes_gemm_exp *attrs
+          = (cl_dbk_attributes_gemm_exp *)kernel_attributes;
+        free ((void *)attrs->a.layout);
+        free ((void *)attrs->b.layout);
+        free ((void *)attrs->c_in.layout);
+        free ((void *)attrs->c_out.layout);
+        free (attrs);
         return CL_SUCCESS;
       }
-    case POCL_CDBI_DBK_EXP_MATMUL:
+    case CL_DBK_MATMUL_EXP:
       {
-        cl_dbk_attributes_exp_matmul *attrs
-          = (cl_dbk_attributes_exp_matmul *)kernel_attributes;
-        POCL_MEM_FREE (attrs->a.layout);
-        POCL_MEM_FREE (attrs->b.layout);
-        POCL_MEM_FREE (attrs->c.layout);
-        POCL_MEM_FREE (attrs);
+        cl_dbk_attributes_matmul_exp *attrs
+          = (cl_dbk_attributes_matmul_exp *)kernel_attributes;
+        free ((void *)attrs->a.layout);
+        free ((void *)attrs->b.layout);
+        free ((void *)attrs->c.layout);
+        free (attrs);
         return CL_SUCCESS;
       }
-    case POCL_CDBI_DBK_EXP_JPEG_ENCODE:
-    case POCL_CDBI_DBK_EXP_JPEG_DECODE:
+    case CL_DBK_JPEG_ENCODE_EXP:
+    case CL_DBK_JPEG_DECODE_EXP:
       return pocl_release_dbk_attributes_khr_jpeg (kernel_id,
                                                    kernel_attributes);
 #ifdef HAVE_ONNXRT
-    case POCL_CDBI_DBK_EXP_ONNX_INFERENCE:
+    case CL_DBK_ONNX_INFERENCE_EXP:
       {
         pocl_release_onnx_inference_dbk_attributes (kernel_attributes);
         return CL_SUCCESS;
@@ -972,7 +989,7 @@ pocl_release_defined_builtin_attributes (BuiltinKernelId kernel_id,
     default:
       break;
     }
-  POCL_RETURN_ERROR (CL_INVALID_DBK_ID, "Unknown builtin kernel ID: %u.\n",
+  POCL_RETURN_ERROR (CL_DBK_INVALID_ID_EXP, "Unknown builtin kernel ID: %u.\n",
                      kernel_id);
 }
 
@@ -1004,7 +1021,7 @@ pocl_release_defined_builtin_attributes (BuiltinKernelId kernel_id,
   while (0)
 
 uint64_t
-pocl_serialize_cl_tensor_desc (const cl_tensor_desc *t, char **buf)
+pocl_serialize_cl_tensor_desc (const cl_tensor_desc_exp *t, char **buf)
 {
   uint64_t total = 0;
   uint8_t has_layout = t->layout != NULL;
@@ -1019,16 +1036,22 @@ pocl_serialize_cl_tensor_desc (const cl_tensor_desc *t, char **buf)
     {
       switch (t->layout_type)
         {
-        case CL_TENSOR_LAYOUT_BLAS:
+        case CL_TENSOR_LAYOUT_BLAS_EXP:
           {
-            cl_tensor_layout_blas *layout = t->layout;
+            const cl_tensor_layout_blas_exp *layout = t->layout;
+            SERIALIZE (layout->leading_dims);
+            break;
+          }
+        case CL_TENSOR_LAYOUT_BLAS_PITCHED_EXP:
+          {
+            const cl_tensor_layout_blas_pitched_exp *layout = t->layout;
             SERIALIZE (layout->leading_dims);
             SERIALIZE (layout->leading_strides);
             break;
           }
-        case CL_TENSOR_LAYOUT_ML:
+        case CL_TENSOR_LAYOUT_ML_EXP:
           {
-            cl_tensor_layout_ml *layout = t->layout;
+            const cl_tensor_layout_ml_exp *layout = t->layout;
             SERIALIZE (layout->ml_type);
             break;
           }
@@ -1041,20 +1064,20 @@ pocl_serialize_cl_tensor_desc (const cl_tensor_desc *t, char **buf)
 }
 
 uint64_t
-pocl_serialize_dbk_attribs (BuiltinKernelId id,
+pocl_serialize_dbk_attribs (cl_dbk_id_exp id,
                             const void *attributes,
                             char **buf)
 {
-  /* First item shall be the BuiltinKernelId */
+  /* First item shall be the cl_dbk_id_exp */
   uint64_t total = 0;
   uint64_t dbk_id = id;
 
   SERIALIZE (dbk_id);
   switch (id)
     {
-    case POCL_CDBI_DBK_EXP_GEMM:
+    case CL_DBK_GEMM_EXP:
       {
-        const cl_dbk_attributes_exp_gemm *attr = attributes;
+        const cl_dbk_attributes_gemm_exp *attr = attributes;
         total += pocl_serialize_cl_tensor_desc (&attr->a, buf);
         total += pocl_serialize_cl_tensor_desc (&attr->b, buf);
         total += pocl_serialize_cl_tensor_desc (&attr->c_in, buf);
@@ -1066,9 +1089,9 @@ pocl_serialize_dbk_attribs (BuiltinKernelId id,
         SERIALIZE (attr->kernel_props);
         break;
       }
-    case POCL_CDBI_DBK_EXP_MATMUL:
+    case CL_DBK_MATMUL_EXP:
       {
-        const cl_dbk_attributes_exp_matmul *attr = attributes;
+        const cl_dbk_attributes_matmul_exp *attr = attributes;
         total += pocl_serialize_cl_tensor_desc (&attr->a, buf);
         total += pocl_serialize_cl_tensor_desc (&attr->b, buf);
         total += pocl_serialize_cl_tensor_desc (&attr->c, buf);
@@ -1077,17 +1100,17 @@ pocl_serialize_dbk_attribs (BuiltinKernelId id,
         SERIALIZE (attr->kernel_props);
         break;
       }
-    case POCL_CDBI_DBK_EXP_JPEG_ENCODE:
+    case CL_DBK_JPEG_ENCODE_EXP:
       {
-        const cl_dbk_attributes_exp_jpeg_encode *attr = attributes;
+        const cl_dbk_attributes_jpeg_encode_exp *attr = attributes;
         SERIALIZE (attr->width);
         SERIALIZE (attr->height);
         SERIALIZE (attr->quality);
         break;
       }
-    case POCL_CDBI_DBK_EXP_ONNX_INFERENCE:
+    case CL_DBK_ONNX_INFERENCE_EXP:
       {
-        const cl_dbk_attributes_exp_onnx_inference *attr = attributes;
+        const cl_dbk_attributes_onnx_inference_exp *attr = attributes;
         uint64_t model_size = attr->model_size;
         uint64_t num_inputs = attr->num_inputs;
         uint64_t num_outputs = attr->num_outputs;
@@ -1159,7 +1182,7 @@ pocl_serialize_dbk_attribs (BuiltinKernelId id,
   while (0)
 
 int
-pocl_deserialize_cl_tensor_desc (cl_tensor_desc *t, const char **buf)
+pocl_deserialize_cl_tensor_desc (cl_tensor_desc_exp *t, const char **buf)
 {
   uint8_t has_layout = 0;
   DESERIALIZE (t->rank);
@@ -1172,19 +1195,27 @@ pocl_deserialize_cl_tensor_desc (cl_tensor_desc *t, const char **buf)
     {
       switch (t->layout_type)
         {
-        case CL_TENSOR_LAYOUT_BLAS:
+        case CL_TENSOR_LAYOUT_BLAS_EXP:
           {
-            cl_tensor_layout_blas *layout
-              = malloc (sizeof (cl_tensor_layout_blas));
+            cl_tensor_layout_blas_exp *layout
+              = malloc (sizeof (cl_tensor_layout_blas_exp));
+            DESERIALIZE (layout->leading_dims);
+            t->layout = layout;
+            break;
+          }
+        case CL_TENSOR_LAYOUT_BLAS_PITCHED_EXP:
+          {
+            cl_tensor_layout_blas_pitched_exp *layout
+              = malloc (sizeof (cl_tensor_layout_blas_pitched_exp));
             DESERIALIZE (layout->leading_dims);
             DESERIALIZE (layout->leading_strides);
             t->layout = layout;
             break;
           }
-        case CL_TENSOR_LAYOUT_ML:
+        case CL_TENSOR_LAYOUT_ML_EXP:
           {
-            cl_tensor_layout_ml *layout
-              = malloc (sizeof (cl_tensor_layout_ml));
+            cl_tensor_layout_ml_exp *layout
+              = malloc (sizeof (cl_tensor_layout_ml_exp));
             DESERIALIZE (layout->ml_type);
             t->layout = layout;
             break;
@@ -1200,19 +1231,19 @@ pocl_deserialize_cl_tensor_desc (cl_tensor_desc *t, const char **buf)
 }
 
 int
-pocl_deserialize_dbk_attribs (BuiltinKernelId *id,
+pocl_deserialize_dbk_attribs (cl_dbk_id_exp *id,
                               void **attributes,
                               const char **buf)
 {
   uint64_t dbk_id;
   DESERIALIZE (dbk_id);
-  *id = (BuiltinKernelId)dbk_id;
+  *id = (cl_dbk_id_exp)dbk_id;
   switch (dbk_id)
     {
-    case POCL_CDBI_DBK_EXP_GEMM:
+    case CL_DBK_GEMM_EXP:
       {
-        cl_dbk_attributes_exp_gemm *attr
-          = malloc (sizeof (cl_dbk_attributes_exp_gemm));
+        cl_dbk_attributes_gemm_exp *attr
+          = malloc (sizeof (cl_dbk_attributes_gemm_exp));
         pocl_deserialize_cl_tensor_desc (&attr->a, buf);
         pocl_deserialize_cl_tensor_desc (&attr->b, buf);
         pocl_deserialize_cl_tensor_desc (&attr->c_in, buf);
@@ -1225,10 +1256,10 @@ pocl_deserialize_dbk_attribs (BuiltinKernelId *id,
         *attributes = attr;
         break;
       }
-    case POCL_CDBI_DBK_EXP_MATMUL:
+    case CL_DBK_MATMUL_EXP:
       {
-        cl_dbk_attributes_exp_matmul *attr
-          = malloc (sizeof (cl_dbk_attributes_exp_matmul));
+        cl_dbk_attributes_matmul_exp *attr
+          = malloc (sizeof (cl_dbk_attributes_matmul_exp));
         pocl_deserialize_cl_tensor_desc (&attr->a, buf);
         pocl_deserialize_cl_tensor_desc (&attr->b, buf);
         pocl_deserialize_cl_tensor_desc (&attr->c, buf);
@@ -1238,20 +1269,20 @@ pocl_deserialize_dbk_attribs (BuiltinKernelId *id,
         *attributes = attr;
         break;
       }
-    case POCL_CDBI_DBK_EXP_JPEG_ENCODE:
+    case CL_DBK_JPEG_ENCODE_EXP:
       {
-        cl_dbk_attributes_exp_jpeg_encode *attr
-          = malloc (sizeof (cl_dbk_attributes_exp_jpeg_encode));
+        cl_dbk_attributes_jpeg_encode_exp *attr
+          = malloc (sizeof (cl_dbk_attributes_jpeg_encode_exp));
         DESERIALIZE (attr->width);
         DESERIALIZE (attr->height);
         DESERIALIZE (attr->quality);
         *attributes = attr;
         break;
       }
-    case POCL_CDBI_DBK_EXP_ONNX_INFERENCE:
+    case CL_DBK_ONNX_INFERENCE_EXP:
       {
-        cl_dbk_attributes_exp_onnx_inference *attr
-          = calloc (1, sizeof (cl_dbk_attributes_exp_onnx_inference));
+        cl_dbk_attributes_onnx_inference_exp *attr
+          = calloc (1, sizeof (cl_dbk_attributes_onnx_inference_exp));
         uint64_t model_size;
         uint64_t num_inputs;
         uint64_t num_outputs;
@@ -1269,7 +1300,7 @@ pocl_deserialize_dbk_attribs (BuiltinKernelId *id,
           {
             attr->input_tensor_names = malloc (sizeof (char *) * num_inputs);
             attr->input_tensor_descs
-              = malloc (sizeof (cl_tensor_desc) * num_inputs);
+              = malloc (sizeof (cl_tensor_desc_exp) * num_inputs);
             for (size_t i = 0; i < num_inputs; ++i)
               {
                 uint64_t name_len;
@@ -1279,7 +1310,7 @@ pocl_deserialize_dbk_attribs (BuiltinKernelId *id,
                 COPY ((char *)attr->input_tensor_names[i], name_len);
                 ((char *)attr->input_tensor_names[i])[name_len] = 0;
                 pocl_deserialize_cl_tensor_desc (
-                  (cl_tensor_desc *)&(attr->input_tensor_descs[i]), buf);
+                  (cl_tensor_desc_exp *)&(attr->input_tensor_descs[i]), buf);
               }
           }
 
@@ -1289,7 +1320,7 @@ pocl_deserialize_dbk_attribs (BuiltinKernelId *id,
           {
             attr->output_tensor_names = malloc (sizeof (char *) * num_outputs);
             attr->output_tensor_descs
-              = malloc (sizeof (cl_tensor_desc) * num_outputs);
+              = malloc (sizeof (cl_tensor_desc_exp) * num_outputs);
             for (size_t i = 0; i < num_outputs; ++i)
               {
                 uint64_t name_len;
@@ -1299,7 +1330,7 @@ pocl_deserialize_dbk_attribs (BuiltinKernelId *id,
                 COPY ((char *)attr->output_tensor_names[i], name_len);
                 ((char *)attr->output_tensor_names[i])[name_len] = 0;
                 pocl_deserialize_cl_tensor_desc (
-                  (cl_tensor_desc *)&(attr->output_tensor_descs[i]), buf);
+                  (cl_tensor_desc_exp *)&(attr->output_tensor_descs[i]), buf);
               }
           }
 
@@ -1310,7 +1341,7 @@ pocl_deserialize_dbk_attribs (BuiltinKernelId *id,
             attr->initializer_names
               = malloc (sizeof (char *) * num_initializers);
             attr->initializer_tensor_descs
-              = malloc (sizeof (cl_tensor_desc) * num_initializers);
+              = malloc (sizeof (cl_tensor_desc_exp) * num_initializers);
             attr->initializer_data
               = malloc (sizeof (char *) * num_initializers);
             for (size_t i = 0; i < num_initializers; ++i)
@@ -1323,7 +1354,8 @@ pocl_deserialize_dbk_attribs (BuiltinKernelId *id,
                 COPY ((char *)attr->initializer_names[i], name_len);
                 ((char *)attr->initializer_names[i])[name_len] = 0;
                 pocl_deserialize_cl_tensor_desc (
-                  (cl_tensor_desc *)&(attr->initializer_tensor_descs[i]), buf);
+                  (cl_tensor_desc_exp *)&(attr->initializer_tensor_descs[i]),
+                  buf);
                 DESERIALIZE (data_len);
                 if (data_len > 0)
                   {

--- a/lib/CL/pocl_builtin_kernels.h
+++ b/lib/CL/pocl_builtin_kernels.h
@@ -54,37 +54,37 @@ extern "C"
   typedef int
   pocl_validate_khr_gemm_callback_t (cl_bool TransA,
                                      cl_bool TransB,
-                                     const cl_tensor_desc *TenA,
-                                     const cl_tensor_desc *TenB,
-                                     const cl_tensor_desc *TenCIOpt,
-                                     const cl_tensor_desc *TenCOut,
-                                     const cl_tensor_datatype_value *Alpha,
-                                     const cl_tensor_datatype_value *Beta);
+                                     const cl_tensor_desc_exp *TenA,
+                                     const cl_tensor_desc_exp *TenB,
+                                     const cl_tensor_desc_exp *TenCIOpt,
+                                     const cl_tensor_desc_exp *TenCOut,
+                                     const cl_tensor_datatype_value_exp *Alpha,
+                                     const cl_tensor_datatype_value_exp *Beta);
 
   /* GemmCB can be NULL, in which case the "generic" validation is run,
    * which checks the basic sanity. If it's non-NULL it's expected to check
    * device-specific validity. */
   POCL_EXPORT
-  int pocl_validate_dbk_attributes (BuiltinKernelId kernel_id,
+  int pocl_validate_dbk_attributes (cl_dbk_id_exp kernel_id,
                                     const void *kernel_attributes,
                                     pocl_validate_khr_gemm_callback_t GemmCB);
 
-  void *pocl_copy_defined_builtin_attributes (BuiltinKernelId kernel_id,
+  void *pocl_copy_defined_builtin_attributes (cl_dbk_id_exp kernel_id,
                                               const void *kernel_attributes);
 
-  int pocl_release_defined_builtin_attributes (BuiltinKernelId kernel_id,
+  int pocl_release_defined_builtin_attributes (cl_dbk_id_exp kernel_id,
                                                void *kernel_attributes);
 
-  POCL_EXPORT uint64_t pocl_serialize_cl_tensor_desc (const cl_tensor_desc *t,
-                                                      char **buf);
-  POCL_EXPORT uint64_t pocl_serialize_dbk_attribs (BuiltinKernelId id,
+  POCL_EXPORT uint64_t
+  pocl_serialize_cl_tensor_desc (const cl_tensor_desc_exp *t, char **buf);
+  POCL_EXPORT uint64_t pocl_serialize_dbk_attribs (cl_dbk_id_exp id,
                                                    const void *attributes,
                                                    char **buf);
 
-  POCL_EXPORT int pocl_deserialize_cl_tensor_desc (cl_tensor_desc *t,
+  POCL_EXPORT int pocl_deserialize_cl_tensor_desc (cl_tensor_desc_exp *t,
                                                    const char **buf);
 
-  POCL_EXPORT int pocl_deserialize_dbk_attribs (BuiltinKernelId *id,
+  POCL_EXPORT int pocl_deserialize_dbk_attribs (cl_dbk_id_exp *id,
                                                 void **attributes,
                                                 const char **buf);
 #ifdef __cplusplus

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -797,7 +797,7 @@ struct pocl_device_ops {
    * Note: the attributes have been already validated by runtime at this point
    */
   int (*supports_dbk) (cl_device_id device,
-                       BuiltinKernelId kernel_id,
+                       cl_dbk_id_exp kernel_id,
                        const void *kernel_attributes);
 
   /** Optional: If the driver needs to use hardware resources
@@ -1772,9 +1772,9 @@ struct _cl_mem {
 
   /* Tensor Properties */
   cl_uint tensor_rank;
-  cl_tensor_shape tensor_shape[CL_MEM_MAX_TENSOR_RANK];
-  cl_tensor_datatype tensor_dtype;
-  cl_tensor_layout_type tensor_layout_type;
+  cl_tensor_shape_exp tensor_shape[CL_MEM_MAX_TENSOR_RANK_EXP];
+  cl_tensor_datatype_exp tensor_dtype;
+  cl_tensor_layout_type_exp tensor_layout_type;
   void *tensor_layout;
   // properties
   char is_tensor;
@@ -1830,7 +1830,7 @@ typedef struct pocl_kernel_metadata_s
   /* per-device array of hashes */
   pocl_kernel_hash_t *build_hash;
 
-  /* enum BuiltinKernelId */
+  /* enum cl_dbk_id_exp */
   unsigned builtin_kernel_id;
   /* only for defined builtin kernels */
   void *builtin_kernel_attrs;
@@ -1880,7 +1880,7 @@ struct _cl_program {
   char **builtin_kernel_names;
   char *concated_builtin_names;
   // relevant only for DefinedBuiltinKernels:
-  BuiltinKernelId *builtin_kernel_ids;
+  cl_dbk_id_exp *builtin_kernel_ids;
   void **builtin_kernel_attributes;
 
   /* Poclcc binary format.  */

--- a/lib/CL/pocl_intfn.h
+++ b/lib/CL/pocl_intfn.h
@@ -225,7 +225,7 @@ POdeclsym(clEnqueueSVMMemcpyRectPOCL)
 POdeclsym (clSetKernelArgDevicePointerEXT)
 
 /* cl_exp_defined_builtin_kernels */
-POdeclsym (clCreateProgramWithDefinedBuiltInKernels)
+POdeclsym (clCreateProgramWithDefinedBuiltInKernelsEXP)
 
 /* clang-format on */
 

--- a/lib/CL/pocl_tensor_util.c
+++ b/lib/CL/pocl_tensor_util.c
@@ -25,17 +25,17 @@
 #include "pocl_cl_half_util.h"
 
 /* Check the tensor layout is well defined.
- * Return CL_INVALID_TENSOR_LAYOUT if there is an error. */
+ * Return CL_INVALID_TENSOR_LAYOUT_EXP if there is an error. */
 int
 pocl_check_tensor_layout (cl_uint rank,
-                          const cl_tensor_shape *shape,
-                          cl_tensor_layout_type layout_type,
+                          const cl_tensor_shape_exp *shape,
+                          cl_tensor_layout_type_exp layout_type,
                           const void *layout)
 {
   /* Checked already at check_tensor_desc(). */
-  assert (rank > 0 && rank <= CL_MEM_MAX_TENSOR_RANK);
+  assert (rank > 0 && rank <= CL_MEM_MAX_TENSOR_RANK_EXP);
 
-  if (layout == NULL && layout_type == CL_TENSOR_LAYOUT_NONE)
+  if (layout == NULL && layout_type == CL_TENSOR_LAYOUT_OPAQUE_EXP)
     {
       /* TODO: we should allow this at some point,
         but this needs more support. For now, return error.
@@ -48,34 +48,35 @@ pocl_check_tensor_layout (cl_uint rank,
         mapped to the allocation. Perhaps, we could support this
         case, if we extend the clGetMemObjectInfo() to return the
         datalayout the driver picked (and wants to expose)? */
-      POCL_RETURN_ERROR (CL_INVALID_TENSOR_LAYOUT,
+      POCL_RETURN_ERROR (CL_INVALID_TENSOR_LAYOUT_EXP,
                          "NULL layout currently unsupported\n");
     }
 
   POCL_RETURN_ERROR_ON (
-    (layout_type == CL_TENSOR_LAYOUT_NONE || layout == NULL),
-    CL_INVALID_TENSOR_LAYOUT,
-    "layout == NULL must be used with CL_TENSOR_LAYOUT_NONE\n");
+    (layout_type == CL_TENSOR_LAYOUT_OPAQUE_EXP || layout == NULL),
+    CL_INVALID_TENSOR_LAYOUT_EXP,
+    "layout == NULL must be used with CL_TENSOR_LAYOUT_OPAQUE_EXP\n");
 
   switch (layout_type)
     {
-    case CL_TENSOR_LAYOUT_NONE:
+    case CL_TENSOR_LAYOUT_OPAQUE_EXP:
     default:
       assert (0 && "should have been handled");
-      return CL_INVALID_TENSOR_LAYOUT;
-    case CL_TENSOR_LAYOUT_ML:
+      return CL_INVALID_TENSOR_LAYOUT_EXP;
+    case CL_TENSOR_LAYOUT_ML_EXP:
       {
-        cl_tensor_layout_ml *ml_layout = (cl_tensor_layout_ml *)layout;
+        cl_tensor_layout_ml_exp *ml_layout = (cl_tensor_layout_ml_exp *)layout;
         POCL_RETURN_ERROR_ON (
           (ml_layout->ml_type == CL_TENSOR_LAYOUT_ML_UNKNOWN
            || ml_layout->ml_type >= CL_TENSOR_LAYOUT_ML_LAST),
-          CL_INVALID_TENSOR_LAYOUT, "ML layout: unknown type %u",
+          CL_INVALID_TENSOR_LAYOUT_EXP, "ML layout: unknown type %u",
           ml_layout->ml_type);
         return CL_SUCCESS;
       }
-    case CL_TENSOR_LAYOUT_BLAS:
+    case CL_TENSOR_LAYOUT_BLAS_EXP:
       {
-        cl_tensor_layout_blas *blas_layout = (cl_tensor_layout_blas *)layout;
+        cl_tensor_layout_blas_exp *blas_layout
+          = (cl_tensor_layout_blas_exp *)layout;
 
         /* Check leading_dims array does not point out-of-rank dimensions
          * nor the same dimension index does not appear twice.
@@ -84,27 +85,56 @@ pocl_check_tensor_layout (cl_uint rank,
          * tensor_rank == 4: leading_dims = {0, 4, 1} --> error.
          * tensor_rank == 4: leading_dims = {1, 1, 0} --> error. */
         unsigned defined_dims = 0;
-        const cl_tensor_dim *ld = blas_layout->leading_dims;
+        const cl_tensor_dim_exp *ld = blas_layout->leading_dims;
         for (unsigned i = 0; i < rank - 1; i++)
           {
             POCL_RETURN_ERROR_ON (
-              ld[i] >= rank, CL_INVALID_TENSOR_LAYOUT,
+              ld[i] >= rank, CL_INVALID_TENSOR_LAYOUT_EXP,
               "BLAS layout: out-of-bounds tensor dimension! %u >= %u\n", ld[i],
               rank);
             POCL_RETURN_ERROR_ON ((defined_dims & (1u << ld[i])),
-                                  CL_INVALID_TENSOR_LAYOUT,
+                                  CL_INVALID_TENSOR_LAYOUT_EXP,
+                                  "BLAS layout: Dimension defined "
+                                  "twice!\n");
+            defined_dims |= (1u << ld[i]);
+          }
+      }
+    case CL_TENSOR_LAYOUT_BLAS_PITCHED_EXP:
+      {
+        cl_tensor_layout_blas_pitched_exp *blas_layout
+          = (cl_tensor_layout_blas_pitched_exp *)layout;
+
+        /* Check leading_dims array does not point out-of-rank dimensions
+         * nor the same dimension index does not appear twice.
+         *
+         * tensor_rank == 4: leading_dims = {0, 2, 1} --> Ok.
+         * tensor_rank == 4: leading_dims = {0, 4, 1} --> error.
+         * tensor_rank == 4: leading_dims = {1, 1, 0} --> error. */
+        unsigned defined_dims = 0;
+        const cl_tensor_dim_exp *ld = blas_layout->leading_dims;
+        for (unsigned i = 0; i < rank - 1; i++)
+          {
+            POCL_RETURN_ERROR_ON (
+              ld[i] >= rank, CL_INVALID_TENSOR_LAYOUT_EXP,
+              "BLAS layout: out-of-bounds tensor dimension! %u >= %u\n", ld[i],
+              rank);
+            POCL_RETURN_ERROR_ON ((defined_dims & (1u << ld[i])),
+                                  CL_INVALID_TENSOR_LAYOUT_EXP,
                                   "BLAS layout: Dimension defined "
                                   "twice!\n");
             defined_dims |= (1u << ld[i]);
           }
 
-        const cl_tensor_stride *ls = blas_layout->leading_strides;
-        cl_tensor_stride prev_stride = 0;
+        cl_tensor_layout_blas_pitched_exp *blas_pitched_layout
+          = (cl_tensor_layout_blas_pitched_exp *)layout;
+
+        const cl_tensor_stride_exp *ls = blas_pitched_layout->leading_strides;
+        cl_tensor_stride_exp prev_stride = 0;
         for (unsigned i = 0; i < rank - 1; i++)
           {
             /* Check the stride configuration does not cause aliasing. */
             POCL_RETURN_ERROR_ON (ls[i] <= shape[ld[i]] * prev_stride,
-                                  CL_INVALID_TENSOR_LAYOUT,
+                                  CL_INVALID_TENSOR_LAYOUT_EXP,
                                   "BLAS layout: Invalid stride\n");
             prev_stride = ls[i];
           }
@@ -114,35 +144,36 @@ pocl_check_tensor_layout (cl_uint rank,
     }
 
   assert (!"Unreachable!");
-  return CL_INVALID_TENSOR_LAYOUT;
+  return CL_INVALID_TENSOR_LAYOUT_EXP;
 }
 
 /* Checks validity of the tensor shape. Returns CL_INVALID_XYZ on error. */
 int
-pocl_check_tensor_desc (const cl_tensor_desc *tdesc)
+pocl_check_tensor_desc (const cl_tensor_desc_exp *tdesc)
 {
   /* Invalid to pass NULL tensor description in clCreateBufferWithProperties.
    */
   POCL_RETURN_ERROR_COND ((tdesc == NULL), CL_INVALID_ARG_VALUE);
 
-  POCL_RETURN_ERROR_ON ((tdesc->rank > CL_MEM_MAX_TENSOR_RANK),
-                        CL_INVALID_TENSOR_RANK, "Unsupported tensor rank.");
+  POCL_RETURN_ERROR_ON ((tdesc->rank > CL_MEM_MAX_TENSOR_RANK_EXP),
+                        CL_INVALID_TENSOR_RANK_EXP,
+                        "Unsupported tensor rank.");
 
   for (unsigned i = 0; i < tdesc->rank; i++)
-    POCL_RETURN_ERROR_ON ((tdesc->shape[i] == 0), CL_INVALID_TENSOR_SHAPE,
+    POCL_RETURN_ERROR_ON ((tdesc->shape[i] == 0), CL_INVALID_TENSOR_SHAPE_EXP,
                           "Tensor shape must be fully specified!");
 
-  const cl_tensor_properties *P = tdesc->properties;
+  const cl_tensor_properties_exp *P = tdesc->properties;
   while (*P)
     {
       switch (*P)
         {
-        case CL_TENSOR_PROPERTY_MUTABLE_SHAPE:
-        case CL_TENSOR_PROPERTY_MUTABLE_DTYPE:
-        case CL_TENSOR_PROPERTY_MUTABLE_LAYOUT:
+        case CL_TENSOR_PROPERTY_MUTABLE_SHAPE_EXP:
+        case CL_TENSOR_PROPERTY_MUTABLE_DTYPE_EXP:
+        case CL_TENSOR_PROPERTY_MUTABLE_LAYOUT_EXP:
           break;
         default:
-          POCL_RETURN_ERROR (CL_INVALID_TENSOR_PROPERTY,
+          POCL_RETURN_ERROR (CL_INVALID_TENSOR_PROPERTY_EXP,
                              "Unknown property %" PRIu64 "\n", *P);
         }
       ++P;
@@ -167,7 +198,7 @@ duplicate_array (const void *src, size_t num_objects, size_t object_size)
 /* Copies the tensor description (deep copy) into the cl_mem.
  * The 'tdesc' must be valid (checked by check_tensor_desc). */
 int
-pocl_copy_tensor_desc2mem (cl_mem mem, const cl_tensor_desc *tdesc)
+pocl_copy_tensor_desc2mem (cl_mem mem, const cl_tensor_desc_exp *tdesc)
 {
   if (!tdesc)
     return CL_SUCCESS;
@@ -181,45 +212,63 @@ pocl_copy_tensor_desc2mem (cl_mem mem, const cl_tensor_desc *tdesc)
 
   if (!tdesc->layout)
     {
-      assert (tdesc->layout_type == CL_TENSOR_LAYOUT_NONE);
+      assert (tdesc->layout_type == CL_TENSOR_LAYOUT_OPAQUE_EXP);
       return CL_SUCCESS;
     }
 
-  cl_tensor_layout_ml *new_layout1 = NULL;
-  cl_tensor_layout_blas *new_layout2 = NULL;
+  cl_tensor_layout_ml_exp *new_layout1 = NULL;
+  cl_tensor_layout_blas_exp *new_layout2 = NULL;
+  cl_tensor_layout_blas_pitched_exp *new_layout3 = NULL;
 
   switch (tdesc->layout_type)
     {
     default:
-    case CL_TENSOR_LAYOUT_NONE:
+    case CL_TENSOR_LAYOUT_OPAQUE_EXP:
       assert (0 && "this should have been caught earlier");
       return CL_FAILED;
 
-    case CL_TENSOR_LAYOUT_ML:
+    case CL_TENSOR_LAYOUT_ML_EXP:
       {
-        cl_tensor_layout_ml *ml_layout = (cl_tensor_layout_ml *)tdesc->layout;
-        new_layout1 = DUPLICATE_ARRAY (ml_layout, 1, cl_tensor_layout_blas);
+        cl_tensor_layout_ml_exp *ml_layout
+          = (cl_tensor_layout_ml_exp *)tdesc->layout;
+        new_layout1 = DUPLICATE_ARRAY (ml_layout, 1, cl_tensor_layout_ml_exp);
         if (!new_layout1)
           goto error;
         mem->tensor_layout = new_layout1;
-        mem->tensor_layout_type = CL_TENSOR_LAYOUT_ML;
+        mem->tensor_layout_type = CL_TENSOR_LAYOUT_ML_EXP;
         return CL_SUCCESS;
       }
 
-    case CL_TENSOR_LAYOUT_BLAS:
+    case CL_TENSOR_LAYOUT_BLAS_EXP:
       {
-        cl_tensor_layout_blas *blas_layout
-          = (cl_tensor_layout_blas *)tdesc->layout;
-        new_layout2 = DUPLICATE_ARRAY (blas_layout, 1, cl_tensor_layout_blas);
+        cl_tensor_layout_blas_exp *blas_layout
+          = (cl_tensor_layout_blas_exp *)tdesc->layout;
+        new_layout2
+          = DUPLICATE_ARRAY (blas_layout, 1, cl_tensor_layout_blas_exp);
         if (!new_layout2)
           goto error;
 
         memcpy (new_layout2->leading_dims, blas_layout->leading_dims,
                 sizeof (blas_layout->leading_dims));
-        memcpy (new_layout2->leading_strides, blas_layout->leading_strides,
-                sizeof (blas_layout->leading_strides));
         mem->tensor_layout = new_layout2;
-        mem->tensor_layout_type = CL_TENSOR_LAYOUT_BLAS;
+        mem->tensor_layout_type = CL_TENSOR_LAYOUT_BLAS_EXP;
+        return CL_SUCCESS;
+      }
+    case CL_TENSOR_LAYOUT_BLAS_PITCHED_EXP:
+      {
+        cl_tensor_layout_blas_pitched_exp *blas_layout
+          = (cl_tensor_layout_blas_pitched_exp *)tdesc->layout;
+        new_layout3 = DUPLICATE_ARRAY (blas_layout, 1,
+                                       cl_tensor_layout_blas_pitched_exp);
+        if (!new_layout3)
+          goto error;
+
+        memcpy (new_layout3->leading_dims, blas_layout->leading_dims,
+                sizeof (blas_layout->leading_dims));
+        memcpy (new_layout3->leading_strides, blas_layout->leading_strides,
+                sizeof (blas_layout->leading_strides));
+        mem->tensor_layout = new_layout3;
+        mem->tensor_layout_type = CL_TENSOR_LAYOUT_BLAS_PITCHED_EXP;
         return CL_SUCCESS;
       }
     }
@@ -227,25 +276,34 @@ pocl_copy_tensor_desc2mem (cl_mem mem, const cl_tensor_desc *tdesc)
 error:
   free (new_layout1);
   free (new_layout2);
+  free (new_layout3);
   return CL_OUT_OF_HOST_MEMORY;
 }
 
 /* Copies the tensor layout only
  * The 'src' must be valid (checked by check_tensor_desc). */
 int
-pocl_copy_tensor_desc_layout (cl_tensor_desc *dest, const cl_tensor_desc *src)
+pocl_copy_tensor_desc_layout (cl_tensor_desc_exp *dest,
+                              const cl_tensor_desc_exp *src)
 {
   if (src == NULL)
     return CL_SUCCESS;
   switch (src->layout_type)
     {
-    case CL_TENSOR_LAYOUT_ML:
-      dest->layout = malloc (sizeof (cl_tensor_layout_ml));
-      memcpy (dest->layout, src->layout, sizeof (cl_tensor_layout_ml));
+    case CL_TENSOR_LAYOUT_ML_EXP:
+      dest->layout = malloc (sizeof (cl_tensor_layout_ml_exp));
+      memcpy ((void *)dest->layout, src->layout,
+              sizeof (cl_tensor_layout_ml_exp));
       return CL_SUCCESS;
-    case CL_TENSOR_LAYOUT_BLAS:
-      dest->layout = malloc (sizeof (cl_tensor_layout_blas));
-      memcpy (dest->layout, src->layout, sizeof (cl_tensor_layout_blas));
+    case CL_TENSOR_LAYOUT_BLAS_EXP:
+      dest->layout = malloc (sizeof (cl_tensor_layout_blas_exp));
+      memcpy ((void *)dest->layout, src->layout,
+              sizeof (cl_tensor_layout_blas_exp));
+      return CL_SUCCESS;
+    case CL_TENSOR_LAYOUT_BLAS_PITCHED_EXP:
+      dest->layout = malloc (sizeof (cl_tensor_layout_blas_pitched_exp));
+      memcpy ((void *)dest->layout, src->layout,
+              sizeof (cl_tensor_layout_blas_pitched_exp));
       return CL_SUCCESS;
     default:
       return CL_SUCCESS;
@@ -253,26 +311,27 @@ pocl_copy_tensor_desc_layout (cl_tensor_desc *dest, const cl_tensor_desc *src)
 }
 
 int
-pocl_tensor_type_is_int (cl_tensor_datatype T)
+pocl_tensor_type_is_int (cl_tensor_datatype_exp dtype)
 {
-  switch (T)
+  switch (dtype)
     {
-    case CL_TENSOR_DTYPE_FP64:
-    case CL_TENSOR_DTYPE_FP32:
-    case CL_TENSOR_DTYPE_FP16:
-    case CL_TENSOR_DTYPE_FP8:
+    case CL_TENSOR_DTYPE_FP64_EXP:
+    case CL_TENSOR_DTYPE_FP32_EXP:
+    case CL_TENSOR_DTYPE_FP16_EXP:
+    case CL_TENSOR_DTYPE_FP8E4M3_EXP:
+    case CL_TENSOR_DTYPE_FP8E5M2_EXP:
       return 0;
 
-    case CL_TENSOR_DTYPE_INT64:
-    case CL_TENSOR_DTYPE_UINT64:
-    case CL_TENSOR_DTYPE_INT32:
-    case CL_TENSOR_DTYPE_UINT32:
-    case CL_TENSOR_DTYPE_INT16:
-    case CL_TENSOR_DTYPE_UINT16:
-    case CL_TENSOR_DTYPE_INT8:
-    case CL_TENSOR_DTYPE_UINT8:
-    case CL_TENSOR_DTYPE_INT4:
-    case CL_TENSOR_DTYPE_UINT4:
+    case CL_TENSOR_DTYPE_INT64_EXP:
+    case CL_TENSOR_DTYPE_UINT64_EXP:
+    case CL_TENSOR_DTYPE_INT32_EXP:
+    case CL_TENSOR_DTYPE_UINT32_EXP:
+    case CL_TENSOR_DTYPE_INT16_EXP:
+    case CL_TENSOR_DTYPE_UINT16_EXP:
+    case CL_TENSOR_DTYPE_INT8_EXP:
+    case CL_TENSOR_DTYPE_UINT8_EXP:
+    case CL_TENSOR_DTYPE_INT4_EXP:
+    case CL_TENSOR_DTYPE_UINT4_EXP:
       return 1;
 
     case CL_TENSOR_DTYPE_UNKNOWN:
@@ -282,27 +341,28 @@ pocl_tensor_type_is_int (cl_tensor_datatype T)
 }
 
 int
-pocl_tensor_type_size (cl_tensor_datatype T)
+pocl_tensor_type_size (cl_tensor_datatype_exp dtype)
 {
-  switch (T)
+  switch (dtype)
     {
-    case CL_TENSOR_DTYPE_FP64:
-    case CL_TENSOR_DTYPE_INT64:
-    case CL_TENSOR_DTYPE_UINT64:
+    case CL_TENSOR_DTYPE_FP64_EXP:
+    case CL_TENSOR_DTYPE_INT64_EXP:
+    case CL_TENSOR_DTYPE_UINT64_EXP:
       return 8;
-    case CL_TENSOR_DTYPE_FP32:
-    case CL_TENSOR_DTYPE_INT32:
-    case CL_TENSOR_DTYPE_UINT32:
+    case CL_TENSOR_DTYPE_FP32_EXP:
+    case CL_TENSOR_DTYPE_INT32_EXP:
+    case CL_TENSOR_DTYPE_UINT32_EXP:
       return 4;
-    case CL_TENSOR_DTYPE_FP16:
-    case CL_TENSOR_DTYPE_INT16:
-    case CL_TENSOR_DTYPE_UINT16:
+    case CL_TENSOR_DTYPE_FP16_EXP:
+    case CL_TENSOR_DTYPE_INT16_EXP:
+    case CL_TENSOR_DTYPE_UINT16_EXP:
       return 2;
-    case CL_TENSOR_DTYPE_FP8:
-    case CL_TENSOR_DTYPE_INT8:
-    case CL_TENSOR_DTYPE_UINT8:
-    case CL_TENSOR_DTYPE_INT4:
-    case CL_TENSOR_DTYPE_UINT4:
+    case CL_TENSOR_DTYPE_FP8E4M3_EXP:
+    case CL_TENSOR_DTYPE_FP8E5M2_EXP:
+    case CL_TENSOR_DTYPE_INT8_EXP:
+    case CL_TENSOR_DTYPE_UINT8_EXP:
+    case CL_TENSOR_DTYPE_INT4_EXP:
+    case CL_TENSOR_DTYPE_UINT4_EXP:
       return 1;
     case CL_TENSOR_DTYPE_UNKNOWN:
     default:
@@ -311,7 +371,7 @@ pocl_tensor_type_size (cl_tensor_datatype T)
 }
 
 size_t
-pocl_tensor_data_size (const cl_tensor_desc *t)
+pocl_tensor_data_size (const cl_tensor_desc_exp *t)
 {
   size_t data_len = pocl_tensor_type_size (t->dtype);
   for (size_t dim = 0; dim < t->rank; ++dim)
@@ -322,47 +382,51 @@ pocl_tensor_data_size (const cl_tensor_desc *t)
 }
 
 cl_bool
-pocl_tensor_dtype_value_equals (const cl_tensor_datatype DType,
-                                const cl_tensor_datatype_value *Value,
-                                cl_double doubleConst,
-                                cl_long longConst,
-                                cl_ulong ulongConst,
-                                char fp8Const,
-                                char int4Const)
+pocl_tensor_dtype_value_equals (const cl_tensor_datatype_exp dtype,
+                                const cl_tensor_datatype_value_exp *value,
+                                cl_double double_const,
+                                cl_long long_const,
+                                cl_ulong ulong_const,
+                                char fp8_const,
+                                char int4_const)
 {
-  cl_float floatConst = (cl_float)doubleConst;
-  cl_half halfConst = pocl_float_to_half (floatConst);
-  switch (DType)
+  cl_float float_const = (cl_float)double_const;
+  cl_half half_const = pocl_float_to_half (float_const);
+  switch (dtype)
     {
-    case CL_TENSOR_DTYPE_FP64:
-      return (Value->d == doubleConst);
-    case CL_TENSOR_DTYPE_FP32:
-      return (Value->f == floatConst);
-    case CL_TENSOR_DTYPE_FP16:
-      return (Value->h == halfConst);
+    case CL_TENSOR_DTYPE_FP64_EXP:
+      return (value->fd == double_const);
+    case CL_TENSOR_DTYPE_FP32_EXP:
+      return (value->ff == float_const);
+    case CL_TENSOR_DTYPE_FP16_EXP:
+      return (value->fh == half_const);
     /* TODO fp8 comparison */
-    case CL_TENSOR_DTYPE_FP8:
-      return (Value->c == fp8Const);
-    case CL_TENSOR_DTYPE_INT64:
-      return (Value->l == longConst);
-    case CL_TENSOR_DTYPE_UINT64:
-      return ((cl_ulong)Value->l == ulongConst);
-    case CL_TENSOR_DTYPE_INT32:
-      return (Value->l == longConst);
-    case CL_TENSOR_DTYPE_UINT32:
-      return ((cl_ulong)Value->i == ulongConst);
-    case CL_TENSOR_DTYPE_INT16:
-      return ((cl_long)Value->s == longConst);
-    case CL_TENSOR_DTYPE_UINT16:
-      return ((cl_ulong)Value->s == ulongConst);
-    case CL_TENSOR_DTYPE_INT8:
-      return ((cl_long)Value->c == longConst);
-    case CL_TENSOR_DTYPE_UINT8:
-      return ((cl_ulong)Value->c == ulongConst);
+    case CL_TENSOR_DTYPE_FP8E4M3_EXP:
+    case CL_TENSOR_DTYPE_FP8E5M2_EXP:
+      /* FIXME: Need to add new union members or pack them into value->raw. */
+      return (value->uc == fp8_const);
+    case CL_TENSOR_DTYPE_INT64_EXP:
+      return (value->sl == long_const);
+    case CL_TENSOR_DTYPE_UINT64_EXP:
+      return ((cl_ulong)value->ul == ulong_const);
+    case CL_TENSOR_DTYPE_INT32_EXP:
+      return (value->sl == long_const);
+    case CL_TENSOR_DTYPE_UINT32_EXP:
+      return ((cl_ulong)value->ui == ulong_const);
+    case CL_TENSOR_DTYPE_INT16_EXP:
+      return ((cl_long)value->ss == long_const);
+    case CL_TENSOR_DTYPE_UINT16_EXP:
+      return ((cl_ulong)value->us == ulong_const);
+    case CL_TENSOR_DTYPE_INT8_EXP:
+      return ((cl_long)value->sc == long_const);
+    case CL_TENSOR_DTYPE_UINT8_EXP:
+      return ((cl_ulong)value->uc == ulong_const);
     /* TODO int4 comparison */
-    case CL_TENSOR_DTYPE_INT4:
-    case CL_TENSOR_DTYPE_UINT4:
-      return (Value->c == int4Const);
+    case CL_TENSOR_DTYPE_INT4_EXP:
+    case CL_TENSOR_DTYPE_UINT4_EXP:
+      /* FIXME: Need to specify how objects less than 8-bit are represented.
+       *        One object per byte? Multiple objects per byte? */
+      return (value->uc == int4_const);
     default:
       return CL_FALSE;
     }

--- a/lib/CL/pocl_tensor_util.h
+++ b/lib/CL/pocl_tensor_util.h
@@ -24,27 +24,28 @@
 #include "pocl_cl.h"
 
 int pocl_check_tensor_layout (cl_uint rank,
-                              const cl_tensor_shape *shape,
-                              cl_tensor_layout_type layout_type,
+                              const cl_tensor_shape_exp *shape,
+                              cl_tensor_layout_type_exp layout_type,
                               const void *layout);
 
-int pocl_check_tensor_desc (const cl_tensor_desc *tdesc);
+int pocl_check_tensor_desc (const cl_tensor_desc_exp *tdesc);
 
-int pocl_copy_tensor_desc2mem (cl_mem mem, const cl_tensor_desc *tdesc);
+int pocl_copy_tensor_desc2mem (cl_mem mem, const cl_tensor_desc_exp *tdesc);
 
-int pocl_copy_tensor_desc_layout (cl_tensor_desc *dest,
-                                  const cl_tensor_desc *src);
+int pocl_copy_tensor_desc_layout (cl_tensor_desc_exp *dest,
+                                  const cl_tensor_desc_exp *src);
 
-int pocl_tensor_type_is_int (cl_tensor_datatype T);
+int pocl_tensor_type_is_int (cl_tensor_datatype_exp dtype);
 
-int pocl_tensor_type_size (cl_tensor_datatype T);
+int pocl_tensor_type_size (cl_tensor_datatype_exp dtype);
 
-size_t pocl_tensor_data_size (const cl_tensor_desc *t);
+size_t pocl_tensor_data_size (const cl_tensor_desc_exp *t);
 
-cl_bool pocl_tensor_dtype_value_equals (const cl_tensor_datatype DType,
-                                        const cl_tensor_datatype_value *Value,
-                                        cl_double doubleConst,
-                                        cl_long longConst,
-                                        cl_ulong ulongConst,
-                                        char fp8Const,
-                                        char int4Const);
+cl_bool
+pocl_tensor_dtype_value_equals (const cl_tensor_datatype_exp dtype,
+                                const cl_tensor_datatype_value_exp *value,
+                                cl_double double_const,
+                                cl_long long_const,
+                                cl_ulong ulong_const,
+                                char fp8_const,
+                                char int4_const);

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -90,7 +90,7 @@ class SharedCLContext final : public SharedContextBase {
   std::vector<cl::Device> CLDevices;
   std::vector<cl::Device> CLDevicesWithSVMSupport;
 
-  clCreateProgramWithDefinedBuiltInKernels_fn createProgramWithDBKs;
+  clCreateProgramWithDefinedBuiltInKernelsEXP_fn createProgramWithDBKs;
 
   std::unordered_map<uint32_t, clSamplerPtr> SamplerIDmap;
   std::unordered_map<uint32_t, clImagePtr> ImageIDmap;
@@ -562,9 +562,9 @@ SharedCLContext::SharedCLContext(cl::Platform *p, unsigned pid,
                                  ReplyQueueThread *s, ReplyQueueThread *f) {
   p->getDevices(CL_DEVICE_TYPE_ALL, &CLDevices);
 
-  createProgramWithDBKs = (clCreateProgramWithDefinedBuiltInKernels_fn)
+  createProgramWithDBKs = (clCreateProgramWithDefinedBuiltInKernelsEXP_fn)
       clGetExtensionFunctionAddressForPlatform(
-          (*p)(), "clCreateProgramWithDefinedBuiltInKernels");
+          (*p)(), "clCreateProgramWithDefinedBuiltInKernelsEXP");
 
   cl_context_properties Properties[] = {
       CL_CONTEXT_PLATFORM, reinterpret_cast<intptr_t>(p->operator()()),
@@ -1479,7 +1479,7 @@ int SharedCLContext::buildOrLinkProgram(
 
     uint64_t num_kernels;
     std::vector<const char *> kernel_names;
-    std::vector<BuiltinKernelId> kernel_ids;
+    std::vector<cl_dbk_id_exp> kernel_ids;
     std::vector<void *> kernel_attributes;
 
     const char *cursor = src;

--- a/tests/runtime/test_dbk_jpeg.c
+++ b/tests/runtime/test_dbk_jpeg.c
@@ -133,15 +133,14 @@ main (int argc, char const *argv[])
         }
   }
 
-  clCreateProgramWithDefinedBuiltInKernels_fn createProgramWithDBKs;
-  createProgramWithDBKs = (clCreateProgramWithDefinedBuiltInKernels_fn)
+  clCreateProgramWithDefinedBuiltInKernelsEXP_fn createProgramWithDBKs;
+  createProgramWithDBKs = (clCreateProgramWithDefinedBuiltInKernelsEXP_fn)
     clGetExtensionFunctionAddressForPlatform (
-      platform, "clCreateProgramWithDefinedBuiltInKernels");
+      platform, "clCreateProgramWithDefinedBuiltInKernelsEXP");
   TEST_ASSERT (createProgramWithDBKs != NULL);
-  BuiltinKernelId dbk_ids[]
-    = { POCL_CDBI_DBK_EXP_JPEG_ENCODE, POCL_CDBI_DBK_EXP_JPEG_DECODE };
-  const char *kernel_names[] = { "exp_jpeg_encode", "exp_jpeg_decode" };
-  cl_dbk_attributes_exp_jpeg_encode encode_attributes = { width, height, 80 };
+  cl_dbk_id_exp dbk_ids[] = { CL_DBK_JPEG_ENCODE_EXP, CL_DBK_JPEG_DECODE_EXP };
+  const char *kernel_names[] = { "jpeg_encode_exp", "jpeg_decode_exp" };
+  cl_dbk_attributes_jpeg_encode_exp encode_attributes = { width, height, 80 };
   const void *attributes[] = { &encode_attributes, NULL };
   cl_int device_support[] = { 0, 0 };
   cl_program program = createProgramWithDBKs (

--- a/tests/runtime/test_dbk_onnx_inference.c
+++ b/tests/runtime/test_dbk_onnx_inference.c
@@ -101,7 +101,7 @@ main (int _argc, char **_argv)
                                  { num_elements },
                                  &tensor_layout,
                                  CL_TENSOR_LAYOUT_ML };
-  BuiltinKernelId dbk_id = POCL_CDBI_DBK_EXP_ONNX_INFERENCE;
+  cl_dbk_id_exp dbk_id = POCL_CDBI_DBK_EXP_ONNX_INFERENCE;
   const char *dbk_name = "exp_onnx_inference";
   const char *input_tensor_names[] = { "A", "B" };
   const char *output_tensor_names[] = { "C" };


### PR DESCRIPTION
Update tensor and DBK work to match cl_exp_tensor v0.2.0 and cl_exp_defined_builtin_kernels v0.3.1. The changes are mostly just renames and reformatting.