### PR TITLE
Cleanups [NFC]

### DIFF
--- a/lib/llvmopencl/Barrier.h
+++ b/lib/llvmopencl/Barrier.h
@@ -50,7 +50,7 @@ namespace pocl {
       }
     }
 
-    static bool IsLoopWithBarrier(llvm::Loop &L) {
+    static bool isLoopWithBarrier(llvm::Loop &L) {
       for (llvm::Loop::block_iterator i = L.block_begin(), e = L.block_end();
            i != e; ++i) {
         for (llvm::BasicBlock::iterator j = (*i)->begin(), e = (*i)->end();

--- a/lib/llvmopencl/DebugHelpers.h
+++ b/lib/llvmopencl/DebugHelpers.h
@@ -72,16 +72,26 @@ bool chopBBs (llvm::Function &F, llvm::Pass &P);
   };
 };
 
-// Controls the debug output from Kernel.cc parallel region generation:
-//#define DEBUG_PR_CREATION
+// Controls the debug output from BarrierTailReplication.cc.
+//#define DEBUG_BARRIER_REPL
 
-// Controls the debug output from ImplicitConditionalBarriers.cc:
+// Controls the debug output from ImplicitConditionalBarriers.cc.
 //#define DEBUG_COND_BARRIERS
 
 // Controls the debug output from Workgroup.cc
-// #define DEBUG_WORK_GROUP_GEN
+//#define DEBUG_WORK_GROUP_GEN
 
-// Controls the debug output from PHIsToAllocas.cc
+// Controls the debug output from PHIsToAllocas.cc.
 //#define DEBUG_PHIS_TO_ALLOCAS
+
+// Controls the debug output from Kernel.cc parallel region generation.
+//#define DEBUG_PR_CREATION
+
+// Controls the debug output from WorkitemLoops.cc parallel region generation.
+//#define DEBUG_WORK_ITEM_LOOPS
+
+// Enable CFG dumps from various spots during the kernel compilation.
+//#define POCL_KERNEL_COMPILER_DUMP_CFGS
+
 
 #endif

--- a/lib/llvmopencl/ImplicitConditionalBarriers.cc
+++ b/lib/llvmopencl/ImplicitConditionalBarriers.cc
@@ -31,6 +31,7 @@ IGNORE_COMPILER_WARNING("-Wmaybe-uninitialized")
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 
 #include "Barrier.h"
+#include "DebugHelpers.h"
 #include "ImplicitConditionalBarriers.h"
 #include "LLVMUtils.h"
 #include "VariableUniformityAnalysis.h"
@@ -42,8 +43,6 @@ POP_COMPILER_DIAGS
 #include <iostream>
 
 #include "pocl.h"
-
-// #define DEBUG_COND_BARRIERS
 
 #define PASS_NAME "implicit-cond-barriers"
 #define PASS_CLASS pocl::ImplicitConditionalBarriers
@@ -85,6 +84,11 @@ ImplicitConditionalBarriers::run(llvm::Function &F,
   WorkitemHandlerType WIH = FAM.getResult<WorkitemHandlerChooser>(F).WIH;
   if (WIH == WorkitemHandlerType::CBS)
     return PreservedAnalyses::all();
+
+#ifdef POCL_KERNEL_COMPILER_DUMP_CFGS
+  dumpCFG(F, F.getName().str() + "_before_implicit_cond_barriers.dot", nullptr,
+          nullptr);
+#endif
 
   llvm::PostDominatorTree &PDT = FAM.getResult<PostDominatorTreeAnalysis>(F);
   llvm::DominatorTree &DT = FAM.getResult<DominatorTreeAnalysis>(F);
@@ -188,6 +192,11 @@ ImplicitConditionalBarriers::run(llvm::Function &F,
 #ifdef DEBUG_COND_BARRIERS
   std::cerr << "### After implicit conditional barrier handling:" << std::endl;
   F.dump();
+#endif
+
+#ifdef POCL_KERNEL_COMPILER_DUMP_CFGS
+  dumpCFG(F, F.getName().str() + "_after_implicit_cond_barriers.dot", nullptr,
+          nullptr);
 #endif
 
   return Changed ? PAChanged : PreservedAnalyses::all();

--- a/lib/llvmopencl/Kernel.cc
+++ b/lib/llvmopencl/Kernel.cc
@@ -170,7 +170,6 @@ void Kernel::getParallelRegions(
 
   // First find all the ParallelRegions in the Function.
   while (!exit_blocks.empty()) {
-    
     // We start on an exit block and process the parallel regions upwards
     // (finding an execution trace).
     BasicBlock *exit = exit_blocks.back();
@@ -181,7 +180,7 @@ void Kernel::getParallelRegions(
       continue;
 
     while (ParallelRegion *PR = createParallelRegionBefore(exit)) {
-      assert(PR != NULL && !PR->empty() && 
+      assert(PR != NULL && !PR->empty() &&
              "Empty parallel region in kernel (contiguous barriers)!");
 
       found_barriers.insert(exit);

--- a/lib/llvmopencl/LLVMUtils.cc
+++ b/lib/llvmopencl/LLVMUtils.cc
@@ -725,15 +725,15 @@ llvm::Type *SizeT(llvm::Module *M) {
 }
 
 bool isWorkitemFunctionWithOnlyCompilerExpandableCalls(const llvm::Function &F) {
-    Instruction::const_use_iterator UI = F.use_begin(), UE = F.use_end();
-    for (; UI != UE; ++UI) {
-      llvm::CallInst *Call = dyn_cast<llvm::CallInst>(UI->getUser());
-      if (Call == nullptr)
-        continue;
-      if (!isCompilerExpandableWIFunctionCall(*Call))
-        return false;
-    }
-    return true;
+  Instruction::const_use_iterator UI = F.use_begin(), UE = F.use_end();
+  for (; UI != UE; ++UI) {
+    llvm::CallInst *Call = dyn_cast<llvm::CallInst>(UI->getUser());
+    if (Call == nullptr)
+      continue;
+    if (!isCompilerExpandableWIFunctionCall(*Call))
+      return false;
+  }
+  return true;
 }
 
 bool isCompilerExpandableWIFunctionCall(const llvm::CallInst &Call) {

--- a/lib/llvmopencl/LoopBarriers.cc
+++ b/lib/llvmopencl/LoopBarriers.cc
@@ -148,7 +148,7 @@ static bool processLoopWithBarriers(Loop &L, llvm::DominatorTree &DT,
 static bool processLoop(Loop &L, llvm::DominatorTree &DT,
                         VariableUniformityAnalysisResult &VUA) {
 
-  if (Barrier::IsLoopWithBarrier(L))
+  if (Barrier::isLoopWithBarrier(L))
     return processLoopWithBarriers(L, DT, VUA);
 
   // This is a loop without a barrier. Ensure we have a non-barrier
@@ -168,7 +168,7 @@ static bool processLoop(Loop &L, llvm::DominatorTree &DT,
   // to the innermost loop if we process that first, ruining the
   // idea for multi-level loops.
   Loop *ParentLoop = L.getParentLoop();
-  if (!(ParentLoop == nullptr || Barrier::IsLoopWithBarrier(*ParentLoop)))
+  if (!(ParentLoop == nullptr || Barrier::isLoopWithBarrier(*ParentLoop)))
     return false;
 
   BasicBlock *Preheader = L.getLoopPreheader();

--- a/lib/llvmopencl/WorkitemHandler.cc
+++ b/lib/llvmopencl/WorkitemHandler.cc
@@ -572,7 +572,7 @@ llvm::AllocaInst *WorkitemHandler::createAlignedAndPaddedContextAlloca(
 #ifdef DEBUG_WORK_ITEM_LOOPS
     std::cerr << "### VariableDebugMeta :  ";
     VariableDebugMeta->dump();
-    std::cerr << "### sizeBits :  " << sizeBits << "  alignBits: " << alignBits
+    std::cerr << "### sizeBits :  " << SizeBits << "  alignBits: " << AlignBits
               << "\n";
 #endif
 

--- a/tests/workgroup/CMakeLists.txt
+++ b/tests/workgroup/CMakeLists.txt
@@ -2,6 +2,7 @@
 #   CMake build system files
 #
 #   Copyright (c) 2014-2024 pocl developers
+#                 2024 Pekka Jääskeläinen / Intel Finland Oy
 #
 #   Permission is hereby granted, free of charge, to any person obtaining a copy
 #   of this software and associated documentation files (the "Software"), to deal

--- a/tests/workgroup/for_with_divergent_return.cl
+++ b/tests/workgroup/for_with_divergent_return.cl
@@ -3,7 +3,7 @@ test_kernel (global int *output)
 {
   int gid_x = get_global_id (0);
 
-  for (volatile int i = 0; i < 1024; ++i)
+  for (volatile int i = 0; i < 100; ++i)
     {
       if (i == 1 && gid_x == 0)
         {


### PR DESCRIPTION
Also dropped the crazy INT_MAX iteration count in for_divergent_return.cl to 100 to reduce the runtime of the test case without affecting the tested aspect.