### PR TITLE
Extend general SPIR-V support to 1.6

### DIFF
--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1781,7 +1781,7 @@ pocl_init_default_device_infos (cl_device_id dev,
 #endif
 
 #if defined(ENABLE_SPIRV) && LLVM_MAJOR >= 20
-  dev->supported_spir_v_versions = "SPIR-V_1.6 SPIR-V_1.5 SPIR-V_1.4 SPIR-V_1.3 SPIR-V_1.2 SPIR-V_1.1 SPIR-V_1.0";
+  dev->supported_spir_v_versions = "SPIR-V_1.5 SPIR-V_1.4 SPIR-V_1.3 SPIR-V_1.2 SPIR-V_1.1 SPIR-V_1.0";
 #elif defined(ENABLE_SPIRV)
   dev->supported_spir_v_versions = "SPIR-V_1.2 SPIR-V_1.1 SPIR-V_1.0";
 #else

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1780,7 +1780,9 @@ pocl_init_default_device_infos (cl_device_id dev,
     dev->llvm_target_triplet = "";
 #endif
 
-#ifdef ENABLE_SPIRV
+#if defined(ENABLE_SPIRV) && LLVM_MAJOR >= 19
+  dev->supported_spir_v_versions = "SPIR-V_1.6 SPIR-V_1.5 SPIR-V_1.4 SPIR-V_1.3 SPIR-V_1.2 SPIR-V_1.1 SPIR-V_1.0";
+#elif defined(ENABLE_SPIRV)
   dev->supported_spir_v_versions = "SPIR-V_1.2 SPIR-V_1.1 SPIR-V_1.0";
 #else
   dev->supported_spir_v_versions = "";
@@ -1974,7 +1976,8 @@ static const cl_name_version OPENCL_SPIRV_VERSIONS[]
         { CL_MAKE_VERSION (1, 2, 0), "SPIR-V" },
         { CL_MAKE_VERSION (1, 3, 0), "SPIR-V" },
         { CL_MAKE_VERSION (1, 4, 0), "SPIR-V" },
-        { CL_MAKE_VERSION (1, 5, 0), "SPIR-V" } };
+        { CL_MAKE_VERSION (1, 5, 0), "SPIR-V" },
+        { CL_MAKE_VERSION (1, 6, 0), "SPIR-V" } };
 
 const size_t OPENCL_SPIRV_VERSIONS_NUM
     = sizeof (OPENCL_SPIRV_VERSIONS) / sizeof (OPENCL_SPIRV_VERSIONS[0]);

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1780,7 +1780,7 @@ pocl_init_default_device_infos (cl_device_id dev,
     dev->llvm_target_triplet = "";
 #endif
 
-#if defined(ENABLE_SPIRV) && LLVM_MAJOR >= 19
+#if defined(ENABLE_SPIRV) && LLVM_MAJOR >= 20
   dev->supported_spir_v_versions = "SPIR-V_1.6 SPIR-V_1.5 SPIR-V_1.4 SPIR-V_1.3 SPIR-V_1.2 SPIR-V_1.1 SPIR-V_1.0";
 #elif defined(ENABLE_SPIRV)
   dev->supported_spir_v_versions = "SPIR-V_1.2 SPIR-V_1.1 SPIR-V_1.0";


### PR DESCRIPTION
I tested this with the CPU runtime using clang 19, and it works.
clInfo announces the new SPIR-V versions, and I can query them with `clGetDeviceInfo` and `CL_DEVICE_IL_VERSION`.
However, `ILs with version`  only reports version 1.0 to 1.5. I don't really understand why. As far as I understand, the list is created here: https://github.com/pocl/pocl/blob/a4799460ffb0cd45d16a894bfe653acb5b6d28f2/lib/CL/devices/common.c#L2011
I don't fully digged into the code, but not clear to me why it would not list 1.6.