### PR TITLE
[LLVM20] CompilerInstance::createDiagnostics API change

### DIFF
--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -615,8 +615,11 @@ int pocl_llvm_build_program(cl_program program,
 #ifdef DEBUG_POCL_LLVM_API
   std::cout << "### Triple: " << ta.Triple.c_str() <<  ", CPU: " << ta.CPU.c_str();
 #endif
+#if LLVM_MAJOR < 20
   CI.createDiagnostics(diagsBuffer, false);
-
+#else
+  CI.createDiagnostics(CI.getVirtualFileSystem(), diagsBuffer, false);
+#endif
   FrontendOptions &fe = pocl_build.getFrontendOpts();
   // The CreateFromArgs created an stdin input which we should remove first.
   fe.Inputs.clear();


### PR DESCRIPTION
Now the function takes a new first argument, a
`llvm::vfs::FileSystem`.
