### PR TITLE
WG: Remove the original kernel if not needed any longer

### DIFF
--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -1423,8 +1423,13 @@ void WorkgroupImpl::createDefaultWorkgroupLauncher(llvm::Function *F) {
 
   Builder.CreateRetVoid();
 
+  Function *Callee = CI->getCalledFunction();
+
   InlineFunctionInfo IFI;
   InlineFunction(*CI, IFI);
+
+  if (Callee->getNumUses() == 0)
+    Callee->eraseFromParent();
 }
 
 static inline uint64_t


### PR DESCRIPTION
This should at speed up at least codegen and dlopen() somewhat as it typically splits the LLVM Module size to about half.