### PR TITLE
[CUDA] Thread safe queue join and wait events

### DIFF
--- a/doc/sphinx/source/cuda.rst
+++ b/doc/sphinx/source/cuda.rst
@@ -62,12 +62,6 @@ Building PoCL with CUDA support
   dump the LLVM IR that is fed into the NVPTX backend for debugging purposes
   (requires ``POCL_DEBUG=1``).
 
-  The ``POCL_CUDA_DISABLE_QUEUE_THREADS`` environment variable indicates usage
-  of background threads for handling command submission. Defaults to ``1``, set to
-  ``0`` to enable background threads.
-  Disabled threads can potentially reduce command launch latency, but can
-  cause problems if using user events or sharing a context with a non-CUDA device.
-
 CUDA backend status
 -------------------
 

--- a/doc/sphinx/source/notes_7_3.rst
+++ b/doc/sphinx/source/notes_7_3.rst
@@ -12,3 +12,5 @@ CUDA driver
 
 * Make event synchronisation (clFinish and clWaitEvents) thread safe with non
   threaded queue handling
+* Remove threaded queue handling and POCL_DISABLE_QUEUE_THREADS environment 
+  variable

--- a/doc/sphinx/source/notes_7_3.rst
+++ b/doc/sphinx/source/notes_7_3.rst
@@ -12,5 +12,5 @@ CUDA driver
 
 * Make event synchronisation (clFinish and clWaitEvents) thread safe with non
   threaded queue handling
-* Remove threaded queue handling and POCL_DISABLE_QUEUE_THREADS environment 
+* Remove threaded queue handling and POCL_CUDA_DISABLE_QUEUE_THREADS environment 
   variable

