### PR TITLE
CPU: indirect SVM/USM was not set

### DIFF
--- a/lib/CL/devices/basic/basic.c
+++ b/lib/CL/devices/basic/basic.c
@@ -970,21 +970,24 @@ pocl_basic_get_subgroup_info_ext (cl_device_id device,
 cl_int
 pocl_basic_set_kernel_exec_info_ext (cl_device_id dev,
                                      unsigned program_device_i,
-                                     cl_kernel Kernel, cl_uint param_name,
+                                     cl_kernel kernel, cl_uint param_name,
                                      size_t param_value_size,
                                      const void *param_value)
 {
 
   switch (param_name)
     {
-    case CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM:
     case CL_KERNEL_EXEC_INFO_SVM_PTRS:
     case CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL:
+      {
+        return CL_SUCCESS;
+      }
+    case CL_KERNEL_EXEC_INFO_SVM_FINE_GRAIN_SYSTEM:
     case CL_KERNEL_EXEC_INFO_DEVICE_PTRS_EXT:
     case CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL:
     case CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL:
     case CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL:
-    return CL_SUCCESS;
+      return CL_SUCCESS;
     default:
       return CL_INVALID_VALUE;
     }

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -3108,17 +3108,7 @@ pocl_remote_set_kernel_exec_info_ext (cl_device_id dev,
     {
     case CL_KERNEL_EXEC_INFO_SVM_PTRS:
     case CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL:
-      {
-        for (size_t i = 0; i < param_value_size / sizeof (void *); ++i)
-          {
-            struct _pocl_ptr_list_node *n
-                = malloc (sizeof (struct _pocl_ptr_list_node));
-            n->ptr = ((void **)param_value)[i];
-            DL_APPEND (kernel->indirect_raw_ptrs, n);
-            POCL_MSG_PRINT_MEMORY ("Set a indirect SVM/USM ptr %p\n", n->ptr);
-          }
-        return CL_SUCCESS;
-      }
+      return CL_SUCCESS;
     case CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL:
     case CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL:
     case CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL:

--- a/lib/CL/pocl_mem_management.h
+++ b/lib/CL/pocl_mem_management.h
@@ -106,6 +106,14 @@ pocl_buffer_migration_info *
 pocl_convert_to_subbuffer_migrations (pocl_buffer_migration_info *buffer_usage,
                                       cl_int *err);
 
+/* Sets the indirect_raw_ptrs of the kernel to the given list array
+ * of pointers.
+ *
+ * Clears up the possible previously set pointers.
+ */
+void
+pocl_reset_indirect_ptrs (cl_kernel kernel, void **ptrs, size_t n);
+
 /* Increments a buffer's reference counter. */
 #define POCL_RETAIN_BUFFER_UNLOCKED(__OBJ__)                                  \
   do                                                                          \

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -28,7 +28,9 @@
 #include "pocl_compiler_macros.h"
 #include "pocl_cl.h"
 #define _BSD_SOURCE
+#ifndef _DEFAULT_SOURCE
 #define _DEFAULT_SOURCE
+#endif
 #define _POSIX_C_SOURCE 200809L
 
 #include <errno.h>
@@ -2248,7 +2250,6 @@ pocl_str_append (const char **dst, const char *src)
   *dst = new_dst;
   return old_dst;
 }
-
 
 int
 pocl_fill_aligned_buf_with_pattern (void *__restrict__ ptr, size_t offset,


### PR DESCRIPTION
Setting of the indirect pointer info was omitted, likely due to not considering multi-device cases. This was not a problem with CPU-only platforms, but affects migration of indirect-access buffers residing on other devices' memories.

I have additional tests upcoming in a later PR.
