### PR TITLE
Improve formatter scripts

### DIFF
--- a/tools/scripts/format-branch.sh
+++ b/tools/scripts/format-branch.sh
@@ -1,34 +1,3 @@
 #!/usr/bin/env bash
-
-GITROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-if [ $? -ne 0 ]; then
-  echo "must be run in git repo"
-  exit 1
-fi
-
-SCRIPTPATH=$( realpath "$0"  )
-RELPATH=$(dirname "$SCRIPTPATH")
-
-# cd to root directory of the git repo
-pushd "${GITROOT}" > /dev/null || exit 1
-
-case "$(git describe --always --dirty=-DIRTY)" in
-  *-DIRTY)
-    echo "There are uncommitted changes - aborting."
-    exit 1
-esac
-
-PATCHY=$(mktemp /tmp/pocl.XXXXXXXX.patch)
-trap 'rm -f $PATCHY' EXIT
-
-git diff main -U0 --no-color >"$PATCHY"
-
-"$RELPATH"/clang-format-diff.py -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 -style=file:"$RELPATH/style.GNU" <"$PATCHY"
-
-# We need to recreate the diff since the old patch is stale.
-git diff main -U0 --no-color >"$PATCHY"
-
-"$RELPATH"/clang-format-diff.py -v -regex '(.*(\.hpp$|\.hh$|\.cc$|\.cpp$|lib/llvmopencl/.*$|/lib/CL/devices/tce/.*$))' -i -p1 -style=file:"$RELPATH/style.CPP" <"$PATCHY"
-
-# cd back whence we were previously
-popd > /dev/null || exit 1
+RELPATH=$(dirname "$(realpath "$0")")
+$RELPATH/format-diff.sh main "$@"

--- a/tools/scripts/format-diff.sh
+++ b/tools/scripts/format-diff.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
+# USAGE:
+#
+# 1) format-diff.sh
+# 2) format-diff.sh <commit>
+#
+# 1) formats current unstaged changes and 2) formats changes since the
+# commit or changes between commit range (XREF..YREF).
 
 GITROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 if [ $? -ne 0 ]; then
-  echo "must be run in git repo"
+  >&2 echo "must be run in git repo"
   exit 1
 fi
 
@@ -10,19 +17,41 @@ SCRIPTPATH=$( realpath "$0"  )
 RELPATH=$(dirname "$SCRIPTPATH")
 
 # cd to root directory of the git repo
