### PR TITLE
event: add retain event during event sync

### DIFF
--- a/include/pocl.h
+++ b/include/pocl.h
@@ -506,6 +506,17 @@ typedef union
 typedef struct _pocl_buffer_migration_info
   pocl_buffer_migration_info;
 
+/**
+ * Enum that represents different possible states of a command node.
+ */
+typedef enum
+{
+  POCL_COMMAND_FAILED = -1,
+  /* Default unless set to ready. */
+  POCL_COMMAND_NOT_READY = 0,
+  POCL_COMMAND_READY = 1,
+} pocl_command_state;
+
 /* One item in a command queue or a command buffer. */
 typedef struct _cl_command_node _cl_command_node;
 struct _cl_command_node
@@ -538,7 +549,10 @@ struct _cl_command_node
   cl_device_id device;
   /* The index of the targeted device in the **program** device list. */
   unsigned program_device_i;
-  cl_int ready;
+
+  /* Used to indicate if a node is ready to be executed or failed. */
+  pocl_command_state state;
+
   /* true if the node belongs to a cl_command_buffer_khr */
   cl_int buffered;
 

--- a/lib/CL/devices/almaif/almaif.cc
+++ b/lib/CL/devices/almaif/almaif.cc
@@ -723,7 +723,7 @@ bool only_custom_device_events_left(cl_event event) {
 
 void pocl_almaif_submit(_cl_command_node *Node, cl_command_queue /*CQ*/) {
 
-  Node->ready = 1;
+  Node->state = POCL_COMMAND_READY;
 
   struct AlmaifData *D = (AlmaifData *)Node->device->data;
   cl_event E = Node->sync.event.event;
@@ -798,8 +798,12 @@ void pocl_almaif_notify(cl_device_id Device, cl_event Event, cl_event Finished) 
     return;
   }
 
-  if (!Node->ready)
+  if (Node->state != POCL_COMMAND_READY) {
+    POCL_MSG_PRINT_EVENTS(
+        "almaif: command related to the notified event %lu not ready\n",
+        Event->id);
     return;
+  }
 
   if (Event->command->type != CL_COMMAND_NDRANGE_KERNEL) {
     if (pocl_command_is_ready(Event)) {

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -571,7 +571,16 @@ pocl_basic_notify (cl_device_id device, cl_event event, cl_event finished)
 
   if (finished->status < CL_COMPLETE)
     {
-      pocl_update_event_failed_locked (event);
+      /* Unlock the finished event in order to prevent a lock order violation
+       * with the command queue that will be locked during
+       * pocl_update_event_failed.
+       */
+      pocl_unlock_events_inorder (event, finished);
+      pocl_update_event_failed (CL_FAILED, NULL, 0, event, NULL);
+      /* Lock events in this order to avoid a lock order violation between
+       * the finished/notifier and event/wait events.
+       */
+      pocl_lock_events_inorder (finished, event);
       return;
     }
 

--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -524,14 +524,14 @@ pocl_basic_submit (_cl_command_node *node, cl_command_queue cq)
             {
               pocl_update_event_running_unlocked (node->sync.event.event);
               POCL_UNLOCK_OBJ (node->sync.event.event);
-              POCL_UPDATE_EVENT_FAILED (node->sync.event.event);
+              POCL_UPDATE_EVENT_FAILED (CL_FAILED, node->sync.event.event);
               return;
             }
           node->command.run.device_data = handle;
         }
     }
 
-  node->ready = 1;
+  node->state = POCL_COMMAND_READY;
   POCL_LOCK (d->cq_lock);
   pocl_command_push(node, &d->ready_list, &d->command_list);
 
@@ -575,8 +575,13 @@ pocl_basic_notify (cl_device_id device, cl_event event, cl_event finished)
       return;
     }
 
