### PR TITLE
A fix for self-referential macros of OCL builtins

### DIFF
--- a/cmake/bitcode_rules.cmake
+++ b/cmake/bitcode_rules.cmake
@@ -91,10 +91,12 @@ function(compile_cl_to_bc FILENAME SUBDIR BC_FILE_LIST EXTRA_CONFIG)
     endif()
 
     set(DEPENDLIST
+          "${CMAKE_SOURCE_DIR}/include/_builtin_renames.h"
           "${CMAKE_SOURCE_DIR}/include/_kernel.h"
           "${CMAKE_SOURCE_DIR}/include/_kernel_c.h"
           "${CMAKE_SOURCE_DIR}/include/pocl_types.h")
     set(INCLUDELIST
+        "-include" "${CMAKE_SOURCE_DIR}/include/_builtin_renames.h"
         "-include" "${CMAKE_SOURCE_DIR}/include/_kernel.h"
         "-include" "${CMAKE_SOURCE_DIR}/include/_enable_all_exts.h")
 

--- a/include/_kernel.h
+++ b/include/_kernel.h
@@ -51,8 +51,6 @@
 
 #include "_enable_all_exts.h"
 
-#include "_builtin_renames.h"
-
 /* Define some feature test macros to help write generic code. These are used
  * mostly in _pocl_opencl.h header + some .cl files in kernel library */
 

--- a/lib/kernel/CMakeLists.txt
+++ b/lib/kernel/CMakeLists.txt
@@ -234,6 +234,7 @@ add_custom_command( OUTPUT "${CMAKE_BINARY_DIR}/kernellib_hash.h"
       -DOUTPUT='${CMAKE_BINARY_DIR}/kernellib_hash.h'
       -P "${CMAKE_SOURCE_DIR}/cmake/kernellib_hash.cmake"
   DEPENDS ${KERNEL_BC_LIST}
+      "${CMAKE_SOURCE_DIR}/include/_builtin_renames.h"
       "${CMAKE_SOURCE_DIR}/include/_kernel.h"
       "${CMAKE_SOURCE_DIR}/include/_kernel_c.h"
       "${CMAKE_SOURCE_DIR}/include/pocl_types.h"

--- a/tests/kernel/CMakeLists.txt
+++ b/tests/kernel/CMakeLists.txt
@@ -269,6 +269,9 @@ if(ENABLE_POCLCC)
   add_test(NAME "kernel/test_ptr_compare_build"
     COMMAND "${CMAKE_BINARY_DIR}/bin/poclcc" -o /dev/null
       "${CMAKE_CURRENT_SOURCE_DIR}/test_ptr_compare.cl")
+  add_test(NAME "kernel/test_self_ref_macros_build"
+    COMMAND "${CMAKE_BINARY_DIR}/bin/poclcc" -o /dev/null
+      "${CMAKE_CURRENT_SOURCE_DIR}/test_self_ref_macros.cl")
 endif()
 
 ######################################################################

--- a/tests/kernel/test_self_ref_macros.cl
+++ b/tests/kernel/test_self_ref_macros.cl
@@ -1,0 +1,41 @@
+/*
+   Copyright (c) 2024 Henry Linjamäki / Intel Finland Oy
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+/* A regression test (#1735) for a self referential macro over an OpenCL
+ * built-in:  */
+
+/*   error: (...)/tempfile_TnTaja.cl:2:40 */
+/*      <Spelling=(...)/tempfile_TnTaja.cl:1:30>: use of undeclared */
+/*      identifier 'sub_group_reduce_add' */
+/*   warning: (...)/tempfile_TnTaja.cl:1:9: 'sub_group_reduce_add' macro */
+/*      redefined */
+/*   warning: (...)/tempfile_TnTaja.cl:1:9: 'sub_group_reduce_add' macro */
+/*      redefined */
+
+#define sub_group_reduce_add sub_group_reduce_add
+
+kernel void
+k (global int *d)
+{
+  unsigned id = get_global_id (0);
+  d[id] = sub_group_reduce_add (d[id]);
+}


### PR DESCRIPTION
Fixes #1735 by including the OpenCL built-in rename header in a separate preprocessing step.