### PR TITLE
Fix missing LLVM rpath when building with STATIC_LLVM=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,13 @@ endif()
 
 option(STATIC_LLVM "If ON, link to static LLVM libraries. OFF (default) = link to shared LLVM libraries." ${DEFAULT_STATIC_LLVM})
 
+# When dynamically linking LLVM, add rpaths to installed binaries so they can
+# find LLVM libraries without requiring LD_LIBRARY_PATH/DYLD_LIBRARY_PATH.
+# This is especially important on macOS where DYLD_LIBRARY_PATH doesn't help
+# resolve @rpath references.
+if(NOT STATIC_LLVM)
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
+endif()
 
 if(WIN32)
   set(DEFAULT_LLVM_PLATFORM_SUPPORT ON)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -39,12 +39,28 @@ if(ENABLE_SPIRV)
   harden(spirv_fix_atomic_compare_exchange)
   target_link_libraries(spirv_fix_atomic_compare_exchange poclu ${OPENCL_LIBS})
   target_include_directories(spirv_fix_atomic_compare_exchange PRIVATE "${SPVSRC}")
+  # Installed executables need rpath to find the PoCL library.
+  # CMAKE_INSTALL_RPATH_USE_LINK_PATH handles external dependencies like LLVM,
+  # but the PoCL library is linked from the build tree, so its install
+  # location must be added explicitly.
+  if(NOT STATIC_LLVM)
+    set_target_properties(spirv_fix_atomic_compare_exchange PROPERTIES
+      INSTALL_RPATH "${POCL_INSTALL_PUBLIC_LIBDIR}")
+  endif()
 endif()
 
 if(ENABLE_POCLCC)
   add_executable(poclcc poclcc.c)
   harden(poclcc)
   target_link_libraries(poclcc poclu ${OPENCL_LIBS})
+  # Installed executables need rpath to find the PoCL library.
+  # CMAKE_INSTALL_RPATH_USE_LINK_PATH handles external dependencies like LLVM,
+  # but the PoCL library is linked from the build tree, so its install
+  # location must be added explicitly.
+  if(NOT STATIC_LLVM)
+    set_target_properties(poclcc PROPERTIES
+      INSTALL_RPATH "${POCL_INSTALL_PUBLIC_LIBDIR}")
+  endif()
 
   install(TARGETS "poclcc" RUNTIME
           DESTINATION "${POCL_INSTALL_PUBLIC_BINDIR_REL}" COMPONENT "poclcc")

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -39,12 +39,26 @@ if(ENABLE_SPIRV)
   harden(spirv_fix_atomic_compare_exchange)
   target_link_libraries(spirv_fix_atomic_compare_exchange poclu ${OPENCL_LIBS})
   target_include_directories(spirv_fix_atomic_compare_exchange PRIVATE "${SPVSRC}")
+  # On macOS, installed executables need rpath to find the PoCL library.
+  # CMAKE_INSTALL_RPATH_USE_LINK_PATH handles external dependencies like LLVM,
+  # but the PoCL library is linked from the build tree, so its install
+  # location must be added explicitly.
+  if(APPLE AND NOT STATIC_LLVM)
+    set_target_properties(spirv_fix_atomic_compare_exchange PROPERTIES
+      INSTALL_RPATH "${POCL_INSTALL_PUBLIC_LIBDIR}")
+  endif()
 endif()
 
 if(ENABLE_POCLCC)
   add_executable(poclcc poclcc.c)
   harden(poclcc)
   target_link_libraries(poclcc poclu ${OPENCL_LIBS})
+  # On macOS, installed executables need rpath to find the PoCL library.
+  # (Same rationale as spirv_fix_atomic_compare_exchange above.)
+  if(APPLE AND NOT STATIC_LLVM)
+    set_target_properties(poclcc PROPERTIES
+      INSTALL_RPATH "${POCL_INSTALL_PUBLIC_LIBDIR}")
+  endif()
 
   install(TARGETS "poclcc" RUNTIME
           DESTINATION "${POCL_INSTALL_PUBLIC_BINDIR_REL}" COMPONENT "poclcc")


### PR DESCRIPTION
## Summary

When building PoCL with dynamic LLVM linking (`STATIC_LLVM=OFF`), the resulting library depends on LLVM shared libraries (`libclang-cpp`, `libLLVM`). However, the library had no rpath entries to locate these dependencies at runtime.

This causes runtime failures unless users manually set `LD_LIBRARY_PATH` (Linux) or `DYLD_LIBRARY_PATH` (macOS) to include LLVM's lib directory.

## The Fix

Adds `INSTALL_RPATH` and `BUILD_RPATH` properties to the library target when `STATIC_LLVM=OFF`, pointing to `LLVM_LIBDIR`.

```cmake
if(NOT STATIC_LLVM AND LLVM_LIBDIR)
  set_target_properties("${POCL_LIBRARY_NAME}" PROPERTIES
    INSTALL_RPATH "${LLVM_LIBDIR}"
    BUILD_RPATH "${LLVM_LIBDIR}")
endif()
```

This is preferable to the global `-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON` workaround because:
- It only adds the rpath when actually needed (`STATIC_LLVM=OFF`)
- It targets only the LLVM dependency, not all link directories
- Users don't need to know about the workaround — it just works

## Testing

Tested on macOS (Apple Silicon) with LLVM 21 and chipStar. The built `libOpenCL.dylib` now includes the LLVM lib path in its rpath, and programs using HIP runtime compilation work without requiring manual rpath workarounds.

Fixes #2098