### PR TITLE
A non-robust work-around for #1887

### DIFF
--- a/lib/CL/pocl_cache.c
+++ b/lib/CL/pocl_cache.c
@@ -563,13 +563,14 @@ pocl_cache_init_topdir ()
       return CL_FAILED;
 
 #elif defined(_WIN32)
-        tmp_path = getenv("LOCALAPPDATA");
-        if (!tmp_path)
-          tmp_path = getenv ("TEMP");
-        if (tmp_path == NULL)
-          return CL_FAILED;
-        needed = snprintf (cache_topdir, POCL_MAX_PATHNAME_LENGTH, "%s\\pocl",
-                           tmp_path);
+      tmp_path = getenv ("TEMP");
+      if (!tmp_path) {
+	tmp_path = getenv("LOCALAPPDATA");
+      }
+      if (tmp_path == NULL)
+	return CL_FAILED;
+      needed = snprintf (cache_topdir, POCL_MAX_PATHNAME_LENGTH, "%s\\pocl",
+                         tmp_path);
 #else
         // "If $XDG_CACHE_HOME is either not set or empty, a default equal to
         // $HOME/.cache should be used."


### PR DESCRIPTION
This fixes an issue seen in #1887 but there is still possibility of the bug re-occurring. The reason is that that the `$TEMP` environment variable point into user's home directory too (by default) but in different form which in my case is `C:\Users\HENRYL~1\AppData\Local\Temp`. This works for me but might fail for other users in case there are "wide" characters appearing in very beginning of the home directory name.