### PR TITLE
Be a bit more explicit about DBK build dependencies

### DIFF
--- a/.github/workflows/build_linux_gh.yml
+++ b/.github/workflows/build_linux_gh.yml
@@ -107,7 +107,7 @@ jobs:
            sudo ln -s /opt/libjpeg-turbo/lib64 /opt/libjpeg-turbo/lib &&
            sudo ln -s /opt/onnx/lib /opt/onnx/lib64 &&
            sudo mv /opt/onnx/include /opt/onnxruntime && sudo mkdir /opt/onnx/include && sudo mv /opt/onnxruntime /opt/onnx/include/ &&
-           sudo bash -c 'mkdir /opt/source && cd /opt/source && git clone https://github.com/libxsmm/libxsmm.git && cd libxsmm && make -j3 STATIC=0 FORTRAN=0 AVX=2 install DESTDIR=/opt/xsmm'
+           sudo bash -c 'mkdir /opt/source && cd /opt/source && git clone https://github.com/libxsmm/libxsmm.git && cd libxsmm && echo "unstable-1.17.1" > version.txt && make -j3 STATIC=0 FORTRAN=0 AVX=2 install DESTDIR=/opt/xsmm'
 
       - name: CMake
         id: cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1144,14 +1144,17 @@ endif()
 ######################################################################################
 
 if(ENABLE_HOST_CPU_DEVICES AND PKG_CONFIG_FOUND AND NOT ENABLE_CONFORMANCE)
+  # PoCL requires libxsmm to support LIBXSMM_DATATYPE_F16, which was added after the
+  # 1.17 release. Until there is a new release, building libxsmm from git and
+  # manually updating the version number in version.txt before building is necessary.
   if(BUILD_SHARED_LIBS)
-    pkg_check_modules(LIBXSMM IMPORTED_TARGET libxsmm-shared>=1.15)
+    pkg_check_modules(LIBXSMM IMPORTED_TARGET libxsmm-shared>1.17.0)
   endif()
   if(NOT LIBXSMM_FOUND)
-    pkg_check_modules(LIBXSMM IMPORTED_TARGET libxsmm-static>=1.15)
+    pkg_check_modules(LIBXSMM IMPORTED_TARGET libxsmm-static>1.17.0)
   endif()
   if(NOT LIBXSMM_FOUND)
-    pkg_check_modules(LIBXSMM IMPORTED_TARGET libxsmm>=1.15)
+    pkg_check_modules(LIBXSMM IMPORTED_TARGET libxsmm>1.17.0)
   endif()
 
   # libxsmm needs BLAS as fallback
@@ -1166,6 +1169,8 @@ if(LIBXSMM_FOUND AND TARGET BLAS::BLAS)
 else()
   set(HAVE_LIBXSMM 0)
   message(STATUS "libxsmm or libblas not found, XSMM disabled")
+  message(STATUS "NOTE: If you meant to use a git build of libxsmm you may have to manually bump "
+          "the version in its version.txt before building.")
 endif()
 
 function(print_target_properties target)
@@ -1204,7 +1209,9 @@ if(ENABLE_HOST_CPU_DEVICES AND NOT ENABLE_CONFORMANCE)
       set(HAVE_ONNXRT ON)
     endif ()
   else ()
-    find_package(onnxruntime QUIET)
+    # PoCL requires SetUserLoggingFunction which was introduced in 1.17,
+    # search for a version that is compatible with this.
+    find_package(onnxruntime 1.17 QUIET)
     set(HAVE_ONNXRT ${onnxruntime_FOUND})
     if (${HAVE_ONNXRT})
       # TODO: this is a hack, just passing onnxruntime::onnxruntime

--- a/doc/sphinx/source/dbk.rst
+++ b/doc/sphinx/source/dbk.rst
@@ -61,7 +61,8 @@ Building with a custom ONNX Runtime
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Some popular Linux distributions don't provide prebuilt packages of ONNX Runtime
-so you may have to
+so you may have to `grab a prebuilt copy from Github
+<https://github.com/microsoft/onnxruntime/releases>` or
 `build your own <https://onnxruntime.ai/docs/build/inferencing.html>` and tell
 CMake where to find it. Steps for building a suitable copy of ONNX Runtime (run
 outside of the PoCL source tree) are as follows:
@@ -89,3 +90,6 @@ configuration files of ONNX Runtime:
     cd build
     cmake .. -Donnxruntime_DIR=${HOME}/onnxruntime-bin/lib/cmake/onnxruntime
     make -j$(nproc)
+
+If you downloaded a prebuilt binary, replace `${HOME}/onnxruntime-bin` in the
+cmake command with the path where you unpacked the bundle to.

--- a/lib/CL/devices/cpu_dbk/pocl_dbk_khr_onnxrt_cpu.c
+++ b/lib/CL/devices/cpu_dbk/pocl_dbk_khr_onnxrt_cpu.c
@@ -40,14 +40,14 @@
 
 static OrtApi *ort_api = NULL;
 
-typedef struct onnxrt_instance
+struct onnxrt_instance
 {
   OrtEnv *env;
   OrtMemoryInfo *mem_info;
   OrtSession *session;
   OrtSessionOptions *session_options;
   const cl_dbk_attributes_onnx_inference_exp *attributes;
-} onnxrt_instance_t;
+};
 
 static void
 pocl_ort_logger (void *_param,

--- a/lib/CL/devices/cpu_dbk/pocl_dbk_khr_onnxrt_cpu.c
+++ b/lib/CL/devices/cpu_dbk/pocl_dbk_khr_onnxrt_cpu.c
@@ -29,7 +29,6 @@
 #include "CL/cl_exp_tensor.h"
 #include "onnxruntime_c_api.h"
 
-#include "pocl_builtin_kernels.h"
 #include "pocl_cl.h"
 #include "pocl_debug.h"
 #include "pocl_dbk_khr_onnxrt_cpu.h"
@@ -37,7 +36,7 @@
 
 /* Update as needed, but make sure to remove uses of deprecated functions when
  * doing so. */
-#define TARGET_ORT_API_VERSION 16
+#define TARGET_ORT_API_VERSION 17
 
 static OrtApi *ort_api = NULL;
 


### PR DESCRIPTION
The version requirements for onnxruntime and libxsmm in CMakeLists.txt were wrong. Additionally ubuntu 24.04 finally packages libxsmm and that version was accepted by the build scripts... but then fails at build time with little indication of what the problem actually is. This should help avoid losing much time to confusion in the future.

@franz if you have libxsmm set up on CI somewhere this probably breaks since upstream still declares its version as 0.17.0 (latest release tag) even for git builds.