--- a/doc/sphinx/source/notes_7_3.rst
+++ b/doc/sphinx/source/notes_7_3.rst
@@ -1,0 +1,14 @@
+**************************
+Release Notes for PoCL 7.3
+**************************
+
+===========================
+Driver-specific features
+===========================
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+CUDA driver
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Make event synchronisation (clFinish and clWaitEvents) thread safe with non
+  threaded queue handling

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -625,11 +625,11 @@ pocl_cuda_init (unsigned j, cl_device_id dev, const char *parameters)
     {
       result = cuDriverGetVersion(&driver_version);
       if (CUDA_CHECK_ERROR (result, "cuDriverGetVersion"))
-	{
+        {
           ret = CL_INVALID_DEVICE;
-	}
+        }
       else
-	{
+        {
 #if CUDA_VERSION >= 11010
           if (driver_version >= 11010)
             {
@@ -857,9 +857,9 @@ pocl_cuda_init_queue (cl_device_id device, cl_command_queue queue)
   queue_data->use_threads
       = !pocl_get_bool_option ("POCL_CUDA_DISABLE_QUEUE_THREADS", 1);
 
+  PTHREAD_CHECK (pthread_mutex_init (&queue_data->lock, NULL));
   if (queue_data->use_threads)
     {
-      PTHREAD_CHECK (pthread_mutex_init (&queue_data->lock, NULL));
       PTHREAD_CHECK (pthread_cond_init (&queue_data->pending_cond, NULL));
       PTHREAD_CHECK (pthread_cond_init (&queue_data->running_cond, NULL));
       int err = pthread_create (&queue_data->submit_thread, NULL,
@@ -2406,11 +2406,11 @@ pocl_cuda_submit_node (_cl_command_node *node, cl_command_queue cq, int locked)
         {
           for (unsigned int i = 0; i < cmd->svm_free.num_svm_pointers; i++)
             {
-	      void *ptr = cmd->svm_free.svm_pointers[i];
-	      /* This updates bookkeeping associated with the 'ptr'
-		 done by the PoCL core. */
-	      POname (clSVMFree) (event->context, ptr);
-	    }
+          void *ptr = cmd->svm_free.svm_pointers[i];
+          /* This updates bookkeeping associated with the 'ptr'
+         done by the PoCL core. */
+          POname (clSVMFree) (event->context, ptr);
+        }
         }
       break;
     case CL_COMMAND_READ_IMAGE:
@@ -2598,14 +2598,24 @@ pocl_cuda_update_event (cl_device_id device, cl_event event)
     }
 }
 
+/* Waits for event and dependencies to be completed */
+/* Should be called with queue->data locked */
 void
 pocl_cuda_wait_event_recurse (cl_device_id device, cl_event event)
 {
   while (event->wait_list)
     pocl_cuda_wait_event_recurse (device, event->wait_list->event);
 
-  if (event->status > CL_COMPLETE)
-    pocl_cuda_finalize_command (device, event);
+  assert (event->status > CL_COMPLETE);
+  /* If another thread has handled submission, event data might not have been created yet */
+   while (!event->data)
+     ;
+  pocl_cuda_event_data_t *e_d = (pocl_cuda_event_data_t *)event->data;
+  while (!e_d->events_ready)
+    ;
+  assert (event->status == CL_SUBMITTED);
+  pocl_cuda_finalize_command (device, event);
+  assert (event->status == CL_COMPLETE);
 }
 
 void
@@ -2620,9 +2630,10 @@ pocl_cuda_notify_event_finished (cl_event event)
 void
 pocl_cuda_wait_event (cl_device_id device, cl_event event)
 {
+  pocl_cuda_queue_data_t *q_d = (pocl_cuda_queue_data_t *)event->queue->data;
   pocl_cuda_event_data_t *e_d = (pocl_cuda_event_data_t *)event->data;
 
-  if (((pocl_cuda_queue_data_t *)event->queue->data)->use_threads)
+  if (q_d->use_threads)
     {
       /* Wait until background thread marks command as complete */
       POCL_LOCK_OBJ (event);
@@ -2635,8 +2646,11 @@ pocl_cuda_wait_event (cl_device_id device, cl_event event)
     }
   else
     {
-      /* Recursively finalize commands in this thread */
-      pocl_cuda_wait_event_recurse (device, event);
+      PTHREAD_CHECK (pthread_mutex_lock (&q_d->lock));
+      /* Ensure this event is completed */
+      if (event->status > CL_COMPLETE)
+        pocl_cuda_wait_event_recurse (device, event);
+      PTHREAD_CHECK (pthread_mutex_unlock (&q_d->lock));
     }
 }
 
@@ -2663,20 +2677,48 @@ pocl_cuda_free_event_data (cl_event event)
 void
 pocl_cuda_join (cl_device_id device, cl_command_queue cq)
 {
-  /* Grab event at end of queue */
+  /* Grab event at end of queue as soon as possible */
   POCL_LOCK_OBJ (cq);
   cl_event event = cq->last_event.event;
+  uint64_t event_id;
+  if (event)
+    event_id = event->id;
+  POCL_UNLOCK_OBJ (cq);
   if (!event)
+    return;
+
+  /* Only one user thread at a time may wait for events (non-threaded queue) */
+  pocl_cuda_queue_data_t *queue_data = (pocl_cuda_queue_data_t *)cq->data;
+  if (!queue_data->use_threads)
+    PTHREAD_CHECK (pthread_mutex_lock (&queue_data->lock));
+
+  POCL_LOCK_OBJ (cq);
+
+  /* Check if event has already been handled */
+  cl_event wait_event;
+  for (wait_event = cq->last_event.event; wait_event; wait_event = wait_event->wait_list->event)
+    {
+      if (wait_event->id == event_id)
+        break;
+    }
+  if (!wait_event)
     {
       POCL_UNLOCK_OBJ (cq);
+      if (!queue_data->use_threads)
+        PTHREAD_CHECK (pthread_mutex_unlock (&queue_data->lock));
       return;
     }
   POname (clRetainEvent) (event);
   POCL_UNLOCK_OBJ (cq);
 
-  pocl_cuda_wait_event (device, event);
+  if (queue_data->use_threads)
+    pocl_cuda_wait_event (device, event);
+  else
+    pocl_cuda_wait_event_recurse (device, event);
 
   POname (clReleaseEvent) (event);
+  if (!queue_data->use_threads)
+    PTHREAD_CHECK (pthread_mutex_unlock (&queue_data->lock));
 }
 
 void *

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -2147,7 +2147,7 @@ pocl_cuda_submit_node (_cl_command_node *node, cl_command_queue cq, int locked)
                 = (pocl_cuda_event_data_t *)dep->event->data;
 
             /* Wait until dependency has finished being submitted */
-            while (!dep_data->events_ready)
+            while (!POCL_ATOMIC_LOAD (dep_data->events_ready))
               ;
 
             result = cuStreamWaitEvent (stream, dep_data->end, 0);
@@ -2379,7 +2379,7 @@ pocl_cuda_submit_node (_cl_command_node *node, cl_command_queue cq, int locked)
   result = cuEventRecord (event_data->end, stream);
   CUDA_CHECK_ABORT (result, "cuEventRecord");
 
-  event_data->events_ready = 1;
+  POCL_ATOMIC_STORE (event_data->events_ready, 1);
 }
 
 void
@@ -2532,12 +2532,23 @@ pocl_cuda_update_event (cl_device_id device, cl_event event)
 void
 pocl_cuda_wait_event_recurse (cl_device_id device, cl_event event)
 {
-  while (event->wait_list)
-    pocl_cuda_wait_event_recurse (device, event->wait_list->event);
+  while (1)
+    {
+      POCL_LOCK_OBJ (event);
+      /* Lock event so that wait list is not modified in pocl_create_event_sync() */
+      if (!event->wait_list)
+        { 
+          POCL_UNLOCK_OBJ (event);
+          break;
+        }
+      cl_event wait_event = event->wait_list->event;
+      POCL_UNLOCK_OBJ (event);
+      pocl_cuda_wait_event_recurse(device, wait_event);
+    }
 
   assert (event->status > CL_COMPLETE);
   /* If another thread has handled submission, event data might not have been created yet */
-  while (!POCL_ATOMIC_LOAD (event->data))
+   while (!POCL_ATOMIC_LOAD (event->data))
     ;
   pocl_cuda_event_data_t *e_d = (pocl_cuda_event_data_t *)event->data;
   while (!POCL_ATOMIC_LOAD (e_d->events_ready))
@@ -2598,6 +2609,7 @@ pocl_cuda_join (cl_device_id device, cl_command_queue cq)
   POCL_LOCK_OBJ (cq);
 
   /* Check if event has already been handled */
+  /* The command queue is locked so no need to obtain a lock on wait list events */
   cl_event wait_event;
   for (wait_event = cq->last_event.event; wait_event; wait_event = wait_event->wait_list->event)
     {

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -113,14 +113,7 @@ void pocl_cuda_svm_copy_async (CUstream, void *restrict, const void *restrict,
 typedef struct pocl_cuda_queue_data_s
 {
   CUstream stream;
-  int use_threads;
-  pthread_t submit_thread;
-  pthread_t finalize_thread;
   pthread_mutex_t lock;
-  pthread_cond_t pending_cond;
-  pthread_cond_t running_cond;
-  _cl_command_node *volatile pending_queue;
-  _cl_command_node *volatile running_queue;
   cl_command_queue queue;
 } pocl_cuda_queue_data_t;
 
@@ -150,7 +143,6 @@ typedef struct pocl_cuda_event_data_s
   CUevent end;
   volatile int events_ready;
   cl_int *ext_event_flag;
-  pthread_cond_t event_cond;
   volatile unsigned num_ext_events;
 } pocl_cuda_event_data_t;
 
@@ -178,9 +170,6 @@ typedef struct pocl_cuda_device_data_s
 } pocl_cuda_device_data_t;
 
 extern uint64_t pocl_num_devices;
-
-void *pocl_cuda_submit_thread (void *);
-void *pocl_cuda_finalize_thread (void *);
 
 static void
 pocl_cuda_abort_on_error (CUresult result, unsigned line, const char *func,
@@ -462,7 +451,7 @@ pocl_cuda_init_device_ops (struct pocl_device_ops *ops)
   ops->flush = pocl_cuda_flush;
   ops->init_build = pocl_cuda_init_build;
   // TODO
-  ops->notify_event_finished = pocl_cuda_notify_event_finished;
+  ops->notify_event_finished = NULL;
 
   ops->get_device_info_ext = pocl_cuda_get_device_info_ext;
   ops->set_kernel_exec_info_ext = pocl_cuda_set_kernel_exec_info_ext;
@@ -854,31 +843,7 @@ pocl_cuda_init_queue (cl_device_id device, cl_command_queue queue)
   if (CUDA_CHECK_ERROR (result, "cuStreamCreate"))
     return CL_OUT_OF_RESOURCES;
 
-  queue_data->use_threads
-      = !pocl_get_bool_option ("POCL_CUDA_DISABLE_QUEUE_THREADS", 1);
-
   PTHREAD_CHECK (pthread_mutex_init (&queue_data->lock, NULL));
-  if (queue_data->use_threads)
-    {
-      PTHREAD_CHECK (pthread_cond_init (&queue_data->pending_cond, NULL));
-      PTHREAD_CHECK (pthread_cond_init (&queue_data->running_cond, NULL));
-      int err = pthread_create (&queue_data->submit_thread, NULL,
-                                pocl_cuda_submit_thread, queue_data);
-      if (err)
-        {
-          POCL_MSG_ERR ("[CUDA] Error creating submit thread: %d\n", err);
-          return CL_OUT_OF_RESOURCES;
-        }
-
-      err = pthread_create (&queue_data->finalize_thread, NULL,
-                            pocl_cuda_finalize_thread, queue_data);
-      if (err)
-        {
-          POCL_MSG_ERR ("[CUDA] Error creating finalize thread: %d\n", err);
-          return CL_OUT_OF_RESOURCES;
-        }
-    }
-
   return CL_SUCCESS;
 }
 
@@ -889,21 +854,6 @@ pocl_cuda_free_queue (cl_device_id device, cl_command_queue queue)
 
   cuCtxSetCurrent (((pocl_cuda_device_data_t *)queue->device->data)->context);
   cuStreamDestroy (queue_data->stream);
-
-  assert (queue_data->pending_queue == NULL);
-  assert (queue_data->running_queue == NULL);
-
-  /* Kill queue threads */
-  if (queue_data->use_threads)
-    {
-      PTHREAD_CHECK (pthread_mutex_lock (&queue_data->lock));
-      queue_data->queue = NULL;
-      PTHREAD_CHECK (pthread_cond_signal (&queue_data->pending_cond));
-      PTHREAD_CHECK (pthread_cond_signal (&queue_data->running_cond));
-      PTHREAD_CHECK (pthread_mutex_unlock (&queue_data->lock));
-      PTHREAD_CHECK (pthread_join (queue_data->submit_thread, NULL));
-      PTHREAD_CHECK (pthread_join (queue_data->finalize_thread, NULL));
-    }
 
   POCL_MEM_FREE(queue->data);
 
@@ -2205,13 +2155,7 @@ pocl_cuda_submit_node (_cl_command_node *node, cl_command_queue cq, int locked)
           }
       }
     else
-      {
-        if (!((pocl_cuda_queue_data_t *)cq->data)->use_threads)
-          POCL_ABORT (
-              "Can't handle non-CUDA dependencies without queue threads\n");
-
-        event_data->num_ext_events++;
-      }
+      event_data->num_ext_events++;
     }
 
   /* Wait on flag for external events */
