### PR TITLE
dbk: rename onnxrt types

### DIFF
--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -1032,7 +1032,7 @@ pocl_basic_create_kernel (cl_device_id device,
       }
 #endif
 #ifdef HAVE_ONNXRT
-    case POCL_CDBI_DBK_EXP_ONNX_INFERENCE:
+    case CL_DBK_ONNX_INFERENCE_EXP:
       {
         status = pocl_create_ort_instance (
             p->builtin_kernel_attributes[dbk_index],
@@ -1087,7 +1087,7 @@ pocl_basic_free_kernel (cl_device_id device,
       }
 #endif
 #ifdef HAVE_ONNXRT
-    case POCL_CDBI_DBK_EXP_ONNX_INFERENCE:
+    case CL_DBK_ONNX_INFERENCE_EXP:
       {
         status = pocl_destroy_ort_instance (
             (onnxrt_instance_t **)&(k->data[device_i]));

--- a/lib/CL/devices/common_utils.c
+++ b/lib/CL/devices/common_utils.c
@@ -829,7 +829,7 @@ pocl_cpu_supports_dbk (cl_device_id device,
       return pocl_validate_dbk_attributes (kernel_id, kernel_attributes, NULL);
 #endif
 #ifdef HAVE_ONNXRT
-    case POCL_CDBI_DBK_EXP_ONNX_INFERENCE:
+    case CL_DBK_ONNX_INFERENCE_EXP:
       return pocl_validate_dbk_attributes (kernel_id, kernel_attributes, NULL);
 #endif
     default:
@@ -1197,7 +1197,7 @@ pocl_cpu_execute_dbk (cl_program program,
                                                    dev_i, arguments);
 #endif
 #ifdef HAVE_ONNXRT
-    case POCL_CDBI_DBK_EXP_ONNX_INFERENCE:
+    case CL_DBK_ONNX_INFERENCE_EXP:
       {
         cl_device_id dev = program->devices[dev_i];
         unsigned mem_id = dev->global_mem_id;

--- a/lib/CL/devices/cpu_dbk/pocl_dbk_khr_onnxrt_cpu.h
+++ b/lib/CL/devices/cpu_dbk/pocl_dbk_khr_onnxrt_cpu.h
@@ -33,8 +33,9 @@
 typedef struct onnxrt_instance onnxrt_instance_t;
 
 POCL_EXPORT
-cl_int pocl_create_ort_instance (const cl_dbk_attributes_exp_onnx_inference *attrs,
-                                 onnxrt_instance_t **onnxrt);
+cl_int
+pocl_create_ort_instance (const cl_dbk_attributes_onnx_inference_exp *attrs,
+                          onnxrt_instance_t **onnxrt);
 
 POCL_EXPORT
 cl_int pocl_destroy_ort_instance (onnxrt_instance_t **onnxrt);

--- a/tests/runtime/test_dbk_onnx_inference.c
+++ b/tests/runtime/test_dbk_onnx_inference.c
@@ -53,7 +53,7 @@ main (int _argc, char **_argv)
 {
   struct
   {
-    clCreateProgramWithDefinedBuiltInKernels_fn
+    clCreateProgramWithDefinedBuiltInKernelsEXP_fn
       clCreateProgramWithDefinedBuiltInKernels;
   } ext;
 
@@ -94,33 +94,34 @@ main (int _argc, char **_argv)
   fclose (f);
   TEST_ASSERT (bytes_read == model_size);
 
-  cl_tensor_layout_ml tensor_layout = { CL_TENSOR_LAYOUT_ML_C };
-  cl_tensor_desc tensor_desc = { 1,
-                                 CL_TENSOR_DTYPE_FP32,
-                                 { CL_TENSOR_PROPERTY_NONE },
-                                 { num_elements },
-                                 &tensor_layout,
-                                 CL_TENSOR_LAYOUT_ML };
-  cl_dbk_id_exp dbk_id = POCL_CDBI_DBK_EXP_ONNX_INFERENCE;
+  cl_tensor_layout_ml_exp tensor_layout = { CL_TENSOR_LAYOUT_ML_C_EXP };
+  cl_tensor_desc_exp tensor_desc = { 1,
+                                     CL_TENSOR_DTYPE_FP32_EXP,
+                                     { CL_TENSOR_PROPERTY_NONE_EXP },
+                                     { num_elements },
+                                     &tensor_layout,
+                                     CL_TENSOR_LAYOUT_ML_EXP };
+  cl_dbk_id_exp dbk_id = CL_DBK_ONNX_INFERENCE_EXP;
   const char *dbk_name = "exp_onnx_inference";
   const char *input_tensor_names[] = { "A", "B" };
   const char *output_tensor_names[] = { "C" };
   /* All tensors have the same format */
-  cl_tensor_desc input_tensor_descs[] = { tensor_desc, tensor_desc };
-  cl_tensor_desc output_tensor_descs[] = { tensor_desc };
+  cl_tensor_desc_exp input_tensor_descs[] = { tensor_desc, tensor_desc };
+  cl_tensor_desc_exp output_tensor_descs[] = { tensor_desc };
 
   /* The test model also has IN_MIN but let's not specify that one */
   const char *initializer_names[] = { "IN_MAX" };
   float f1 = 1.0f;
   const float *initializer_data[] = { &f1 };
-  cl_tensor_desc initializer_tensor_descs[] = { { 1,
-                                                  CL_TENSOR_DTYPE_FP32,
-                                                  { CL_TENSOR_PROPERTY_NONE },
-                                                  { 1 },
-                                                  &tensor_layout,
-                                                  CL_TENSOR_LAYOUT_ML } };
+  cl_tensor_desc_exp initializer_tensor_descs[]
+    = { { 1,
+          CL_TENSOR_DTYPE_FP32_EXP,
+          { CL_TENSOR_PROPERTY_NONE_EXP },
+          { 1 },
+          &tensor_layout,
+          CL_TENSOR_LAYOUT_ML_EXP } };
 
-  const cl_dbk_attributes_exp_onnx_inference onnx_inference_attributes
+  const cl_dbk_attributes_onnx_inference_exp onnx_inference_attributes
     = { model_size, model_bytes, 2, input_tensor_names, input_tensor_descs, 1,
         output_tensor_names, output_tensor_descs,
         /* The below attributes are optional and can be left zeroed out */
@@ -138,7 +139,7 @@ main (int _argc, char **_argv)
   CHECK_CL_ERROR (error);
 
   cl_mem_properties mem_props[]
-    = { CL_MEM_TENSOR, (cl_mem_properties)&tensor_desc, 0 };
+    = { CL_MEM_TENSOR_EXP, (cl_mem_properties)&tensor_desc, 0 };
 
   float *test_data = NULL;
   MALLOC_CHECKED (test_data, sizeof (float) * num_elements * 2);


### PR DESCRIPTION
This commit fixes names that were missed with
the refactor to match the dbk spec.

@linehill I noticed there is now the `CL_TENSOR_DTYPE_FP8E4M3_EXP` data type, and I mapped that to onnx's [FP8E4M3FN](https://onnx.ai/onnx/technical/float8.html), which does not represent infinite values. Could this be a problem? Intel's [FP8-emulation-toolkit](https://github.com/IntelLabs/FP8-Emulation-Toolkit) doesn't either so I was wondering if it is the same case here.