### PR TITLE
Fix includepath of LLVMSPIRVLib.h

### DIFF
--- a/cmake/LLVM.cmake
+++ b/cmake/LLVM.cmake
@@ -388,7 +388,7 @@ endif()
 
 # first try to find it in the LLVM's include directories.
 find_path(LLVM_SPIRV_INCLUDEDIR "LLVMSPIRVLib.h"
-  PATHS "${LLVM_INCLUDE_DIRS}/LLVMSPIRVLib" NO_DEFAULT_PATH)
+  PATHS "${LLVM_INCLUDE_DIRS}" NO_DEFAULT_PATH PATH_SUFFIXES "LLVMSPIRVLib")
 find_library(LLVM_SPIRV_LIB "LLVMSPIRVLib" PATHS "${LLVM_LIBDIR}" NO_DEFAULT_PATH)
 
 # Ubuntu's libllvmspirv-XY-dev packages unfortunately use unversioned

--- a/lib/CL/pocl_llvm_spirv.cc
+++ b/lib/CL/pocl_llvm_spirv.cc
@@ -63,7 +63,7 @@ POP_COMPILER_DIAGS
 #include <vector>
 
 #ifdef HAVE_LLVM_SPIRV_LIB
-#include <LLVMSPIRVLib/LLVMSPIRVLib.h>
+#include <LLVMSPIRVLib.h>
 #endif
 
 #include "spirv_parser.hh"


### PR DESCRIPTION
Fixes my observation in https://github.com/pocl/pocl/pull/1809#issuecomment-2700431934

In our Julia build LLVMSPIRLib is not in the same directory as the rest of LLVM and the `find_path` use created a "fully prefixed" include path.

`/home/vchuravy/.julia/artifacts/269dfd41c362fb61600d1b30682dd946a6ff0a5d/include/LLVMSPIRVLib`.

I assume this worked in #1809 if the LLVM include path and the LLVMSPIRVLib include path essentially alias, the header would be found through the include
for LLVM.

I was considering stripping the suffix, but this seemed more straightforward.
