### PR TITLE
Fix wrong computation of dynamic WG size

### DIFF
--- a/lib/llvmopencl/WorkitemHandler.cc
+++ b/lib/llvmopencl/WorkitemHandler.cc
@@ -515,7 +515,7 @@ llvm::AllocaInst *WorkitemHandler::createAlignedAndPaddedContextAlloca(
     GlobalVariable *LocalSize;
     LoadInst *LocalSizeLoad[3];
     for (int i = 0; i < 3; ++i) {
-      std::string Name = LID_G_NAME(i);
+      std::string Name = LS_G_NAME(i);
       LocalSize = cast<GlobalVariable>(M->getOrInsertGlobal(Name, ST));
       LocalSizeLoad[i] = Builder.CreateLoad(ST, LocalSize);
     }

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -160,9 +160,7 @@ set_tests_properties(
   set_tests_properties(
     "regression/test_program_from_binary_with_local_1_1_1_${VARIANT}"
     PROPERTIES
-      # TO FIX: This test fails with outer loop vectorization. It's likely
-      # confused by diverging code inside the built-in function call.
-      ENVIRONMENT "POCL_WORK_GROUP_SPECIALIZATION=0;POCL_FORCE_PARALLEL_OUTER_LOOP=0"
+      ENVIRONMENT "POCL_WORK_GROUP_SPECIALIZATION=0"
    )
 endforeach()
 


### PR DESCRIPTION
This caused the failure of test_program_from_binary_with_local with specialization off and outer loop vectorization on.