### PR TITLE
Allow for -DENABLE_ICD=OFF -DRENAME_POCL=ON

### DIFF
--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -279,8 +279,14 @@ extern pocl_obj_id_t last_object_id;
 
 #  define POname(name) PO##name
 
+#if defined(RENAME_POCL) && !defined(BUILD_ICD)
+#define POdeclsym(name) POCL_EXPORT __typeof__ (name) PO##name;
+#define POdeclsymExport(name) POdeclsym(name)
+#else
 #define POdeclsym(name) __typeof__ (name) PO##name;
 #define POdeclsymExport(name) POCL_EXPORT POdeclsym(name)
+#endif
+
 #  define POCL_ALIAS_OPENCL_SYMBOL(name)                                \
   __typeof__(name) name __attribute__((alias ("PO" #name), visibility("default")));
 


### PR DESCRIPTION
For a deployment situation I would like to both disable ICD support as well as renaming the POCL symbols.
I only want to access the pthread devices and want to avoid any symbol collisions with other OpenCL libraries
that may be loaded.
