### PR TITLE
fix issue #2103: pow(-inf, +inf) returns -inf instead of +inf

### DIFF
--- a/lib/kernel/libclc/pow_base_fp32.cl
+++ b/lib/kernel/libclc/pow_base_fp32.cl
@@ -45,7 +45,7 @@ MATH_MANGLE(pow)(vtype x, vtype y)
 #else
 
     vtype tay = BUILTIN_TRUNC_F32(ay);
-    itype is_int = (ay == tay);
+    itype is_int = (ay == tay) && !isinf(ay);
     vtype unused;
     itype is_odd = is_int ? (fract(tay*0.5f, &unused) != vZERO_SP32) : (itype)0;
 

--- a/lib/kernel/libclc/pow_base_fp64.cl
+++ b/lib/kernel/libclc/pow_base_fp64.cl
@@ -43,7 +43,7 @@ MATH_MANGLE(pow)(vtype x, vtype y)
     itype is_odd = (nyi << 63);
 #else
     vtype tay = BUILTIN_TRUNC_F64(ay);
-    itype is_int = (ay == tay);
+    itype is_int = (ay == tay) && !isinf(ay);
     vtype unused;
     itype is_odd = is_int ? (fract(tay*0.5, &unused) != vZERO_DP64) : (itype)0;
 


### PR DESCRIPTION

Closing #2103.
This PR fixes a bug where `pow(-inf, +inf)` in libclc incorrectly returns `-inf` instead of `+inf`.

## Problem

When `y = +inf`, the `is_int` check `(ay == tay)` evaluates to true because `trunc(inf)` returns `inf`. This causes `is_odd` to be incorrectly set to true (since `fract(inf * 0.5)` returns NaN, and `NaN != 0` is true). As a result, the wrong branch is taken at lines 179-180, returning `-inf` instead of `+inf`.

## Fix

Added `!isinf(ay)` to the `is_int` condition to ensure infinity is not treated as an integer:

```c
itype is_int = (ay == tay) && !isinf(ay);
```
By this fix, pow(-inf, +inf) returns -inf as excepted.

