### PR TITLE
Update OpenCL-CTS + OpenCL headers

### DIFF
--- a/examples/conformance/CMakeLists.txt
+++ b/examples/conformance/CMakeLists.txt
@@ -85,7 +85,7 @@ if(CUSTOM_CTS_GIT_TAG)
   set(CTS_GIT_TAG "${CUSTOM_CTS_GIT_TAG}")
 else()
   # Use PoCL's fork which has pending fixes.
-  set(CTS_GIT_TAG "v2025.05.22.1")
+  set(CTS_GIT_TAG "v2025.07.10.1")
 endif()
 
 set(TS_BUILDDIR "${TS_BUILDDIR}/test_conformance")

--- a/examples/conformance/CMakeLists.txt
+++ b/examples/conformance/CMakeLists.txt
@@ -85,7 +85,7 @@ if(CUSTOM_CTS_GIT_TAG)
   set(CTS_GIT_TAG "${CUSTOM_CTS_GIT_TAG}")
 else()
   # Use PoCL's fork which has pending fixes.
-  set(CTS_GIT_TAG "v2025.07.10.1")
+  set(CTS_GIT_TAG "v2025.07.11")
 endif()
 
 set(TS_BUILDDIR "${TS_BUILDDIR}/test_conformance")

--- a/include/CL/cl.h
+++ b/include/CL/cl.h
@@ -24,6 +24,12 @@
 extern "C" {
 #endif
 
+#if defined(_WIN32) && defined(_MSC_VER) && __CL_HAS_ANON_STRUCT__
+   /* Disable warning C4201: nonstandard extension used : nameless struct/union */
+    #pragma warning( push )
+    #pragma warning( disable : 4201 )
+#endif
+
 /******************************************************************************/
 
 typedef struct _cl_platform_id *    cl_platform_id;
@@ -133,38 +139,13 @@ typedef struct _cl_image_desc {
     size_t                  image_slice_pitch;
     cl_uint                 num_mip_levels;
     cl_uint                 num_samples;
-#ifdef CL_VERSION_2_0
-#if defined(__GNUC__)
-    __extension__                   /* Prevents warnings about anonymous union in -pedantic builds */
-#endif
-#if defined(_MSC_VER) && !defined(__STDC__)
-#pragma warning( push )
-#pragma warning( disable : 4201 )   /* Prevents warning about nameless struct/union in /W4 builds */
-#endif
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wc11-extensions" /* Prevents warning about nameless union being C11 extension*/
-#endif
-#if defined(_MSC_VER) && defined(__STDC__)
-    /* Anonymous unions are not supported in /Za builds */
-#else
-    union {
-#endif
+#if defined(CL_VERSION_2_0) && __CL_HAS_ANON_STRUCT__
+    __CL_ANON_STRUCT__ union {
 #endif
       cl_mem                  buffer;
-#ifdef CL_VERSION_2_0
-#if defined(_MSC_VER) && defined(__STDC__)
-    /* Anonymous unions are not supported in /Za builds */
-#else
+#if defined(CL_VERSION_2_0) && __CL_HAS_ANON_STRUCT__
       cl_mem                  mem_object;
     };
-#endif
-#if defined(_MSC_VER) && !defined(__STDC__)
-#pragma warning( pop )
-#endif
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 #endif
 } cl_image_desc;
 
@@ -1930,6 +1911,10 @@ clEnqueueTask(cl_command_queue  command_queue,
 
 #ifdef __cplusplus
 }
+#endif
+
+#if defined(_WIN32) && defined(_MSC_VER) && __CL_HAS_ANON_STRUCT__
+    #pragma warning( pop )
 #endif
 
 #endif  /* __OPENCL_CL_H */

--- a/include/CL/cl_ext.h
+++ b/include/CL/cl_ext.h
@@ -64,7 +64,8 @@ typedef cl_uint             cl_command_buffer_state_khr;
 typedef cl_properties       cl_command_buffer_properties_khr;
 typedef cl_bitfield         cl_command_buffer_flags_khr;
 typedef cl_properties       cl_command_properties_khr;
-typedef struct _cl_mutable_command_khr* cl_mutable_command_khr;
+/* PoCL change: typedef'd here to point to a command node */
+typedef struct _cl_command_node *cl_mutable_command_khr;
 
 /* cl_device_info */
 #define CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR           0x12A9
@@ -1121,6 +1122,12 @@ clCreateCommandQueueWithPropertiesKHR(
 #define CL_DEVICE_GPU_OVERLAP_NV                            0x4004
 #define CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV                    0x4005
 #define CL_DEVICE_INTEGRATED_MEMORY_NV                      0x4006
+
+/* extension to cl_nv_device_attribute_query */
+#define CL_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT_NV           0x4007
+#define CL_DEVICE_PCI_BUS_ID_NV                             0x4008
+#define CL_DEVICE_PCI_SLOT_ID_NV                            0x4009
+#define CL_DEVICE_PCI_DOMAIN_ID_NV                          0x400A
 
 /***************************************************************
 * cl_amd_device_attribute_query

--- a/include/CL/cl_ext.h
+++ b/include/CL/cl_ext.h
@@ -45,8 +45,10 @@ extern "C" {
 #endif
 
 /***************************************************************
-* cl_khr_command_buffer
+* cl_khr_command_buffer (beta)
 ***************************************************************/
+#if defined(CL_ENABLE_BETA_EXTENSIONS)
+
 #define cl_khr_command_buffer 1
 #define CL_KHR_COMMAND_BUFFER_EXTENSION_NAME \
     "cl_khr_command_buffer"
@@ -62,8 +64,7 @@ typedef cl_uint             cl_command_buffer_state_khr;
 typedef cl_properties       cl_command_buffer_properties_khr;
 typedef cl_bitfield         cl_command_buffer_flags_khr;
 typedef cl_properties       cl_command_properties_khr;
-/* PoCL change: typedef'd here to point to a command node */
-typedef struct _cl_command_node *cl_mutable_command_khr;
+typedef struct _cl_mutable_command_khr* cl_mutable_command_khr;
 
 /* cl_device_info */
 #define CL_DEVICE_COMMAND_BUFFER_CAPABILITIES_KHR           0x12A9
@@ -556,9 +557,13 @@ clCommandSVMMemFillKHR(
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
+#endif /* defined(CL_ENABLE_BETA_EXTENSIONS) */
+
 /***************************************************************
-* cl_khr_command_buffer_multi_device
+* cl_khr_command_buffer_multi_device (beta)
 ***************************************************************/
+#if defined(CL_ENABLE_BETA_EXTENSIONS)
+
 #define cl_khr_command_buffer_multi_device 1
 #define CL_KHR_COMMAND_BUFFER_MULTI_DEVICE_EXTENSION_NAME \
     "cl_khr_command_buffer_multi_device"
@@ -616,9 +621,13 @@ clRemapCommandBufferKHR(
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
+#endif /* defined(CL_ENABLE_BETA_EXTENSIONS) */
+
 /***************************************************************
-* cl_khr_command_buffer_mutable_dispatch
+* cl_khr_command_buffer_mutable_dispatch (beta)
 ***************************************************************/
+#if defined(CL_ENABLE_BETA_EXTENSIONS)
+
 #define cl_khr_command_buffer_mutable_dispatch 1
 #define CL_KHR_COMMAND_BUFFER_MUTABLE_DISPATCH_EXTENSION_NAME \
     "cl_khr_command_buffer_mutable_dispatch"
@@ -736,6 +745,8 @@ clGetMutableCommandInfoKHR(
     size_t* param_value_size_ret) ;
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
+
+#endif /* defined(CL_ENABLE_BETA_EXTENSIONS) */
 
 /***************************************************************
 * cl_khr_fp64
@@ -870,13 +881,20 @@ clLogMessagesToStderrAPPLE(
     "cl_khr_icd"
 
 
-#define CL_KHR_ICD_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 0)
+#define CL_KHR_ICD_EXTENSION_VERSION CL_MAKE_VERSION(2, 0, 0)
 
 /* cl_platform_info */
 #define CL_PLATFORM_ICD_SUFFIX_KHR                          0x0920
 
 /* Error codes */
 #define CL_PLATFORM_NOT_FOUND_KHR                           -1001
+
+/* ICD 2 tag value */
+#if INTPTR_MAX == INT32_MAX
+#define CL_ICD2_TAG_KHR ((intptr_t)0x434C3331)
+#else
+#define CL_ICD2_TAG_KHR ((intptr_t)0x4F50454E434C3331)
+#endif
 
 
 typedef cl_int CL_API_CALL
@@ -888,6 +906,22 @@ clIcdGetPlatformIDsKHR_t(
 typedef clIcdGetPlatformIDsKHR_t *
 clIcdGetPlatformIDsKHR_fn ;
 
+typedef void* CL_API_CALL
+clIcdGetFunctionAddressForPlatformKHR_t(
+    cl_platform_id platform,
+    const char* func_name);
+
+typedef clIcdGetFunctionAddressForPlatformKHR_t *
+clIcdGetFunctionAddressForPlatformKHR_fn ;
+
+typedef cl_int CL_API_CALL
+clIcdSetPlatformDispatchDataKHR_t(
+    cl_platform_id platform,
+    void* dispatch_data);
+
+typedef clIcdSetPlatformDispatchDataKHR_t *
+clIcdSetPlatformDispatchDataKHR_fn ;
+
 #if !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES)
 
 extern CL_API_ENTRY cl_int CL_API_CALL
@@ -895,6 +929,16 @@ clIcdGetPlatformIDsKHR(
     cl_uint num_entries,
     cl_platform_id* platforms,
     cl_uint* num_platforms) ;
+
+extern CL_API_ENTRY void* CL_API_CALL
+clIcdGetFunctionAddressForPlatformKHR(
+    cl_platform_id platform,
+    const char* func_name) ;
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clIcdSetPlatformDispatchDataKHR(
+    cl_platform_id platform,
+    void* dispatch_data) ;
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
@@ -1077,12 +1121,6 @@ clCreateCommandQueueWithPropertiesKHR(
 #define CL_DEVICE_GPU_OVERLAP_NV                            0x4004
 #define CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV                    0x4005
 #define CL_DEVICE_INTEGRATED_MEMORY_NV                      0x4006
-
-/* extension to cl_nv_device_attribute_query */
-#define CL_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT_NV           0x4007
-#define CL_DEVICE_PCI_BUS_ID_NV                             0x4008
-#define CL_DEVICE_PCI_SLOT_ID_NV                            0x4009
-#define CL_DEVICE_PCI_DOMAIN_ID_NV                          0x400A
 
 /***************************************************************
 * cl_amd_device_attribute_query
@@ -2007,6 +2045,23 @@ clGetSemaphoreHandleForTypeKHR(
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
 /***************************************************************
+* cl_khr_external_semaphore_dx_fence (beta)
+***************************************************************/
+#if defined(CL_ENABLE_BETA_EXTENSIONS)
+
+#define cl_khr_external_semaphore_dx_fence 1
+#define CL_KHR_EXTERNAL_SEMAPHORE_DX_FENCE_EXTENSION_NAME \
+    "cl_khr_external_semaphore_dx_fence"
+
+
+#define CL_KHR_EXTERNAL_SEMAPHORE_DX_FENCE_EXTENSION_VERSION CL_MAKE_VERSION(0, 9, 0)
+
+/* cl_external_semaphore_handle_type_khr */
+#define CL_SEMAPHORE_HANDLE_D3D12_FENCE_KHR                 0x2059
+
+#endif /* defined(CL_ENABLE_BETA_EXTENSIONS) */
+
+/***************************************************************
 * cl_khr_external_semaphore_opaque_fd
 ***************************************************************/
 #define cl_khr_external_semaphore_opaque_fd 1
@@ -2055,8 +2110,10 @@ clReImportSemaphoreSyncFdKHR(
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 
 /***************************************************************
-* cl_khr_external_semaphore_win32
+* cl_khr_external_semaphore_win32 (beta)
 ***************************************************************/
+#if defined(CL_ENABLE_BETA_EXTENSIONS)
+
 #define cl_khr_external_semaphore_win32 1
 #define CL_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME \
     "cl_khr_external_semaphore_win32"
@@ -2068,6 +2125,8 @@ clReImportSemaphoreSyncFdKHR(
 #define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KHR                0x2056
 #define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_KMT_KHR            0x2057
 #define CL_SEMAPHORE_HANDLE_OPAQUE_WIN32_NAME_KHR           0x2068
+
+#endif /* defined(CL_ENABLE_BETA_EXTENSIONS) */
 
 /***************************************************************
 * cl_khr_semaphore
@@ -3127,7 +3186,7 @@ typedef cl_bitfield         cl_diagnostic_verbose_level_intel;
     "cl_intel_unified_shared_memory"
 
 
-#define CL_INTEL_UNIFIED_SHARED_MEMORY_EXTENSION_VERSION CL_MAKE_VERSION(0, 0, 0)
+#define CL_INTEL_UNIFIED_SHARED_MEMORY_EXTENSION_VERSION CL_MAKE_VERSION(1, 1, 0)
 
 typedef cl_bitfield         cl_device_unified_shared_memory_capabilities_intel;
 typedef cl_properties       cl_mem_properties_intel;
@@ -3954,6 +4013,23 @@ clSetContentSizeBufferPoCL(
 #define CL_KHR_EXTENDED_BIT_OPS_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 0)
 
 /***************************************************************
+* cl_khr_external_memory_android_hardware_buffer (beta)
+***************************************************************/
+#if defined(CL_ENABLE_BETA_EXTENSIONS)
+
+#define cl_khr_external_memory_android_hardware_buffer 1
+#define CL_KHR_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME \
+    "cl_khr_external_memory_android_hardware_buffer"
+
+
+#define CL_KHR_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_VERSION CL_MAKE_VERSION(0, 9, 2)
+
+/* cl_external_memory_handle_type_khr */
+#define CL_EXTERNAL_MEMORY_HANDLE_ANDROID_HARDWARE_BUFFER_KHR 0x2070
+
+#endif /* defined(CL_ENABLE_BETA_EXTENSIONS) */
+
+/***************************************************************
 * cl_khr_global_int32_base_atomics
 ***************************************************************/
 #define cl_khr_global_int32_base_atomics 1
@@ -4001,7 +4077,7 @@ clSetContentSizeBufferPoCL(
     "cl_khr_kernel_clock"
 
 
-#define CL_KHR_KERNEL_CLOCK_EXTENSION_VERSION CL_MAKE_VERSION(0, 9, 0)
+#define CL_KHR_KERNEL_CLOCK_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 0)
 
 /* cl_device_info */
 #define CL_DEVICE_KERNEL_CLOCK_CAPABILITIES_KHR             0x1076
@@ -4253,6 +4329,37 @@ clSetKernelArgDevicePointerEXT(
 #define CL_UNORM_INT_2_101010_EXT                           0x10E5
 
 /***************************************************************
+* cl_ext_image_unsigned_10x6_12x4_14x2
+***************************************************************/
+#define cl_ext_image_unsigned_10x6_12x4_14x2 1
+#define CL_EXT_IMAGE_UNSIGNED_10X6_12X4_14X2_EXTENSION_NAME \
+    "cl_ext_image_unsigned_10x6_12x4_14x2"
+
+
+#define CL_EXT_IMAGE_UNSIGNED_10X6_12X4_14X2_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 0)
+
+/* cl_channel_type */
+#define CL_UNSIGNED_INT10X6_EXT                             0x10E6
+#define CL_UNSIGNED_INT12X4_EXT                             0x10E7
+#define CL_UNSIGNED_INT14X2_EXT                             0x10E8
+#define CL_UNORM_INT10X6_EXT                                0x10E1
+#define CL_UNORM_INT12X4_EXT                                0x10E9
+#define CL_UNORM_INT14X2_EXT                                0x10EA
+
+/***************************************************************
+* cl_ext_immutable_memory_objects
+***************************************************************/
+#define cl_ext_immutable_memory_objects 1
+#define CL_EXT_IMMUTABLE_MEMORY_OBJECTS_EXTENSION_NAME \
+    "cl_ext_immutable_memory_objects"
+
+
+#define CL_EXT_IMMUTABLE_MEMORY_OBJECTS_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 0)
+
+/* cl_mem_flags */
+#define CL_MEM_IMMUTABLE_EXT                                (1 << 6)
+
+/***************************************************************
 * cl_img_cancel_command
 ***************************************************************/
 #define cl_img_cancel_command 1
@@ -4280,6 +4387,44 @@ extern CL_API_ENTRY cl_int CL_API_CALL
 clCancelCommandsIMG(
     const cl_event* event_list,
     size_t num_events_in_list) ;
+
+#endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
+
+/***************************************************************
+* cl_qcom_perf_hint
+***************************************************************/
+#define cl_qcom_perf_hint 1
+#define CL_QCOM_PERF_HINT_EXTENSION_NAME \
+    "cl_qcom_perf_hint"
+
+
+#define CL_QCOM_PERF_HINT_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 5)
+
+typedef cl_uint             cl_perf_hint_qcom;
+
+/* cl_perf_hint_qcom */
+#define CL_PERF_HINT_HIGH_QCOM                              0x40C3
+#define CL_PERF_HINT_NORMAL_QCOM                            0x40C4
+#define CL_PERF_HINT_LOW_QCOM                               0x40C5
+
+/* cl_context_info */
+#define CL_CONTEXT_PERF_HINT_QCOM                           0x40C2
+
+
+typedef cl_int CL_API_CALL
+clSetPerfHintQCOM_t(
+    cl_context context,
+    cl_perf_hint_qcom perf_hint);
+
+typedef clSetPerfHintQCOM_t *
+clSetPerfHintQCOM_fn ;
+
+#if !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES)
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clSetPerfHintQCOM(
+    cl_context context,
+    cl_perf_hint_qcom perf_hint) ;
 
 #endif /* !defined(CL_NO_NON_ICD_DISPATCH_EXTENSION_PROTOTYPES) */
 

--- a/include/CL/cl_ext.h
+++ b/include/CL/cl_ext.h
@@ -17,6 +17,8 @@
 #ifndef OPENCL_CL_EXT_H_
 #define OPENCL_CL_EXT_H_
 
+#define CL_ENABLE_BETA_EXTENSIONS
+
 /*
 ** This header is generated from the Khronos OpenCL XML API Registry.
 */

--- a/include/CL/cl_icd.h
+++ b/include/CL/cl_icd.h
@@ -22,11 +22,18 @@
 #include <CL/cl_egl.h>
 #include <CL/cl_ext.h>
 #include <CL/cl_gl.h>
+#include <CL/cl_platform.h>
 
 #if defined(_WIN32)
 #include <CL/cl_d3d11.h>
 #include <CL/cl_d3d10.h>
 #include <CL/cl_dx9_media_sharing.h>
+#endif
+
+#if defined(_WIN32) && defined(_MSC_VER) && __CL_HAS_ANON_STRUCT__
+   /* Disable warning C4201: nonstandard extension used : nameless struct/union */
+    #pragma warning( push )
+    #pragma warning( disable : 4201 )
 #endif
 
 #ifdef __cplusplus
@@ -37,7 +44,15 @@ extern "C" {
 
 typedef struct _cl_icd_dispatch {
   /* OpenCL 1.0 */
-  clGetPlatformIDs_t *clGetPlatformIDs;
+#if __CL_HAS_ANON_STRUCT__
+  __CL_ANON_STRUCT__ union {
+#endif
+    clGetPlatformIDs_t *clGetPlatformIDs;
+#if __CL_HAS_ANON_STRUCT__
+    /* Set to CL_ICD2_TAG_KHR for cl_khr_icd 2.0.0 */
+    intptr_t clGetPlatformIDs_icd2_tag;
+  };
+#endif
   clGetPlatformInfo_t *clGetPlatformInfo;
   clGetDeviceIDs_t *clGetDeviceIDs;
   clGetDeviceInfo_t *clGetDeviceInfo;
@@ -68,7 +83,15 @@ typedef struct _cl_icd_dispatch {
   clRetainProgram_t *clRetainProgram;
   clReleaseProgram_t *clReleaseProgram;
   clBuildProgram_t *clBuildProgram;
-  clUnloadCompiler_t *clUnloadCompiler;
+#if __CL_HAS_ANON_STRUCT__
+  __CL_ANON_STRUCT__ union {
+#endif
+    clUnloadCompiler_t *clUnloadCompiler;
+#if __CL_HAS_ANON_STRUCT__
+    /* Set to CL_ICD2_TAG_KHR for cl_khr_icd 2.0.0 */
+    intptr_t clUnloadCompiler_icd2_tag;
+  };
+#endif
   clGetProgramInfo_t *clGetProgramInfo;
   clGetProgramBuildInfo_t *clGetProgramBuildInfo;
   clCreateKernel_t *clCreateKernel;
@@ -310,6 +333,10 @@ typedef struct _cl_icd_dispatch {
 
 #ifdef __cplusplus
 }
+#endif
+
+#if defined(_WIN32) && defined(_MSC_VER) && __CL_HAS_ANON_STRUCT__
+    #pragma warning( pop )
 #endif
 
 #endif /* #ifndef OPENCL_CL_ICD_H */

--- a/include/CL/opencl.h
+++ b/include/CL/opencl.h
@@ -23,7 +23,10 @@ extern "C" {
 
 #include <CL/cl.h>
 #include <CL/cl_gl.h>
+#include <CL/cl_exp_tensor.h>
+#include <CL/cl_exp_defined_builtin_kernels.h>
 #include <CL/cl_ext.h>
+#include <CL/cl_ext_pocl.h>
 
 #ifdef __cplusplus
 }

--- a/include/CL/opencl.h
+++ b/include/CL/opencl.h
@@ -23,10 +23,7 @@ extern "C" {
 
 #include <CL/cl.h>
 #include <CL/cl_gl.h>
-#include <CL/cl_exp_tensor.h>
-#include <CL/cl_exp_defined_builtin_kernels.h>
 #include <CL/cl_ext.h>
-#include <CL/cl_ext_pocl.h>
 
 #ifdef __cplusplus
 }

--- a/lib/CL/clGetPlatformIDs.c
+++ b/lib/CL/clGetPlatformIDs.c
@@ -249,14 +249,18 @@ POname(clGetPlatformIDs)(cl_uint           num_entries,
                          cl_platform_id *  platforms,
                          cl_uint *         num_platforms) CL_API_SUFFIX__VERSION_1_0
 {
-  POCL_RETURN_ERROR_COND ((platforms == NULL && num_entries > 0),
-                          CL_INVALID_VALUE);
-
+  /* CL_INVALID_VALUE if
+   *   num_entries is equal to zero and platforms is not NULL
+   *   if both num_platforms and platforms are NULL.
+   */
   POCL_RETURN_ERROR_COND ((platforms != NULL && num_entries == 0),
                           CL_INVALID_VALUE);
 
+  POCL_RETURN_ERROR_COND ((num_platforms == NULL && platforms == 0),
+                          CL_INVALID_VALUE);
+
   POCL_RETURN_ERROR_COND ((num_platforms == NULL && num_entries == 0),
-                          CL_SUCCESS);
+                              CL_SUCCESS);
 
   if (platforms != NULL) {
       platforms[0] = &_platforms[0];


### PR DESCRIPTION
This is mainly to add `cl_khr_spirv_queries` to list of recognized extensions, missing of which caused the weekly Full CTS runs to fail, but also fixes a few bugs found.