-  if (!node->ready)
-    return;
+  if (node->state != POCL_COMMAND_READY)
+    {
+      POCL_MSG_PRINT_EVENTS (
+        "basic: command related to the notified event %lu not ready\n",
+        event->id);
+      return;
+    }
 
   if (pocl_command_is_ready (event))
     {

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -823,7 +823,7 @@ pocl_exec_command (_cl_command_node *node)
     default:
       pocl_update_event_running (event);
       POCL_UPDATE_EVENT_FAILED_MSG (
-        event, "pocl_exec_command: Unknown command type\n");
+        CL_FAILED, event, "pocl_exec_command: Unknown command type\n");
       break;
     }
 }

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -848,13 +848,6 @@ pocl_broadcast (cl_event brc_event)
   while ((target = brc_event->notify_list))
     {
       POCL_LOCK_OBJ (target->event);
-      if (target != brc_event->notify_list)
-        {
-          assert (0 && "should be unreachable");
-          pocl_unlock_events_inorder (brc_event, target->event);
-          POCL_LOCK_OBJ (brc_event);
-          continue;
-        }
 
       /* remove event from wait list */
       LL_FOREACH (target->event->wait_list, tmp)
@@ -867,29 +860,35 @@ pocl_broadcast (cl_event brc_event)
             }
         }
 
-        if ((target->event->status == CL_SUBMITTED)
-            || (target->event->status == CL_QUEUED))
-          {
-            target->event->command->device->ops->notify (
-                target->event->command->device, target->event, brc_event);
-          }
+      if ((target->event->status == CL_SUBMITTED)
+          || (target->event->status == CL_QUEUED))
+        {
+          target->event->command->device->ops->notify (
+            target->event->command->device, target->event, brc_event);
+        }
 
-        if (pocl_is_tracing_enabled() && target->event->meta_data)
-          {
-            pocl_event_md *md = target->event->meta_data;
-            for (size_t i = 0; i < md->num_deps; ++i)
-              if (md->dep_ids[i] == brc_event->id)
-                {
-                  md->dep_ts[i] = brc_event->time_end;
-                  break;
-                }
-          }
-        LL_DELETE (brc_event->notify_list, target);
-        POCL_UNLOCK_OBJ (target->event);
-        /* Now that the event is deleted from the notify_list,
-         * undo the retain done during pocl_create_event_sync. */
-        POname (clReleaseEvent) (target->event);
-        pocl_mem_manager_free_event_node (target);
+      if (pocl_is_tracing_enabled () && target->event->meta_data)
+        {
+          pocl_event_md *md = target->event->meta_data;
+          for (size_t i = 0; i < md->num_deps; ++i)
+            if (md->dep_ids[i] == brc_event->id)
+              {
+                md->dep_ts[i] = brc_event->time_end;
+                break;
+              }
+        }
+      LL_DELETE (brc_event->notify_list, target);
+      POCL_UNLOCK_OBJ (target->event);
+      /* Unlock and lock brc_event to prevent lock order violations with the
+       * command queue when calling clReleaseEvent as it can call
+       * clReleaseCommandQueue.
+       */
+      POCL_UNLOCK_OBJ (brc_event);
+      /* Now that the event is deleted from the notify_list,
+       * undo the retain done during pocl_create_event_sync. */
+      POname (clReleaseEvent) (target->event);
+      POCL_LOCK_OBJ (brc_event);
+      pocl_mem_manager_free_event_node (target);
     }
   POCL_UNLOCK_OBJ (brc_event);
 }

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -2531,7 +2531,7 @@ pocl_cuda_finalize_command (cl_device_id device, cl_event event)
 
   pocl_update_event_running (event);
   if (event->status < 0)
-    POCL_UPDATE_EVENT_FAILED_MSG (event, "CUDA event failed");
+    POCL_UPDATE_EVENT_FAILED_MSG (CL_FAILED, event, "CUDA event failed");
   else
     POCL_UPDATE_EVENT_COMPLETE_MSG (event, "CUDA event");
 }

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -1613,7 +1613,16 @@ pocl_hsa_notify (cl_device_id device, cl_event event, cl_event finished)
 
   if (finished->status < CL_COMPLETE)
     {
-      pocl_update_event_failed_locked (event);
+      /* Unlock the finished event in order to prevent a lock order violation
+       * with the command queue that will be locked during
+       * pocl_update_event_failed.
+       */
+      pocl_unlock_events_inorder (event, finished);
+      pocl_update_event_failed (CL_FAILED, NULL, 0, event, NULL);
+      /* Lock events in this order to avoid a lock order violation between
+       * the finished/notifier and event/wait events.
+       */
+      pocl_lock_events_inorder (finished, event);
       return;
     }
 

