### PR TITLE
level0: pick smallest queue ordinals

### DIFF
--- a/lib/CL/devices/level0/level0-driver.cc
+++ b/lib/CL/devices/level0/level0-driver.cc
@@ -2628,17 +2628,17 @@ bool Level0Device::setupQueueGroupProperties() {
                        ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COMPUTE) != 0);
     bool IsCopy = ((QGroupProps[i].flags &
                     ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COPY) != 0);
-    if (IsCompute && IsCopy) {
+    if (IsCompute && IsCopy && UniversalQueueOrd == UINT32_MAX) {
       UniversalQueueOrd = i;
       NumUniversalQueues = QGroupProps[i].numQueues;
     }
 
-    if (IsCompute && !IsCopy) {
+    if (IsCompute && !IsCopy && ComputeQueueOrd == UINT32_MAX) {
       ComputeQueueOrd = i;
       NumComputeQueues = QGroupProps[i].numQueues;
     }
 
-    if (!IsCompute && IsCopy) {
+    if (!IsCompute && IsCopy && CopyQueueOrd == UINT32_MAX) {
       CopyQueueOrd = i;
       NumCopyQueues = QGroupProps[i].numQueues;
     }


### PR DESCRIPTION
On an Arrow Lake machine where there are multiple command queue groups to create queues from, picking the lowest ordinal speed up OpenVINO inference:

* `benchmark_app -d GPU.0 -hint none -nstreams 1 -nireq 1 -b 1 -t 20 -m resnet-50/resnet-50.xml`: 8 FPS -> 24 FPS.

* `benchmark_app -d GPU.0 -hint none -nstreams 2 -nireq 4 -b 1 -t 20 -m resnet-50/resnet-50.xml`: 28 FPS -> 40 FPS.

However, reportedly gains are not seen on Intel Battlemage GPUs.