### PR TITLE
Yet more misc. fixes

### DIFF
--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -132,7 +132,9 @@ endif()
 
 string(REPLACE "${LLVM_PREFIX}" "${LLVM_PREFIX_CMAKE}" LLVM_OBJ_ROOT "${LLVM_OBJ_ROOT}")
 run_llvm_config(LLVM_ALL_TARGETS --targets-built)
-run_llvm_config(LLVM_HOST_TARGET --host-target)
+if (NOT DEFINED LLVM_HOST_TARGET)
+  run_llvm_config(LLVM_HOST_TARGET --host-target)
+endif()
 run_llvm_config(LLVM_BUILD_MODE --build-mode)
 run_llvm_config(LLVM_ASSERTS_BUILD --assertion-mode)
 

--- a/lib/CL/clGetDeviceInfo.c
+++ b/lib/CL/clGetDeviceInfo.c
@@ -1,13 +1,13 @@
 /* OpenCL runtime library: clGetDeviceInfo()
 
    Copyright (c) 2011-2012 Kalle Raiskila and Pekka Jääskeläinen
-                 2022-2023 Pekka Jääskeläinen / Intel Finland Oy
+                 2022-2024 Pekka Jääskeläinen / Intel Finland Oy
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
 
    The above copyright notice and this permission notice shall be included in
@@ -17,17 +17,17 @@
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
 */
 
 #include "pocl_util.h"
 
 #ifdef DEVELOPER_MODE
-/* A version for querying the info and in case the device returns 
-   a zero, assume the device info query hasn't been implemented 
-   for the device driver at hand. Warns about an incomplete 
+/* A version for querying the info and in case the device returns
+   a zero, assume the device info query hasn't been implemented
+   for the device driver at hand. Warns about an incomplete
    implementation. */
 #define POCL_RETURN_DEVICE_INFO_WITH_IMPL_CHECK(__TYPE__, __VALUE__)          \
   if (__VALUE__ == (__TYPE__)0)                                               \

