### PR TITLE
remote: handle EINTR error

### DIFF
--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -319,6 +319,13 @@ connection_read_full (remote_connection_t *connection,
       res = read (connection->fd, ptr + readb, remain);
       if (res < 0)
         { /* ERROR */
+
+          /* In the case of these errors, try again. */
+          int e = errno;
+          if (e == EAGAIN || e == EWOULDBLOCK || e == EINTR)
+            continue;
+          POCL_MSG_ERR ("error reading remote data: %d (%s).\n", errno,
+                        strerror (errno));
           return -1;
         }
       if (res == 0)
@@ -350,7 +357,7 @@ connection_write_full (remote_connection_t *connection,
       if (res < 0)
         {
           int e = errno;
-          if (e == EAGAIN || e == EWOULDBLOCK)
+          if (e == EAGAIN || e == EWOULDBLOCK || e == EINTR)
             continue;
           else
             return -1;

--- a/pocld/connection.cc
+++ b/pocld/connection.cc
@@ -68,7 +68,7 @@ ssize_t Connection::writeFull(const void *Source, size_t Bytes) {
     Res = ::write(Fd, Ptr + Written, Remaining);
     if (Res < 0) {
       int e = errno;
-      if (e == EAGAIN || e == EWOULDBLOCK)
+      if (e == EAGAIN || e == EWOULDBLOCK || e == EINTR)
         continue;
       else
         return -1;
@@ -93,7 +93,7 @@ int Connection::readFull(void *Destination, size_t Bytes) {
     res = ::read(Fd, Ptr + readb, Remain);
     if (res < 0) {
       int e = errno;
-      if (e == EAGAIN || e == EWOULDBLOCK)
+      if (e == EAGAIN || e == EWOULDBLOCK || e == EINTR)
         continue;
       else
         return -1;


### PR DESCRIPTION
In the case of an interrupt, try reading the data
again. This may not be the most considerate thing
to do, but it will read th data.

I encountered this case on Android where establishing the connection can take a while.