### PR TITLE
Initialize pocl_version_t members using braces.

### DIFF
--- a/include/pocl.h
+++ b/include/pocl.h
@@ -582,9 +582,9 @@ typedef struct pocl_version_t
   unsigned minor;
 
 #ifdef __cplusplus
-  pocl_version_t () : major (0), minor (0) {}
+  pocl_version_t () : major{0}, minor{0} {}
   pocl_version_t (unsigned the_major, unsigned the_minor)
-    : major (the_major), minor (the_minor)
+    : major{the_major}, minor{the_minor}
   {
   }
 #endif


### PR DESCRIPTION
Otherwise the major/minor field references can conflict with macro definitions pulled from `sys/sysmacros.h`:

```
[13:10:48] /workspace/srcdir/include/pocl.h: In constructor ‘pocl_version_t::pocl_version_t()’:
[13:10:48] /workspace/srcdir/include/pocl.h:585:23: error: class ‘pocl_version_t’ does not have any field named ‘gnu_dev_major’
[13:10:48]   585 |   pocl_version_t () : major (0), minor (0) {}
[13:10:48]       |                       ^~~~~
```

x-ref https://stackoverflow.com/a/33681284