### PR TITLE
SPIR-V fixes

### DIFF
--- a/.github/workflows/build_full_cts.yml
+++ b/.github/workflows/build_full_cts.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Run CMake
         id: cmake
+        timeout-minutes: 60
         run: |
           rm -rf ${{ github.workspace }}/build
           mkdir ${{ github.workspace }}/build
@@ -54,6 +55,7 @@ jobs:
 
       - name: Run Build
         id: build
+        timeout-minutes: 60
         run: |
           cd ${{ github.workspace }}/build && make -j$(nproc) && make -j$(nproc) prepare_examples
 
@@ -102,6 +104,7 @@ jobs:
 
       - name: Run CMake
         id: cmake
+        timeout-minutes: 60
         run: |
           rm -rf ${{ github.workspace }}/build
           mkdir ${{ github.workspace }}/build
@@ -118,6 +121,7 @@ jobs:
 
       - name: Run Build
         id: build
+        timeout-minutes: 60
         run: |
           cd ${{ github.workspace }}/build && make -j4 && make -j4 prepare_examples
 
@@ -125,7 +129,6 @@ jobs:
         env:
           POCL_CACHE_DIR: "${{ runner.temp }}/GH_POCL_CACHE"
         id: ctest
-        timeout-minutes: 450
         run: |
           runCTest() {
             cd ${{ github.workspace }}/build && ${{ github.workspace }}/tools/scripts/run_level0_tests -j4 $CTEST_FLAGS "$@"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2128,8 +2128,13 @@ rename_if_different("${CMAKE_BINARY_DIR}/pocl_version.h.new" "${CMAKE_BINARY_DIR
 configure_file("pocl_opencl.h.in.cmake" "pocl_opencl.h.new")
 rename_if_different("${CMAKE_BINARY_DIR}/pocl_opencl.h.new" "${CMAKE_BINARY_DIR}/pocl_opencl.h" 0)
 
-configure_file("cl_offline_compiler.sh.in.cmake" "cl_offline_compiler.sh.in.new" @ONLY)
-rename_if_different("${CMAKE_BINARY_DIR}/cl_offline_compiler.sh.in.new" "${CMAKE_BINARY_DIR}/cl_offline_compiler.sh" 1)
+configure_file("cl_offline_compiler.sh.in.cmake" "cl_offline_compiler.sh.config.new" @ONLY)
+rename_if_different(
+  "${CMAKE_BINARY_DIR}/cl_offline_compiler.sh.config.new"
+  "${CMAKE_BINARY_DIR}/cl_offline_compiler.sh.config" 1)
+file(GENERATE
+  OUTPUT "${CMAKE_BINARY_DIR}/cl_offline_compiler.sh"
+  INPUT "${CMAKE_BINARY_DIR}/cl_offline_compiler.sh.config")
 
 include_directories("${CMAKE_BINARY_DIR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1430,9 +1430,8 @@ cl_intel_unified_shared_memory cl_ext_buffer_device_address")
 # .... seems like a bug in CTS, but needs to be investigated.
 set(HOST_DEVICE_FEATURES_30 "__opencl_c_3d_image_writes  __opencl_c_images \
 __opencl_c_atomic_order_acq_rel __opencl_c_atomic_order_seq_cst \
-__opencl_c_atomic_scope_device __opencl_c_program_scope_global_variables \
-__opencl_c_atomic_scope_all_devices __opencl_c_generic_address_space \
-__opencl_c_work_group_collective_functions")
+__opencl_c_atomic_scope_device __opencl_c_atomic_scope_all_devices \
+__opencl_c_generic_address_space __opencl_c_work_group_collective_functions")
 
 # enabled by default
 # when disabled, depending on setting of ENABLE_CONFORMANCE, denorms are disabled
@@ -1462,7 +1461,8 @@ if(NOT ENABLE_CONFORMANCE)
 cl_khr_subgroup_shuffle cl_intel_subgroups cl_intel_subgroups_short cl_intel_subgroups_char \
 cl_ext_float_atomics cl_intel_required_subgroup_size")
   # read-write images are still partially broken
-  set( HOST_DEVICE_FEATURES_30  "${HOST_DEVICE_FEATURES_30} __opencl_c_read_write_images")
+  # program-scope variables work on OpenCL C input, but breaks with SPIR-V input (llvm-spirv bugs)
+  set(HOST_DEVICE_FEATURES_30  "${HOST_DEVICE_FEATURES_30} __opencl_c_read_write_images __opencl_c_program_scope_global_variables")
 endif()
 
 # Extensions that are considered feature-complete (preferably CTS-tested).

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -27,8 +27,15 @@ set_opencl_header_includes()
 
 add_executable(poclcc poclcc.c)
 harden(poclcc)
-
 target_link_libraries(poclcc poclu ${OPENCL_LIBS})
+
+# TODO refactor spirv-parser into its own library
+set(SPVSRC "${CMAKE_SOURCE_DIR}/lib/CL/devices")
+add_executable(spirv_fix_atomic_compare_exchange spirv_fix_atomic_compare_exchange.cc
+  "${SPVSRC}/spirv_parser.hh" "${SPVSRC}/spirv_parser.cc")
+harden(spirv_fix_atomic_compare_exchange)
+target_link_libraries(spirv_fix_atomic_compare_exchange poclu ${OPENCL_LIBS})
+target_include_directories(spirv_fix_atomic_compare_exchange PRIVATE "${SPVSRC}")
 
 install(TARGETS "poclcc" RUNTIME
         DESTINATION "${POCL_INSTALL_PUBLIC_BINDIR}" COMPONENT "poclcc")

--- a/bin/spirv_fix_atomic_compare_exchange.cc
+++ b/bin/spirv_fix_atomic_compare_exchange.cc
@@ -1,0 +1,63 @@
+/* spirv_fix_atomic_compare_exchange: remove an unnecessary bitcast in the input
+   SPIR-V that causes SPIR-V validation to fail with an error.
+
+   Copyright (c) 2024 Michal Babej / Intel Finland Oy
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+#include "poclu.h"
+
+#define CL_HPP_ENABLE_EXCEPTIONS
+#include <CL/opencl.hpp>
+
+#include <cassert>
+#include <iostream>
+
+#include "spirv_parser.hh"
+
+using namespace std;
+
+int main(int Argc, char *Argv[]) {
+  if (Argc != 3) {
+    std::cerr << "USAGE: $0 input output\n";
+    return EXIT_FAILURE;
+  }
+
+  std::string InputName(Argv[1]);
+  std::string OutputName(Argv[2]);
+  size_t InputSize, OutputSize;
+  char *InputChars = poclu_read_binfile(InputName.c_str(), &InputSize);
+  if (InputChars == nullptr || InputSize == 0) {
+    std::cerr << "Can't read input file: " << InputName << "\n";
+    return EXIT_FAILURE;
+  }
+  std::vector<int32_t> InStream(InputSize / 4 + 1);
+  memcpy(InStream.data(), InputChars, InputSize);
+  free(InputChars);
+  std::vector<uint8_t> OutStream;
+  if (!SPIRVParser::applyAtomicCmpXchgWorkaround(InStream.data(), InputSize / 4,
+                                                 OutStream))
+    return EXIT_FAILURE;
+
+  int Ret = poclu_write_binfile(OutputName.c_str(), (char *)OutStream.data(),
+                                OutStream.size());
+
+  return Ret ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/cl_offline_compiler.sh.in.cmake
+++ b/cl_offline_compiler.sh.in.cmake
@@ -95,7 +95,7 @@ fi
 CL_IS_30=false
 CL_FAST_MATH=false
 CL_UNSAFE_MATH=false
-BUILD_OPTIONS=""
+BUILD_OPTIONS="-cl-opt-disable"
 CL_STD="-cl-std=CL1.2"
 
 for i in "$@"; do
@@ -255,18 +255,14 @@ if [ "$DEBUG" = "true" ]; then
   echo "OUTPUT: ${OUTPUT}"
 fi
 
-if [ "$CL_OFFLINE_COMPILER_DISABLE_OPT" = "1" ]; then
-  BUILD_OPTIONS="${BUILD_OPTIONS} -cl-opt-disable"
-fi
-
-ALL_OPTIONS="--target=${TARGET} -x cl ${CL_STD} ${BUILD_OPTIONS} -o ${TEMP_BC_FILE} -emit-llvm -c ${SOURCE}"
+CLANG_OPTIONS="--target=${TARGET} -x cl ${CL_STD} ${BUILD_OPTIONS} -o ${TEMP_BC_FILE} -emit-llvm -c ${SOURCE}"
 
 LLVM_SPIRV_OPTIONS="--spirv-gen-kernel-arg-name-md --spirv-max-version=1.2 -o ${TEMP_SPV_FILE} ${TEMP_BC_FILE}"
 
 if [ "$DEBUG" = "true" ]; then
-  echo "Running @CLANG@ ${ALL_OPTIONS}"
+  echo "Running @CLANG@ ${CLANG_OPTIONS}"
 fi
-@CLANG@ ${ALL_OPTIONS} || exit 1
+@CLANG@ ${CLANG_OPTIONS} || exit 1
 
 if [ "$DEBUG" = "true" ]; then
   echo "Running @LLVM_SPIRV@ ${LLVM_SPIRV_OPTIONS}"

--- a/lib/CL/devices/common_utils.c
+++ b/lib/CL/devices/common_utils.c
@@ -336,7 +336,8 @@ pocl_cpu_init_common (cl_device_id device)
   device->extensions = HOST_DEVICE_EXTENSIONS;
 
   device->features = HOST_DEVICE_FEATURES_30;
-  device->run_program_scope_variables_pass = CL_TRUE;
+  if (strstr (HOST_DEVICE_FEATURES_30, "__opencl_c_program_scope_global_variables") != NULL)
+    device->run_program_scope_variables_pass = CL_TRUE;
   device->generic_as_support = CL_TRUE;
   device->wg_collective_func_support = CL_TRUE;
   device->device_side_printf = CL_TRUE;

--- a/lib/CL/devices/spirv_parser.cc
+++ b/lib/CL/devices/spirv_parser.cc
@@ -723,7 +723,7 @@ public:
     const int32_t *PastHeaderPtr = InStream;
     HeaderOK_ = parseHeader(PastHeaderPtr, NumWords);
     if (!HeaderOK_) {
-      logError("SPIR-V parser: Corrupted header.\n");
+      logError("SPIR-V parser: corrupted header, or not a SPIR-V file.\n");
       return false;
     }
 
@@ -1060,13 +1060,15 @@ bool parseSPIRV(const int32_t *Stream, size_t NumWords,
   return Mod.fillModuleInfo(Output);
 }
 
-void applyAtomicCmpXchgWorkaround(const int32_t *InStream, size_t NumWords,
+bool applyAtomicCmpXchgWorkaround(const int32_t *InStream, size_t NumWords,
                                   std::vector<uint8_t> &OutStream) {
   SPIRVmodule Mod;
   std::vector<int32_t> Out;
-  Mod.applyCmpXchgWorkaround(InStream, NumWords, Out);
+  if (!Mod.applyCmpXchgWorkaround(InStream, NumWords, Out))
+    return false;
   OutStream.resize(Out.size() * 4);
   std::memcpy(OutStream.data(), Out.data(), Out.size() * 4);
+  return true;
 }
 
 } // namespace SPIRVParser

--- a/lib/CL/devices/spirv_parser.cc
+++ b/lib/CL/devices/spirv_parser.cc
@@ -35,18 +35,20 @@
 #include "spirv.hh"
 #include "spirv_parser.hh"
 
-#include "pocl_debug.h"
-
 // uncomment to enable extra messages from the parser
 //#define DEBUG_SPIRV_PARSER
 
 #ifdef DEBUG_SPIRV_PARSER
+#include "pocl_debug.h"
 #define logTrace(...) POCL_MSG_PRINT_INFO(__VA_ARGS__);
-#else
-#define logTrace(...) ((void)0)
-#endif
 #define logWarn(...) POCL_MSG_WARN(__VA_ARGS__);
 #define logError(...) POCL_MSG_ERR(__VA_ARGS__);
+#else
+#define logTrace(...) ((void)0)
+#define logWarn(...) fprintf(stderr, __VA_ARGS__)
+#define logError(...) fprintf(stderr, __VA_ARGS__)
+#endif
+
 
 namespace SPIRVParser {
 

--- a/lib/CL/devices/spirv_parser.hh
+++ b/lib/CL/devices/spirv_parser.hh
@@ -97,7 +97,7 @@ bool parseSPIRV(const int32_t *Stream, size_t NumWords,
                 OpenCLFunctionInfoMap &FuncInfoMap);
 
 POCL_EXPORT
-void applyAtomicCmpXchgWorkaround(const int32_t *InStream, size_t NumWords,
+bool applyAtomicCmpXchgWorkaround(const int32_t *InStream, size_t NumWords,
                                   std::vector<uint8_t> &OutStream);
 
 } // namespace SPIRVParser

--- a/lib/CL/devices/spirv_parser.hh
+++ b/lib/CL/devices/spirv_parser.hh
@@ -26,7 +26,6 @@
 #ifndef HIP_COMMON_HH
 #define HIP_COMMON_HH
 
-#include "pocl_cl.h"
 #include "pocl_export.h"
 
 #include <map>
@@ -35,8 +34,6 @@
 #include <string>
 #include <vector>
 
-namespace SPIRVParser {
-
 #ifndef HAVE_SIZE_T_3
 #define HAVE_SIZE_T_3
 typedef struct
@@ -44,6 +41,8 @@ typedef struct
   size_t size[3];
 } size_t_3;
 #endif
+
+namespace SPIRVParser {
 
 enum class OCLType : unsigned {
   POD,

--- a/tools/scripts/run_level0_tests
+++ b/tools/scripts/run_level0_tests
@@ -26,8 +26,6 @@ export POCL_BUILDING=1
 export POCL_DEVICES="level0"
 export IGC_EnableDPEmulation=1
 export OverrideDefaultFP64Settings=1
-# necessary to workaround issues with llvm-spirv translator
-export CL_OFFLINE_COMPILER_DISABLE_OPT=1
 
 if [ -z "$OCL_ICD_VENDORS" ]; then
   export OCL_ICD_VENDORS=$PWD/ocl-vendors


### PR DESCRIPTION
Fixes all remaining OpenCL-CTS SPIR-V tests. Howewer, had to disable program-scope variables (for ENABLE_CONFORMANCE=ON).