### PR TITLE
Initial LLVM20 support

### DIFF
--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -39,6 +39,7 @@ else()
     NAMES
       "llvmtce-config"
       "llvm-config"
+      "llvm-config-mp-20.0" "llvm-config-mp-20" "llvm-config-20" "llvm-config200"
       "llvm-config-mp-19.0" "llvm-config-mp-19" "llvm-config-19" "llvm-config190"
       "llvm-config-mp-18.0" "llvm-config-mp-18" "llvm-config-18" "llvm-config180"
       "llvm-config-mp-17.0" "llvm-config-mp-17" "llvm-config-17" "llvm-config170"
@@ -102,8 +103,8 @@ string(REGEX REPLACE "([0-9]+)\\.([0-9]+).*" "\\1.\\2" LLVM_VERSION "${LLVM_VERS
 message(STATUS "LLVM_VERSION: ${LLVM_VERSION}")
 
 # required for sources..
-if((LLVM_VERSION_MAJOR LESS 14) OR (LLVM_VERSION_MAJOR GREATER 19))
-  message(FATAL_ERROR "LLVM version between 14.0 and 19.0 required, found: ${LLVM_VERSION_MAJOR}")
+if((LLVM_VERSION_MAJOR LESS 14) OR (LLVM_VERSION_MAJOR GREATER 20))
+  message(FATAL_ERROR "LLVM version between 14.0 and 20.0 required, found: ${LLVM_VERSION_MAJOR}")
 endif()
 
 string(REPLACE "." ";" LLVM_VERSION_PARSED "${LLVM_VERSION}")

--- a/config.h.in.cmake
+++ b/config.h.in.cmake
@@ -179,7 +179,7 @@
 
 #ifdef BUILD_LEVEL0
 
-#define CLANG "@CLANG@"
+#define CLANGCC "@CLANG@"
 
 #define LLVM_SPIRV "@LLVM_SPIRV@"
 
@@ -197,7 +197,7 @@
 
 #cmakedefine KERNELLIB_HOST_DISTRO_VARIANTS
 
-#define CLANG "@CLANG@"
+#define CLANGCC "@CLANG@"
 
 #define CLANG_RESOURCE_DIR "@CLANG_RESOURCE_DIR@"
 

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -244,7 +244,7 @@ llvm_codegen (char *output, unsigned device_i, cl_kernel kernel,
       /* Link through Clang driver interface which knows the correct toolchains
          for all of its targets.  */
       const char *cmd_line[64]
-        = { pocl_get_path ("CLANG", CLANG), "-o", tmp_module, tmp_objfile };
+        = { pocl_get_path ("CLANG", CLANGCC), "-o", tmp_module, tmp_objfile };
       unsigned last_arg_idx = 4;
 
 #ifdef _MSC_VER

--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -1046,7 +1046,7 @@ int pocl_invoke_clang(cl_device_id Device, const char** Args) {
 
   DiagnosticsEngine Diags(DiagID, &*DiagOpts, DiagClient);
 
-  clang::driver::Driver TheDriver(pocl_get_path("CLANG", CLANG),
+  clang::driver::Driver TheDriver(pocl_get_path("CLANG", CLANGCC),
                                   Device->llvm_target_triplet, Diags);
 
   const char **ArgsEnd = Args;

--- a/lib/CL/pocl_llvm_wg.cc
+++ b/lib/CL/pocl_llvm_wg.cc
@@ -1616,7 +1616,7 @@ int pocl_llvm_codegen(cl_device_id Device, cl_program program, void *Modp,
                          ? (std::string(CLANG_MARCH_FLAG) + Device->llvm_cpu)
                          : "";
 
-  const char *Args[] = {pocl_get_path("CLANG", CLANG),
+  const char *Args[] = {pocl_get_path("CLANG", CLANGCC),
                         AsmFileName,
                         "-c",
                         "-o",

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -604,8 +604,8 @@ SharedCLContext::SharedCLContext(cl::Platform *p, unsigned pid,
         CommandQueueUPtr(new CommandQueue(this, (DEFAULT_QUE_ID + i), i, s, f));
   }
 
-#if !defined(CLANG) || !defined(LLVM_SPIRV)
-  // We require CLANG and LLVM_SPIRV for manipulating the SPIRVs to adjust
+#if !defined(CLANGCC) || !defined(LLVM_SPIRV)
+  // We require CLANGCC and LLVM_SPIRV for manipulating the SPIRVs to adjust
   // mismatching client/host SVM pool offsets.
   SVMRegionsStartAddress = nullptr;
   SVMRegionsEndAddress = nullptr;
@@ -1230,7 +1230,7 @@ int SharedCLContext::freeQueue(uint32_t queue_id) {
   buf += len;                                                                  \
   assert((size_t)(buf - buffer) <= buffer_size);
 
-#if defined(CLANG) && defined(LLVM_SPIRV)
+#if defined(CLANGCC) && defined(LLVM_SPIRV)
 /**
  * Creates a SPIRV with all global memory addresses adjusted by adding
  * the SVMOffset.
@@ -1282,7 +1282,7 @@ bool createSPIRVWithSVMOffset(const std::vector<unsigned char> *InputSPV,
     // https://www.khronos.org/blog/offline-compilation-of-opencl-kernels-into-
     // spir-v-using-open-source-tooling
     std::stringstream OpenCLCCmd;
-    OpenCLCCmd << pocl_get_path("CLANG", CLANG)
+    OpenCLCCmd << pocl_get_path("CLANG", CLANGCC)
                << " -c -target spir64 -cl-kernel-arg-info -cl-std=CL3.0 "
                << SrcFileName.c_str() << " " << BuildOptions
                << " -emit-llvm -o " << OrigBcFileName.c_str();
@@ -1436,7 +1436,7 @@ int SharedCLContext::buildOrLinkProgram(
     std::vector<char> SVMOffsettedSPIRV;
 
 
-#if defined(CLANG) && defined(LLVM_SPIRV)
+#if defined(CLANGCC) && defined(LLVM_SPIRV)
     // Adjust the SVM region offset to the kernel code.
     bool SuccessfulOffsetting = createSPIRVWithSVMOffset(
         is_spirv ? &(*InputBinaries.begin()).second : nullptr, src, src_size,


### PR DESCRIPTION
clang/include/clang/Basic/AttributeCommonInfo.h now has this
`enum class Scope { NONE, CLANG, GNU, MSVC, OMP, HLSL, GSL, RISCV };`
 which conflicts with the config.h generated
`#define CLANG "@CLANG@"`.
This renames `CLANG` to `CLANGCC`.

It teaches LLVM.cmake to allow and detect llvm 20 as well.

Link: https://gerrit.kalray.eu/id/Ifb026be79d50537531e3013c6e6356434616ac5a