--- a/lib/CL/devices/hsa/pocl-hsa.c
+++ b/lib/CL/devices/hsa/pocl-hsa.c
@@ -1533,7 +1533,7 @@ pocl_hsa_submit (_cl_command_node *node, cl_command_queue cq)
 
   PTHREAD_CHECK (pthread_mutex_lock (&d->list_mutex));
 
-  node->ready = 1;
+  node->state = POCL_COMMAND_READY;
   if (pocl_command_is_ready (node->sync.event.event))
     {
       pocl_update_event_submitted (node->sync.event.event);
@@ -1617,8 +1617,13 @@ pocl_hsa_notify (cl_device_id device, cl_event event, cl_event finished)
       return;
     }
 
-  if (!node->ready)
-    return;
+  if (node->state != POCL_COMMAND_READY)
+    {
+      POCL_MSG_PRINT_EVENTS (
+        "hsa: command related to the notified event %lu not ready\n",
+        event->id);
+      return;
+    }
 
   if (pocl_command_is_ready (event))
     {

--- a/lib/CL/devices/level0/pocl-level0.cc
+++ b/lib/CL/devices/level0/pocl-level0.cc
@@ -1335,7 +1335,7 @@ void pocl_level0_submit(_cl_command_node *Node, cl_command_queue Queue) {
   PoclL0QueueData *QD = (PoclL0QueueData *)Queue->data;
   cl_event Ev = Node->sync.event.event;
 
-  Node->ready = CL_TRUE;
+  Node->state = POCL_COMMAND_READY;
   assert(Ev->data);
   PoclL0EventData *EvData = (PoclL0EventData *)Ev->data;
 
@@ -1370,7 +1370,7 @@ void pocl_level0_notify(cl_device_id ClDev, cl_event Event, cl_event Finished) {
 
   // node is ready to execute
   POCL_MSG_PRINT_LEVEL0("notify on event %zu | READY %i\n", Event->id,
-                        Node->ready);
+                        Node->state);
 
   assert(Event->queue);
   if (pocl_level0_queue_supports_batching(Event->queue, Device)) {
@@ -1380,7 +1380,8 @@ void pocl_level0_notify(cl_device_id ClDev, cl_event Event, cl_event Finished) {
     if (!SubmitBatch.empty())
       Device->pushCommandBatch(std::move(SubmitBatch));
   } else {
-    if (Node->ready == CL_TRUE && pocl_command_is_ready(Event) != 0) {
+    if (Node->state == POCL_COMMAND_READY &&
+        pocl_command_is_ready(Event) != 0) {
       pocl_update_event_submitted(Event);
       Device->pushCommand(Node);
     }

--- a/lib/CL/devices/proxy/pocl_proxy.cpp
+++ b/lib/CL/devices/proxy/pocl_proxy.cpp
@@ -1748,11 +1748,19 @@ pocl_proxy_notify (cl_device_id device, cl_event event, cl_event finished)
 {
   _cl_command_node *node = event->command;
 
-  if (finished->status < CL_COMPLETE)
-    {
-      pocl_update_event_failed_locked (event);
-      return;
-    }
+  if (finished->status < CL_COMPLETE) {
+    /* Unlock the finished event in order to prevent a lock order violation
+     * with the command queue that will be locked during
+     * pocl_update_event_failed.
+     */
+    pocl_unlock_events_inorder(event, finished);
+    pocl_update_event_failed(CL_FAILED, NULL, 0, event, NULL);
+    /* Lock events in this order to avoid a lock order violation between
+     * the finished/notifier and event/wait events.
+     */
+    pocl_lock_events_inorder(finished, event);
+    return;
+  }
 
     if (node->state != POCL_COMMAND_READY) {
       POCL_MSG_PRINT_EVENTS(

--- a/lib/CL/devices/proxy/pocl_proxy.cpp
+++ b/lib/CL/devices/proxy/pocl_proxy.cpp
@@ -1698,7 +1698,7 @@ pocl_proxy_submit (_cl_command_node *node, cl_command_queue cq)
   POCL_INIT_COND (e_d->event_cond);
   e->data = (void *)e_d;
 
-  node->ready = 1;
+  node->state = POCL_COMMAND_READY;
   if (pocl_command_is_ready (e))
     {
       pocl_update_event_submitted (e);
@@ -1754,8 +1754,12 @@ pocl_proxy_notify (cl_device_id device, cl_event event, cl_event finished)
       return;
     }
 
-  if (!node->ready)
-    return;
+    if (node->state != POCL_COMMAND_READY) {
+      POCL_MSG_PRINT_EVENTS(
+          "proxy: command related to the notified event %lu not ready\n",
+          event->id);
+      return;
+    }
 
   if (pocl_command_is_ready (node->sync.event.event))
     {

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -258,7 +258,16 @@ pocl_pthread_notify (cl_device_id device, cl_event event, cl_event finished)
 
   if (finished->status < CL_COMPLETE)
     {
-      pocl_update_event_failed_locked (event);
+      /* Unlock the finished event in order to prevent a lock order violation
+       * with the command queue that will be locked during
+       * pocl_update_event_failed.
+       */
+      pocl_unlock_events_inorder (event, finished);
+      pocl_update_event_failed (CL_FAILED, NULL, 0, event, NULL);
+      /* Lock events in this order to avoid a lock order violation between
+       * the finished/notifier and event/wait events.
+       */
+      pocl_lock_events_inorder (finished, event);
       return;
     }
 

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -215,7 +215,7 @@ pocl_pthread_run (void *data, _cl_command_node *cmd)
 void
 pocl_pthread_submit (_cl_command_node *node, cl_command_queue cq)
 {
-  node->ready = 1;
+  node->state = POCL_COMMAND_READY;
   if (pocl_command_is_ready (node->sync.event.event))
     {
       pocl_update_event_submitted (node->sync.event.event);
@@ -262,8 +262,13 @@ pocl_pthread_notify (cl_device_id device, cl_event event, cl_event finished)
       return;
     }
 
-  if (!node->ready)
-    return;
+  if (node->state != POCL_COMMAND_READY)
+    {
+      POCL_MSG_PRINT_EVENTS (
+        "pthread: command related to the notified event %lu not ready\n",
+        event->id);
+      return;
+    }
 
   if (pocl_command_is_ready (node->sync.event.event))
     {

--- a/lib/CL/devices/pthread/pthread_scheduler.c
+++ b/lib/CL/devices/pthread/pthread_scheduler.c
@@ -443,7 +443,7 @@ pocl_pthread_prepare_kernel (void *data, _cl_command_node *cmd)
       != 0)
     {
       pocl_update_event_running (cmd->sync.event.event);
-      POCL_UPDATE_EVENT_FAILED_MSG (cmd->sync.event.event,
+      POCL_UPDATE_EVENT_FAILED_MSG (CL_FAILED, cmd->sync.event.event,
                                     "CPU: failed to compile GVar init kernel");
       return NULL;
     }
@@ -456,7 +456,7 @@ pocl_pthread_prepare_kernel (void *data, _cl_command_node *cmd)
   if (ci == NULL)
     {
       pocl_update_event_running (cmd->sync.event.event);
-      POCL_UPDATE_EVENT_FAILED_MSG (cmd->sync.event.event,
+      POCL_UPDATE_EVENT_FAILED_MSG (CL_FAILED, cmd->sync.event.event,
                                     "CPU: failed to compile kernel");
       return NULL;
     }

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -1536,7 +1536,7 @@ pocl_remote_submit (_cl_command_node *node, cl_command_queue cq)
   POCL_INIT_COND (e_d->event_cond);
   e->data = (void *)e_d;
 
-  node->ready = 1;
+  node->state = POCL_COMMAND_READY;
   if (pocl_command_is_ready (node->sync.event.event))
     {
       pocl_update_event_submitted (node->sync.event.event);
@@ -1599,7 +1599,7 @@ pocl_remote_notify (cl_device_id device, cl_event event, cl_event finished)
       return;
     }
 
-  if (!node->ready)
+  if (node->state != POCL_COMMAND_READY)
     {
       POCL_MSG_PRINT_EVENTS (
           "remote: command related to the notified event %lu not ready\n",
@@ -2424,7 +2424,7 @@ remote_start_command (remote_device_data_t *d, _cl_command_node *node)
 
   if (*(cq->device->available) == CL_FALSE)
     {
-      pocl_update_event_device_lost (event);
+      node->state = POCL_COMMAND_FAILED;
       goto EARLY_FINISH;
     }
   pocl_update_event_running (event);
@@ -2739,7 +2739,18 @@ pocl_remote_driver_pthread (void *cldev)
           char msg[128] = "Event ";
           strcat (msg, cstr);
 
-          POCL_UPDATE_EVENT_COMPLETE_MSG (event, msg);
+          /* update event status */
+          if (finished->state == POCL_COMMAND_READY)
+            {
+              POCL_UPDATE_EVENT_COMPLETE_MSG (event, msg);
+            }
+          else
+            {
+              cl_int status = CL_FAILED;
+              if (*(event->queue->device->available) == CL_FALSE)
+                status = CL_DEVICE_NOT_AVAILABLE;
+              POCL_UPDATE_EVENT_FAILED_MSG (status, event, msg);
+            }
 
           POCL_LOCK (d->wq_lock);
         }

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -1595,7 +1595,16 @@ pocl_remote_notify (cl_device_id device, cl_event event, cl_event finished)
 
   if (finished->status < CL_COMPLETE)
     {
-      pocl_update_event_failed_locked (event);
+      /* Unlock the finished event in order to prevent a lock order violation
+       * with the command queue that will be locked during
+       * pocl_update_event_failed.
+       */
+      pocl_unlock_events_inorder (event, finished);
+      pocl_update_event_failed (CL_FAILED, NULL, 0, event, NULL);
+      /* Lock events in this order to avoid a lock order violation between
+       * the finished/notifier and event/wait events.
+       */
+      pocl_lock_events_inorder (finished, event);
       return;
     }
 

--- a/lib/CL/devices/tbb/tbb.c
+++ b/lib/CL/devices/tbb/tbb.c
@@ -273,7 +273,7 @@ tbb_scheduler_push_command (_cl_command_node *cmd)
 }
 
 void pocl_tbb_submit(_cl_command_node *node, cl_command_queue cq) {
-  node->ready = 1;
+  node->state = POCL_COMMAND_READY;
   if (pocl_command_is_ready(node->sync.event.event)) {
     pocl_update_event_submitted(node->sync.event.event);
     tbb_scheduler_push_command(node);
@@ -291,8 +291,13 @@ void pocl_tbb_notify(cl_device_id device, cl_event event, cl_event finished) {
       return;
   }
 
-  if (!node->ready)
-    return;
+  if (node->state != POCL_COMMAND_READY)
+    {
+      POCL_MSG_PRINT_EVENTS (
+        "tbb: command related to the notified event %lu not ready\n",
+        event->id);
+      return;
+    }
 
   if (pocl_command_is_ready(node->sync.event.event)) {
     if (event->status == CL_QUEUED) {

--- a/lib/CL/devices/tbb/tbb.c
+++ b/lib/CL/devices/tbb/tbb.c
@@ -286,9 +286,19 @@ void pocl_tbb_notify(cl_device_id device, cl_event event, cl_event finished) {
   cl_bool wake_thread = CL_FALSE;
   _cl_command_node *node = event->command;
 
-  if (finished->status < CL_COMPLETE) {
-      pocl_update_event_failed_locked (event);
-      return;
+  if (finished->status < CL_COMPLETE)
+  {
+    /* Unlock the finished event in order to prevent a lock order violation
+     * with the command queue that will be locked during
+     * pocl_update_event_failed.
+     */
+    pocl_unlock_events_inorder (event, finished);
+    pocl_update_event_failed (CL_FAILED, NULL, 0, event, NULL);
+    /* Lock events in this order to avoid a lock order violation between
+     * the finished/notifier and event/wait events.
+     */
+    pocl_lock_events_inorder (finished, event);
+    return;
   }
 
   if (node->state != POCL_COMMAND_READY)

--- a/lib/CL/devices/tbb/tbb_scheduler.cc
+++ b/lib/CL/devices/tbb/tbb_scheduler.cc
@@ -180,7 +180,7 @@ prepareKernelCommand(pocl_tbb_scheduler_data *SchedData,
   if (pocl_driver_build_gvar_init_kernel(Program, DevI, Cmd->device,
                                          pocl_cpu_gvar_init_callback) != 0) {
     pocl_update_event_running(Cmd->sync.event.event);
-    POCL_UPDATE_EVENT_FAILED_MSG(Cmd->sync.event.event,
+    POCL_UPDATE_EVENT_FAILED_MSG(CL_FAILED, Cmd->sync.event.event,
                                  "CPU: failed to compile GVar init kernel");
     return NULL;
   }
@@ -192,7 +192,7 @@ prepareKernelCommand(pocl_tbb_scheduler_data *SchedData,
   pocl_restore_builtin_kernel_name(Kernel, SavedName);
   if (ci == NULL) {
     pocl_update_event_running(Cmd->sync.event.event);
-    POCL_UPDATE_EVENT_FAILED_MSG(Cmd->sync.event.event,
+    POCL_UPDATE_EVENT_FAILED_MSG(CL_FAILED, Cmd->sync.event.event,
                                  "CPU: failed to compile kernel");
     return NULL;
   }

--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -1129,7 +1129,7 @@ void pocl_tce_submit(_cl_command_node *node, cl_command_queue cq) {
   POCL_INIT_COND(e_d->event_cond);
   e->data = (void *)e_d;
 
-  node->ready = 1;
+  node->state = POCL_COMMAND_READY;
   if (pocl_command_is_ready(node->sync.event.event)) {
     pocl_update_event_submitted(node->sync.event.event);
     tce_push_command(node);
@@ -1175,8 +1175,12 @@ pocl_tce_notify (cl_device_id device, cl_event event, cl_event finished)
     return;
   }
 
-  if (!node->ready)
+  if (node->state != POCL_COMMAND_READY) {
+    POCL_MSG_PRINT_EVENTS(
+        "tce: command related to the notified event %lu not ready\n",
+        event->id);
     return;
+  }
 
   if (pocl_command_is_ready(node->sync.event.event)) {
     assert(event->status == CL_QUEUED);

--- a/lib/CL/devices/tce/tce_common.cc
+++ b/lib/CL/devices/tce/tce_common.cc
@@ -1171,7 +1171,16 @@ pocl_tce_notify (cl_device_id device, cl_event event, cl_event finished)
   _cl_command_node *node = event->command;
 
   if (finished->status < CL_COMPLETE) {
-    pocl_update_event_failed_locked(event);
+    /* Unlock the finished event in order to prevent a lock order violation
+     * with the command queue that will be locked during
+     * pocl_update_event_failed.
+     */
+    pocl_unlock_events_inorder(event, finished);
+    pocl_update_event_failed(CL_FAILED, NULL, 0, event, NULL);
+    /* Lock events in this order to avoid a lock order violation between
+     * the finished/notifier and event/wait events.
+     */
+    pocl_lock_events_inorder(finished, event);
     return;
   }
 

--- a/lib/CL/devices/vulkan/pocl-vulkan.c
+++ b/lib/CL/devices/vulkan/pocl-vulkan.c
@@ -2847,7 +2847,7 @@ vulkan_push_command (cl_device_id dev, _cl_command_node *cmd)
 void
 pocl_vulkan_submit (_cl_command_node *node, cl_command_queue cq)
 {
-  node->ready = 1;
+  node->state = POCL_COMMAND_READY;
   if (pocl_command_is_ready (node->sync.event.event))
     {
       pocl_update_event_submitted (node->sync.event.event);
@@ -2939,8 +2939,13 @@ pocl_vulkan_notify (cl_device_id device, cl_event event, cl_event finished)
       return;
     }
 
-  if (!node->ready)
-    return;
+  if (node->state != POCL_COMMAND_READY)
+    {
+      POCL_MSG_PRINT_EVENTS (
+        "vulkan: command related to the notified event %lu not ready\n",
+        event->id);
+      return;
+    }
 
   POCL_MSG_PRINT_VULKAN ("notify on event %zu \n", event->id);
 
@@ -3368,7 +3373,7 @@ void pocl_vulkan_memfill(void *data,
   cmd.sync.event.event = NULL;
   cmd.next = NULL;
   cmd.prev = NULL;
-  cmd.ready = 1;
+  cmd.state = POCL_COMMAND_READY;
 
   co->wg = NULL;
   co->hash = NULL;

--- a/lib/CL/devices/vulkan/pocl-vulkan.c
+++ b/lib/CL/devices/vulkan/pocl-vulkan.c
@@ -2935,7 +2935,16 @@ pocl_vulkan_notify (cl_device_id device, cl_event event, cl_event finished)
 
   if (finished->status < CL_COMPLETE)
     {
-      pocl_update_event_failed_locked (event);
+      /* Unlock the finished event in order to prevent a lock order violation
+       * with the command queue that will be locked during
+       * pocl_update_event_failed.
+       */
+      pocl_unlock_events_inorder (event, finished);
+      pocl_update_event_failed (CL_FAILED, NULL, 0, event, NULL);
+      /* Lock events in this order to avoid a lock order violation between
+       * the finished/notifier and event/wait events.
+       */
+      pocl_lock_events_inorder (finished, event);
       return;
     }
 

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -2103,12 +2103,15 @@ pocl_update_event_finished (cl_int status, const char *func, unsigned line,
 }
 
 void
-pocl_update_event_failed (const char *func,
+pocl_update_event_failed (cl_int status,
+                          const char *func,
                           unsigned line,
                           cl_event event,
                           const char *msg)
 {
-  pocl_update_event_finished (CL_FAILED, func, line, event, msg);
+  /* Should only be used with error statuses. */
+  assert (status < 0);
+  pocl_update_event_finished (status, func, line, event, msg);
 }
 
 void

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -364,8 +364,20 @@ pocl_create_event_sync (cl_event notifier_event, cl_event waiting_event)
         }
     }
 
-  if (notifier_event->status == CL_COMPLETE)
-    goto FINISH;
+  /* If the notifier event is already complete (or failed),
+     don't create an event sync. This is fine since if the wait
+     event has no notifier events and gets submitted, it can start
+     right away.
+   */
+  if (notifier_event->status < 0 || notifier_event->status == CL_COMPLETE)
+    {
+      POCL_MSG_PRINT_EVENTS (
+        "notifier event %" PRIu64
+        " already complete, not creating sync with event %" PRIu64 "\n",
+        notifier_event->id, waiting_event->id);
+      goto FINISH;
+    }
+
   notify_target = pocl_mem_manager_new_event_node();
   wait_list_item = pocl_mem_manager_new_event_node();
   if (!notify_target || !wait_list_item)
@@ -377,6 +389,11 @@ pocl_create_event_sync (cl_event notifier_event, cl_event waiting_event)
 
   notify_target->event = waiting_event;
   wait_list_item->event = notifier_event;
+  /* Retain the waiting_event since we hold a reference to it in the notify
+     list. This is not needed for the wait_list since the only purpose is to
+     keep a count of the number of events it's waiting on.
+   */
+  POCL_RETAIN_OBJECT_UNLOCKED (waiting_event);
   LL_PREPEND (notifier_event->notify_list, notify_target);
   LL_PREPEND (waiting_event->wait_list, wait_list_item);
 
@@ -1980,7 +1997,6 @@ pocl_update_event_finished (cl_int status, const char *func, unsigned line,
 {
   assert (event != NULL);
   assert (event->queue != NULL);
-  assert (event->status > CL_COMPLETE);
   int notify_cmdq = CL_FALSE;
   cl_command_buffer_khr command_buffer = NULL;
   _cl_command_node *node = NULL;
@@ -1988,6 +2004,7 @@ pocl_update_event_finished (cl_int status, const char *func, unsigned line,
   cl_command_queue cq = event->queue;
   POCL_LOCK_OBJ (cq);
   POCL_LOCK_OBJ (event);
+  assert (event->status > CL_COMPLETE);
   if ((cq->properties & CL_QUEUE_PROFILING_ENABLE)
       && (cq->device->has_own_timer == 0))
     event->time_end = pocl_gettimemono_ns ();
@@ -2063,45 +2080,6 @@ pocl_update_event_finished (cl_int status, const char *func, unsigned line,
   }
 
   ops->broadcast (event);
-
-#ifdef ENABLE_REMOTE_CLIENT
-  /* With remote being asynchronous it is possible that an event completion
-   * signal is received before some of its dependencies. Therefore this event
-   * has to be removed from the notify lists of any remaining events in the
-   * wait list.
-   *
-   * Mind the acrobatics of trying to avoid races with pocl_broadcast and
-   * pocl_create_event_sync. */
-  event_node *tmp;
-  POCL_LOCK_OBJ (event);
-  while ((tmp = event->wait_list))
-    {
-      cl_event notifier = tmp->event;
-      POCL_UNLOCK_OBJ (event);
-      pocl_lock_events_inorder (notifier, event);
-      if (tmp != event->wait_list)
-        {
-          pocl_unlock_events_inorder (notifier, event);
-          POCL_LOCK_OBJ (event);
-          continue;
-        }
-      event_node *tmp2;
-      LL_FOREACH (notifier->notify_list, tmp2)
-      {
-        if (tmp2->event == event)
-          {
-            LL_DELETE (notifier->notify_list, tmp2);
-            pocl_mem_manager_free_event_node (tmp2);
-            break;
-          }
-      }
-      LL_DELETE (event->wait_list, tmp);
-      pocl_unlock_events_inorder (notifier, event);
-      pocl_mem_manager_free_event_node (tmp);
-      POCL_LOCK_OBJ (event);
-    }
-  POCL_UNLOCK_OBJ (event);
-#endif
 
 #ifdef POCL_DEBUG_MESSAGES
   if (msg != NULL)

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -286,16 +286,25 @@ void pocl_update_event_complete (const char *func, unsigned line,
                                  cl_event event, const char *msg);
 
 /**
- * Should be called by a driver when the event execution fails for some reason
+ * Mark the event as failed with the status and do all the required
+ * cleanup work (releasing memory, notifying others waiting on the event, etc).
  *
- * Sets the event status to failure (CL_FAILED) and does all the required
- * cleanup work (releasing memory, notifying others waiting on the event, etc)
+ * \warning Call with event unlocked.
+ * \warning Eventually clReleaseEvent is called, so this function can end up
+ * freeing the event.
+ * \param status [in] Status to be set for the event. Should be an error status
+ * like CL_FAILED or CL_DEVICE_NOT_AVAILABLE.
+ * \param func [in] Can be NULL, the function name calling this function.
+ * \param line [in] Can be 0, the line number which failed.
+ * \param event [in/out] Event to be marked as failed.
+ * \param msg [in] Can be NULL, informative error message.
  */
-POCL_EXPORT
-void pocl_update_event_failed (const char *func,
-                               unsigned line,
-                               cl_event event,
-                               const char *msg);
+POCL_EXPORT void
+pocl_update_event_failed (cl_int status,
+                          const char *func,
+                          unsigned line,
+                          cl_event event,
+                          const char *msg);
 
 /**
  * Same as pocl_update_event_failed, except assumes the event is locked.
@@ -313,11 +322,11 @@ void pocl_update_event_device_lost (cl_event event);
 #define POCL_UPDATE_EVENT_COMPLETE(__event)                                   \
   pocl_update_event_complete (__func__, __LINE__, (__event), NULL)
 
-#define POCL_UPDATE_EVENT_FAILED(__event)                                     \
-pocl_update_event_failed (__func__, __LINE__, (__event), NULL)
+#define POCL_UPDATE_EVENT_FAILED(status, __event)                             \
+pocl_update_event_failed ((status), __func__, __LINE__, (__event), NULL)
 
-#define POCL_UPDATE_EVENT_FAILED_MSG(__event, msg)                            \
-pocl_update_event_failed (__func__, __LINE__, (__event), msg)
+#define POCL_UPDATE_EVENT_FAILED_MSG(status, __event, msg)                    \
+pocl_update_event_failed ((status), __func__, __LINE__, (__event), msg)
 
 POCL_EXPORT
 int pocl_copy_command_node (_cl_command_node *dst_node,

--- a/lib/CL/pocl_util.h
+++ b/lib/CL/pocl_util.h
@@ -92,8 +92,8 @@ void pocl_aligned_free (void *ptr);
 /* locks / unlocks two events in order of their event-id.
  * This avoids any potential deadlocks of threads should
  * they try to lock events in opposite order. */
-void pocl_lock_events_inorder (cl_event ev1, cl_event ev2);
-void pocl_unlock_events_inorder (cl_event ev1, cl_event ev2);
+POCL_EXPORT void pocl_lock_events_inorder (cl_event ev1, cl_event ev2);
+POCL_EXPORT void pocl_unlock_events_inorder (cl_event ev1, cl_event ev2);
 
 /* Function for creating events */
 cl_int pocl_create_event (cl_event *event,


### PR DESCRIPTION
This is for now a wip and is intended for people who are interested in things related to events. This is a second attempt at #1459 .

Since the waiting event is added to the notify_list of the notifier_event, a reference should be kept
to prevent the notifier event from notifying an
event that doesn't exist anymore. With the recent
changes to the lock_events_inorder, this also
greatly simplifies the broadcast code.