### PR TITLE
Fix `Expression: It != UnbundledHeaders.end()` error

### DIFF
--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -216,7 +216,7 @@ static bool generateProgramBC(PoclLLVMContextData *Context, llvm::Module *Mod,
 }
 
 #ifdef ENABLE_HEADER_BUNDLING
-static std::map<const char *, std::string> UnbundledHeaders;
+static std::map<std::string_view, std::string> UnbundledHeaders;
 static bool UnbundledHeadersInitialized = false;
 
 static void addHeader(const char *Source, unsigned SourceLen,


### PR DESCRIPTION
This occurred because of `const char *` being used as a key in the `UnbundledHeaders` map resulting in pointer comparison instead of string comparison. The error itself was caused by string literals with same contents but different pointer - one used for adding an entry and the other used for lookup.