-pushd "${GITROOT}" > /dev/null || exit 1
+cd "${GITROOT}" || exit 1
+
+if [ $# -ne 1 ]; then
+    if git status --porcelain=1 -uno | grep '^.[MTDRC] '; then
+	>&2 echo "There are unstaged changes - aborting."
+	exit 1
+    fi
+fi
 
 PATCHY=$(mktemp /tmp/pocl.XXXXXXXX.patch)
 trap 'rm -f $PATCHY' EXIT
 
-git diff $* -U0 --no-color >$PATCHY
+git diff "$@" -U0 --no-color >"$PATCHY"
 
-"$RELPATH"/clang-format-diff.py -v -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 -style=file:"$RELPATH/style.GNU" <"$PATCHY"
+if [ -z "${CLANG_FORMAT_BIN}" ]; then
+    CLANG_FORMAT_BIN=clang-format
+    # clang-format v15 is the lowest version that supports the custom
+    # style files ahead.
+    for i in {25..15}; do
+	cand_bin=$(command -v "clang-format-$i") || continue
+	CLANG_FORMAT_BIN=$cand_bin
+	break;
+    done
+fi
+
+echo "Using: $CLANG_FORMAT_BIN"
+
+"$RELPATH"/clang-format-diff.py -v -binary "$CLANG_FORMAT_BIN" \
+	  -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 \
+	  -style=file:"$RELPATH/style.GNU" <"$PATCHY"
 
 # We need to recreate the diff since the old patch is stale.
-git diff $* -U0 --no-color >$PATCHY
+git diff "$@" -U0 --no-color >"$PATCHY"
 
-"$RELPATH"/clang-format-diff.py -v -regex '(.*(\.hpp$|\.hh$|\.cc$|\.cpp$|lib/llvmopencl/.*\.h$|/lib/CL/devices/tce/.*$))' -i -p1 -style=file:"$RELPATH/style.CPP" <"$PATCHY"
+"$RELPATH"/clang-format-diff.py -v -binary "$CLANG_FORMAT_BIN" \
+	  -regex '(.*(\.hpp$|\.hh$|\.cc$|\.cpp$|lib/llvmopencl/.*$|/lib/CL/devices/tce/.*$))' \
+	  -i -p1 -style=file:"$RELPATH/style.CPP" <"$PATCHY"
 
-# cd back wherever we were previously
-popd > /dev/null || exit 1

--- a/tools/scripts/format-last-commit.sh
+++ b/tools/scripts/format-last-commit.sh
@@ -1,36 +1,3 @@
 #!/usr/bin/env bash
-
-GITROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-if [ $? -ne 0 ]; then
-  echo "must be run in git repo"
-  exit 1
-fi
-
-SCRIPTPATH=$( realpath "$0"  )
-RELPATH=$(dirname "$SCRIPTPATH")
-
-# cd to root directory of the git repo
-pushd "${GITROOT}" > /dev/null || exit 1
-
-case "$(git describe --always --dirty=-DIRTY)" in
-  *-DIRTY)
-    echo "There are uncommitted changes - aborting."
-    exit 1
-esac
-
-PATCHY=$(mktemp /tmp/pocl.XXXXXXXX.patch)
-trap 'rm -f $PATCHY' EXIT
-
-git show -U0 --no-color >"$PATCHY"
-
-"$RELPATH"/clang-format-diff.py -regex '.*(\.h$|\.c$|\.cl$)' -i -p1 -style=file:"$RELPATH/style.GNU" <"$PATCHY"
-
-"$RELPATH"/clang-format-diff.py -regex '(.*(\.hpp$|\.hh$|\.cc$|\.cpp$))|(lib/llvmopencl/.*)|(lib/CL/devices/tce/.*)' -i -p1 -style=file:"$RELPATH/style.CPP" <"$PATCHY"
-
-if [ -z "$(git diff)" ]; then
-  echo "No changes."
-  exit 0
-fi
-
-# cd back whence we were previously
-popd > /dev/null || exit 1
+RELPATH=$(dirname "$(realpath "$0")")
+$RELPATH/format-diff.sh HEAD~1 "$@"


### PR DESCRIPTION
* Try use the latest `clang-format-XX` in the PATH first.

format-branch.sh failed with following error:
```
/mnt/md1/linehill/ws-pocl-2/pocl/tools/scripts/style.GNU:25:3: error: unknown enumerated scalar
  Enabled:         false
  ^
Error reading /mnt/md1/linehill/ws-pocl-2/pocl/tools/scripts/style.GNU: Invalid argument
Formatting pocld/shared_cl_context.cc
/mnt/md1/linehill/ws-pocl-2/pocl/tools/scripts/style.CPP:26:3: error: unknown enumerated scalar
  Enabled:         false
  ^
Error reading /mnt/md1/linehill/ws-pocl-2/pocl/tools/scripts/style.CPP: Invalid argument
```

Perhaps, due to the `clang-format` (v14) on my system being too old for the custom style files. There are other formatters in `clang-format-XX` form in the PATH and using the lates one (`clang-format-19`) fixes the issue. Change the `format-branch.sh` to use the latest `clang-format-XX` found in path and, otherwise, fall-back to `clang-format`.

* Remove duplicated formatter logic.

* Verbose output when formatting C++ sources - not only when formatting C sources.

* Allow formatting if there are staged changes (previously couldn't do this).