### PR TITLE
Better logic for the ID built-in expansion decision

### DIFF
--- a/lib/llvmopencl/KernelCompilerUtils.h
+++ b/lib/llvmopencl/KernelCompilerUtils.h
@@ -31,6 +31,8 @@
 #define GID_G_NAME(DIM) (std::string("_global_id_") + (char)('x' + DIM))
 // Generates the name for the global magic variable for the group id.
 #define GROUP_ID_G_NAME(DIM) (std::string("_group_id_") + (char)('x' + DIM))
+// Generates the name for the global magic variable for the get_num_groups
+#define NGROUPS_G_NAME(DIM) (std::string("_num_groups_") + (char)('x' + DIM))
 // Generates the name for the global magic variable for the local size.
 #define LS_G_NAME(DIM) (std::string("_local_size_") + (char)('x' + DIM))
 

--- a/lib/llvmopencl/WorkitemHandler.cc
+++ b/lib/llvmopencl/WorkitemHandler.cc
@@ -120,6 +120,10 @@ void WorkitemHandler::Initialize(Kernel *K_) {
                     M->getOrInsertGlobal(GROUP_ID_G_NAME(1), ST),
                     M->getOrInsertGlobal(GROUP_ID_G_NAME(2), ST)};
 
+  NumGroupsGlobals = {M->getOrInsertGlobal(NGROUPS_G_NAME(0), ST),
+                      M->getOrInsertGlobal(NGROUPS_G_NAME(1), ST),
+                      M->getOrInsertGlobal(NGROUPS_G_NAME(2), ST)};
+
   GlobalIdOrigins = {0, 0, 0};
   GlobalSizes = {0, 0, 0};
 }
@@ -791,6 +795,8 @@ void WorkitemHandler::handleWorkitemFunctions() {
             Replacement = Builder.CreateLoad(ST, GlobalIdGlobals[Dim]);
           else if (Callee->getName() == GROUP_ID_BUILTIN_NAME)
             Replacement = Builder.CreateLoad(ST, GroupIdGlobals[Dim]);
+          else if (Callee->getName() == NGROUPS_BUILTIN_NAME)
+            Replacement = Builder.CreateLoad(ST, NumGroupsGlobals[Dim]);
           else if (Callee->getName() == LS_BUILTIN_NAME)
             Replacement = Builder.CreateLoad(ST, LocalSizeGlobals[Dim]);
           else if (Callee->getName() == LID_BUILTIN_NAME)

--- a/lib/llvmopencl/WorkitemHandler.h
+++ b/lib/llvmopencl/WorkitemHandler.h
@@ -89,6 +89,7 @@ protected:
   std::array<llvm::Value *, 3> LocalSizeGlobals;
   std::array<llvm::Value *, 3> GlobalIdGlobals;
   std::array<llvm::Value *, 3> GroupIdGlobals;
+  std::array<llvm::Value *, 3> NumGroupsGlobals;
 
   // Points to the global size computation instructions in the entry
   // block of the currently handled kernel.


### PR DESCRIPTION
* Convert the built-ins to declarations after first linking them in to handle all cases similarly.  Previously, if a built-in called an ID built-in, it was linked in as a defined one and the logic of excluding them didn't work.
* Also add get_num_groups() to the expanded built-ins to avoid yet one more source of messy switch..cases.