@@ -2446,24 +2390,9 @@ pocl_cuda_submit (_cl_command_node *node, cl_command_queue cq)
       = (pocl_cuda_event_data_t *)calloc (1, sizeof (pocl_cuda_event_data_t));
   node->sync.event.event->data = p;
 
-  if (((pocl_cuda_queue_data_t *)cq->data)->use_threads)
-    {
-
-      PTHREAD_CHECK (pthread_cond_init (&p->event_cond, NULL));
-      /* Add command to work queue */
-      POCL_UNLOCK_OBJ (node->sync.event.event);
-      pocl_cuda_queue_data_t *queue_data = (pocl_cuda_queue_data_t *)cq->data;
-      PTHREAD_CHECK (pthread_mutex_lock (&queue_data->lock));
-      DL_APPEND (queue_data->pending_queue, node);
-      PTHREAD_CHECK (pthread_cond_signal (&queue_data->pending_cond));
-      PTHREAD_CHECK (pthread_mutex_unlock (&queue_data->lock));
-    }
-  else
-    {
-      /* Submit command in this thread */
-      cuCtxSetCurrent (((pocl_cuda_device_data_t *)cq->device->data)->context);
-      pocl_cuda_submit_node (node, cq, 1);
-    }
+  /* Submit command in this thread */
+  cuCtxSetCurrent (((pocl_cuda_device_data_t *)cq->device->data)->context);
+  pocl_cuda_submit_node (node, cq, 1);
 }
 
 void
