### PR TITLE
Build fix with ENABLE_POCLCC=0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2171,9 +2171,11 @@ configure_file("cl_offline_compiler.sh.in.cmake" "cl_offline_compiler.sh.config.
 rename_if_different(
   "${CMAKE_BINARY_DIR}/cl_offline_compiler.sh.config.new"
   "${CMAKE_BINARY_DIR}/cl_offline_compiler.sh.config" 1)
-file(GENERATE
-  OUTPUT "${CMAKE_BINARY_DIR}/cl_offline_compiler.sh"
-  INPUT "${CMAKE_BINARY_DIR}/cl_offline_compiler.sh.config")
+if(ENABLE_SPIRV)
+  file(GENERATE
+    OUTPUT "${CMAKE_BINARY_DIR}/cl_offline_compiler.sh"
+    INPUT "${CMAKE_BINARY_DIR}/cl_offline_compiler.sh.config")
+endif()
 
 include_directories("${CMAKE_BINARY_DIR}")
 
@@ -2290,7 +2292,7 @@ set(POCLU_LINK_OPTIONS poclu ${OPENCL_LIBS} ${LIBMATH})
 message(STATUS "POCLU LINK OPTS: ${POCLU_LINK_OPTIONS}")
 
 # poclcc bin
-if(ENABLE_POCLCC)
+if(ENABLE_POCLCC OR ENABLE_SPIRV)
     add_subdirectory("bin")
 endif()
 

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -25,22 +25,26 @@
 
 set_opencl_header_includes()
 
-add_executable(poclcc poclcc.c)
-harden(poclcc)
-target_link_libraries(poclcc poclu ${OPENCL_LIBS})
+if(ENABLE_SPIRV)
+  # TODO refactor spirv-parser into its own library
+  set(SPVSRC "${CMAKE_SOURCE_DIR}/lib/CL/devices")
+  add_executable(spirv_fix_atomic_compare_exchange spirv_fix_atomic_compare_exchange.cc
+    "${SPVSRC}/spirv_parser.hh" "${SPVSRC}/spirv_parser.cc")
+  harden(spirv_fix_atomic_compare_exchange)
+  target_link_libraries(spirv_fix_atomic_compare_exchange poclu ${OPENCL_LIBS})
+  target_include_directories(spirv_fix_atomic_compare_exchange PRIVATE "${SPVSRC}")
+endif()
 
-# TODO refactor spirv-parser into its own library
-set(SPVSRC "${CMAKE_SOURCE_DIR}/lib/CL/devices")
-add_executable(spirv_fix_atomic_compare_exchange spirv_fix_atomic_compare_exchange.cc
-  "${SPVSRC}/spirv_parser.hh" "${SPVSRC}/spirv_parser.cc")
-harden(spirv_fix_atomic_compare_exchange)
-target_link_libraries(spirv_fix_atomic_compare_exchange poclu ${OPENCL_LIBS})
-target_include_directories(spirv_fix_atomic_compare_exchange PRIVATE "${SPVSRC}")
+if(ENABLE_POCLCC)
+  add_executable(poclcc poclcc.c)
+  harden(poclcc)
+  target_link_libraries(poclcc poclu ${OPENCL_LIBS})
 
-install(TARGETS "poclcc" RUNTIME
-        DESTINATION "${POCL_INSTALL_PUBLIC_BINDIR}" COMPONENT "poclcc")
+  install(TARGETS "poclcc" RUNTIME
+          DESTINATION "${POCL_INSTALL_PUBLIC_BINDIR}" COMPONENT "poclcc")
 
-set("CPACK_DEBIAN_POCLCC_PACKAGE_NAME" "poclcc")
-list(APPEND CPACK_DEBIAN_POCLCC_PACKAGE_DEPENDS "opencl-icd")
+  set("CPACK_DEBIAN_POCLCC_PACKAGE_NAME" "poclcc")
+  list(APPEND CPACK_DEBIAN_POCLCC_PACKAGE_DEPENDS "opencl-icd")
+endif()
 
 pass_through_cpack_vars()


### PR DESCRIPTION
cl_offline_compiler.sh.in.cmake includes the target 'spirv_fix_atomic_compare_exchange', which is not added if ENABLE_POCLCC=0.

I am not sure if this is the correct fix for this. 