### PR TITLE
fix cudaMalloc argument type

### DIFF
--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -1887,7 +1887,7 @@ submit_cudnn_kernel(CUstream stream, _cl_command_node *cmd,
   CUDNN_CALL(cudnnGetConvolutionForwardWorkspaceSize(
         cudnn, in_desc, filt_desc, conv_desc, out_desc, algo, &ws_size));
   float *ws_data;
-  CUDA_CALL(cudaMalloc(&ws_data, ws_size));
+  CUDA_CALL(cudaMalloc((void **)&ws_data, ws_size));
 
   CUDNN_CALL(cudnnConvolutionForward(
       cudnn,


### PR DESCRIPTION
Fixes:

```text
/build/pocl/src/pocl/lib/CL/devices/cuda/pocl-cuda.c:1887:24: error: passing argument 1 of ‘cudaMalloc’ from incompatible pointer type [-Wincompatible-pointer-types]
 1887 |   CUDA_CALL(cudaMalloc(&ws_data, ws_size));
      |                        ^~~~~~~~
      |                        |
      |                        float **
/build/pocl/src/pocl/lib/CL/devices/cuda/pocl-cuda.c:69:24: note: in definition of macro ‘CUDA_CALL’                                                                                  69 |     cudaError_t err = (f);                                                    \
      |                        ^
In file included from /opt/cuda/include/cuda_runtime.h:95,
                 from /build/pocl/src/pocl/lib/CL/devices/cuda/pocl-cuda.c:51:
/opt/cuda/include/cuda_runtime_api.h:5476:76: note: expected ‘void **’ but argument is of type ‘float **’                                                                           5476 | extern __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaMalloc(void **devPtr, size_t size);
      |                                                                     ~~~~~~~^~~~~~
```