### PR TITLE
[level0] Don't probe NPU drivers when -DENABLE_NPU=0

### DIFF
--- a/lib/CL/devices/level0/pocl-level0.cc
+++ b/lib/CL/devices/level0/pocl-level0.cc
@@ -388,15 +388,19 @@ unsigned int pocl_level0_probe(struct pocl_device_ops *Ops) {
   ze_driver_handle_t DrvHandles[64];
 
 #if ZE_API_VERSION_CURRENT_M >= ZE_MAKE_VERSION(1, 10)
+  ze_init_driver_type_flags_t DeviceTypes = ZE_INIT_DRIVER_TYPE_FLAG_GPU;
+#ifdef ENABLE_NPU
+  DeviceTypes |= ZE_INIT_DRIVER_TYPE_FLAG_NPU;
+#endif
+
   if (LoaderVersion.major == 1 && LoaderVersion.minor > 18) {
 
     ze_init_driver_type_desc_t DriverDesc{};
-    DriverDesc.flags =
-        ZE_INIT_DRIVER_TYPE_FLAG_GPU | ZE_INIT_DRIVER_TYPE_FLAG_NPU;
+    DriverDesc.flags = DeviceTypes;
     Res = zeInitDrivers(&DriverCount, DrvHandles, &DriverDesc);
     if (Res != ZE_RESULT_SUCCESS) {
       // TODO: retry with deprecated zeDriverGet()?
-      POCL_MSG_ERR("zeInitDrivers FAILED\n");
+      POCL_MSG_ERR("zeInitDrivers FAILED (error code: 0x%x)\n", Res);
       return 0;
     }
   } else {


### PR DESCRIPTION
PoCL aborts with following message on Windows machine with NPU drivers:

```
Error 7800000c from LevelZero API:
zeEventPoolCreate( Dev->getContextHandle(), &EvtPoolDesc, 1, &DevH, &EvtPoolH)
```

even when `-DENABLE_NPU=0`. Fix by disabling probing for NPU drivers when `-DENABLE_NPU=0`.

This PR aims to remove a blocker for #2038.