### PR TITLE
cuda: fix pre-mangled subgroup intrinsic names

### DIFF
--- a/lib/kernel/cuda/subgroup.ll
+++ b/lib/kernel/cuda/subgroup.ll
@@ -4,7 +4,7 @@ target datalayout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64"
 target triple = "nvptx64-nvidia-cuda"
 
 ; Function Attrs: convergent mustprogress nounwind
-define void @_Z17_cl_sub_group_barrieri(i32 noundef %0) local_unnamed_addr #0 {
+define void @_Z21_cl_sub_group_barrieri(i32 noundef %0) local_unnamed_addr #0 {
   tail call void @llvm.nvvm.bar.warp.sync(i32 -1)
   %2 = and i32 %0, 1
   %3 = icmp eq i32 %2, 0
@@ -37,7 +37,7 @@ declare void @llvm.nvvm.membar.cta() #2
 declare void @llvm.nvvm.membar.gl() #2
 
 ; Function Attrs: convergent mustprogress nounwind
-define noundef i32 @_Z22_cl_get_sub_group_local_idv() local_unnamed_addr #0 {
+define noundef i32 @_Z26_cl_get_sub_group_local_idv() local_unnamed_addr #0 {
   %1 = tail call noundef i64 @_Z19get_local_linear_idv() #6
   %2 = trunc i64 %1 to i32
   %3 = and i32 %2, 31


### PR DESCRIPTION
Since the length of the function names changed in 5ce63a155d7c9fd47814880e48f8e0645345657a `llvm-cxxfilt` was extracting complete nonsense from these.

OTOH this does not seem to really have affected anything, which raises the question whether this file is even doing anything useful nowadays? `lib/kernel/subgroups.cl` already defines (much more human-readable) implementations for those functions, too.