@@ -2608,10 +2537,10 @@ pocl_cuda_wait_event_recurse (cl_device_id device, cl_event event)
 
   assert (event->status > CL_COMPLETE);
   /* If another thread has handled submission, event data might not have been created yet */
-  while (POCL_ATOMIC_LOAD (!event->data))
+  while (!POCL_ATOMIC_LOAD (event->data))
     ;
   pocl_cuda_event_data_t *e_d = (pocl_cuda_event_data_t *)event->data;
-  while (POCL_ATOMIC_LOAD (!e_d->events_ready))
+  while (!POCL_ATOMIC_LOAD (e_d->events_ready))
     ;
   assert (event->status == CL_SUBMITTED);
   pocl_cuda_finalize_command (device, event);
@@ -2619,39 +2548,15 @@ pocl_cuda_wait_event_recurse (cl_device_id device, cl_event event)
 }
 
 void
-pocl_cuda_notify_event_finished (cl_event event)
-{
-  pocl_cuda_event_data_t *e_d = (pocl_cuda_event_data_t *)event->data;
-
-  if (((pocl_cuda_queue_data_t *)event->queue->data)->use_threads)
-    PTHREAD_CHECK (pthread_cond_broadcast (&e_d->event_cond));
-}
-
-void
 pocl_cuda_wait_event (cl_device_id device, cl_event event)
 {
   pocl_cuda_queue_data_t *q_d = (pocl_cuda_queue_data_t *)event->queue->data;
-  pocl_cuda_event_data_t *e_d = (pocl_cuda_event_data_t *)event->data;
 
-  if (q_d->use_threads)
-    {
-      /* Wait until background thread marks command as complete */
-      POCL_LOCK_OBJ (event);
-      while (event->status > CL_COMPLETE)
-        {
-          PTHREAD_CHECK (
-              pthread_cond_wait (&e_d->event_cond, &event->pocl_lock));
-        }
-      POCL_UNLOCK_OBJ (event);
-    }
-  else
-    {
-      PTHREAD_CHECK (pthread_mutex_lock (&q_d->lock));
-      /* Ensure this event is completed */
-      if (event->status > CL_COMPLETE)
-        pocl_cuda_wait_event_recurse (device, event);
-      PTHREAD_CHECK (pthread_mutex_unlock (&q_d->lock));
-    }
+  PTHREAD_CHECK (pthread_mutex_lock (&q_d->lock));
+  /* Ensure this event is completed */
+  if (event->status > CL_COMPLETE)
+	pocl_cuda_wait_event_recurse (device, event);
+  PTHREAD_CHECK (pthread_mutex_unlock (&q_d->lock));
 }
 
 void
