### PR TITLE
dbk fixes

### DIFF
--- a/lib/CL/clCreateProgramWithDefinedBuiltInKernels.c
+++ b/lib/CL/clCreateProgramWithDefinedBuiltInKernels.c
@@ -110,7 +110,11 @@ POname (clCreateProgramWithDefinedBuiltInKernelsEXP) (
       unsigned num_supported_kernels = 0;
       cl_device_id dev = device_list[i];
       if (dev->ops->supports_dbk == NULL)
-        continue;
+        {
+          if (device_support)
+            device_support[i] = CL_DBK_UNSUPPORTED_EXP;
+          continue;
+        }
       for (j = 0; j < num_kernels; ++j)
         {
           errcode = dev->ops->supports_dbk (dev, kernel_ids[j],

--- a/lib/CL/dbk/pocl_dbk_khr_onnxrt_shared.c
+++ b/lib/CL/dbk/pocl_dbk_khr_onnxrt_shared.c
@@ -127,6 +127,12 @@ pocl_copy_onnx_inference_dbk_attributes (
                   data_len);
         }
     }
+  else
+    {
+      attrs->initializer_names = NULL;
+      attrs->initializer_data = NULL;
+      attrs->initializer_tensor_descs = NULL;
+    }
 
   return attrs;
 

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -1310,16 +1310,15 @@ pocl_remote_supports_dbk (cl_device_id device,
           if (kernel_id != meta->builtin_kernel_id)
             continue;
 
-          if (strstr (device->builtin_kernel_list, meta->name) == NULL)
+          if (strstr (device->builtin_kernel_list, meta->name) != NULL)
             return pocl_validate_dbk_attributes (kernel_id, kernel_attributes,
-                                                 NULL)
-                   == CL_SUCCESS;
+                                                 NULL);
 
-          return 0;
+          return CL_DBK_UNSUPPORTED_EXP;
         }
     }
 
-  return 0;
+  return CL_DBK_UNSUPPORTED_EXP;
 }
 
 int

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -1154,6 +1154,7 @@ pocl_remote_build_defined_builtin (cl_program program, cl_uint device_i)
     &d->remote_platform_index, // relevant_platforms,,
     1, &build_log, NULL, 0, 0, 0, 0);
 
+  free(payload);
   if (err)
     return err;
 


### PR DESCRIPTION
A number of small fixes. And while looking at the the create DBK code, I was wondering why it only returns an invalid value if none of the devices support the set of requested DBKs. I would imagine that would lead to unexpected errors when the program is created just fine, but an error occurs when trying to run the DBK on an unsupported device.