### PR TITLE
Fix unsupported SPIR-V was generated from OpenCL C

### DIFF
--- a/include/pocl.h
+++ b/include/pocl.h
@@ -565,4 +565,18 @@ typedef enum
   POCL_AUTOLOCALS_TO_ARGS_ONLY_IF_DYNAMIC_LOCALS_PRESENT = 2,
 } pocl_autolocals_to_args_strategy;
 
+typedef struct pocl_version_t
+{
+  unsigned major;
+  unsigned minor;
+
+#ifdef __cplusplus
+  pocl_version_t () : major (0), minor (0) {}
+  pocl_version_t (unsigned the_major, unsigned the_minor)
+    : major (the_major), minor (the_minor)
+  {
+  }
+#endif
+} pocl_version_t;
+
 #endif /* POCL_H */

--- a/lib/CL/devices/level0/level0-driver.cc
+++ b/lib/CL/devices/level0/level0-driver.cc
@@ -2401,6 +2401,11 @@ bool Level0Device::setupModuleProperties(bool &SupportsInt64Atomics,
   if (ModuleProperties.maxArgumentsSize > 256)
     ClDev->max_parameter_size = ModuleProperties.maxArgumentsSize - 64;
 #endif
+
+  uint32_t SpvVer = ModuleProperties.spirvVersionSupported;
+  SupportedSpvVersion =
+      pocl_version_t(ZE_MAJOR_VERSION(SpvVer), ZE_MINOR_VERSION(SpvVer));
+
   return true;
 }
 

--- a/lib/CL/devices/level0/level0-driver.hh
+++ b/lib/CL/devices/level0/level0-driver.hh
@@ -447,6 +447,12 @@ public:
   // the batch needs to be split at points where memcpy is required.
   bool prefersHostQueues() { return ClDev->type == CL_DEVICE_TYPE_CUSTOM; }
 
+  /// Return a SPIR-V version the device supports.
+  pocl_version_t getSupportedSpvVersion() const {
+    assert(SupportedSpvVersion.major && "SPIR-V is not supported?");
+    return SupportedSpvVersion;
+  }
+
 private:
   Level0AllocatorSPtr Alloc;
   std::deque<Level0EventPool> EventPools;
@@ -496,6 +502,7 @@ private:
   uint32_t MaxMemoryFillPatternSize = 0;
   uint32_t GlobalMemOrd = UINT32_MAX;
   std::vector<size_t> SupportedSubgroupSizes;
+  pocl_version_t SupportedSpvVersion = pocl_version_t();
 
   /// initializes kernels used internally by the driver
   /// to implement functionality missing in the Level Zero API,

--- a/lib/CL/pocl_llvm.h
+++ b/lib/CL/pocl_llvm.h
@@ -144,7 +144,8 @@ extern "C" {
   void *pocl_llvm_create_context_for_program (char *ProgramBcContent,
                                               size_t ProgramBcSize,
                                               char **LinkinSpirvContent,
-                                              uint64_t *LinkinSpirvSize);
+                                              uint64_t *LinkinSpirvSize,
+                                              pocl_version_t TargetVersion);
 
   /**
   * \brief extracts SPIR-V of a single Kernel (plus all functions it uses)
@@ -159,11 +160,12 @@ extern "C" {
   *
   */
   POCL_EXPORT
-  int pocl_llvm_extract_kernel_spirv(void* ProgCtx,
-                                     const char* KernelName,
-                                     void* BuildLogStr,
-                                     char **SpirvContent,
-                                     uint64_t *SpirvSize);
+  int pocl_llvm_extract_kernel_spirv (void *ProgCtx,
+                                      const char *KernelName,
+                                      void *BuildLogStr,
+                                      char **SpirvContent,
+                                      uint64_t *SpirvSize,
+                                      pocl_version_t TargetVersion);
 
   /**
   * \brief destroys the instance of hidden class used to extract kernel SPIR-V
@@ -214,6 +216,7 @@ extern "C" {
    * nullptr \param [out] SpirvContent pointer where to store the raw output.
    *              can be nullptr
    * \param [out] SpirvSize size of data stored at SpirvContent
+   * \param [in] TargetVersion The SPIR-V version to emit.
    * \returns 0 on success
    *
    */
