### PR TITLE
Windows: Fix ENABLE_RELOCATION=ON issues

### DIFF
--- a/include/pocl.h
+++ b/include/pocl.h
@@ -93,6 +93,12 @@ typedef uint64_t pocl_obj_id_t;
 #  error "Don't know alignas() counterpart for this compiler!"
 #endif
 
+#ifndef _WIN32
+#define POCL_PATH_SEPARATOR "/"
+#else
+#define POCL_PATH_SEPARATOR "\\"
+#endif
+
 /* Always align buffer allocations, context data, and kernel arguments to
    sizeof(double16) to enforce easier vectorization for targets with naturally
    aligned loads/stores. */

--- a/lib/CL/devices/devices.c
+++ b/lib/CL/devices/devices.c
@@ -252,12 +252,6 @@ extern pocl_lock_t pocl_init_lock;
 
 static void *pocl_device_handles[POCL_NUM_DEVICE_TYPES];
 
-#ifndef _WIN32
-#define POCL_PATH_SEPARATOR "/"
-#else
-#define POCL_PATH_SEPARATOR "\\"
-#endif
-
 static void
 get_pocl_device_lib_path (char *result, char *device_name, int absolute_path)
 {

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -2467,7 +2467,7 @@ int pocl_get_private_datadir(char* private_datadir)
   if (Path)
     {
       strncpy (private_datadir, Path, POCL_MAX_PATHNAME_LENGTH);
-      char *last_slash = strrchr (private_datadir, '/');
+      char *last_slash = strrchr (private_datadir, POCL_PATH_SEPARATOR[0]);
       if (last_slash)
         {
           ++last_slash;

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -2459,6 +2459,7 @@ pocl_escape_quoted_whitespace (char *temp_options, char *replace_me)
 }
 
 /* returns private datadir, possibly using relative path to libpocl sharedlib */
+POCL_EXPORT
 int pocl_get_private_datadir(char* private_datadir)
 {
 #ifdef ENABLE_RELOCATION


### PR DESCRIPTION

* Fix `pocl_dynlib_pathname()` failed. Or rather `GetModuleHandleEx()` call failed because an `address` argument was pointing to a function that was not exported properly (its definition lacked `POCL_EXPORT`).
* Fix failure to find builtin OpenCL C headers on `ENABLE_HEADER_BUNDLING=OFF` configuration. This occurred because
`pocl_get_private_datadir()` returned incorrect path.