### PR TITLE
Expand matmul DBK on PoCL-L0-NPU for Llama.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1676,11 +1676,11 @@ if(NOT ENABLE_CONFORMANCE)
 
   if (HAVE_LIBXSMM OR HAVE_ONNXRT OR HAVE_LIBJPEG_TURBO OR HAVE_OPENCV)
     set(HOST_DEVICE_EXTENSIONS "${HOST_DEVICE_EXTENSIONS} \
-      cl_exp_tensor cl_exp_defined_builtin_kernels")
+      cl_exp_defined_builtin_kernels")
   endif()
   set(HOST_DEVICE_EXTENSIONS "${HOST_DEVICE_EXTENSIONS} \
 cl_khr_subgroups cl_khr_subgroup_ballot cl_khr_subgroup_shuffle \
-cl_intel_subgroups cl_intel_subgroups_short cl_intel_subgroups_char cl_intel_required_subgroup_size")
+cl_intel_subgroups cl_intel_subgroups_short cl_intel_subgroups_char cl_intel_required_subgroup_size cl_exp_tensor")
   # read-write images are still partially broken
   # program-scope variables work on OpenCL C input, but breaks with SPIR-V input (llvm-spirv bugs)
   set(HOST_DEVICE_FEATURES_30  "${HOST_DEVICE_FEATURES_30} __opencl_c_subgroups __opencl_c_read_write_images __opencl_c_program_scope_global_variables")

--- a/include/CL/cl_exp_defined_builtin_kernels.h
+++ b/include/CL/cl_exp_defined_builtin_kernels.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022-2024 Henry Linjamäki, Michal Babej / Intel Finland Oy
+ * Copyright (c) 2022-2025 Henry Linjamäki, Michal Babej / Intel Finland Oy
  *
  * PoCL-specific proof-of-concept (draft) of Defined Builtin Kernels extension.
  *
@@ -34,6 +34,8 @@
 /* Based on spec v.0.3.1
  * https://github.com/KhronosGroup/OpenCL-Docs/pull/1007
  */
+#define CL_EXP_DEFINED_BUILTIN_KERNELS_EXTENSION_VERSION                      \
+  CL_MAKE_VERSION (0, 3, 1)
 
 #include "cl_exp_tensor.h"
 

--- a/include/CL/cl_exp_tensor.h
+++ b/include/CL/cl_exp_tensor.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022-2024 Henry Linjamäki, Michal Babej / Intel Finland Oy
+ * Copyright (c) 2022-2025 Henry Linjamäki, Michal Babej / Intel Finland Oy
  *
  * PoCL-specific proof-of-concept (draft) of Defined Builtin Kernels extension.
  *
@@ -28,7 +28,6 @@
  * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
  ******************************************************************************/
 
-
 #ifndef OPENCL_EXP_TENSOR_H
 #define OPENCL_EXP_TENSOR_H
 #include <CL/cl.h>
@@ -36,6 +35,7 @@
 /* Based on spec v0.2.0
  * https://github.com/KhronosGroup/OpenCL-Docs/pull/1006
  */
+#define CL_EXP_TENSOR_EXTENSION_VERSION CL_MAKE_VERSION (0, 2, 1)
 
 /* types for describing dimensions & stride */
 typedef cl_ulong cl_tensor_shape_exp;
@@ -248,5 +248,28 @@ typedef struct _cl_tensor_layout_ml_exp
 {
   cl_tensor_layout_ml_type_exp ml_type;
 } cl_tensor_layout_ml_exp;
+
+/* A cl_buffer_create_type for clCreateSubBuffer() for which
+ * buffer_create_info structure points to cl_tensor_view_exp. This
+ * creation type allows viewing a region of the parent-buffer as a
+ * tensor of the given shape and datalayout.
+ *
+ * cl_tensor_view::tensor_desc must have a static, defined shape and
+ * data layout.
+ *
+ * Same limitations and requirements apply to this creation type as
+ * for CL_BUFFER_CREATE_TYPE_REGION (alignment requirements and
+ * behavior of concurrent accesses).
+ */
+#define CL_BUFFER_CREATE_TYPE_TENSOR_VIEW_EXP 0x12340001
+
+typedef struct _cl_tensor_view_exp
+{
+  /* In bytes. Must be at least CL_DEVICE_MEM_BASE_ADDR_ALIGN. */
+  size_t origin;
+
+  /* Tensor description. Its data layout must be well defined.  */
+  const cl_tensor_desc_exp *tensor_desc;
+} cl_tensor_view_exp;
 
 #endif /* OPENCL_EXP_TENSOR_H */

