### PR TITLE
Add debugger friendly `dumpCFG()` overloads, add `viewCFG()`

### DIFF
--- a/lib/llvmopencl/DebugHelpers.cc
+++ b/lib/llvmopencl/DebugHelpers.cc
@@ -34,6 +34,7 @@ IGNORE_COMPILER_WARNING("-Wunused-parameter")
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
+#include <llvm/Support/GraphWriter.h>
 #include <llvm/Transforms/Utils/BasicBlockUtils.h>
 
 #include "Barrier.h"
@@ -247,6 +248,20 @@ void dumpCFG(llvm::Function &F, std::string fname,
 #if 0
   std::cout << "### dumped CFG to " << fname << std::endl;
 #endif
+}
+
+void dumpCFG(llvm::Function &F, const char *Filename) {
+  dumpCFG(F, std::string(Filename));
+}
+
+void dumpCFG(llvm::Function &F) {
+  dumpCFG(F, "");
+}
+
+void viewCFG(llvm::Function &F) {
+  std::string Filename = std::string("pocl_cfg.") + F.getName().str() + ".dot";
+  dumpCFG(F, Filename);
+  llvm::DisplayGraph(Filename, /*wait=*/false, GraphProgram::DOT);
 }
 
 bool chopBBs(llvm::Function &F, llvm::Pass &) {

--- a/lib/llvmopencl/DebugHelpers.h
+++ b/lib/llvmopencl/DebugHelpers.h
@@ -42,10 +42,17 @@ class Region;
 
 namespace pocl {
   // View CFG with visual aids to debug kernel compiler problems.
-void dumpCFG(llvm::Function &F, std::string fname = "",
+void dumpCFG(llvm::Function &F, std::string Filename,
              const std::vector<llvm::Region *> *Regions = nullptr,
              const ParallelRegion::ParallelRegionVector *ParRegions = nullptr,
              const std::set<llvm::BasicBlock *> *highlights = nullptr);
+
+/// Overloads for debbuggers (the above is too complicated to be called in gdb).
+void dumpCFG(llvm::Function &F);
+void dumpCFG(llvm::Function &F, const char *Filename);
+
+/// Opens CFG graph in a viewer.
+void viewCFG(llvm::Function &F);
 
 // Split large basic blocks to smaller one so dot doesn't crash when
 // calling viewCFG on it. This should be fixed in LLVM upstream.


### PR DESCRIPTION
* Add `dumpCFG()` overloads that are more simpler to invoke in debuggers.

* Add `viewCFG()` method that opens CFG graph of a function in a viewer (chosen by `llvm::DisplayGraph()`).