@@ -2661,7 +2566,6 @@ pocl_cuda_free_event_data (cl_event event)
     {
       pocl_cuda_event_data_t *event_data
           = (pocl_cuda_event_data_t *)event->data;
-      PTHREAD_CHECK (pthread_cond_destroy (&event_data->event_cond));
       if (event->queue->properties & CL_QUEUE_PROFILING_ENABLE)
         cuEventDestroy (event_data->start);
       cuEventDestroy (event_data->end);
@@ -2689,8 +2593,7 @@ pocl_cuda_join (cl_device_id device, cl_command_queue cq)
 
   /* Only one user thread at a time may wait for events (non-threaded queue) */
   pocl_cuda_queue_data_t *queue_data = (pocl_cuda_queue_data_t *)cq->data;
-  if (!queue_data->use_threads)
-    PTHREAD_CHECK (pthread_mutex_lock (&queue_data->lock));
+  PTHREAD_CHECK (pthread_mutex_lock (&queue_data->lock));
 
   POCL_LOCK_OBJ (cq);
 
@@ -2704,115 +2607,16 @@ pocl_cuda_join (cl_device_id device, cl_command_queue cq)
   if (!wait_event)
     {
       POCL_UNLOCK_OBJ (cq);
-      if (!queue_data->use_threads)
-        PTHREAD_CHECK (pthread_mutex_unlock (&queue_data->lock));
+      PTHREAD_CHECK (pthread_mutex_unlock (&queue_data->lock));
       return;
     }
   POname (clRetainEvent) (event);
   POCL_UNLOCK_OBJ (cq);
 
-  if (queue_data->use_threads)
-    pocl_cuda_wait_event (device, event);
-  else
-    pocl_cuda_wait_event_recurse (device, event);
+  pocl_cuda_wait_event_recurse (device, event);
 
   POname (clReleaseEvent) (event);
-  if (!queue_data->use_threads)
-    PTHREAD_CHECK (pthread_mutex_unlock (&queue_data->lock));
-}
-
-void *
-pocl_cuda_submit_thread (void *data)
-{
-  pocl_cuda_queue_data_t *queue_data = (pocl_cuda_queue_data_t *)data;
-
-  cl_command_queue queue = queue_data->queue;
-  if (queue)
-    cuCtxSetCurrent (
-        ((pocl_cuda_device_data_t *)queue->device->data)->context);
-  else
-    /* This queue has already been released */
-    return NULL;
-
-  while (1)
-    {
-      /* Attempt to get next command from work queue */
-      _cl_command_node *node = NULL;
-      PTHREAD_CHECK (pthread_mutex_lock (&queue_data->lock));
-      if (!queue_data->queue)
-        {
-          PTHREAD_CHECK (pthread_mutex_unlock (&queue_data->lock));
-          break;
-        }
-      if (!queue_data->pending_queue)
-        {
-          PTHREAD_CHECK (pthread_cond_wait (&queue_data->pending_cond,
-                                            &queue_data->lock));
-        }
-      if (queue_data->pending_queue)
-        {
-          node = queue_data->pending_queue;
-          DL_DELETE (queue_data->pending_queue, node);
-        }
-      PTHREAD_CHECK (pthread_mutex_unlock (&queue_data->lock));
-
-      /* Submit command, if we found one */
-      if (node)
-        {
-          pocl_cuda_submit_node (node, queue_data->queue, 0);
-
-          /* Add command to running queue */
-          PTHREAD_CHECK (pthread_mutex_lock (&queue_data->lock));
-          DL_APPEND (queue_data->running_queue, node);
-          PTHREAD_CHECK (pthread_cond_signal (&queue_data->running_cond));
-          PTHREAD_CHECK (pthread_mutex_unlock (&queue_data->lock));
-        }
-    }
-
-  return NULL;
-}
-
-void *
-pocl_cuda_finalize_thread (void *data)
-{
-  pocl_cuda_queue_data_t *queue_data = (pocl_cuda_queue_data_t *)data;
-
-  cl_command_queue queue = queue_data->queue;
-  if (queue)
-    cuCtxSetCurrent (
-        ((pocl_cuda_device_data_t *)queue->device->data)->context);
-  else
-    /* This queue has already been released */
-    return NULL;
-
-  while (1)
-    {
-      /* Attempt to get next node from running queue */
-      _cl_command_node *node = NULL;
-      PTHREAD_CHECK (pthread_mutex_lock (&queue_data->lock));
-      if (!queue_data->queue)
-        {
-          PTHREAD_CHECK (pthread_mutex_unlock (&queue_data->lock));
-          break;
-        }
-      if (!queue_data->running_queue)
-        {
-          PTHREAD_CHECK (pthread_cond_wait (&queue_data->running_cond,
-                                            &queue_data->lock));
-        }
-      if (queue_data->running_queue)
-        {
-          node = queue_data->running_queue;
-          DL_DELETE (queue_data->running_queue, node);
-        }
-      PTHREAD_CHECK (pthread_mutex_unlock (&queue_data->lock));
-
-      /* Wait for command to finish, if we found one */
-      if (node)
-        pocl_cuda_finalize_command (queue->device, node->sync.event.event);
-    }
-
-  return NULL;
+  PTHREAD_CHECK (pthread_mutex_unlock (&queue_data->lock));
 }
 
 char* pocl_cuda_init_build(void *data)