@@ -225,7 +228,8 @@ extern "C" {
                                                  int UseIntelExts,
                                                  char *TempSpirvPathOut,
                                                  char **SpirvContent,
-                                                 uint64_t *SpirvSize);
+                                                 uint64_t *SpirvSize,
+                                                 pocl_version_t TargetVersion);
 
   /**
    * \brief converts LLVM IR with "spir64-unknown-unknown" triple to SPIR-V
@@ -233,14 +237,16 @@ extern "C" {
    * The same as pocl_convert_bitcode_to_spirv, but takes a std::string*
    * cast to void* as buildLog argument
    */
-  POCL_EXPORT int pocl_convert_bitcode_to_spirv2 (char *TempBitcodePath,
-                                                  const char *Bitcode,
-                                                  uint64_t BitcodeSize,
-                                                  void *BuildLog,
-                                                  int UseIntelExts,
-                                                  char *TempSpirvPathOut,
-                                                  char **SpirvContent,
-                                                  uint64_t *SpirvSize);
+  POCL_EXPORT int
+  pocl_convert_bitcode_to_spirv2 (char *TempBitcodePath,
+                                  const char *Bitcode,
+                                  uint64_t BitcodeSize,
+                                  void *BuildLog,
+                                  int UseIntelExts,
+                                  char *TempSpirvPathOut,
+                                  char **SpirvContent,
+                                  uint64_t *SpirvSize,
+                                  pocl_version_t TargetVersion);
 
   /**
    * \brief converts SPIR-V to LLVM IR with "spir64-unknown-unknown" triple

--- a/lib/CL/pocl_llvm_wg.cc
+++ b/lib/CL/pocl_llvm_wg.cc
@@ -74,6 +74,7 @@ POP_COMPILER_DIAGS
 #include "pocl.h"
 #include "pocl_cache.h"
 #include "pocl_file_util.h"
+#include "pocl_llvm.h"
 #include "pocl_llvm_api.h"
 #include "pocl_spir.h"
 #include "pocl_util.h"
@@ -819,13 +820,11 @@ public:
 // shared code for calling llvm-spirv
 static int convertBCorSPV(char *InputPath,
                           const char *InputContent, // LLVM bitcode as string
-                          uint64_t InputSize,
-                          std::string *BuildLog,
+                          uint64_t InputSize, std::string *BuildLog,
                           int useIntelExts,
-                          int reverse, // add "-r"
-                          char *OutputPath,
-                          char **OutContent,
-                          uint64_t *OutSize) {
+                          int Reverse, // add "-r"
+                          char *OutputPath, char **OutContent,
+                          uint64_t *OutSize, pocl_version_t TargetVersion) {
   char HiddenOutputPath[POCL_MAX_PATHNAME_LENGTH];
   char HiddenInputPath[POCL_MAX_PATHNAME_LENGTH];
   char CapturedOutput[MAX_OUTPUT_BYTES];
@@ -837,6 +836,8 @@ static int convertBCorSPV(char *InputPath,
   char *Content = nullptr;
   uint64_t ContentSize = 0;
   llvm::LLVMContext LLVMCtx;
+
+  assert(Reverse || TargetVersion.major && "Invalid SPIR-V target version!");
 
 #ifdef HAVE_LLVM_SPIRV_LIB
   std::string Errors;
@@ -856,7 +857,36 @@ static int convertBCorSPV(char *InputPath,
 #if LLVM_MAJOR >= 18
   EnabledExts[SPIRV::ExtensionID::SPV_EXT_shader_atomic_float16_add] = true;
 #endif
-  SPIRV::TranslatorOpts Opts(SPIRV::VersionNumber::SPIRV_1_3, EnabledExts);
+
+  SPIRV::VersionNumber TargetVersionEnum = SPIRV::VersionNumber::SPIRV_1_3;
+  switch (TargetVersion.major * 100 + TargetVersion.minor) {
+  default:
+    assert(!"Unrecognized SPIR-V version!");
+    break;
+  case 100:
+    SPIRV::VersionNumber::SPIRV_1_0;
+    break;
+  case 110:
+    SPIRV::VersionNumber::SPIRV_1_1;
+    break;
+  case 120:
+    SPIRV::VersionNumber::SPIRV_1_2;
+    break;
+  case 130:
+    SPIRV::VersionNumber::SPIRV_1_3;
+    break;
+  case 140:
+    SPIRV::VersionNumber::SPIRV_1_4;
+    break;
+  case 150:
+    SPIRV::VersionNumber::SPIRV_1_5;
+    break;
+  case 160:
+    SPIRV::VersionNumber::SPIRV_1_6;
+    break;
+  }
+
+  SPIRV::TranslatorOpts Opts(TargetVersionEnum, EnabledExts);
   Opts.setDesiredBIsRepresentation(SPIRV::BIsRepresentation::OpenCL20);
 #endif
   int r = -1;
@@ -867,12 +897,12 @@ static int convertBCorSPV(char *InputPath,
     if (OutputPath[0]) {
       strncpy(HiddenOutputPath, OutputPath, POCL_MAX_PATHNAME_LENGTH);
     } else {
-      pocl_cache_tempname(HiddenOutputPath, (reverse ? ".bc" : ".spv"), NULL);
+      pocl_cache_tempname(HiddenOutputPath, (Reverse ? ".bc" : ".spv"), NULL);
       strncpy(OutputPath, HiddenOutputPath, POCL_MAX_PATHNAME_LENGTH);
     }
   } else {
     assert(OutContent);
-    pocl_cache_tempname(HiddenOutputPath, (reverse ? ".bc" : ".spv"), NULL);
+    pocl_cache_tempname(HiddenOutputPath, (Reverse ? ".bc" : ".spv"), NULL);
   }
 
   bool keepInputPath = false;
@@ -881,12 +911,12 @@ static int convertBCorSPV(char *InputPath,
     if (InputPath[0]) {
       strncpy(HiddenInputPath, InputPath, POCL_MAX_PATHNAME_LENGTH);
     } else {
-      pocl_cache_tempname(HiddenInputPath, (reverse ? ".spv" : ".bc"), NULL);
+      pocl_cache_tempname(HiddenInputPath, (Reverse ? ".spv" : ".bc"), NULL);
       strncpy(InputPath, HiddenInputPath, POCL_MAX_PATHNAME_LENGTH);
     }
   } else {
     assert(InputContent);
-    pocl_cache_tempname(HiddenInputPath, (reverse ? ".spv" : ".bc"), NULL);
+    pocl_cache_tempname(HiddenInputPath, (Reverse ? ".spv" : ".bc"), NULL);
   }
 
   if (InputContent && InputSize) {
@@ -898,7 +928,7 @@ static int convertBCorSPV(char *InputPath,
   }
 
 #ifdef HAVE_LLVM_SPIRV_LIB
-  if (reverse) {
+  if (Reverse) {
     // SPIRV to BC
     std::string InputS;
     if (InputContent && InputSize) {
@@ -993,9 +1023,15 @@ static int convertBCorSPV(char *InputPath,
     CompilationArgs.push_back(ALLOW_INTEL_EXTS);
   else
     CompilationArgs.push_back(ALLOW_EXTS);
-  // TODO ze_device_module_properties_t.spirvVersionSupported
-  CompilationArgs.push_back("--spirv-max-version=1.4");
-  if (reverse) {
+
+  if (!Reverse) {
+    const auto TargetVersionOpt = std::string("--spirv-max-version=") +
+                                  std::to_string(TargetVersion.major) + "." +
+                                  std::to_string(TargetVersion.minor);
+    CompilationArgs.push_back(TargetVersionOpt);
+  }
+
+  if (Reverse) {
     CompilationArgs.push_back("-r");
     CompilationArgs.push_back("--spirv-target-env=CL2.0");
   }
@@ -1021,7 +1057,7 @@ static int convertBCorSPV(char *InputPath,
     BuildLog->append("failed to read output file from llvm-spirv\n");
     goto FINISHED;
   }
-  if (!reverse) {
+  if (!Reverse) {
     SPIRVParser::applyAtomicCmpXchgWorkaround((const int32_t *)Content,
                                               ContentSize / 4, FinalSpirv);
     assert(FinalSpirv.size() <= ContentSize);
@@ -1065,13 +1101,14 @@ int pocl_convert_bitcode_to_spirv(char *TempBitcodePath, const char *Bitcode,
                                   uint64_t BitcodeSize, cl_program Program,
                                   cl_uint DeviceI, int UseIntelExts,
                                   char *TempSpirvPathOut, char **SpirvContent,
-                                  uint64_t *SpirvSize) {
+                                  uint64_t *SpirvSize,
+                                  pocl_version_t TargetVersion) {
 
   std::string BuildLog;
-  int R = convertBCorSPV(TempBitcodePath, Bitcode, BitcodeSize, &BuildLog,
-                         UseIntelExts,
-                         0, // reverse
-                         TempSpirvPathOut, SpirvContent, SpirvSize);
+  int R = convertBCorSPV(
+      TempBitcodePath, Bitcode, BitcodeSize, &BuildLog, UseIntelExts,
+      0, // = Reverse
+      TempSpirvPathOut, SpirvContent, SpirvSize, TargetVersion);
 
   if (!BuildLog.empty())
     pocl_append_to_buildlog(Program, DeviceI, strdup(BuildLog.c_str()),
@@ -1079,21 +1116,16 @@ int pocl_convert_bitcode_to_spirv(char *TempBitcodePath, const char *Bitcode,
   return R;
 }
 
-int pocl_convert_bitcode_to_spirv2(char *TempBitcodePath,
-                                   const char *Bitcode,
-                                   uint64_t BitcodeSize,
-                                   void *BuildLog,
-                                   int UseIntelExts,
-                                   char *TempSpirvPathOut,
-                                   char **SpirvContent,
-                                   uint64_t *SpirvSize) {
+int pocl_convert_bitcode_to_spirv2(char *TempBitcodePath, const char *Bitcode,
+                                   uint64_t BitcodeSize, void *BuildLog,
+                                   int UseIntelExts, char *TempSpirvPathOut,
+                                   char **SpirvContent, uint64_t *SpirvSize,
+                                   pocl_version_t TargetVersion) {
 
-  return convertBCorSPV(TempBitcodePath,
-                        Bitcode, BitcodeSize,
-                        (std::string *)BuildLog,
-                        UseIntelExts, 0, // reverse
-                        TempSpirvPathOut,
-                        SpirvContent, SpirvSize);
+  return convertBCorSPV(TempBitcodePath, Bitcode, BitcodeSize,
+                        (std::string *)BuildLog, UseIntelExts, 0, // = Reverse
+                        TempSpirvPathOut, SpirvContent, SpirvSize,
+                        TargetVersion);
 }
 
 int pocl_convert_spirv_to_bitcode(char *TempSpirvPath,
@@ -1106,22 +1138,21 @@ int pocl_convert_spirv_to_bitcode(char *TempSpirvPath,
                                   uint64_t *BitcodeSize) {
 
   std::string BuildLog;
-  int R = convertBCorSPV(TempSpirvPath,
-                         SpirvContent, SpirvSize,
-                         &BuildLog,
-                         UseIntelExts, 1, // reverse
-                         TempBitcodePathOut,
-                         BitcodeContent, BitcodeSize);
+  int R = convertBCorSPV(
+      TempSpirvPath, SpirvContent, SpirvSize, &BuildLog, UseIntelExts,
+      1, // = Reverse.
+      TempBitcodePathOut, BitcodeContent, BitcodeSize,
+      // Target version for SPIR-V emission. Ignored in reverse translation.
+      pocl_version_t());
   if (!BuildLog.empty())
     pocl_append_to_buildlog(Program, DeviceI, strdup(BuildLog.c_str()),
                             BuildLog.size());
   return R;
 }
 
-void *pocl_llvm_create_context_for_program(char *ProgramBcContent,
-                                           size_t ProgramBcSize,
-                                           char **LinkinSpirvContent,
-                                           uint64_t *LinkinSpirvSize) {
+extern "C" void *pocl_llvm_create_context_for_program(
+    char *ProgramBcContent, size_t ProgramBcSize, char **LinkinSpirvContent,
+    uint64_t *LinkinSpirvSize, pocl_version_t TargetVersion) {
   assert(ProgramBcContent);
   assert(ProgramBcSize > 0);
 
@@ -1139,7 +1170,7 @@ void *pocl_llvm_create_context_for_program(char *ProgramBcContent,
   if (pocl_convert_bitcode_to_spirv2(
           nullptr, ProgramBcContent, ProgramBcSize, &BuildLog,
           1, // useIntelExt
-          nullptr, LinkinSpirvContent, LinkinSpirvSize) != 0) {
+          nullptr, LinkinSpirvContent, LinkinSpirvSize, TargetVersion) != 0) {
     POCL_MSG_ERR("failed to create program for context, log:%s\n",
                  BuildLog.c_str());
     return nullptr;
@@ -1156,11 +1187,9 @@ void pocl_llvm_release_context_for_program(void *ProgCtx) {
 }
 
 // extract SPIRV of a single Kernel from a program
-int pocl_llvm_extract_kernel_spirv(void* ProgCtx,
-                                   const char* KernelName,
-                                   void* BuildLogStr,
-                                   char **SpirvContent,
-                                   uint64_t *SpirvSize) {
+extern "C" int pocl_llvm_extract_kernel_spirv(
+    void *ProgCtx, const char *KernelName, void *BuildLogStr,
+    char **SpirvContent, uint64_t *SpirvSize, pocl_version_t TargetVersion) {
 
   POCL_MEASURE_START(extractKernel);
 
@@ -1173,14 +1202,14 @@ int pocl_llvm_extract_kernel_spirv(void* ProgCtx,
     return -1;
   }
 
-  int r = pocl_convert_bitcode_to_spirv2(nullptr, OutputBitcode.data(),
-                                         OutputBitcode.size(), &BuildLog,
-                                         1,       // useIntelExts
-                                         nullptr, // SpirvOutputPath
-                                         SpirvContent, SpirvSize);
+  int R = pocl_convert_bitcode_to_spirv2(
+      nullptr, OutputBitcode.data(), OutputBitcode.size(), &BuildLog,
+      1,       // useIntelExts
+      nullptr, // SpirvOutputPath
+      SpirvContent, SpirvSize, TargetVersion);
 
   POCL_MEASURE_FINISH(extractKernel);
-  return r;
+  return R;
 }
 
 static int pocl_llvm_run_pocl_passes(llvm::Module *Bitcode,

--- a/tests/kernel/CMakeLists.txt
+++ b/tests/kernel/CMakeLists.txt
@@ -265,6 +265,12 @@ foreach(VARIANT ${VARIANTS})
 
 endforeach()
 
+if(ENABLE_POCLCC)
+  add_test(NAME "kernel/test_ptr_compare_build"
+    COMMAND "${CMAKE_BINARY_DIR}/bin/poclcc" -o /dev/null
+      "${CMAKE_CURRENT_SOURCE_DIR}/test_ptr_compare.cl")
+endif()
+
 ######################################################################
 
 

--- a/tests/kernel/test_ptr_compare.cl
+++ b/tests/kernel/test_ptr_compare.cl
@@ -1,0 +1,30 @@
+/*
+   Copyright (c) 2024 Henry Linjamäki / Intel Finland Oy
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+/* A regression test for level0 driver which crashed in the presence
+ * of OpPtrEqual in the translated SPIR-V and the driver didn't
+ * support SPIR-V version that enables it (v1.4). */
+kernel void
+k (global int *res, global int *a, global int *b)
+{
+  *res = a == b;
+}


### PR DESCRIPTION
Fix PoCL/level0 generated SPIR-V from OpenCL C with a version not supported by the driver and crashed in the presence of an instruction the version enabled (OpPtrEqual).