### PR TITLE
MinGW: Default to `BUILD_SHARED_LIBS=ON`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,10 +245,6 @@ set(CPACK_PACKAGE_VERSION_MINOR "${MINOR_VERSION}")
 set(CPACK_PACKAGE_VERSION_PATCH "0")
 
 set(BUILD_SHARED_LIBS_DEFAULT ON)
-if(MINGW)
-  # Building PoCL as shared library does not work yet with MinGW.
-  set(BUILD_SHARED_LIBS_DEFAULT OFF)
-endif()
 
 ##################################################################################
 


### PR DESCRIPTION
We've been doing this for the Julia PoCL build for a while, and it seems to be working fine.

@linehill Did you run into specific issues?