### PR TITLE
pocld: bump cmake minimum version to 3.5

### DIFF
--- a/pocld/CMakeLists.txt
+++ b/pocld/CMakeLists.txt
@@ -24,7 +24,7 @@
 #
 #=============================================================================
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(pocld)
 
 add_definitions(-DCL_TARGET_OPENCL_VERSION=${OPENCL_HEADER_VERSION}

--- a/pocld/CMakeLists.txt
+++ b/pocld/CMakeLists.txt
@@ -24,7 +24,7 @@
 #
 #=============================================================================
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.0...4.0)
 project(pocld)
 
 add_definitions(-DCL_TARGET_OPENCL_VERSION=${OPENCL_HEADER_VERSION}


### PR DESCRIPTION
Compatibility with cmake versions <3.5 has been removed in cmake 4.0: https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features

Without this patch, building with cmake 4.0 causes the following error message: 

```
CMake Error at pocld/CMakeLists.txt:27 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```