### PR TITLE
Enable SPIR-V 1.3 with LLVM v19

### DIFF
--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1781,16 +1781,21 @@ pocl_init_default_device_infos (cl_device_id dev,
     dev->llvm_target_triplet = "";
 #endif
 
-#if defined(ENABLE_SPIRV) && LLVM_MAJOR >= 20
-  dev->supported_spir_v_versions = "SPIR-V_1.5 SPIR-V_1.4 SPIR-V_1.3 SPIR-V_1.2 SPIR-V_1.1 SPIR-V_1.0";
+#if defined(ENABLE_SPIRV)
   dev->supported_spirv_extensions = "+SPV_KHR_no_integer_wrap_decoration"
                                     ",+SPV_INTEL_fp_fast_math_mode"
+                                    ",+SPV_EXT_shader_atomic_float_add"
                                     ",+SPV_INTEL_inline_assembly";
-#elif defined(ENABLE_SPIRV)
+#if LLVM_MAJOR >= 20
+  dev->supported_spir_v_versions
+    = "SPIR-V_1.5 SPIR-V_1.4 SPIR-V_1.3 SPIR-V_1.2 SPIR-V_1.1 SPIR-V_1.0";
+#elif LLVM_MAJOR >= 19
+  dev->supported_spir_v_versions
+    = "SPIR-V_1.3 SPIR-V_1.2 SPIR-V_1.1 SPIR-V_1.0";
+#else
   dev->supported_spir_v_versions = "SPIR-V_1.2 SPIR-V_1.1 SPIR-V_1.0";
-  dev->supported_spirv_extensions = "+SPV_KHR_no_integer_wrap_decoration"
-                                    ",+SPV_INTEL_fp_fast_math_mode"
-                                    ",+SPV_INTEL_inline_assembly";
+#endif
+
 #else
   dev->supported_spir_v_versions = "";
   dev->supported_spirv_extensions = "";


### PR DESCRIPTION
This brings in the subgroup ballot support which chipStar can use.

This exposes an issue in TestBallot (at least for me):

```
/home/pjaaskel/src/chipStar/build-llvm-19/tests/runtime/TestBallot
TestBallot: /home/pjaaskel/src/chipStar/llvm-project/llvm/lib/Transforms/Utils/ValueMapper.cpp:978: void {anonymous}::Mapper::remapInstruction(llvm::Instruction*): Assertion `(Flags & RF_IgnoreMissingLocals) && "Referenced value not in value map!"' failed.
...
(gdb) call I
$1 = (llvm::Instruction *) 0x55556656e5f0
(gdb) call I->dump()
  %22 = load i64, ptr %_local_size_x, align 8

```
Let's see if the CI also fails.
