### PR TITLE
build fixes for android reference app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1044,7 +1044,9 @@ if(WIN32 AND (NOT MINGW))
 
 elseif(UNIX)
 
-  if (CMAKE_CROSSCOMPILING AND (NOT ENABLE_HOST_CPU_DEVICES) AND (NOT ENABLE_HSA))
+  # if proxy uses opencl-stub then dlfcn is required.
+  if (CMAKE_CROSSCOMPILING AND (NOT ENABLE_HOST_CPU_DEVICES) AND (NOT ENABLE_HSA)
+        AND (NOT PROXY_USE_LIBOPENCL_STUB))
     message(STATUS "Cross-compiling without CPU/HSA devices -> skipping LIBDL search")
   else()
 
@@ -1682,6 +1684,9 @@ if(ENABLE_PROXY_DEVICE)
 
   endif()
 
+  # an option parameter to link to libopencl-stub
+  # source code: https://github.com/krrishnarraj/libopencl-stub
+  OPTION(PROXY_USE_LIBOPENCL_STUB "link the proxy device to libopencl-stub instead of system opencl" OFF)
   if(RENAME_POCL AND PROXY_USE_LIBOPENCL_STUB)
     message(FATAL_ERROR "RENAME_POCL and PROXY_USE_LIBOPENCL_STUB can not be used together")
   endif()

--- a/lib/CL/devices/CMakeLists.txt
+++ b/lib/CL/devices/CMakeLists.txt
@@ -109,7 +109,9 @@ if(ENABLE_PROXY_DEVICE)
   set(POCL_DEVICES_OBJS "${POCL_DEVICES_OBJS}"
     "$<TARGET_OBJECTS:pocl-devices-proxy>")
   # link to libOpenCL(-stub)
-  list(APPEND POCL_DEVICES_LINK_LIST OpenCL)
+  if(NOT PROXY_USE_LIBOPENCL_STUB)
+    list(APPEND POCL_DEVICES_LINK_LIST OpenCL)
+  endif()
 
 endif()
 

--- a/lib/CL/devices/proxy/CMakeLists.txt
+++ b/lib/CL/devices/proxy/CMakeLists.txt
@@ -25,9 +25,6 @@
 
 add_pocl_device_library("pocl-devices-proxy" pocl_proxy.hpp pocl_proxy.cpp)
 
-# an option parameter to link to libopencl-stub instead.
-# source code: https://github.com/krrishnarraj/libopencl-stub
-OPTION(PROXY_USE_LIBOPENCL_STUB "link the proxy device to libopencl-stub instead of system opencl" OFF)
 if(PROXY_USE_LIBOPENCL_STUB)
 
     set(STUB_SOURCES libopencl_stub/openclstub.c libopencl_stub/openclstub.h libopencl_stub/rename_stub.h)

--- a/lib/CL/pocl_networking.c
+++ b/lib/CL/pocl_networking.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/time.h>
+#include <ctype.h>
 
 #ifdef HAVE_LINUX_VSOCK_H
 #include <linux/vm_sockets.h>


### PR DESCRIPTION
Some changes to fix building the android reference app with latest pocl main.
 
When PROXY_USE_LIBOPENCL_STUB is enabled then the libopen_stub included in the proxy device is used and we do not need to link to libopencl.