### PR TITLE
 doc: advertise server-side command buffers in 6.1 relnotes

### DIFF
--- a/doc/sphinx/source/notes_6_1.rst
+++ b/doc/sphinx/source/notes_6_1.rst
@@ -41,6 +41,10 @@ Miscellaneous
 Remote driver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* Command buffers that refer to only a single remote device are
+  now handled entirely on the server side as described in
+  `this publication <https://doi.org/10.1145/3731125.3731129>`
+  for some massive reductions in communication overhead.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Level Zero driver


### PR DESCRIPTION
DOI is not live yet, let's hope that changes before release.