--- a/lib/CL/clReleaseMemObject.c
+++ b/lib/CL/clReleaseMemObject.c
@@ -197,6 +197,7 @@ POname(clReleaseMemObject)(cl_mem memobj) CL_API_SUFFIX__VERSION_1_0
           POCL_UNLOCK_OBJ (context);
         }
 
+      POCL_MEM_FREE (memobj->tensor_layout);
       POCL_DESTROY_OBJECT (memobj);
       POCL_MEM_FREE(memobj);
 

--- a/lib/CL/devices/common_utils.c
+++ b/lib/CL/devices/common_utils.c
@@ -1006,7 +1006,7 @@ tensor_get_blas_stride_in_elements (const cl_tensor_desc_exp *A, unsigned Dim)
     {
       const cl_tensor_layout_blas_exp *BL = A->layout;
       cl_tensor_stride_exp stride = 1;
-      for (unsigned i = 0; i < Dim; i++)
+      for (unsigned i = 0; i <= Dim; i++)
         {
           assert (A->shape[BL->leading_dims[i]]);
           stride *= A->shape[BL->leading_dims[i]];

--- a/lib/CL/devices/level0/level0-compilation.cc
+++ b/lib/CL/devices/level0/level0-compilation.cc
@@ -1340,29 +1340,60 @@ const char *dtype2elemtype(cl_tensor_datatype_exp dtype) {
   return nullptr;
 }
 
-const char *layout2str(cl_tensor_layout_ml_type_exp l) {
-  switch (l) {
-  case CL_TENSOR_LAYOUT_ML_C_EXP:
-    return "C";
-  case CL_TENSOR_LAYOUT_ML_NC_EXP:
-    return "NC";
-  case CL_TENSOR_LAYOUT_ML_CN_EXP:
-    return "CN";
-  case CL_TENSOR_LAYOUT_ML_HW_EXP:
-    return "HW";
-  case CL_TENSOR_LAYOUT_ML_WH_EXP:
-    return "WH";
-  case CL_TENSOR_LAYOUT_ML_CHW_EXP:
-    return "CHW";
-  case CL_TENSOR_LAYOUT_ML_NCHW_EXP:
-    return "NCHW";
-  case CL_TENSOR_LAYOUT_ML_NHWC_EXP:
-    return "NHWC";
+const char *layout2str(const cl_tensor_desc_exp &Tensor) {
+  switch (Tensor.layout_type) {
   default:
     return "NULL";
+  case CL_TENSOR_LAYOUT_ML_EXP: {
+    const auto *Ptr =
+        static_cast<const cl_tensor_layout_ml_exp *>(Tensor.layout);
+    switch (Ptr->ml_type) {
+    case CL_TENSOR_LAYOUT_ML_C_EXP:
+      return "C";
+    case CL_TENSOR_LAYOUT_ML_NC_EXP:
+      return "NC";
+    case CL_TENSOR_LAYOUT_ML_CN_EXP:
+      return "CN";
+    case CL_TENSOR_LAYOUT_ML_HW_EXP:
+      return "HW";
+    case CL_TENSOR_LAYOUT_ML_WH_EXP:
+      return "WH";
+    case CL_TENSOR_LAYOUT_ML_CHW_EXP:
+      return "CHW";
+    case CL_TENSOR_LAYOUT_ML_NCHW_EXP:
+      return "NCHW";
+    case CL_TENSOR_LAYOUT_ML_NHWC_EXP:
+      return "NHWC";
+    default:
+      return "NULL";
+    }
   }
-}
+  case CL_TENSOR_LAYOUT_BLAS_EXP: {
+    const auto *Ptr =
+        static_cast<const cl_tensor_layout_blas_exp *>(Tensor.layout);
+    for (unsigned I = 0; I < Tensor.rank - 1; I++) {
+      if (Ptr->leading_dims[I] != (Tensor.rank - I - 1)) {
+        return "NULL";
+      }
+    }
+    switch (Tensor.rank) {
+    default:
+      return "NULL";
+    case 1:
+      return "C";
+    case 2:
+      return "NC";
+    case 3:
+      return "CHW";
+    case 4:
+      return "NCHW";
+    }
+  }
+  }
 
+  assert(!"UNREACHABLE");
+  return "NULL";
+}
 
 /// @brief Loads a native model from disk cache, or builds an XML+BIN model,
 /// or builds a DBK template model

--- a/lib/CL/devices/level0/level0-driver.cc
+++ b/lib/CL/devices/level0/level0-driver.cc
@@ -4509,16 +4509,16 @@ void *DMABufAllocation::allocImport(Level0Device *D,
 
 bool DMABufAllocation::free(Level0Device *D) {
   if (D == ExportDev) {
-    if (BufferImportMap.empty()) {
-      D->freeUSMMem(ExportPtr);
-      ExportPtr = nullptr;
-      ExportDev = nullptr;
-      FD = -1;
-    } else {
-      POCL_MSG_PRINT_LEVEL0("Not freeing Export alloc "
-                            "because Import(s) remain\n");
-      return false; // can we release export mem while we have active imports?
-    }
+    // It's not specified whether an export allocation can be freed
+    // before its import allocations. Free it anyway and cross
+    // fingers. The reason for doing this is that the context the
+    // export allocation is bound to may be released and this has lead
+    // to segfault in the level zero driver when the export allocation
+    // gets to be free'd later on.
+    D->freeUSMMem(ExportPtr);
+    ExportPtr = nullptr;
+    ExportDev = nullptr;
+    FD = -1;
   } else {
     auto It = BufferImportMap.find(D);
     if (It == BufferImportMap.end()) {

--- a/lib/CL/devices/level0/npu_dbk.h
+++ b/lib/CL/devices/level0/npu_dbk.h
@@ -7,7 +7,7 @@ const char* dtype2precision(cl_tensor_datatype_exp dtype);
 
 const char* dtype2elemtype(cl_tensor_datatype_exp dtype);
 
-const char* layout2str(cl_tensor_layout_ml_type_exp l);
+const char *layout2str (const cl_tensor_desc_exp &tensor);
 
 bool instantiateTemplateMATMUL(const void* KernelAttrs,
                                     std::string &ModelXMLInstance,

--- a/lib/CL/devices/level0/npu_dbk_gemm.cc
+++ b/lib/CL/devices/level0/npu_dbk_gemm.cc
@@ -102,15 +102,8 @@ bool instantiateTemplateGEMM(const void *KernelAttrs,
   ReplaceMap["INPUT_ELEM_TYPE"] = dtype2elemtype(Attrs->a.dtype);
   ReplaceMap["INPUT_ELEM_TYPE"] = dtype2elemtype(Attrs->c_out.dtype);
 
-  assert(Attrs->a.layout_type == CL_TENSOR_LAYOUT_ML_EXP);
-  L = (cl_tensor_layout_ml_exp *)Attrs->a.layout;
-  ReplaceMap["INPUT_LAYOUT"] = layout2str(L->ml_type);
-  L = (cl_tensor_layout_ml_exp *)Attrs->b.layout;
-  ReplaceMap["INPUT_LAYOUT"] = layout2str(L->ml_type);
-
-  assert(Attrs->c_out.layout_type == CL_TENSOR_LAYOUT_ML_EXP);
-  L = (cl_tensor_layout_ml_exp *)Attrs->c_out.layout;
-  ReplaceMap["OUTPUT_LAYOUT"] = layout2str(L->ml_type);
+  ReplaceMap["INPUT_LAYOUT"] = layout2str(Attrs->a);
+  ReplaceMap["OUTPUT_LAYOUT"] = layout2str(Attrs->c_out);
 
   ReplaceMap["TRANSPOSE_A"] = Attrs->trans_a ? "true" : "false";
   ReplaceMap["TRANSPOSE_B"] = Attrs->trans_b ? "true" : "false";

--- a/lib/CL/devices/level0/npu_dbk_matmul.cc
+++ b/lib/CL/devices/level0/npu_dbk_matmul.cc
@@ -10,61 +10,171 @@
 #ifndef NPU_GEMM_H
 #define NPU_GEMM_H
 
-const char *MATMUL_XML_Template = R"(
+// Template for matmul(T, T) -> T.
+const char *MATMUL_T_XML_Template = R"(
 <?xml version="1.0"?>
 <net name="TensorFlow_Frontend_IR" version="11">
   <layers>
     <layer id="1" name="x1" type="Parameter" version="opset1">
-      <data shape="SHAPE_M,SHAPE_K" element_type="INPUT_ELEM_TYPE" />
+      <data shape="SHAPE_A_ROWS,SHAPE_A_COLS" element_type="OUTPUT_ELEM_TYPE" />
       <output>
-        <port id="0" precision="INPUT_PREC" names="x1">
-          <dim>SHAPE_M</dim>
-          <dim>SHAPE_K</dim>
+        <port id="0" precision="OUTPUT_PREC" names="x1">
+          <dim>SHAPE_A_ROWS</dim>
+          <dim>SHAPE_A_COLS</dim>
         </port>
       </output>
     </layer>
+
     <layer id="0" name="x2" type="Parameter" version="opset1">
-      <data shape="SHAPE_K,SHAPE_N" element_type="INPUT_ELEM_TYPE" />
+      <data shape="SHAPE_B_ROWS,SHAPE_B_COLS" element_type="OUTPUT_ELEM_TYPE" />
       <output>
-        <port id="0" precision="INPUT_PREC" names="x2">
-          <dim>SHAPE_K</dim>
-          <dim>SHAPE_N</dim>
+        <port id="0" precision="OUTPUT_PREC" names="x2">
+          <dim>SHAPE_B_ROWS</dim>
+          <dim>SHAPE_B_COLS</dim>
         </port>
       </output>
     </layer>
+
     <layer id="2" name="model/dot/MatMul" type="MatMul" version="opset1">
       <data transpose_a="TRANSPOSE_A" transpose_b="TRANSPOSE_B" />
       <input>
-        <port id="0" precision="INPUT_PREC">
-          <dim>SHAPE_M</dim>
-          <dim>SHAPE_K</dim>
+        <port id="0" precision="OUTPUT_PREC">
+          <dim>SHAPE_A_ROWS</dim>
+          <dim>SHAPE_A_COLS</dim>
         </port>
-        <port id="1" precision="INPUT_PREC">
-          <dim>SHAPE_K</dim>
-          <dim>SHAPE_N</dim>
+        <port id="1" precision="OUTPUT_PREC">
+          <dim>SHAPE_B_ROWS</dim>
+          <dim>SHAPE_B_COLS</dim>
         </port>
       </input>
       <output>
         <port id="2" precision="OUTPUT_PREC" names="dot">
-          <dim>SHAPE_M</dim>
-          <dim>SHAPE_N</dim>
+          <dim>SHAPE_C_ROWS</dim>
+          <dim>SHAPE_C_COLS</dim>
         </port>
       </output>
     </layer>
+
     <layer id="3" name="dot" type="Result" version="opset1">
       <input>
         <port id="0" precision="OUTPUT_PREC">
-          <dim>SHAPE_M</dim>
-          <dim>SHAPE_N</dim>
+          <dim>SHAPE_C_ROWS</dim>
+          <dim>SHAPE_C_COLS</dim>
         </port>
       </input>
     </layer>
   </layers>
+
   <edges>
     <edge from-layer="0" from-port="0" to-layer="2" to-port="1" />
     <edge from-layer="1" from-port="0" to-layer="2" to-port="0" />
     <edge from-layer="2" from-port="2" to-layer="3" to-port="0" />
   </edges>
+
+  <rt_info>
+    <Runtime_version value="2023.3.0-13775-ceeafaf64f3-releases/2023/3" />
+    <conversion_parameters>
+      <is_python_object value="False" />
+    </conversion_parameters>
+  </rt_info>
+</net>
+)";
+
+// Template for matmul(T, T) -> U.
+const char *MATMUL_T_U_XML_Template = R"(
+<?xml version="1.0"?>
+<net name="TensorFlow_Frontend_IR" version="11">
+  <layers>
+    <layer id="1" name="x1" type="Parameter" version="opset1">
+      <data shape="SHAPE_A_ROWS,SHAPE_A_COLS" element_type="INPUT_ELEM_TYPE" />
+      <output>
+        <port id="0" precision="INPUT_PREC" names="x1">
+          <dim>SHAPE_A_ROWS</dim>
+          <dim>SHAPE_A_COLS</dim>
+        </port>
+      </output>
+    </layer>
+
+    <layer id="0" name="x2" type="Parameter" version="opset1">
+      <data shape="SHAPE_B_ROWS,SHAPE_B_COLS" element_type="INPUT_ELEM_TYPE" />
+      <output>
+        <port id="0" precision="INPUT_PREC" names="x2">
+          <dim>SHAPE_B_ROWS</dim>
+          <dim>SHAPE_B_COLS</dim>
+        </port>
+      </output>
+    </layer>
+
+    <layer id="2" name="convert0" type="Convert" version="opset1">
+      <data destination_type="OUTPUT_ELEM_TYPE" />
+      <input>
+        <port id="0" precision="INPUT_PREC">
+          <dim>SHAPE_A_ROWS</dim>
+          <dim>SHAPE_A_COLS</dim>
+        </port>
+      </input>
+      <output>
+        <port id="1" precision="OUTPUT_PREC">
+          <dim>SHAPE_A_ROWS</dim>
+          <dim>SHAPE_A_COLS</dim>
+        </port>
+      </output>
+    </layer>
+
+    <layer id="3" name="convert1" type="Convert" version="opset1">
+      <data destination_type="OUTPUT_ELEM_TYPE" />
+      <input>
+        <port id="0" precision="INPUT_PREC">
+          <dim>SHAPE_B_ROWS</dim>
+          <dim>SHAPE_B_COLS</dim>
+        </port>
+      </input>
+      <output>
+        <port id="1" precision="OUTPUT_PREC">
+          <dim>SHAPE_B_ROWS</dim>
+          <dim>SHAPE_B_COLS</dim>
+        </port>
+      </output>
+    </layer>
+
+    <layer id="4" name="model/dot/MatMul" type="MatMul" version="opset1">
+      <data transpose_a="TRANSPOSE_A" transpose_b="TRANSPOSE_B" />
+      <input>
+        <port id="0" precision="OUTPUT_PREC">
+          <dim>SHAPE_A_ROWS</dim>
+          <dim>SHAPE_A_COLS</dim>
+        </port>
+        <port id="1" precision="OUTPUT_PREC">
+          <dim>SHAPE_B_ROWS</dim>
+          <dim>SHAPE_B_COLS</dim>
+        </port>
+      </input>
+      <output>
+        <port id="2" precision="OUTPUT_PREC" names="dot">
+          <dim>SHAPE_C_ROWS</dim>
+          <dim>SHAPE_C_COLS</dim>
+        </port>
+      </output>
+    </layer>
+
+    <layer id="5" name="dot" type="Result" version="opset1">
+      <input>
+        <port id="0" precision="OUTPUT_PREC">
+          <dim>SHAPE_C_ROWS</dim>
+          <dim>SHAPE_C_COLS</dim>
+        </port>
+      </input>
+    </layer>
+  </layers>
+
+  <edges>
+    <edge from-layer="0" from-port="0" to-layer="3" to-port="0" />
+    <edge from-layer="1" from-port="0" to-layer="2" to-port="0" />
+    <edge from-layer="2" from-port="1" to-layer="4" to-port="0" />
+    <edge from-layer="3" from-port="1" to-layer="4" to-port="1" />
+    <edge from-layer="4" from-port="2" to-layer="5" to-port="0" />
+  </edges>
+
   <rt_info>
     <Runtime_version value="2023.3.0-13775-ceeafaf64f3-releases/2023/3" />
     <conversion_parameters>
@@ -80,35 +190,44 @@ const char *MATMUL_Flags_Template =
 bool instantiateTemplateMATMUL(const void *KernelAttrs,
                                std::string &ModelXMLInstance,
                                std::string &BuildFlagsInstance) {
-  ModelXMLInstance = MATMUL_XML_Template;
+
+  auto *Attrs = (const cl_dbk_attributes_matmul_exp *)KernelAttrs;
+  ModelXMLInstance = (Attrs->a.dtype == Attrs->c.dtype)
+                         ? MATMUL_T_XML_Template
+                         : MATMUL_T_U_XML_Template;
+
   BuildFlagsInstance = MATMUL_Flags_Template;
   ReplaceMapT ReplaceMap;
   cl_tensor_layout_ml_exp *L = nullptr;
 
-  const cl_dbk_attributes_matmul_exp *Attrs =
-      (const cl_dbk_attributes_matmul_exp *)KernelAttrs;
-  ReplaceMap["SHAPE_M"] = std::to_string(Attrs->a.shape[0]);
-  ReplaceMap["SHAPE_K"] = std::to_string(Attrs->a.shape[1]);
-  assert(Attrs->a.shape[1] == Attrs->b.shape[0]);
-  ReplaceMap["SHAPE_N"] = std::to_string(Attrs->b.shape[1]);
+  // Batch dimension is not supported yet.
+  assert(Attrs->a.rank == 2 || (Attrs->a.rank == 3 && Attrs->a.shape[0] == 1));
 
-  assert(Attrs->a.layout_type == CL_TENSOR_LAYOUT_ML_EXP);
+  size_t MatDimOffset = Attrs->a.rank - 2;
+
+  ReplaceMap["SHAPE_A_ROWS"] = std::to_string(Attrs->a.shape[MatDimOffset + 0]);
+  ReplaceMap["SHAPE_A_COLS"] = std::to_string(Attrs->a.shape[MatDimOffset + 1]);
+
+  ReplaceMap["SHAPE_B_ROWS"] = std::to_string(Attrs->b.shape[MatDimOffset + 0]);
+  ReplaceMap["SHAPE_B_COLS"] = std::to_string(Attrs->b.shape[MatDimOffset + 1]);
+
+  ReplaceMap["SHAPE_C_ROWS"] = std::to_string(Attrs->c.shape[MatDimOffset + 0]);
+  ReplaceMap["SHAPE_C_COLS"] = std::to_string(Attrs->c.shape[MatDimOffset + 1]);
+
+  // TODO: Fix this assert to take account transpose settings.
+  // assert(Attrs->a.shape[1] == Attrs->b.shape[0]);
+
+  assert(Attrs->a.layout_type == CL_TENSOR_LAYOUT_ML_EXP ||
+         Attrs->a.layout_type == CL_TENSOR_LAYOUT_BLAS_EXP);
 
   ReplaceMap["INPUT_PREC"] = dtype2precision(Attrs->a.dtype);
   ReplaceMap["OUTPUT_PREC"] = dtype2precision(Attrs->c.dtype);
   ReplaceMap["INPUT_ELEM_TYPE"] = dtype2elemtype(Attrs->a.dtype);
-  ReplaceMap["INPUT_ELEM_TYPE"] = dtype2elemtype(Attrs->c.dtype);
+  ReplaceMap["OUTPUT_ELEM_TYPE"] = dtype2elemtype(Attrs->c.dtype);
 
-  assert(Attrs->a.layout_type == CL_TENSOR_LAYOUT_ML_EXP);
-  assert(Attrs->b.layout_type == CL_TENSOR_LAYOUT_ML_EXP);
-  L = (cl_tensor_layout_ml_exp *)Attrs->a.layout;
-  ReplaceMap["INPUT_LAYOUT"] = layout2str(L->ml_type);
-  L = (cl_tensor_layout_ml_exp *)Attrs->b.layout;
-  ReplaceMap["INPUT_LAYOUT"] = layout2str(L->ml_type);
-
-  assert(Attrs->c.layout_type == CL_TENSOR_LAYOUT_ML_EXP);
-  L = (cl_tensor_layout_ml_exp *)Attrs->c.layout;
-  ReplaceMap["OUTPUT_LAYOUT"] = layout2str(L->ml_type);
+  ReplaceMap["INPUT_LAYOUT"] = layout2str(Attrs->a);
+  ReplaceMap["INPUT_LAYOUT"] = layout2str(Attrs->b);
+  ReplaceMap["OUTPUT_LAYOUT"] = layout2str(Attrs->c);
 
   ReplaceMap["TRANSPOSE_A"] = Attrs->trans_a ? "true" : "false";
   ReplaceMap["TRANSPOSE_B"] = Attrs->trans_b ? "true" : "false";

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -54,7 +54,7 @@ if(HAVE_ONNXRT)
 endif()
 
 set(CXX_PROGRAMS_TO_BUILD test_device_address test_svm test_large_buf
-  test_subbuffers test_compile_n_link test_dbk_matmul)
+  test_subbuffers test_compile_n_link test_dbk_matmul test_tensor_view)
 
 add_compile_options(${OPENCL_CFLAGS} -I${CMAKE_SOURCE_DIR}/include)
 
@@ -179,6 +179,14 @@ if(HAVE_LIBXSMM)
     SKIP_RETURN_CODE 77
     DEPENDS "pocl_version_check")
 endif()
+
+add_test(NAME "runtime/test_tensor_view" COMMAND test_tensor_view)
+set_tests_properties("runtime/test_tensor_view"
+  PROPERTIES
+  COST 2.0
+  PROCESSORS 1
+  SKIP_RETURN_CODE 77
+  DEPENDS "pocl_version_check")
 
 if(HAVE_ONNXRT)
   add_test(NAME "runtime/test_dbk_onnx_inference" COMMAND "test_dbk_onnx_inference")

--- a/tests/runtime/test_tensor_view.cpp
+++ b/tests/runtime/test_tensor_view.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2025 Henry Linjamäki / Intel Finland Oy
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#define CL_HPP_TARGET_OPENCL_VERSION 300
+#define CL_HPP_ENABLE_EXCEPTIONS
+#include "CL/opencl.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <iostream>
+#include <random>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+static void test(cl::Device &Dev) {
+  auto Ctx = cl::Context(Dev);
+  size_t SubBufAlignment = Dev.getInfo<CL_DEVICE_MEM_BASE_ADDR_ALIGN>();
+
+  cl::Buffer Buffer(Ctx, 0, SubBufAlignment * 2);
+
+  cl_tensor_layout_blas_exp Layout;
+  Layout.leading_dims[0] = 1;
+  Layout.leading_dims[1] = 0;
+
+  cl_tensor_desc_exp TensorDesc;
+  TensorDesc.rank = 1;
+  TensorDesc.dtype = CL_TENSOR_DTYPE_FP32_EXP;
+  TensorDesc.properties[0] = 0;
+  TensorDesc.shape[0] = SubBufAlignment / sizeof(float);
+  TensorDesc.layout = &Layout;
+  TensorDesc.layout_type = CL_TENSOR_LAYOUT_BLAS_EXP;
+
+  {
+    cl_tensor_view_exp TensorViewConfig{SubBufAlignment, &TensorDesc};
+    auto TensorView = Buffer.createSubBuffer(
+        0, CL_BUFFER_CREATE_TYPE_TENSOR_VIEW_EXP, &TensorViewConfig);
+  }
+  std::cout << "OK!" << std::endl;
+}
+
+int main() try {
+  std::vector<cl::Platform> Platforms;
+  std::vector<cl::Device> Devices;
+  cl::Platform::get(&Platforms);
+  cl::Device Device;
+
+  for (auto P : Platforms) {
+    P.getDevices(CL_DEVICE_TYPE_ALL, &Devices);
+    if (Devices.size() == 0)
+      P.getDevices(CL_DEVICE_TYPE_CUSTOM, &Devices);
+
+    for (cl::Device &D : Devices) {
+      std::string Exts = D.getInfo<CL_DEVICE_EXTENSIONS>();
+      std::string Name = D.getInfo<CL_DEVICE_NAME>();
+      if (Exts.find("cl_exp_tensor") == std::string::npos) {
+        std::cerr << "Device " << Name
+                  << " does not support cl_exp_tensor: skip\n";
+        continue;
+      }
+
+      std::cout << "Test on device '" << Name << "'" << std::endl;
+      test(D);
+    }
+  }
+
+  return 0;
+} catch (cl::Error &err) {
+  std::cerr << "ERROR: " << err.what() << "(" << err.err() << ")" << std::endl;
+  return EXIT_FAILURE;
+}


### PR DESCRIPTION
Expand matmul DBK on PoCL-Level0-npu device by supporting `CL_TENSOR_LAYOUT_BLAS_EXP` datalayout (support is limited to row-major and alikes), supporting mixed input-output element type and adding new sub-buffer creation type for viewing regions of buffers as tensors.

Other changes:

* Fix tensor datalayouts were leaked (`cl_mem::tensor_layout`).

* Fix segfault when releasing an export allocation in level0 driver when a context, the allocation was bound to, was released.

* Enable cl_exp_tensor on host device without dependencies to external libraries such as libxssm, opencv and so on which are meant for DBKs.

* Fix off-by-one errors.

* Add `CL_EXP_{TENSOR,DEFINED_BUILTIN_KERNELS}_EXTENSION_VERSION`.
