### PR TITLE
Fix DMABufAllocation::allocExport() triggered assert(FD < 0)

### DIFF
--- a/lib/CL/devices/level0/level0-driver.cc
+++ b/lib/CL/devices/level0/level0-driver.cc
@@ -4212,6 +4212,7 @@ bool DMABufAllocation::free(Level0Device *D) {
       D->freeUSMMem(ExportPtr);
       ExportPtr = nullptr;
       ExportDev = nullptr;
+      FD = -1;
     } else {
       POCL_MSG_PRINT_LEVEL0("Not freeing Export alloc "
                             "because Import(s) remain\n");


### PR DESCRIPTION
I think this was caused by not having `DMABufAllocation`'s "export" state resetted fully in `DMABufAllocation::free()` call.