### PR TITLE
MinGW: Also use `--exclude-libs,ALL`

### DIFF
--- a/lib/CL/CMakeLists.txt
+++ b/lib/CL/CMakeLists.txt
@@ -375,7 +375,7 @@ endif()
 
 harden("${POCL_LIBRARY_NAME}")
 
-if(UNIX AND (NOT APPLE))
+if((UNIX OR MINGW) AND (NOT APPLE))
   target_link_options("${POCL_LIBRARY_NAME}" PRIVATE "LINKER:--exclude-libs,ALL")
 endif()
 if(WIN32)


### PR DESCRIPTION
Without it, I run into the dreaded `export ordinal too large` error caused by too many symbols being exported (when statically linking LLVM):

```
FAILED: lib/CL/pocl.dll lib/CL/libpocl.dll.a
C:\WINDOWS\system32\cmd.exe /C "cd . && C:\msys64\mingw64\bin\c++.exe -fdiagnostics-color=always -O3 -DNDEBUG  -LC:/Users/Tim/Julia/src/llvm-project/install/dev/lib    -Wl,--enable-auto-import,--enable-runtime-pseudo-reloc -shared -o lib\CL\pocl.dll -Wl,--out-implib,lib\CL\libpocl.dll.a -Wl,--major-image-version,2,--minor-image-version,15 @CMakeFiles\pocl.rsp && cd ."
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/15.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: error: export ordinal too large: 90735
collect2.exe: error: ld returned 1 exit status    
```