--- a/lib/CL/devices/cuda/pocl-cuda.c
+++ b/lib/CL/devices/cuda/pocl-cuda.c
@@ -2608,10 +2608,10 @@ pocl_cuda_wait_event_recurse (cl_device_id device, cl_event event)
 
   assert (event->status > CL_COMPLETE);
   /* If another thread has handled submission, event data might not have been created yet */
-   while (!event->data)
-     ;
+  while (POCL_ATOMIC_LOAD (!event->data))
+    ;
   pocl_cuda_event_data_t *e_d = (pocl_cuda_event_data_t *)event->data;
-  while (!e_d->events_ready)
+  while (POCL_ATOMIC_LOAD (!e_d->events_ready))
     ;
   assert (event->status == CL_SUBMITTED);
   pocl_cuda_finalize_command (device, event);


### PR DESCRIPTION
Closing #2024

This PR makes events and queues thread safe on the CUDA driver with `POCL_CUDA_DISABLE_QUEUE_THREADS=1` (default setting). Specifically, event/queue synchronisation commands `clFinish` (which is also used by blocking commands) and `clWaitForEvents` can be called from multiple user threads. Note that this is not the case for threaded event handling (ie. `POCL_CUDA_DISABLE_QUEUE_THREADS=0`), that is still not thread safe but could be probably be fixed in a similar way.

