### PR TITLE
OpenCL-CTS / LevelZero

### DIFF
--- a/examples/conformance/CMakeLists.txt
+++ b/examples/conformance/CMakeLists.txt
@@ -85,7 +85,7 @@ if(CUSTOM_CTS_GIT_TAG)
   set(CTS_GIT_TAG "${CUSTOM_CTS_GIT_TAG}")
 else()
   # Use PoCL's fork which has pending fixes.
-  set(CTS_GIT_TAG "v2024.10.28")
+  set(CTS_GIT_TAG "v2024.12.03")
 endif()
 
 set(TS_BUILDDIR "${TS_BUILDDIR}/test_conformance")

--- a/lib/CL/devices/level0/level0-driver.cc
+++ b/lib/CL/devices/level0/level0-driver.cc
@@ -2388,7 +2388,20 @@ bool Level0Device::setupModuleProperties(bool &SupportsInt64Atomics,
 
   ClDev->device_side_printf = 0;
   ClDev->printf_buffer_size = ModuleProperties.printfBufferSize;
+  // leaving the default gives an error with CTS test_api:
+  //
+  // error: Total size of kernel arguments exceeds limit!
+  //        Total arguments size: 2060, limit: 2048
+  // in kernel: 'get_kernel_arg_info'
+  //
+  // this is a bug in the CTS, fixed in our branch,
+  // but this workaround is needed for upstream CTS
   ClDev->max_parameter_size = ModuleProperties.maxArgumentsSize;
+#ifdef ENABLE_CONFORMANCE
+  if (ModuleProperties.maxArgumentsSize > 256) {
+    ClDev->max_parameter_size = ModuleProperties.maxArgumentsSize - 64;
+  }
+#endif
   return true;
 }
 

--- a/lib/CL/devices/level0/level0-driver.cc
+++ b/lib/CL/devices/level0/level0-driver.cc
@@ -2398,9 +2398,8 @@ bool Level0Device::setupModuleProperties(bool &SupportsInt64Atomics,
   // but this workaround is needed for upstream CTS
   ClDev->max_parameter_size = ModuleProperties.maxArgumentsSize;
 #ifdef ENABLE_CONFORMANCE
-  if (ModuleProperties.maxArgumentsSize > 256) {
+  if (ModuleProperties.maxArgumentsSize > 256)
     ClDev->max_parameter_size = ModuleProperties.maxArgumentsSize - 64;
-  }
 #endif
   return true;
 }

--- a/lib/CL/devices/level0/level0-driver.cc
+++ b/lib/CL/devices/level0/level0-driver.cc
@@ -68,6 +68,8 @@
 #define ENABLE_SUBGROUPS
 // this is emulated on consumer hardware and fails math corner cases
 #define ENABLE_FP64
+// this is failing some CTS test cases (math/fract)
+#define ENABLE_FP16
 // fails a single test (progvar_prog_scope_init) in CTS test "basic"
 #define ENABLE_PROGVARS
 // fails a c11_atomics subtest with GPU hang (even with increased timeout)
@@ -2338,9 +2340,11 @@ bool Level0Device::setupModuleProperties(bool &SupportsInt64Atomics,
     ClDev->double_fp_config = convertZeFPFlags(ModuleProperties.fp64flags);
   }
 #endif
+#ifdef ENABLE_FP16
   if ((ModuleProperties.flags & ZE_DEVICE_MODULE_FLAG_FP16) != 0u) {
     ClDev->half_fp_config = convertZeFPFlags(ModuleProperties.fp16flags);
   }
+#endif
 
 #ifdef ENABLE_64BIT_ATOMICS
   SupportsInt64Atomics = (ModuleProperties.flags &


### PR DESCRIPTION
Adds workarounds for issues encountered when running OpenCL-CTS.

* FP16 has been disabled in conformance mode for now, this needs a fix in the GPU drivers.
* `test_api` fails the `get_kernel_arg_info` test, because it incorrectly calculates argument sizes. Fixed in our CTS fork, workarounded in PoCL (upstreaming takes a while)