### PR TITLE
scripts: make format-diff work on non-committed changes again

### DIFF
--- a/tools/scripts/format-diff.sh
+++ b/tools/scripts/format-diff.sh
@@ -19,7 +19,7 @@ RELPATH=$(dirname "$SCRIPTPATH")
 # cd to root directory of the git repo
 cd "${GITROOT}" || exit 1
 
-if [ $# -ne 1 ]; then
+if [ $# -ne 0 ]; then
     if git status --porcelain=1 -uno | grep '^.[MTDRC] '; then
 	>&2 echo "There are unstaged changes - aborting."
 	exit 1


### PR DESCRIPTION
This had broken at some point, apparently $# does not include the script itself, unlike argc, which made it bail out on unstaged changes when trying to... format uncommitted changes.