### PR TITLE
link cudart

### DIFF
--- a/lib/CL/devices/cuda/CMakeLists.txt
+++ b/lib/CL/devices/cuda/CMakeLists.txt
@@ -44,6 +44,10 @@ endif()
 
 if(ENABLE_CUDNN)
     target_link_libraries(pocl-devices-cuda PRIVATE cudnn)
+    find_package(CUDAToolkit)
+    if(TARGET CUDA::cudart)
+        target_link_libraries(pocl-devices-cuda PRIVATE CUDA::cudart)
+    endif()
 endif()
 
 install(FILES "builtins.cl" "builtins_sm50.ptx" "builtins_sm70.ptx"


### PR DESCRIPTION
Fixes failing test:
```text
  4/251 Test   #5: pocl_test_dlopen_device_cuda ..........................................................***Failed    0.16 sec
dlopen($ORIGIN/../../lib/CL/devices/cuda/libpocl-devices-cuda.so, RTLD_NOW) failed: /build/pocl/src/pocl/build/tests/runtime/../../lib/CL/devices/cuda/libpocl-devices-cuda.so: undefined symbol: cudaFree
```

Tested with `clinfo`.