--- a/lib/CL/devices/almaif/openasip/AlmaifCompileOpenasip.cc
+++ b/lib/CL/devices/almaif/openasip/AlmaifCompileOpenasip.cc
@@ -230,10 +230,6 @@ void pocl_openasip_write_kernel_descriptor(char *content, size_t content_size,
            "void _pocl_kernel_%s"
            "_workgroup(uint8_t* args, uint8_t*, "
            "uint32_t, uint32_t, uint32_t);\n"
-           "void _pocl_kernel_%s"
-           "_workgroup_fast(uint8_t* args, uint8_t*, "
-           "uint32_t, uint32_t, uint32_t);\n"
-
            "void %s"
            "_workgroup_argbuffer("
            "uint8_t "

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -149,7 +149,7 @@ pocl_basic_init_device_ops(struct pocl_device_ops *ops)
   ops->svm_migrate = NULL;
   ops->svm_copy = pocl_driver_svm_copy;
   ops->svm_fill = pocl_driver_svm_fill;
-  ops->svm_copy_rect = pocl_driver_svm_copy_rect;
+  ops->svm_copy_rect = pocl_driver_copy_rect_memcpy;
   ops->svm_fill_rect = pocl_driver_svm_fill_rect;
 
   ops->create_kernel = pocl_basic_create_kernel;

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -362,8 +362,9 @@ pocl_fill_dev_image_t (dev_image_t *di, struct pocl_argument *parg,
   di->_data = (mem->device_ptrs[device->global_mem_id].mem_ptr);
 }
 
-/**
- * executes given command. Call with node->sync.event.event UNLOCKED.
+/** Executes a given command using the default PoCL driver hooks.
+ *
+ * Call with node->sync.event.event UNLOCKED.
  */
 void
 pocl_exec_command (_cl_command_node *node)
@@ -1811,6 +1812,12 @@ pocl_init_default_device_infos (cl_device_id dev,
                   "org.khronos.openvx.scale_image.bl.u8;"
                   "org.khronos.openvx.tensor_convert_depth.wrap.u8.f32;");
       dev->num_builtin_kernels = 4;
+    }
+  else
+    {
+      dev->num_builtin_kernels = 0;
+      dev->builtin_kernel_list = "";
+      dev->builtin_kernels_with_version = NULL;
     }
 
   SETUP_DEVICE_CL_VERSION (dev, HOST_DEVICE_CL_VERSION_MAJOR,

--- a/lib/CL/devices/common_driver.h
+++ b/lib/CL/devices/common_driver.h
@@ -8,35 +8,92 @@ extern "C"
 {
 #endif
 
-  typedef void (*gvar_init_callback_t)(cl_program program, cl_uint dev_i,
-                                       _cl_command_node *fake_cmd);
+typedef void (*gvar_init_callback_t)(cl_program program, cl_uint dev_i,
+                                     _cl_command_node *fake_cmd);
 
 POCL_EXPORT
-  void pocl_driver_read (void *data, void *__restrict__ dst_host_ptr,
-                         pocl_mem_identifier *src_mem_id, cl_mem src_buf,
-                         size_t offset, size_t size);
+void pocl_driver_read (void *data, void *__restrict__ dst_host_ptr,
+                       pocl_mem_identifier *src_mem_id, cl_mem src_buf,
+                       size_t offset, size_t size);
+
+/**
+ * Helper function for implementing rect read with an host-side memcpy.
+ */
 POCL_EXPORT
-  void pocl_driver_read_rect (void *data, void *__restrict__ dst_host_ptr,
-                              pocl_mem_identifier *src_mem_id, cl_mem src_buf,
-                              const size_t *buffer_origin,
-                              const size_t *host_origin, const size_t *region,
-                              size_t buffer_row_pitch,
-                              size_t buffer_slice_pitch, size_t host_row_pitch,
-                              size_t host_slice_pitch);
+void
+pocl_driver_read_rect_memcpy (void *data,
+                              void *__restrict__ const host_ptr,
+                              char *device_ptr,
+                              const size_t *__restrict__ const buffer_origin,
+                              const size_t *__restrict__ const host_origin,
+                              const size_t *__restrict__ const region,
+                              size_t const buffer_row_pitch,
+                              size_t const buffer_slice_pitch,
+                              size_t const host_row_pitch,
+                              size_t const host_slice_pitch);
+
+/**
+ * Driver hook-compatibile function for implementing rect read with
+ * a host-side memcpy.
+ *
+ * Can be typically used directly for CPU (host) drivers.
+ */
 POCL_EXPORT
-  void pocl_driver_write (void *data, const void *__restrict__ src_host_ptr,
-                          pocl_mem_identifier *dst_mem_id, cl_mem dst_buf,
-                          size_t offset, size_t size);
+void pocl_driver_read_rect (void *data,
+                            void *__restrict__ dst_host_ptr,
+                            pocl_mem_identifier *src_mem_id,
+                            cl_mem src_buf,
+                            const size_t *buffer_origin,
+                            const size_t *host_origin,
+                            const size_t *region,
+                            size_t buffer_row_pitch,
+                            size_t buffer_slice_pitch,
+                            size_t host_row_pitch,
+                            size_t host_slice_pitch);
+
 POCL_EXPORT
-  void pocl_driver_write_rect (void *data,
-                               const void *__restrict__ src_host_ptr,
-                               pocl_mem_identifier *dst_mem_id, cl_mem dst_buf,
-                               const size_t *buffer_origin,
-                               const size_t *host_origin, const size_t *region,
-                               size_t buffer_row_pitch,
-                               size_t buffer_slice_pitch,
-                               size_t host_row_pitch, size_t host_slice_pitch);
+void pocl_driver_write (void *data,
+                        const void *__restrict__ src_host_ptr,
+                        pocl_mem_identifier *dst_mem_id,
+                        cl_mem dst_buf,
+                        size_t offset,
+                        size_t size);
+
+/**
+ * Helper function for implementing rect write with an host-side memcpy.
+ */
 POCL_EXPORT
+void pocl_driver_write_rect_memcpy (
+  void *dev_data,
+  const void *__restrict__ const host_ptr,
+  char *device_ptr,
+  const size_t *__restrict__ const buffer_origin,
+  const size_t *__restrict__ const host_origin,
+  const size_t *__restrict__ const region,
+  size_t const buffer_row_pitch,
+  size_t const buffer_slice_pitch,
+  size_t const host_row_pitch,
+  size_t const host_slice_pitch);
+
+/**
+ * Driver hook-compatibile function for implementing rect write with
+ * an host-side memcpy.
+ *
+ * Can be typically used directly for CPU (host) drivers.
+ */
+POCL_EXPORT
+void pocl_driver_write_rect (void *data,
+                             const void *__restrict__ src_host_ptr,
+                             pocl_mem_identifier *dst_mem_id,
+                             cl_mem dst_buf,
+                             const size_t *buffer_origin,
+                             const size_t *host_origin,
+                             const size_t *region,
+                             size_t buffer_row_pitch,
+                             size_t buffer_slice_pitch,
+                             size_t host_row_pitch,
+                             size_t host_slice_pitch);
+  POCL_EXPORT
   void pocl_driver_copy (void *data, pocl_mem_identifier *dst_mem_id,
                          cl_mem dst_buf, pocl_mem_identifier *src_mem_id,
                          cl_mem src_buf, size_t dst_offset, size_t src_offset,
@@ -107,17 +164,20 @@ void pocl_driver_svm_fill_rect (cl_device_id dev,
                                 void *__restrict__ pattern,
                                 size_t pattern_size);
 
+/**
+ * Helper function for implementing write rect with an host-side memcpy.
+ */
 POCL_EXPORT
-void pocl_driver_svm_copy_rect (cl_device_id dev,
-                                void *__restrict__ dst_ptr,
-                                const void *__restrict__ src_ptr,
-                                const size_t *__restrict__ const dst_origin,
-                                const size_t *__restrict__ const src_origin,
-                                const size_t *__restrict__ const region,
-                                size_t dst_row_pitch,
-                                size_t dst_slice_pitch,
-                                size_t src_row_pitch,
-                                size_t src_slice_pitch);
+void pocl_driver_copy_rect_memcpy (cl_device_id dev,
+                                   void *__restrict__ dst_ptr,
+                                   const void *__restrict__ src_ptr,
+                                   const size_t *__restrict__ const dst_origin,
+                                   const size_t *__restrict__ const src_origin,
+                                   const size_t *__restrict__ const region,
+                                   size_t dst_row_pitch,
+                                   size_t dst_slice_pitch,
+                                   size_t src_row_pitch,
+                                   size_t src_slice_pitch);
 
 POCL_EXPORT
 int pocl_driver_build_source (cl_program program,

--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -440,11 +440,6 @@ static void pocl_tce_write_kernel_descriptor(_cl_command_node *Command,
           << "void _pocl_kernel_" << meta->name
           << "_workgroup(uint8_t* args, uint8_t* ctx, "
           << "uint32_t, uint32_t, uint32_t);" << std::endl
-
-          << "void _pocl_kernel_" << meta->name
-          << "_workgroup_fast(uint8_t* args, uint8_t* ctx, "
-          << "uint32_t, uint32_t, uint32_t);" << std::endl
-
           << "void " << meta->name << "_workgroup_argbuffer("
           << "uint8_t "
           << "__attribute__((address_space(" << device->global_as_id << ")))"

--- a/lib/CL/devices/tce/tce_common.h
+++ b/lib/CL/devices/tce/tce_common.h
@@ -30,6 +30,15 @@
 
 #include <string>
 
+// To silence warnings due to tce_config.h redefining these.
+#ifdef HAVE_DLFCN_H
+#undef HAVE_DLFCN_H
+#endif
+
+#ifdef LLVM_VERSION
+#undef LLVM_VERSION
+#endif
+
 #include "TCEString.hh"
 #include "pocl_device.h"
 
@@ -114,7 +123,6 @@ class TCEDevice {
   cl_device_id parent;
 
   bool needsByteSwap;
-  volatile bool shutdownRequested;
 
   const TTAProgram::Program* currentProgram;
   const TTAMachine::Machine* machine_;
@@ -123,8 +131,11 @@ class TCEDevice {
   uint32_t statusAddr;
 
   uint32_t curKernelAddr;
+  uint64_t globalCycleCount;
+
   cl_bool available;
   cl_kernel curKernel;
+  volatile bool shutdownRequested;
 
   size_t curLocalX;
   size_t curLocalY;
@@ -133,8 +144,6 @@ class TCEDevice {
   size_t curGoffsX;
   size_t curGoffsY;
   size_t curGoffsZ;
-
-  uint64_t globalCycleCount;
 
   pocl_lock_t wq_lock;
   pocl_cond_t wakeup_cond;

--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -594,7 +594,7 @@ int pocl_llvm_build_program(cl_program program,
   BuiltinRenamesH = IncludeRoot + "/include/_builtin_renames.h";
   PoclTypesH = IncludeRoot + "/include/pocl_types.h";
 
-  if (device->use_only_clang_opencl_headers == CL_FALSE) {
+  if (!device->use_only_clang_opencl_headers) {
     po.Includes.push_back(PoclTypesH);
     po.Includes.push_back(BuiltinRenamesH);
   }

--- a/lib/CL/pocl_mem_management.c
+++ b/lib/CL/pocl_mem_management.c
@@ -574,18 +574,18 @@ update_subbuffer_versioning_data (cl_mem updated_buf)
  * defined using commands, buffers, command queues and events.
  *
  * Attempts to use direct copies from a device instead of a device-host-device
- * hip in case there is an accessible peer device with a fresh copy available.
+ * hop in case there is an accessible peer device with a fresh copy available.
  *
- * @param ev_export_p Optional output parameter for the export event.
- * @param dev Destination device
- * @param user_cmd The event that marks the command that uses the data of the
+ * \param ev_export_p Optional output parameter for the export event.
+ * \param dev Destination device
+ * \param user_cmd The event that marks the command that uses the data of the
  * buffer.
- * @param mem The buffer to migrate.
- * @param gmem Identifier of the global memory where the mem should be
+ * \param mem The buffer to migrate.
+ * \param gmem Identifier of the global memory where the mem should be
  * migrated.
- * @param migration_size Max number of bytes to migrate (caller has to read
+ * \param migration_size Max number of bytes to migrate (caller has to read
  *                       content size from mem->size_buffer if applicable).
- * @param last_migr_event Input/output for dep-chaining the created migration
+ * \param last_migr_event Input/output for dep-chaining the created migration
  * command an event dependency is created to it if non-NULL. The new migration
  * command will be overwritten to it (after reference release).
  */

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -1340,7 +1340,12 @@ static void computeArgBufferOffsets(LLVMValueRef F,
     // TODO: This is a target specific type? We would like to get the
     // natural size or the "packed size" instead...
     uint64_t ByteSize = getArgumentSize(cast<Argument>(*unwrap(Param)));
-    uint64_t Alignment = pocl_size_ceil2_64(ByteSize);
+
+    // Always align each argument by the max extended alignment so we can push
+    // structs and vectors to the buffer without needing to inspect the
+    // content/alignment preferences of the structs. This naturally is a bit
+    // wasteful, but should not matter in the big picture.
+    uint64_t Alignment = MAX_EXTENDED_ALIGNMENT;
 
     assert(ByteSize > 0 && "Arg type size is zero?");
     Offset = align64(Offset, Alignment);

--- a/tests/regression/test_autolocals_in_constexprs.cpp
+++ b/tests/regression/test_autolocals_in_constexprs.cpp
@@ -62,7 +62,7 @@ main(void)
     // Pick first platform
     cl_context_properties cprops[] = {
       CL_CONTEXT_PLATFORM, (cl_context_properties)(platformList[0])(), 0};
-    cl::Context context(CL_DEVICE_TYPE_CPU|CL_DEVICE_TYPE_GPU, cprops);
+    cl::Context context(CL_DEVICE_TYPE_ALL, cprops);
 
     // Query the set of devices attched to the context
     std::vector<cl::Device> devices = context.getInfo<CL_CONTEXT_DEVICES>();

--- a/tests/regression/test_barrier_between_for_loops.cpp
+++ b/tests/regression/test_barrier_between_for_loops.cpp
@@ -1,17 +1,17 @@
 /* Tests the crash with a barrier *between* two for-loops.
 
    Copyright (c) 2012 Pekka Jääskeläinen / Tampere University of Technology
-   
+
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
    in the Software without restriction, including without limitation the rights
    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
    copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:
-   
+
    The above copyright notice and this permission notice shall be included in
    all copies or substantial portions of the Software.
-   
+
    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -92,7 +92,7 @@ main(void)
         // Pick first platform
         cl_context_properties cprops[] = {
             CL_CONTEXT_PLATFORM, (cl_context_properties)(platformList[0])(), 0};
-        cl::Context context(CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU, cprops);
+        cl::Context context(CL_DEVICE_TYPE_ALL, cprops);
 
         // Query the set of devices attched to the context
         std::vector<cl::Device> devices = context.getInfo<CL_CONTEXT_DEVICES>();

--- a/tests/regression/test_issue_757.cpp
+++ b/tests/regression/test_issue_757.cpp
@@ -37,12 +37,12 @@ int main(int argc, char *argv[]) {
   cl::Device device = cl::Device::getDefault();
   try {
     cl::CommandQueue queue = cl::CommandQueue::getDefault();
-    cl::Program program(SOURCE, true);
 
     if (poclu_supports_extension(device.get(), "cl_khr_fp64") == 0) {
       std::cout << "this test requires cl_khr_fp64, test SKIPPED\n";
       return 77;
     }
+    cl::Program program(SOURCE, true);
 
     // Create buffers on the device.
     cl::Buffer buffer_A(CL_MEM_READ_WRITE, sizeof(double) * n);

--- a/tests/regression/test_workitem_func_outside_kernel.cpp
+++ b/tests/regression/test_workitem_func_outside_kernel.cpp
@@ -72,7 +72,7 @@ main(void)
 
         cl_context_properties cprops[] = {
             CL_CONTEXT_PLATFORM, (cl_context_properties)(platformList[0])(), 0};
-        cl::Context context(CL_DEVICE_TYPE_CPU|CL_DEVICE_TYPE_GPU, cprops);
+        cl::Context context(CL_DEVICE_TYPE_ALL, cprops);
 
         std::vector<cl::Device> devices = context.getInfo<CL_CONTEXT_DEVICES>();
 

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -480,10 +480,3 @@ set_property(TEST
   "runtime/test_dbk_matmul"
   "runtime/test_queue_creation_with_hints"
   APPEND PROPERTY LABELS "level0")
-
-if(ENABLE_LEVEL0 AND ENABLE_HOST_CPU_DEVICES)
-  add_test(NAME "runtime/test_subbuffers_multidevice" COMMAND "test_subbuffers")
-  set_property(TEST "runtime/test_subbuffers_multidevice"
-    APPEND PROPERTY ENVIRONMENT "POCL_DEVICES=level0 cpu")
-
-endif()

--- a/tests/runtime/test_subbuffers.cpp
+++ b/tests/runtime/test_subbuffers.cpp
@@ -65,7 +65,7 @@ int TestOutputDataDecomposition() {
 
     cl_context_properties cprops[] = {
         CL_CONTEXT_PLATFORM, (cl_context_properties)(PlatformList[0])(), 0};
-    cl::Context Context(CL_DEVICE_TYPE_CPU | CL_DEVICE_TYPE_GPU, cprops);
+    cl::Context Context(CL_DEVICE_TYPE_ALL, cprops);
 
     std::vector<cl::Device> Devices = Context.getInfo<CL_CONTEXT_DEVICES>();
 
@@ -126,7 +126,7 @@ int TestOutputDataDecomposition() {
     std::vector<cl::CommandQueue> Queues;
     std::vector<cl::Event> KernelEvents;
     // Spawn a bunch of kernel commands in their independent command queues
-    // (which could target different devices) to process their piece of the
+    // (which can target different devices) to process their piece of the
     // data.
     for (size_t i = 0; i < NumParallelQueues; ++i) {
 

--- a/tests/workgroup/for_with_divergent_return.cl
+++ b/tests/workgroup/for_with_divergent_return.cl
@@ -3,7 +3,7 @@ test_kernel (global int *output)
 {
   int gid_x = get_global_id (0);
 
-  for (volatile int i = 0; i < INT_MAX; ++i)
+  for (volatile int i = 0; i < 1024; ++i)
     {
       if (i == 1 && gid_x == 0)
         {

--- a/tools/scripts/run_cpu_tests
+++ b/tools/scripts/run_cpu_tests
@@ -39,10 +39,10 @@ TEST_TYPE=$1
 if [ "$TEST_TYPE" = "cbs" ]; then
   export POCL_WORK_GROUP_METHOD=cbs
   ctest -L internal $@
-if [ "$TEST_TYPE" = "loopvec" ]; then
+elif [ "$TEST_TYPE" = "loopvec" ]; then
   export POCL_WORK_GROUP_METHOD=loopvec
   ctest -L internal $@
-if [ "$TEST_TYPE" = "mingw" ]; then
+elif [ "$TEST_TYPE" = "mingw" ]; then
   ctest -L internal -LE mingw_fail $@
 else
   ctest -L internal $@


### PR DESCRIPTION
 * Reduce the iteration count in for_with_divergent_return test
 * Refactor copy (rect) default implementations: Split to a *memcpy version which takes in a target pointer so it can be called from drivers with a host backing device store pointer or similar use case.
 * tests/kernel/common.cl: enable int64 tests only if cl_khr_int64
 * argbuffer wrapper: Always align args to MAX_EXTENDED_ALIGNMENT to make passing structs on argbuffer feasible.
 * cmake/LLVM: Allow overriding the LLVM_HOST_TARGET
 * Remove test_subbuffers_multidevice: The test runner scripts should setup the device list and run test_subbuffers which tests all available devices.
 * Fix the broken run_cpu_tests script
