### PR TITLE
Fix AMDSDK3.0 testsuite build fails

### DIFF
--- a/examples/AMDSDK3.0/CMakeLists.txt
+++ b/examples/AMDSDK3.0/CMakeLists.txt
@@ -76,7 +76,7 @@ ExternalProject_Add(
   DOWNLOAD_COMMAND ""
 
   PATCH_COMMAND  ${BASH} -c "if [ ! -e ${TS_ROOT}/AMD-APP-SDK-3.0/install.sh ] $<SEMICOLON> then \
-         ${AMD_APP_SDK_TGZ} --noexec --keep --target AMD-APP-SDK-3.0 && \
+         ${AMD_APP_SDK_TGZ} --nox11 --noexec --keep --target AMD-APP-SDK-3.0 && \
          patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/amdsdk3_0.patch && \
          rm ${TS_ROOT}/AMD-APP-SDK-3.0/lib/x86_64/libOpenCL* \
          $<SEMICOLON> fi"


### PR DESCRIPTION
... while executing `AMD-APP-SDK-v3.0.130.13*-GA-linux64.sh` because it wanted to spawn a terminal by default but failed to do so because:

1) none of the terminal emulators it tried to use is installed on a (relatively) fresh Ubuntu 24.04 installation and

2) installing one (tried `konsole`) doesn't work for unknown reason - a separate terminal window gets spawned but it dies too quickly.

Fix by disabling the terminal spawn. Disabling it doesn't seem to affect the testsuite in any way.