### Problem
Previously a race conditions occurred when the user used a queue on multiple threads and performed any synchronisation. When `clFinish` was called from different threads, there was a race condition if one thread was in the process of submitting, while another completed the event. One of two errors would occur:
1. The completed thread has freed the CUDA event, so the submititng thread gets `CUDA_ERROR_INVALID_HANDLE` in `pocl_cuda_finalize_command`
2. The submitting thread fails the `event->status == SUBMITTED` assert in `pocl_update_event_running`
Similarly, this would occur when calling `clWaitForEvents`.

### Solution
The solution is to make sure only one thread calls `pocl_cuda_finalize_command` for any given thread. This is achieved by holding a lock on the queue data of the CUDA driver for the duration of `pocl_cuda_wait_event`. Any subsequent threads trying to wait for this event find it has been completed.

### Changes
- Queue data lock is also created for non threaded event handling
- A lock on queue data is obtained in `pocl_cuda_join` and calls `pocl_wait_event_recurse`
- `pocl_wait_event` also obtains a lock on the queue data, this is only called from `clWaitForEvents`
- Some whitespace fixes

### Testing
I have evaluated this on WSL Ubuntu on a GTX 1070 and RTX 4070, as well as on Ubuntu on a Jetson Orin Nano. I have tested with a small script [opencl-multithread-cpp.txt](https://github.com/user-attachments/files/24189563/opencl-multithread-cpp.txt). As mentioned this (probabalistically) fails in `main`, but is fixed in my PR. I usually run with $10000$ iters to most likely get an error. 