### PR TITLE
fix(macos): Add SDK sysroot to kernel linker flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1150,7 +1150,9 @@ if(UNIX)
     # MacOS ld outputs useless warnings like
     # ld: warning: -macosx_version_min not specificed, assuming 10.7
     # suppress them with -w.
-    set(DEFAULT_HOST_LD_FLAGS "-dynamiclib -w -nostartfiles")
+    # Use execute_process to get SDK path and add -isysroot so clang can find libSystem.tbd
+    execute_process(COMMAND xcrun --show-sdk-path OUTPUT_VARIABLE MACOS_SDK_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(DEFAULT_HOST_LD_FLAGS "-dynamiclib -w -nostartfiles -isysroot ${MACOS_SDK_PATH}")
   elseif(ANDROID)
     # TODO shouldn't Android use -nostartfiles ?
     set(DEFAULT_HOST_LD_FLAGS "-L/system/lib/ -shared -ldl -lc /system/lib/crtbegin_so.o /system/lib/crtend_so.o")


### PR DESCRIPTION
On modern macOS, libSystem is provided by the SDK as libSystem.tbd rather than being in /usr/lib. Without specifying the sysroot, clang's linker driver cannot find libSystem when linking kernel shared objects, resulting in "ld: library 'System' not found" errors.

This commit adds the `-isysroot` flag to DEFAULT_HOST_LD_FLAGS for macOS, pointing to the SDK path obtained via `xcrun --show-sdk-path`.

Fixes JIT compilation errors on macOS 15 (Sequoia) and later.

Error before fix:
  ld: library 'System' not found
  error: linker command failed with exit code 1

Tested on:
  - macOS 15.0.0 (Sequoia)
  - Apple M4 Pro (arm64)
  - Xcode 16

Fixes #2041