### PR TITLE
Fill image info before ops->alloc_mem_obj

### DIFF
--- a/lib/CL/clCreateBuffer.c
+++ b/lib/CL/clCreateBuffer.c
@@ -35,6 +35,7 @@ pocl_create_memobject (cl_context context,
                        cl_mem_flags flags,
                        size_t size,
                        cl_mem_object_type type,
+                       const pocl_image_metadata_t *image_metadata,
                        int **device_image_support,
                        void *host_ptr,
                        int host_ptr_is_svm,
@@ -143,6 +144,8 @@ pocl_create_memobject (cl_context context,
   mem->is_pipe = (type == CL_MEM_OBJECT_PIPE);
   mem->mem_host_ptr_version = 0;
   mem->latest_version = 0;
+  if (image_metadata != NULL)
+    pocl_fill_memobj_image_metadata (mem, image_metadata);
 
   if (flags & CL_MEM_DEVICE_PRIVATE_ADDRESS_EXT)
     {
@@ -327,8 +330,9 @@ CL_API_ENTRY cl_mem CL_API_CALL POname (clCreateBuffer) (
         }
     }
 
-  mem = pocl_create_memobject (context, flags, size, CL_MEM_OBJECT_BUFFER,
-                               NULL, host_ptr, host_ptr_is_svm, &errcode);
+  mem
+    = pocl_create_memobject (context, flags, size, CL_MEM_OBJECT_BUFFER, NULL,
+                             NULL, host_ptr, host_ptr_is_svm, &errcode);
   if (mem == NULL)
     goto ERROR;
 

--- a/lib/CL/clCreatePipe.c
+++ b/lib/CL/clCreatePipe.c
@@ -76,7 +76,8 @@ CL_API_ENTRY cl_mem CL_API_CALL POname (clCreatePipe) (
     }
 
   mem = pocl_create_memobject (context, flags, pipe_max_packets,
-                               CL_MEM_OBJECT_PIPE, NULL, NULL, 0, &errcode);
+                               CL_MEM_OBJECT_PIPE, NULL, NULL, NULL, 0,
+                               &errcode);
   if (mem == NULL)
     goto ERROR;
 

--- a/lib/CL/pocl_shared.h
+++ b/lib/CL/pocl_shared.h
@@ -75,10 +75,15 @@ compile_and_link_program(int compile_program,
 int context_set_properties (cl_context context,
                             const cl_context_properties *properties);
 
+typedef struct pocl_image_metadata_s pocl_image_metadata_t;
+void pocl_fill_memobj_image_metadata (cl_mem mem,
+                                      const pocl_image_metadata_t *meta);
+
 cl_mem pocl_create_memobject (cl_context context,
                               cl_mem_flags flags,
                               size_t size,
                               cl_mem_object_type type,
+                              const pocl_image_metadata_t *image_metadata,
                               int **device_image_support,
                               void *host_ptr,
                               int host_ptr_is_svm,


### PR DESCRIPTION
Optimized texture allocations need info about the format and dimensions so it's better to have this available in the mem object already at device memory allocation time. This doesn't meaningfully change much right now, but it should noticeably simplify adding image support for targets that have specialized handling for sampling 2D images in a cache-friendly way (that is, image storage in non-linear order), such as Vulkan, CUDA and (I think) LevelZero.

One thing that this *does* meaningfully change is image allocations on the proxy driver, which had assumed that image info is filled out prior to the per-device function being called and ended up feeding uninitialized (well, zeroed by `calloc`) values to the underlying driver.