### PR TITLE
Update OpenCL-CTS

### DIFF
--- a/doc/sphinx/source/notes_6_1.rst
+++ b/doc/sphinx/source/notes_6_1.rst
@@ -21,6 +21,9 @@ CPU drivers
   Please note that these DBKs are still a proof-of-concept and
   are subject to change without notice.
 
+* cl_khr_command_buffer implementation has been updated to 0.9.6
+  Note that this version is not backwards compatible with previous versions.
+
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Work-group vectorization improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +74,6 @@ Various improvements were made:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 CUDA driver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 AlmaIF driver (FPGA interfacing)

--- a/examples/AMDSDK3.0/CMakeLists.txt
+++ b/examples/AMDSDK3.0/CMakeLists.txt
@@ -82,7 +82,6 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND X86_64)
     BuiltInScan
     ConcurrentKernel
     DCT
-    DeviceFission
     DeviceFission11Ext
     DwtHaar1D
     FastWalshTransform
@@ -142,6 +141,8 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND X86_64)
     #     RegionGrowingSegmentation SimpleSPIR
     # disabled - requires pipe: PipeProducerConsumerKernels SimplePipe
     # requires OpenCL 2.0: BufferImageInterop
+    # requires subdevices:
+    # DeviceFission
 
     set(HSA_LABELED_TESTS
         AMD_30_BinomialOption AMD_30_DCT AMD_30_BlackScholes

--- a/examples/conformance/CMakeLists.txt
+++ b/examples/conformance/CMakeLists.txt
@@ -85,22 +85,16 @@ if(CUSTOM_CTS_GIT_TAG)
   set(CTS_GIT_TAG "${CUSTOM_CTS_GIT_TAG}")
 else()
   # Use PoCL's fork which has pending fixes.
-  set(CTS_GIT_TAG "v2024.12.03")
+  set(CTS_GIT_TAG "v2025.02.28")
 endif()
 
 set(TS_BUILDDIR "${TS_BUILDDIR}/test_conformance")
 set(TS_SRCDIR "${TS_SRCDIR}/test_conformance")
 
 if(ENABLE_SPIRV AND HAVE_SPIRV_TOOLS)
-  # build SPIR-V binary files required by the SPIR-V subtests
-  set(CTS_INSTALL_COMMAND "${TS_SRCDIR}/spirv_new/assemble_spirv.py"
-    "-s" "${TS_SRCDIR}/spirv_new/spirv_asm"
-    "-o" "${TS_BUILDDIR}/spirv_new/spirv_bin"
-    "-a" "${SPIRV_AS}"
-    "-l" "${SPIRV_VAL}")
+  message(STATUS "OpenCL-CTS: SPIR-V tests enabled")
 else()
   message(WARNING "llvm-spirv or spirv-tools not found - disabling SPIRV tests in CTS")
-  set(CTS_INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "install step disabled")
 endif()
 
 set(UPSTREAM_CMAKE_ARGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
@@ -128,7 +122,7 @@ ExternalProject_Add(
     -DENABLE_ASAN=${ENABLE_ASAN}
     -DENABLE_TSAN=${ENABLE_TSAN}
     "${TS_BASEDIR}/src/${TS_NAME}"
-  INSTALL_COMMAND ${CTS_INSTALL_COMMAND}
+  INSTALL_COMMAND ""
 )
 
 

--- a/include/CL/cl_ext.h
+++ b/include/CL/cl_ext.h
@@ -52,7 +52,7 @@ extern "C" {
     "cl_khr_command_buffer"
 
 
-#define CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION CL_MAKE_VERSION(0, 9, 5)
+#define CL_KHR_COMMAND_BUFFER_EXTENSION_VERSION CL_MAKE_VERSION(0, 9, 7)
 
 typedef cl_bitfield         cl_device_command_buffer_capabilities_khr;
 typedef struct _cl_command_buffer_khr* cl_command_buffer_khr;
@@ -62,18 +62,17 @@ typedef cl_uint             cl_command_buffer_state_khr;
 typedef cl_properties       cl_command_buffer_properties_khr;
 typedef cl_bitfield         cl_command_buffer_flags_khr;
 typedef cl_properties       cl_command_properties_khr;
-/* PoCL change: typedef'd here to point to a command node */
-typedef struct _cl_command_node *cl_mutable_command_khr;
+typedef struct _cl_mutable_command_khr* cl_mutable_command_khr;
 
 /* cl_device_info */
 #define CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR           0x12A9
+#define CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR 0x129A
 #define CL_DEVICE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR 0x12AA
 
 /* cl_device_command_buffer_capabilities_khr - bitfield */
 #define CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR      (1 << 0)
 #define CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR (1 << 1)
 #define CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR   (1 << 2)
-#define CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR       (1 << 3)
 
 /* cl_command_buffer_properties_khr */
 #define CL_COMMAND_BUFFER_FLAGS_KHR                         0x1293
@@ -564,7 +563,7 @@ clCommandSVMMemFillKHR(
     "cl_khr_command_buffer_multi_device"
 
 
-#define CL_KHR_COMMAND_BUFFER_MULTI_DEVICE_EXTENSION_VERSION CL_MAKE_VERSION(0, 9, 1)
+#define CL_KHR_COMMAND_BUFFER_MULTI_DEVICE_EXTENSION_VERSION CL_MAKE_VERSION(0, 9, 2)
 
 typedef cl_bitfield         cl_platform_command_buffer_capabilities_khr;
 
@@ -1077,12 +1076,6 @@ clCreateCommandQueueWithPropertiesKHR(
 #define CL_DEVICE_GPU_OVERLAP_NV                            0x4004
 #define CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV                    0x4005
 #define CL_DEVICE_INTEGRATED_MEMORY_NV                      0x4006
-
-/* extension to cl_nv_device_attribute_query */
-#define CL_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT_NV           0x4007
-#define CL_DEVICE_PCI_BUS_ID_NV                             0x4008
-#define CL_DEVICE_PCI_SLOT_ID_NV                            0x4009
-#define CL_DEVICE_PCI_DOMAIN_ID_NV                          0x400A
 
 /***************************************************************
 * cl_amd_device_attribute_query
@@ -4182,6 +4175,47 @@ typedef cl_bitfield         cl_device_kernel_clock_capabilities_khr;
 
 
 #define CL_KHR_WORK_GROUP_UNIFORM_ARITHMETIC_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 0)
+
+/***************************************************************
+* cl_ext_buffer_device_address
+***************************************************************/
+#define cl_ext_buffer_device_address 1
+#define CL_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME \
+    "cl_ext_buffer_device_address"
+
+
+#define CL_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 2)
+
+typedef cl_ulong            cl_mem_device_address_ext;
+
+
+typedef cl_int CL_API_CALL
+clSetKernelArgDevicePointerEXT_t(
+    cl_kernel kernel,
+    cl_uint arg_index,
+    cl_mem_device_address_ext arg_value);
+
+typedef clSetKernelArgDevicePointerEXT_t *
+clSetKernelArgDevicePointerEXT_fn CL_API_SUFFIX__VERSION_3_0;
+
+#if !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES)
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clSetKernelArgDevicePointerEXT(
+    cl_kernel kernel,
+    cl_uint arg_index,
+    cl_mem_device_address_ext arg_value) CL_API_SUFFIX__VERSION_3_0;
+
+#endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
+
+/* cl_mem_properties */
+#define CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT                   0x5000
+
+/* cl_mem_info */
+#define CL_MEM_DEVICE_ADDRESS_EXT                           0x5001
+
+/* cl_kernel_exec_info */
+#define CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT                 0x5002
 
 /***************************************************************
 * cl_ext_image_unorm_int_2_101010

--- a/include/CL/cl_ext.h
+++ b/include/CL/cl_ext.h
@@ -62,7 +62,8 @@ typedef cl_uint             cl_command_buffer_state_khr;
 typedef cl_properties       cl_command_buffer_properties_khr;
 typedef cl_bitfield         cl_command_buffer_flags_khr;
 typedef cl_properties       cl_command_properties_khr;
-typedef struct _cl_mutable_command_khr* cl_mutable_command_khr;
+/* PoCL change: typedef'd here to point to a command node */
+typedef struct _cl_command_node *cl_mutable_command_khr;
 
 /* cl_device_info */
 #define CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR           0x12A9
@@ -1076,6 +1077,12 @@ clCreateCommandQueueWithPropertiesKHR(
 #define CL_DEVICE_GPU_OVERLAP_NV                            0x4004
 #define CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV                    0x4005
 #define CL_DEVICE_INTEGRATED_MEMORY_NV                      0x4006
+
+/* extension to cl_nv_device_attribute_query */
+#define CL_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT_NV           0x4007
+#define CL_DEVICE_PCI_BUS_ID_NV                             0x4008
+#define CL_DEVICE_PCI_SLOT_ID_NV                            0x4009
+#define CL_DEVICE_PCI_DOMAIN_ID_NV                          0x400A
 
 /***************************************************************
 * cl_amd_device_attribute_query

--- a/include/CL/cl_ext_pocl.h
+++ b/include/CL/cl_ext_pocl.h
@@ -61,56 +61,6 @@ typedef CL_API_ENTRY cl_int
 
 #endif
 
-/* cl_ext_buffer_device_address (experimental version)
- */
-
-#ifndef cl_ext_buffer_device_address
-#define cl_ext_buffer_device_address 1
-
-/* clCreateBuffer() flag: A new cl_mem_flag CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT:
- * When set to CL_TRUE, specifies that the buffer must have a single fixed
- * device-side address for its lifetime, and the address can be queried via
- * clGetMemObjectInfo.
- *
- * Each device in the context can have their own (fixed) device-side address
- * and a copy of the created buffer which are synchronized implicitly by the
- * runtime.
- *
- * The flag might imply that the buffer will be "pinned" permanently to
- * a device's memory, but might not be necessarily so, as long as the address
- * range of the buffer remains constant.
- *
- * The device addresses of sub-buffers derived from
- * CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT allocated buffers can be computed by
- * adding the sub-buffer origin to the device-specific start address.
- */
-#define CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT 0x5000
-
-/* clGetMemObjectInfo(): A new cl_mem_info type CL_MEM_DEVICE_PTR_EXT:
- * Returns the device address for a buffer allocated with
- * CL_MEM_DEVICE_ADDRESS_EXT. If the buffer was not created with the flag,
- * returns CL_INVALID_MEM_OBJECT.
- */
-#define CL_MEM_DEVICE_ADDRESS_EXT 0x5001
-
-typedef cl_ulong cl_mem_device_address_ext;
-
-/* clSetKernelExecInfo(): CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT:
- * Similar to CL_KERNEL_EXEC_INFO_SVM_PTRS except for CL_MEM_DEVICE_ADDRESS_EXT
- * device pointers: If a device pointer accessed by a kernel is not passed as
- * an argument, it must be set by this property.
- */
-#define CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT 0x5002
-
-/* A new function clSetKernelArgDevicePointerEXT() for setting raw device
- * pointers as kernel arguments. */
-
-typedef cl_int (CL_API_CALL *clSetKernelArgDevicePointerEXT_fn) (
-    cl_kernel kernel, cl_uint arg_index, cl_mem_device_address_ext dev_addr);
-
-/* cl_ext_buffer_device_address (experimental stage) */
-#endif
-
 #define CL_DEVICE_REMOTE_TRAFFIC_STATS_POCL 0x4501
 
 #define CL_DEVICE_REMOTE_SERVER_IP_POCL 0x4503

--- a/include/CL/opencl.h
+++ b/include/CL/opencl.h
@@ -23,7 +23,10 @@ extern "C" {
 
 #include <CL/cl.h>
 #include <CL/cl_gl.h>
+#include <CL/cl_exp_tensor.h>
+#include <CL/cl_exp_defined_builtin_kernels.h>
 #include <CL/cl_ext.h>
+#include <CL/cl_ext_pocl.h>
 
 #ifdef __cplusplus
 }

--- a/include/CL/opencl.h
+++ b/include/CL/opencl.h
@@ -23,10 +23,7 @@ extern "C" {
 
 #include <CL/cl.h>
 #include <CL/cl_gl.h>
-#include <CL/cl_exp_tensor.h>
-#include <CL/cl_exp_defined_builtin_kernels.h>
 #include <CL/cl_ext.h>
-#include <CL/cl_ext_pocl.h>
 
 #ifdef __cplusplus
 }

--- a/lib/CL/clCreateCommandBufferKHR.c
+++ b/lib/CL/clCreateCommandBufferKHR.c
@@ -152,15 +152,16 @@ POname (clCreateCommandBufferKHR) (
 
   for (unsigned i = 0; i < num_queues; ++i)
     {
-      if (queues[i]->properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE)
+      if (queues[i]->device->cmdbuf_supported_properties)
         POCL_GOTO_ERROR_ON (
-          ((queues[i]->device->cmdbuf_capabilities
-            & CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR)
-           == 0),
+          ((queues[i]->device->cmdbuf_supported_properties
+            & queues[i]->properties)
+           != queues[i]->properties),
           CL_INCOMPATIBLE_COMMAND_QUEUE_KHR,
-          "queue is an out-of-order "
-          "command-queue but device does not support the CL_COMMAND_BUFFER"
-          "_CAPABILITY_OUT_OF_ORDER_KHR capability\n");
+          "properties of command-queue"
+          " does contain queue properties not supported by CL_DEVI"
+          "CE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR\n");
+
       if (queues[i]->device->cmdbuf_required_properties)
         POCL_GOTO_ERROR_ON (
           ((queues[i]->device->cmdbuf_required_properties
@@ -168,7 +169,7 @@ POname (clCreateCommandBufferKHR) (
            != queues[i]->device->cmdbuf_required_properties),
           CL_INCOMPATIBLE_COMMAND_QUEUE_KHR,
           "properties of command-queue"
-          " does not contain the minimum properties specified by CL_DEVI"
+          " does not contain properties required by CL_DEVI"
           "CE_COMMAND_BUFFER_REQUIRED_QUEUE_PROPERTIES_KHR\n");
     }
 

--- a/lib/CL/clGetDeviceInfo.c
+++ b/lib/CL/clGetDeviceInfo.c
@@ -240,7 +240,10 @@ POname(clGetDeviceInfo)(cl_device_id   device,
   case CL_DEVICE_DOUBLE_FP_CONFIG                  :
     POCL_RETURN_GETINFO (cl_ulong, device->double_fp_config);
   case CL_DEVICE_HALF_FP_CONFIG                    :
-    POCL_RETURN_GETINFO (cl_ulong, device->half_fp_config);
+    if (strstr (device->extensions, "cl_khr_fp16"))
+      POCL_RETURN_GETINFO (cl_ulong, device->half_fp_config);
+    else
+      return CL_INVALID_VALUE;
   case CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF       :
     POCL_RETURN_DEVICE_INFO_WITH_EXT_CHECK(cl_uint, device->preferred_vector_width_half, cl_khr_fp16);
   case CL_DEVICE_HOST_UNIFIED_MEMORY:

--- a/lib/CL/clGetDeviceInfo.c
+++ b/lib/CL/clGetDeviceInfo.c
@@ -415,6 +415,10 @@ POname(clGetDeviceInfo)(cl_device_id   device,
     POCL_RETURN_GETINFO (cl_command_queue_properties,
                          device->cmdbuf_required_properties);
 
+  case CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR:
+    POCL_RETURN_GETINFO (cl_command_queue_properties,
+                         device->cmdbuf_supported_properties);
+
   case CL_DEVICE_MUTABLE_DISPATCH_CAPABILITIES_KHR:
     POCL_RETURN_GETINFO (cl_mutable_dispatch_fields_khr,
                          device->cmdbuf_mutable_dispatch_capabilities);

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1942,7 +1942,7 @@ static const cl_name_version OPENCL_EXTENSIONS[]
       { CL_MAKE_VERSION (1, 0, 0), "cl_khr_pci_bus_info" },
       { CL_MAKE_VERSION (1, 0, 0), "cl_khr_device_uuid" },
 
-      { CL_MAKE_VERSION (0, 9, 5), "cl_khr_command_buffer" },
+      { CL_MAKE_VERSION (0, 9, 6), "cl_khr_command_buffer" },
       { CL_MAKE_VERSION (0, 9, 1), "cl_khr_command_buffer_multi_device" },
       { CL_MAKE_VERSION (0, 9, 3), "cl_khr_command_buffer_mutable_dispatch" },
       { CL_MAKE_VERSION (1, 0, 0), "cl_ext_float_atomics" },

--- a/lib/CL/devices/common_utils.c
+++ b/lib/CL/devices/common_utils.c
@@ -467,9 +467,9 @@ pocl_cpu_init_common (cl_device_id device)
   device->cmdbuf_capabilities
     = CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR
       | CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR
-      | CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR
       | CL_COMMAND_BUFFER_CAPABILITY_MULTIPLE_QUEUE_KHR;
   device->cmdbuf_required_properties = 0;
+  device->cmdbuf_supported_properties = CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
   /* TBD: arguments, in particular buffers, require more work
    * because of migration commands */
   device->cmdbuf_mutable_dispatch_capabilities

--- a/lib/CL/devices/level0/level0-driver.cc
+++ b/lib/CL/devices/level0/level0-driver.cc
@@ -2969,7 +2969,6 @@ Level0Device::Level0Device(Level0Driver *Drv, ze_device_handle_t DeviceH,
     ClDev->cmdbuf_capabilities =
         CL_COMMAND_BUFFER_CAPABILITY_SIMULTANEOUS_USE_KHR |
         CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR;
-    // | CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR
     //| CL_COMMAND_BUFFER_CAPABILITY_MULTIPLE_QUEUE_KHR;
     ClDev->cmdbuf_required_properties = 0;
     ClDev->native_command_buffers = CL_TRUE;

--- a/lib/CL/devices/pthread/pthread.c
+++ b/lib/CL/devices/pthread/pthread.c
@@ -137,7 +137,7 @@ pocl_pthread_init (unsigned j, cl_device_id device, const char* parameters)
 
   /* pthread has elementary partitioning support,
    * but only if OpenMP is disabled */
-#ifdef ENABLE_HOST_CPU_DEVICES_OPENMP
+#if  defined(ENABLE_HOST_CPU_DEVICES_OPENMP) || defined(ENABLE_CONFORMANCE)
   device->max_sub_devices = 0;
   device->num_partition_properties = 0;
   device->num_partition_types = 0;

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -1362,6 +1362,7 @@ struct _cl_device_id {
 
   /* command buffer related properties */
   cl_mutable_dispatch_fields_khr cmdbuf_mutable_dispatch_capabilities;
+  cl_command_queue_properties cmdbuf_supported_properties;
   cl_command_queue_properties cmdbuf_required_properties;
   cl_device_command_buffer_capabilities_khr cmdbuf_capabilities;
 

--- a/tests/runtime/test_command_buffer.c
+++ b/tests/runtime/test_command_buffer.c
@@ -125,14 +125,11 @@ main (int _argc, char **_argv)
       clSetKernelArg (kernel, 2, sizeof (buffer_res), &buffer_res));
 
   cl_command_queue_properties props = 0;
-  CHECK_CL_ERROR (clGetDeviceInfo (device, CL_DEVICE_QUEUE_ON_HOST_PROPERTIES,
-                                   sizeof (props), &props, NULL));
-  cl_device_command_buffer_capabilities_khr caps = 0;
-  CHECK_CL_ERROR (clGetDeviceInfo (device,
-                                   CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR,
-                                   sizeof (caps), &caps, NULL));
-  if ((props & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE)
-      && (caps & CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR))
+  cl_command_queue_properties supported = 0;
+  CHECK_CL_ERROR (clGetDeviceInfo (
+    device, CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR,
+    sizeof (supported), &supported, NULL));
+  if (supported & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE)
     props = CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
   else
     props = 0;

--- a/tests/runtime/test_command_buffer_images.c
+++ b/tests/runtime/test_command_buffer_images.c
@@ -123,14 +123,11 @@ main (int _argc, char **_argv)
   CHECK_CL_ERROR (error);
 
   cl_command_queue_properties props = 0;
-  CHECK_CL_ERROR (clGetDeviceInfo (device, CL_DEVICE_QUEUE_ON_HOST_PROPERTIES,
-                                   sizeof (props), &props, NULL));
-  cl_device_command_buffer_capabilities_khr caps = 0;
-  CHECK_CL_ERROR (clGetDeviceInfo (device,
-                                   CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR,
-                                   sizeof (caps), &caps, NULL));
-  if ((props & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE)
-      && (caps & CL_COMMAND_BUFFER_CAPABILITY_OUT_OF_ORDER_KHR))
+  cl_command_queue_properties supported = 0;
+  CHECK_CL_ERROR (clGetDeviceInfo (
+    device, CL_DEVICE_COMMAND_BUFFER_SUPPORTED_QUEUE_PROPERTIES_KHR,
+    sizeof (supported), &supported, NULL));
+  if (supported & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE)
     props = CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
   else
     props = 0;


### PR DESCRIPTION
rebased CTS & updated libpocl's cl_khr_command_buffer to 0.9.6 (version not backwards compatible)