### PR TITLE
misc: cpp related CI warning fixes

### DIFF
--- a/examples/measure_overhead/measure_migration_overhead.cc
+++ b/examples/measure_overhead/measure_migration_overhead.cc
@@ -263,9 +263,9 @@ bool measure_platform(cl::Platform &platform, int index) {
     cl::Kernel kern(prog, "acc_kernel");
 
     std::vector<cl::CommandQueue> command_queues(devices.size());
-    testing_buffer buffer = {cl::Buffer(ctx, CL_MEM_READ_WRITE,
-                                        options.buffer_size * sizeof(uint32_t),
-                                        nullptr)};
+    testing_buffer buffer;
+    buffer.buffer = cl::Buffer(ctx, CL_MEM_READ_WRITE,
+                               options.buffer_size * sizeof(uint32_t), nullptr);
     std::vector<std::vector<double>> timings_by_device(devices.size());
     for (size_t i = 0; i < devices.size(); ++i) {
       command_queues[i] = cl::CommandQueue(ctx, devices[i],
@@ -287,8 +287,8 @@ bool measure_platform(cl::Platform &platform, int index) {
       print_progress(i + 1, options.sample_count + options.warmup_rounds,
                      starttime);
     }
-    for (int i = 0; i < timings_by_device.size(); ++i)
-      timings_by_device[i].clear();
+    for (auto &i : timings_by_device)
+      i.clear();
 
     for (int i = 0; i < options.sample_count; ++i) {
       run_iteration(kern, command_queues, buffer, timings_by_device);

--- a/lib/CL/devices/printf_base.c
+++ b/lib/CL/devices/printf_base.c
@@ -431,7 +431,7 @@ __pocl_printf_puts_ljust (param_t *p,
 {
   char c;
   unsigned written = 0;
-  unsigned max_width_u = max_width >= 0 ? max_width : UINT_MAX;
+  unsigned max_width_u = max_width >= 0 ? (unsigned)max_width : UINT_MAX;
 
   while ((c = *string++))
     {
@@ -456,7 +456,7 @@ __pocl_printf_puts_rjust (param_t *p,
 {
   char c;
   unsigned i, strleng = 0, written = 0;
-  unsigned max_width_u = max_width >= 0 ? max_width : UINT_MAX;
+  unsigned max_width_u = max_width >= 0 ? (unsigned)max_width : UINT_MAX;
 
   const char *tmp = string;
   while ((c = *tmp++))

--- a/pocld/CMakeLists.txt
+++ b/pocld/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SOURCES pocld.cc daemon.hh daemon.cc cmdline.h cmdline.c
             ../lib/CL/pocl_builtin_kernels.c
             ../lib/CL/pocl_tensor_util.c
             ../lib/CL/pocl_cl_half_util.c
+            ../lib/CL/pocl_compiler_macros.h
             ../lib/CL/dbk/pocl_dbk_khr_jpeg_shared.c
             ../lib/CL/dbk/pocl_dbk_khr_onnxrt_shared.c
             shared_cl_context.cc shared_cl_context.hh

--- a/pocld/connection.cc
+++ b/pocld/connection.cc
@@ -33,7 +33,7 @@
 
 Connection::Connection(transport_domain_t Domain, int Fd,
                        std::shared_ptr<TrafficMonitor> Meter)
-    : Domain(Domain), Fd(Fd), Meter(Meter) {}
+    : Meter(Meter), Domain(Domain), Fd(Fd) {}
 
 Connection::~Connection() {
   shutdown(Fd, SHUT_RDWR);

--- a/pocld/peer.cc
+++ b/pocld/peer.cc
@@ -44,7 +44,7 @@ Peer::Peer(uint64_t id, uint32_t handler_id, VirtualContextBase *ctx,
 #else
 Peer::Peer(uint64_t id, uint32_t handler_id, VirtualContextBase *ctx,
            ExitHelper *eh, std::shared_ptr<Connection> Conn)
-    : id(id), handler_id(handler_id), ctx(ctx), eh(eh), Conn(Conn)
+    : id(id), handler_id(handler_id), Conn(Conn), ctx(ctx), eh(eh)
 #endif
 {
   std::stringstream ss;

--- a/pocld/peer_handler.cc
+++ b/pocld/peer_handler.cc
@@ -69,12 +69,12 @@ PeerHandler::PeerHandler(
     uint32_t id, std::mutex *m,
     std::pair<std::condition_variable, std::vector<PeerConnection>> *incoming,
     VirtualContextBase *c, ExitHelper *e, std::shared_ptr<TrafficMonitor> tm)
-    : id(id), NewConnectionsMutex(m), NewConnections(incoming), ctx(c), eh(e),
+    : id(id), ctx(c), eh(e), NewConnectionsMutex(m), NewConnections(incoming),
       Netstat(tm) {
   IncomingPeerHandler = std::thread(&PeerHandler::handleIncomingPeers, this);
 }
 
-const void set_socket_options(int fd, const char *label) {
+void set_socket_options(int fd, const char *label) {
   int one = 1;
 #ifdef SO_REUSEADDR
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)))

--- a/pocld/reply_th.cc
+++ b/pocld/reply_th.cc
@@ -110,8 +110,8 @@ static const char *reply_to_str(ReplyMessageType type) {
 ReplyQueueThread::ReplyQueueThread(
     std::shared_ptr<Connection> OutboundConnection, VirtualContextBase *c,
     ExitHelper *e, const char *id_str)
-    : Conn(OutboundConnection), virtualContext(c), eh(e),
-      ThreadIdentifier(id_str) {
+    : Conn(OutboundConnection), ThreadIdentifier(id_str), virtualContext(c),
+      eh(e) {
   IOThread = std::thread{&ReplyQueueThread::writeThread, this};
 }
 

--- a/pocld/request.cc
+++ b/pocld/request.cc
@@ -26,6 +26,7 @@
 #include <chrono>
 #include <unistd.h>
 
+#include "pocl_compiler_macros.h"
 #include "pocl_debug.h"
 #include "request.hh"
 #include "tracing.h"
@@ -223,6 +224,7 @@ bool Request::read(Connection *Conn) {
   case MessageType_LinkProgram:
     this->ExtraData2Size = Body->m.build_program.options_len;
     /* intentional fall through to setting payload (i.e. binary) size */
+    POCL_FALLTHROUGH;
   case MessageType_BuildProgramWithBuiltins:
   case MessageType_BuildProgramWithDefinedBuiltins:
     this->ExtraDataSize = Body->m.build_program.payload_size;

--- a/tests/regression/test_issue_757.cpp
+++ b/tests/regression/test_issue_757.cpp
@@ -31,7 +31,7 @@ __kernel void __attribute__ ((reqd_work_group_size(128, 1, 1))) grudge_assign_0(
 
 int main(int argc, char *argv[]) {
   int n = 8;
-  unsigned successful = 0;
+  int successful = 0;
 
   cl::Platform platform = cl::Platform::getDefault();
   cl::Device device = cl::Device::getDefault();

--- a/tests/runtime/test_subbuffers.cpp
+++ b/tests/runtime/test_subbuffers.cpp
@@ -219,11 +219,11 @@ int TestOutputDataDecomposition() {
 
     // Check the data after the parallel sub-buffer launches.
     for (size_t i = 0; i < NumData; ++i) {
-      int Share = i / WorkShare;
+      size_t Share = i / WorkShare;
       if (i >= WorkShare * Share &&
           i < WorkShare * Share + WorkShare - Uncovered &&
           i < WorkShare * NumParallelQueues) {
-        if (AfterSubBufCContents[i] != i + 2) {
+        if ((size_t)AfterSubBufCContents[i] != i + 2) {
           std::cerr << "ERROR: after sub-bufs " << i << " was "
                     << AfterSubBufCContents[i] << " expected " << i + 2
                     << std::endl;
@@ -244,11 +244,11 @@ int TestOutputDataDecomposition() {
 
     // Check the data before the last kernel launch.
     for (size_t i = 0; i < NumData; ++i) {
-      int Share = i / WorkShare;
+      size_t Share = i / WorkShare;
       if (i >= WorkShare * Share &&
           i < WorkShare * Share + WorkShare - Uncovered &&
           i < WorkShare * NumParallelQueues) {
-        if (NewBufCContents[i] != i + 2 + 2) {
+        if ((size_t)NewBufCContents[i] != i + 2 + 2) {
           std::cerr << "ERROR: " << i << " was " << NewBufCContents[i]
                     << " expected " << i + 2 + 2 << std::endl;
           AllOK = false;
@@ -268,12 +268,12 @@ int TestOutputDataDecomposition() {
     // In the final state there should be one additional 2 addition in the
     // last manipulated part of the array.
     for (size_t i = 0; i < NumData; ++i) {
-      int Share = i / WorkShare;
+      size_t Share = i / WorkShare;
       if (i >= WorkShare * Share &&
           i < WorkShare * Share + WorkShare - Uncovered &&
           i < WorkShare * NumParallelQueues) {
         if (i < (WorkShare * (NumParallelQueues - 1))) {
-          if (FinalBufCContents[i] != i + 2 + 2) {
+          if ((size_t)FinalBufCContents[i] != i + 2 + 2) {
             std::cerr << "ERROR: final " << i << " was " << FinalBufCContents[i]
                       << " expected " << i + 2 + 2 << std::endl;
             AllOK = false;
@@ -281,7 +281,7 @@ int TestOutputDataDecomposition() {
           }
         } else if (i < (WorkShare * NumParallelQueues)) {
           // The part which was not touched by sub-buffers.
-          if (FinalBufCContents[i] != i + 2 + 2 + 2) {
+          if ((size_t)FinalBufCContents[i] != i + 2 + 2 + 2) {
             std::cerr << "ERROR: final " << i << " was " << FinalBufCContents[i]
                       << " expected " << i + 2 + 2 << std::endl;
             AllOK = false;


### PR DESCRIPTION
types of fixes include:
* sign compare fixes
* using range operators in for loops
* init clearifications
* warnings related to use of move
* removing const from return types

note: this does not address all warnings