### PR TITLE
pocl_types.h redefined reserve_id_t

### DIFF
--- a/include/pocl_types.h
+++ b/include/pocl_types.h
@@ -36,8 +36,10 @@
 
 #ifdef __OPENCL_VERSION__
 
-/* required for LLVM 13+ */
+#if (__clang_major__ < 18)
+/* Required for LLVM 13 at least. */
 typedef unsigned reserve_id_t;
+#endif
 
 #ifdef __USE_CLANG_OPENCL_C_H
 


### PR DESCRIPTION
It seems at least with LLVM 18 it will be defined in the Clang's header (at least when CLC=2), causing a conflict.