### PR TITLE
misc: remove unused function warnings

### DIFF
--- a/lib/CL/devices/common_driver.c
+++ b/lib/CL/devices/common_driver.c
@@ -591,12 +591,12 @@ pocl_reload_program_bc (char *program_bc_path, cl_program program,
   return 0;
 }
 
+#ifdef ENABLE_SPIRV
 /* if some SPIR-V spec constants were changed, use llvm-spirv --spec-const=...
  * to generate new LLVM bitcode from SPIR-V */
 static int
 pocl_regen_spirv_binary (cl_program program, cl_uint device_i)
 {
-#ifdef ENABLE_SPIRV
   int errcode = CL_SUCCESS;
   cl_device_id device = program->devices[device_i];
   int spec_constants_changed = 0;
@@ -678,10 +678,8 @@ ERROR:
         pocl_remove (program_bc_spirv);
     }
   return errcode;
-#else
-  return -1;
-#endif
 }
+#endif
 
 /* Converts SPIR-V / SPIR to LLVM IR, and links it to pocl's kernel library */
 static int

--- a/lib/CL/devices/common_utils.c
+++ b/lib/CL/devices/common_utils.c
@@ -889,24 +889,6 @@ pocl_cpu_get_ptr (struct pocl_argument *arg, unsigned global_mem_id)
   return (void *)ptr;
 }
 
-/**
- * Get the size of the arg mem_obj that belongs to the global_mem_id.
- *
- * \return 0 if arg->value is NULL or is_raw_ptr, otherwise the size of the mem_obj.
- */
-static size_t
-pocl_cpu_get_memsize (struct pocl_argument *arg, unsigned global_mem_id)
-{
-  if (arg->value == NULL)
-    return 0;
-
-  if (arg->is_raw_ptr)
-    return 0;
-
-  cl_mem mem = *(cl_mem *)(arg->value);
-  return mem->size;
-}
-
 #ifdef HAVE_LIBXSMM
 
 static cl_bool

--- a/lib/CL/pocl_mem_management.c
+++ b/lib/CL/pocl_mem_management.c
@@ -29,6 +29,8 @@
 #include "utlist.h"
 #include <string.h>
 
+/* #define DEBUG_MIGRATIONS */
+
 #ifndef USE_POCL_MEMMANAGER
 
 cl_event pocl_mem_manager_new_event ()
@@ -373,6 +375,7 @@ out:
   return retv;
 }
 
+#ifdef DEBUG_MIGRATIONS
 static void
 pocl_dump_migration_infos (pocl_buffer_migration_info *mis)
 {
@@ -394,6 +397,7 @@ pocl_dump_migration_infos (pocl_buffer_migration_info *mis)
                  mi->buffer->parent->latest_version);
     }
 }
+#endif
 
 /** Creates an implicit sub-buffer to patch up a part left by another
    sub-buffers which ends before an unaligned address.
@@ -461,7 +465,7 @@ pocl_convert_to_subbuffer_migrations (pocl_buffer_migration_info *buffer_usage,
   pocl_buffer_migration_info *extra_migrations = NULL;
   pocl_buffer_migration_info *patch_migrations = NULL;
 
-#if 0
+#ifdef DEBUG_MIGRATIONS
   fprintf (stderr, "Original migrations:\n");
   pocl_dump_migration_infos (buffer_usage);
 #endif
@@ -533,7 +537,7 @@ pocl_convert_to_subbuffer_migrations (pocl_buffer_migration_info *buffer_usage,
   LL_CONCAT (patch_migrations, buffer_usage);
   LL_CONCAT (patch_migrations, extra_migrations);
 
-#if 0
+#ifdef DEBUG_MIGRATIONS
   fprintf (stderr, "Updated sub-buffer-based migrations:\n");
   pocl_dump_migration_infos (patch_migrations);
 #endif

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -77,6 +77,7 @@
 #include "utlist.h"
 #include "utlist_addon.h"
 
+/* #define DEBUG_EVENT_DEPS */
 
 uint32_t
 pocl_byteswap_uint32_t (uint32_t word, char should_swap)
@@ -316,6 +317,7 @@ pocl_create_event (cl_event *event,
   return CL_SUCCESS;
 }
 
+#ifdef DEBUG_EVENT_DEPS
 static int
 check_for_circular_dep (cl_event waiting_event, cl_event notifier_event)
 {
@@ -333,6 +335,7 @@ check_for_circular_dep (cl_event waiting_event, cl_event notifier_event)
   }
   return 0;
 }
+#endif
 
 int
 pocl_create_event_sync (cl_event notifier_event, cl_event waiting_event)
@@ -368,7 +371,9 @@ pocl_create_event_sync (cl_event notifier_event, cl_event waiting_event)
   if (!notify_target || !wait_list_item)
     return CL_OUT_OF_HOST_MEMORY;
 
-  /* check_for_circular_dep (waiting_event, notifier_event); */
+#ifdef DEBUG_EVENT_DEPS
+  check_for_circular_dep (waiting_event, notifier_event);
+#endif
 
   notify_target->event = waiting_event;
   wait_list_item->event = notifier_event;

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -1305,23 +1305,6 @@ static size_t getArgumentSize(llvm::Argument &Arg) {
   return DL.getTypeStoreSize(TypeInBuf);
 }
 
-// Tofix: Why this is duplicated here? pocl_utils.c should be used?
-static uint64_t pocl_size_ceil2_64(uint64_t x) {
-  /* Rounds up to the next highest power of two without branching and
-   * is as fast as a BSR instruction on x86, see:
-   *
-   * http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
-   */
-  --x;
-  x |= x >> 1;
-  x |= x >> 2;
-  x |= x >> 4;
-  x |= x >> 8;
-  x |= x >> 16;
-  x |= x >> 32;
-  return ++x;
-}
-
 static void computeArgBufferOffsets(LLVMValueRef F,
                                     uint64_t *ArgBufferOffsets) {
 


### PR DESCRIPTION
This commit removes functions not needed anymore
and puts debugging functions behind ifdefs.