### PR TITLE
Add Julia CI

### DIFF
--- a/.github/workflows/build_julia.yml
+++ b/.github/workflows/build_julia.yml
@@ -1,0 +1,126 @@
+name: Julia / OpenCL.jl Tests
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release*'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - 'CHANGES'
+      - 'COPYING'
+      - 'CREDITS'
+      - 'LICENSE'
+      - 'README.*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test_julia:
+    name: Julia ${{ matrix.julia-version }} - LLVM ${{ matrix.llvm }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - julia-version: '1.10'
+            llvm: 15
+          - julia-version: '1.11'
+            llvm: 16
+
+    steps:
+      - name: Checkout PoCL
+        uses: actions/checkout@v4
+        with:
+          path: pocl
+
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: x64
+
+      - name: Setup Julia cache
+        uses: julia-actions/cache@v2
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake ninja-build pkg-config
+
+      - name: Install Julia dependencies
+        run: |
+          touch pocl/Project.toml
+          julia --project=pocl --color=yes -e '
+            using Pkg
+
+            # unversioned
+            Pkg.add([
+              "SPIRV_Tools_jll",
+              "OpenCL_jll",
+              "OpenCL_Headers_jll",
+              "Hwloc_jll",
+              "CMake_jll",
+            ])
+
+            # versioned
+            Pkg.add(name="LLVM_full_jll", version="${{ matrix.llvm }}")
+            Pkg.add(name="SPIRV_LLVM_Translator_jll", version="${{ matrix.llvm }}")'
+
+      - name: Build PoCL
+        run: |
+          julia --project=pocl --color=yes -e '
+            using LLVM_full_jll,
+                  SPIRV_Tools_jll, SPIRV_LLVM_Translator_jll,
+                  OpenCL_jll, OpenCL_Headers_jll,
+                  Hwloc_jll, CMake_jll
+
+            sourcedir = joinpath(@__DIR__, "pocl")
+            builddir = joinpath(@__DIR__, "build")
+            destdir = joinpath(@__DIR__, "target")
+
+            prefix = []
+            for jll in [SPIRV_Tools_jll, SPIRV_LLVM_Translator_jll, OpenCL_jll,
+                        OpenCL_Headers_jll, Hwloc_jll]
+                push!(prefix, jll.artifact_dir)
+            end
+
+            withenv("LD_LIBRARY_PATH" => joinpath(Sys.BINDIR, Base.PRIVATE_LIBDIR)) do
+                mkpath(builddir)
+                run(```cmake -B $builddir -S $sourcedir
+                       -GNinja
+                       -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always"
+                       -DCMAKE_C_FLAGS="-fdiagnostics-color=always"
+                       -DCMAKE_BUILD_TYPE=Debug
+                       -DENABLE_TESTS:Bool=OFF
+                       -DPOCL_DEBUG_MESSAGES:Bool=ON
+                       -DCMAKE_INSTALL_PREFIX=$destdir
+                       -DWITH_LLVM_CONFIG=$(LLVM_full_jll.artifact_dir)/tools/llvm-config
+                       -DCMAKE_PREFIX_PATH="$(join(prefix, ";"))"
+                       -DKERNELLIB_HOST_CPU_VARIANTS=distro```)
+
+                run(```$(cmake()) --build $builddir --parallel $(Sys.CPU_THREADS) --target install```)
+            end'
+
+      - name: Checkout OpenCL.jl
+        uses: actions/checkout@v4
+        with:
+          repository: JuliaGPU/OpenCL.jl
+          path: OpenCL.jl
+
+      - name: Setup OpenCL.jl
+        run: |
+          echo '[pocl_jll]' > OpenCL.jl/test/LocalPreferences.toml
+          echo 'libpocl_path="${{ github.workspace }}/target/lib/libpocl.so"' >> OpenCL.jl/test/LocalPreferences.toml
+
+      - name: Test OpenCL.jl
+        uses: julia-actions/julia-runtest@v1
+        with:
+          project: OpenCL.jl
+          test_args: '--platform=pocl'

--- a/.github/workflows/build_julia.yml
+++ b/.github/workflows/build_julia.yml
@@ -53,7 +53,16 @@ jobs:
           arch: x64
 
       - name: Setup Julia cache
-        uses: julia-actions/cache@v2
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/build_julia.yml
+++ b/.github/workflows/build_julia.yml
@@ -30,15 +30,21 @@ jobs:
       matrix:
         include:
           - julia-version: '1.10'
-            llvm: 15
+            llvm: 20
           - julia-version: '1.11'
-            llvm: 16
+            llvm: 20
 
     steps:
       - name: Checkout PoCL
         uses: actions/checkout@v4
         with:
           path: pocl
+
+      - name: Checkout OpenCL.jl
+        uses: actions/checkout@v4
+        with:
+          repository: JuliaGPU/OpenCL.jl
+          path: OpenCL.jl
 
       - name: Setup Julia
         uses: julia-actions/setup-julia@v2
@@ -95,11 +101,9 @@ jobs:
                 mkpath(builddir)
                 run(```cmake -B $builddir -S $sourcedir
                        -GNinja
-                       -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always"
-                       -DCMAKE_C_FLAGS="-fdiagnostics-color=always"
                        -DCMAKE_BUILD_TYPE=Debug
                        -DENABLE_TESTS:Bool=OFF
-                       -DPOCL_DEBUG_MESSAGES:Bool=ON
+                       -DSTATIC_LLVM:Bool=On
                        -DCMAKE_INSTALL_PREFIX=$destdir
                        -DWITH_LLVM_CONFIG=$(LLVM_full_jll.artifact_dir)/tools/llvm-config
                        -DCMAKE_PREFIX_PATH="$(join(prefix, ";"))"
@@ -108,16 +112,19 @@ jobs:
                 run(```$(cmake()) --build $builddir --parallel $(Sys.CPU_THREADS) --target install```)
             end'
 
-      - name: Checkout OpenCL.jl
-        uses: actions/checkout@v4
-        with:
-          repository: JuliaGPU/OpenCL.jl
-          path: OpenCL.jl
+            echo '[pocl_jll]' > OpenCL.jl/test/LocalPreferences.toml
+            echo 'libpocl_path="${{ github.workspace }}/target/lib/libpocl.so"' >> OpenCL.jl/test/LocalPreferences.toml
 
       - name: Setup OpenCL.jl
         run: |
-          echo '[pocl_jll]' > OpenCL.jl/test/LocalPreferences.toml
-          echo 'libpocl_path="${{ github.workspace }}/target/lib/libpocl.so"' >> OpenCL.jl/test/LocalPreferences.toml
+          julia --project=OpenCL.jl -e '
+            using Pkg
+
+            try
+              Pkg.instantiate()
+            catch
+              Pkg.develop(path="lib/intrinsics")
+            end'
 
       - name: Test OpenCL.jl
         uses: julia-actions/julia-runtest@v1


### PR DESCRIPTION
This PR adds CI for Julia, running the OpenCL.jl test suite with PoCL as the only enabled platform (see https://juliagpu.org/post/2025-01-13-opencl_0.10/#jll-based_opencl_drivers for context). I opted to do a build that mimics our use of PoCL as closely as possible:
- using Julia's so-called JLLs to provide binary dependencies
- dynamically linking against the `libLLVM` that's provided by Julia itself (hence the `LD_LIBRARY_DIR` modification during compilation)
- register `libpocl` by overriding the one from the `pocl_jll` binary package, which also provides ~hacks~ wrapper scripts that allow PoCL to execute binaries like `clang` and `ldd`: https://github.com/JuliaPackaging/Yggdrasil/blob/01453664dd8489ef3b4ad6c50dddfa86402b013e/P/pocl/build_tarballs.jl#L161-L239 (this is why I opened an issue to reduce PoCL's reliance on executables)

The actual build script can be found here: https://github.com/JuliaPackaging/Yggdrasil/blob/master/P/pocl/build_tarballs.jl