### PR TITLE
use `CLANG_MARCH_FLAG` for RISC-V build

### DIFF
--- a/lib/kernel/host/CMakeLists.txt
+++ b/lib/kernel/host/CMakeLists.txt
@@ -657,7 +657,7 @@ endif()
 if(X86)
   x86_distro_variant_to_flags("${VARIANT}" LLC_CPUFLAGS CLANG_CPUFLAGS)
 elseif(RISCV)
-  set(CLANG_CPUFLAGS "-mcpu=${VARIANT} -mabi=${HOST_CPU_TARGET_ABI}")
+  set(CLANG_CPUFLAGS "${CLANG_MARCH_FLAG}${VARIANT} -mabi=${HOST_CPU_TARGET_ABI}")
 
   if(LLVM_MARCH)
     set(CLANG_CPUFLAGS "${CLANG_CPUFLAGS} -march=${LLVM_MARCH}")


### PR DESCRIPTION
to fix the build failures encountered in JuliaPackaging/Yggdrasil#12219
