### PR TITLE
[Host] Implement `cl_khr_kernel_clock` extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1659,6 +1659,9 @@ endif()
 set(HOST_DEVICE_CL_VERSION_MAJOR 3)
 set(HOST_DEVICE_CL_VERSION_MINOR 0)
 
+# Probe native host CPU support for cl_khr_kernel_clock
+include(CheckHostCpuKernelClock)
+
 # Host CPU device: list of extensions that are always enabled, for both OpenCL 1.2 and 3.0
 # NOTE: update README.md when changing the list
 set(HOST_DEVICE_EXTENSIONS "cl_khr_byte_addressable_store cl_khr_global_int32_base_atomics \
@@ -1765,6 +1768,18 @@ endif()
 if(HOST_CPU_ENABLE_CL_KHR_FP64)
   set(HOST_DEVICE_EXTENSIONS "${HOST_DEVICE_EXTENSIONS} cl_khr_fp64")
   set(HOST_DEVICE_FEATURES "${HOST_DEVICE_FEATURES} __opencl_c_fp64")
+endif()
+
+if(HOST_CPU_ENABLE_CL_KHR_KERNEL_CLOCK)
+  set(HOST_DEVICE_EXTENSIONS "${HOST_DEVICE_EXTENSIONS} cl_khr_kernel_clock")
+endif()
+
+if(HOST_DEVICE_EXTENSIONS MATCHES "cl_khr_kernel_clock")
+  set(HOST_DEVICE_FEATURES "${HOST_DEVICE_FEATURES} \
+    __opencl_c_kernel_clock_scope_device \
+    __opencl_c_kernel_clock_scope_work_group \
+    __opencl_c_kernel_clock_scope_sub_group"
+  )
 endif()
 
 set(HOST_DEVICE_SPV_EXTENSIONS "+SPV_KHR_no_integer_wrap_decoration,+SPV_KHR_linkonce_odr,+SPV_KHR_expect_assume,+SPV_INTEL_fp_fast_math_mode,+SPV_INTEL_unstructured_loop_controls,+SPV_INTEL_arbitrary_precision_integers,+SPV_INTEL_memory_access_aliasing,+SPV_INTEL_inline_assembly,+SPV_KHR_integer_dot_product")

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ with a few exceptions; these are marked Unsupported in the table.
 | cl_khr_pci_bus_info | :red_circle: | :yellow_circle: :one: | | | |
 | cl_khr_depth_images | :red_circle: | :yellow_circle: :two: | | | |
 | cl_khr_integer_dot_product | :green_circle: | :yellow_circle: :one: | | | |
+| cl_khr_kernel_clock | :yellow_circle: :two: :eight: | | | | |
 | cl_khr_command_buffer | :yellow_circle: :two: | :yellow_circle: :two: | | | |
 | cl_khr_command_buffer_multi_device | :yellow_circle: :two: | | | | | |
 | cl_khr_command_buffer_mutable_dispatch | :yellow_circle: :two: | | | | |
@@ -159,6 +160,9 @@ supported by the device.
 | __opencl_c_work_group_collective_functions | :green_circle: | :green_circle:  | | | |
 | __opencl_c_integer_dot_product_input_4x8bit |  :green_circle: | :yellow_circle: :two: :one: | | | |
 | __opencl_c_integer_dot_product_input_4x8bit_packed | :green_circle: | :yellow_circle: :two: :one: | | | |
+| __opencl_c_kernel_clock_scope_device | :yellow_circle: :two: :eight: | | | | |
+| __opencl_c_kernel_clock_scope_work_group | :yellow_circle: :two: :eight: | | | | |
+| __opencl_c_kernel_clock_scope_sub_group | :yellow_circle: :two: :eight: | | | | |
 | __opencl_c_subgroups | :yellow_circle: :two: | :yellow_circle: :two: :one: | :yellow_circle: :two: | | |
 | __opencl_c_read_write_images | :yellow_circle: :two: | :yellow_circle: :one: | | | |
 | __opencl_c_program_scope_global_variables | :yellow_circle: :two: | :yellow_circle: :two: | :green_circle:  | | |
@@ -189,6 +193,7 @@ supported by the device.
    unless explicitly disabled.
 6. The `cl_khr_extended_bit_ops` is only supported with LLVM 20+.
 7. The `cl_khr_fp16` is supported on CUDA devices with Compute Capability >= 6.0 only.
+8. Kernel clock functionality is only supported on native x86 CPU builds.
 
 
 ## Supported CI environments

--- a/cmake/CheckHostCpuKernelClock.cmake
+++ b/cmake/CheckHostCpuKernelClock.cmake
@@ -1,0 +1,72 @@
+#=============================================================================
+#   CMake build system files
+#
+#   Copyright (c) 2026 pocl developers
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#   THE SOFTWARE.
+#
+#=============================================================================
+
+set(HOST_CPU_ENABLE_CL_KHR_KERNEL_CLOCK 0)
+
+# Probe native host CPU support for cl_khr_kernel_clock
+# __builtin_readcyclecounter() is only auto-enabled for native x86 host builds.
+# On other architectures the builtin may compile but still trap at runtime.
+
+if(ENABLE_LLVM AND ENABLE_HOST_CPU_DEVICES AND X86
+   AND NOT CMAKE_CROSSCOMPILING)
+  set(HOST_KERNEL_CLOCK_TEST_SRC
+      "${CMAKE_BINARY_DIR}/check_host_kernel_clock.c")
+  set(HOST_KERNEL_CLOCK_TEST_BIN
+      "${CMAKE_BINARY_DIR}/check_host_kernel_clock${CMAKE_EXECUTABLE_SUFFIX}")
+
+  file(WRITE "${HOST_KERNEL_CLOCK_TEST_SRC}" [[
+int main(void) {
+  unsigned long long t0 = __builtin_readcyclecounter();
+  for (volatile int i = 0; i < 1000; ++i) {
+  }
+  unsigned long long t1 = __builtin_readcyclecounter();
+  return (t0 > 0 && t1 > t0) ? 0 : 1;
+}
+]])
+
+  set(HOST_KERNEL_CLOCK_TEST_FLAGS "${DEFAULT_HOST_CLANG_FLAGS}")
+  separate_arguments(HOST_KERNEL_CLOCK_TEST_FLAGS)
+  list(APPEND HOST_KERNEL_CLOCK_TEST_FLAGS
+       "-o" "${HOST_KERNEL_CLOCK_TEST_BIN}")
+
+  execute_process(
+    COMMAND "${HOST_CLANG}" ${HOST_KERNEL_CLOCK_TEST_FLAGS}
+            "${HOST_KERNEL_CLOCK_TEST_SRC}"
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+    RESULT_VARIABLE HOST_KERNEL_CLOCK_TEST_COMPILE_RES)
+
+  if(HOST_KERNEL_CLOCK_TEST_COMPILE_RES EQUAL 0)
+    execute_process(
+      COMMAND "${HOST_KERNEL_CLOCK_TEST_BIN}"
+      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+      RESULT_VARIABLE HOST_KERNEL_CLOCK_TEST_RUN_RES)
+    if(HOST_KERNEL_CLOCK_TEST_RUN_RES EQUAL 0)
+      set(HOST_CPU_ENABLE_CL_KHR_KERNEL_CLOCK 1)
+    endif()
+  endif()
+endif()
+
+message(STATUS
+        "HOST_CPU_ENABLE_CL_KHR_KERNEL_CLOCK: ${HOST_CPU_ENABLE_CL_KHR_KERNEL_CLOCK}")

--- a/doc/sphinx/source/notes_7_2.rst
+++ b/doc/sphinx/source/notes_7_2.rst
@@ -54,6 +54,9 @@ CPU driver
 * Implemented new extensions: cl_khr_extended_bit_ops, cl_khr_device_uuid,
   cl_khr_suggested_local_work_size, cl_khr_integer_dot_product
 
+* Implemented experimental host CPU support for the `cl_khr_kernel_clock`
+  extension on native x86 builds (may be disabled in conformance builds).
+
 ===================================
 Deprecation/feature removal notices
 ===================================

--- a/include/_builtin_renames.h
+++ b/include/_builtin_renames.h
@@ -1158,4 +1158,11 @@
 #define dot_acc_sat_4x8packed_us_int _cl_dot_acc_sat_4x8packed_us_int
 #define dot_acc_sat_4x8packed_ss_int _cl_dot_acc_sat_4x8packed_ss_int
 
+#define clock_read_device _cl_clock_read_device
+#define clock_read_work_group _cl_clock_read_work_group
+#define clock_read_sub_group _cl_clock_read_sub_group
+#define clock_read_hilo_device _cl_clock_read_hilo_device
+#define clock_read_hilo_work_group _cl_clock_read_hilo_work_group
+#define clock_read_hilo_sub_group _cl_clock_read_hilo_sub_group
+
 #endif

--- a/include/_clang_opencl.h
+++ b/include/_clang_opencl.h
@@ -127,6 +127,25 @@ double _CL_OVERLOADABLE _CL_READNONE dot (double16 p0, double16 p1);
 
 #endif
 
+#if defined(cl_khr_kernel_clock)
+
+#if defined(__opencl_c_kernel_clock_scope_device)
+ulong _CL_OVERLOADABLE _CL_CONV clock_read_device(void);
+uint2 _CL_OVERLOADABLE _CL_CONV clock_read_hilo_device(void);
+#endif // __opencl_c_kernel_clock_scope_device
+
+#if defined(__opencl_c_kernel_clock_scope_work_group)
+ulong _CL_OVERLOADABLE _CL_CONV clock_read_work_group(void);
+uint2 _CL_OVERLOADABLE _CL_CONV clock_read_hilo_work_group(void);
+#endif // __opencl_c_kernel_clock_scope_work_group
+
+#if defined(__opencl_c_kernel_clock_scope_sub_group)
+ulong _CL_OVERLOADABLE _CL_CONV clock_read_sub_group(void);
+uint2 _CL_OVERLOADABLE _CL_CONV clock_read_hilo_sub_group(void);
+#endif // __opencl_c_kernel_clock_scope_sub_group
+
+#endif // cl_khr_kernel_clock
+
 /**************************************************************************/
 
 #if defined(cl_intel_subgroups_char)

--- a/lib/CL/clGetDeviceInfo.c
+++ b/lib/CL/clGetDeviceInfo.c
@@ -209,6 +209,10 @@ POname(clGetDeviceInfo)(cl_device_id   device,
       cl_device_integer_dot_product_acceleration_properties_khr,
       device->dot_product_accel_props_4x8bit);
 
+  case CL_DEVICE_KERNEL_CLOCK_CAPABILITIES_KHR:
+    POCL_RETURN_GETINFO (cl_device_kernel_clock_capabilities_khr,
+                         device->kernel_clock_caps);
+
   case CL_DEVICE_NAME:
     POCL_RETURN_GETINFO_STR(device->long_name);
    

--- a/lib/CL/devices/common.c
+++ b/lib/CL/devices/common.c
@@ -1915,6 +1915,7 @@ static const cl_name_version OPENCL_EXTENSIONS[]
       { CL_MAKE_VERSION (1, 0, 0), "cl_khr_create_command_queue" },
       { CL_MAKE_VERSION (1, 0, 0), "cl_khr_pci_bus_info" },
       { CL_MAKE_VERSION (1, 0, 0), "cl_khr_device_uuid" },
+      { CL_MAKE_VERSION (1, 0, 0), "cl_khr_kernel_clock" },
 
       { CL_MAKE_VERSION (0, 9, 6), "cl_khr_command_buffer" },
       { CL_MAKE_VERSION (0, 9, 1), "cl_khr_command_buffer_multi_device" },
@@ -2053,6 +2054,9 @@ static const cl_name_version OPENCL_C_FEATURES[] = {
   { CL_MAKE_VERSION (3, 0, 0), "__opencl_c_ext_fp64_local_atomic_load_store" },
   { CL_MAKE_VERSION (3, 0, 0), "__opencl_c_integer_dot_product_input_4x8bit" },
   { CL_MAKE_VERSION (3, 0, 0), "__opencl_c_integer_dot_product_input_4x8bit_packed" },
+  { CL_MAKE_VERSION (3, 0, 0), "__opencl_c_kernel_clock_scope_device" },
+  { CL_MAKE_VERSION (3, 0, 0), "__opencl_c_kernel_clock_scope_work_group" },
+  { CL_MAKE_VERSION (3, 0, 0), "__opencl_c_kernel_clock_scope_sub_group" },
 };
 
 const size_t OPENCL_C_FEATURES_NUM

--- a/lib/CL/devices/common_utils.c
+++ b/lib/CL/devices/common_utils.c
@@ -26,6 +26,7 @@
 #include <string.h>
 
 #include "CL/cl.h"
+#include "config.h"
 #include "config2.h"
 
 #include "common.h"
@@ -563,6 +564,12 @@ pocl_cpu_init_common (cl_device_id device, unsigned dev_i)
   device->cmdbuf_mutable_dispatch_capabilities
     = CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR | CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR
       | CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR;
+
+  if (strstr (HOST_DEVICE_EXTENSIONS, "cl_khr_kernel_clock") != NULL)
+    device->kernel_clock_caps = CL_DEVICE_KERNEL_CLOCK_SCOPE_DEVICE_KHR
+                                | CL_DEVICE_KERNEL_CLOCK_SCOPE_WORK_GROUP_KHR
+                                | CL_DEVICE_KERNEL_CLOCK_SCOPE_SUB_GROUP_KHR;
+
 #endif
 
   pocl_set_device_uuid (device->device_uuid, dev_i, device->ops->device_name);

--- a/lib/CL/pocl_cl.h
+++ b/lib/CL/pocl_cl.h
@@ -1135,6 +1135,7 @@ struct _cl_device_id {
     dot_product_accel_props_8bit;
   cl_device_integer_dot_product_acceleration_properties_khr
     dot_product_accel_props_4x8bit;
+  cl_device_kernel_clock_capabilities_khr kernel_clock_caps;
   cl_device_mem_cache_type global_mem_cache_type;
   cl_uint global_mem_cacheline_size;
   cl_ulong global_mem_cache_size;

--- a/lib/kernel/host/CMakeLists.txt
+++ b/lib/kernel/host/CMakeLists.txt
@@ -386,6 +386,10 @@ if(HOST_DEVICE_EXTENSIONS MATCHES "cl_khr_integer_dot_product")
   list(APPEND SOURCES_WITH_SLEEF integer_dot_product.cl)
 endif()
 
+if(HOST_DEVICE_EXTENSIONS MATCHES "cl_khr_kernel_clock")
+  list(APPEND SOURCES_WITH_SLEEF kernel_clock.cl)
+endif()
+
 include("bitcode_rules")
 
 set(SLEEF_CL_KERNEL_DEPEND_HEADERS "")

--- a/lib/kernel/kernel_clock.cl
+++ b/lib/kernel/kernel_clock.cl
@@ -1,0 +1,32 @@
+#include "templates.h"
+
+#if !defined(__has_builtin) || !__has_builtin(__builtin_readcyclecounter)
+#error "__builtin_readcyclecounter is not available on this target"
+#endif
+
+ulong _CL_OVERLOADABLE _CL_CONV _cl_clock_read_device(void) {
+  return __builtin_readcyclecounter();
+}
+
+ulong _CL_OVERLOADABLE _CL_CONV _cl_clock_read_work_group(void) {
+  return __builtin_readcyclecounter();
+}
+
+ulong _CL_OVERLOADABLE _CL_CONV _cl_clock_read_sub_group(void) {
+  return __builtin_readcyclecounter();
+}
+
+uint2 _CL_OVERLOADABLE _CL_CONV _cl_clock_read_hilo_device(void) {
+  ulong clk = __builtin_readcyclecounter();
+  return (uint2)((uint)(clk & 0xFFFFFFFF), (uint)(clk >> 32));
+}
+
+uint2 _CL_OVERLOADABLE _CL_CONV _cl_clock_read_hilo_work_group(void) {
+  ulong clk = __builtin_readcyclecounter();
+  return (uint2)((uint)(clk & 0xFFFFFFFF), (uint)(clk >> 32));
+}
+
+uint2 _CL_OVERLOADABLE _CL_CONV _cl_clock_read_hilo_sub_group(void) {
+  ulong clk = __builtin_readcyclecounter();
+  return (uint2)((uint)(clk & 0xFFFFFFFF), (uint)(clk >> 32));
+}

--- a/tests/kernel/CMakeLists.txt
+++ b/tests/kernel/CMakeLists.txt
@@ -97,6 +97,11 @@ add_test_pocl(NAME "kernel/test_short16"
 add_test_pocl(NAME "kernel/test_frexp_modf"
               COMMAND "kernel" "test_frexp_modf")
 
+if(HOST_CPU_ENABLE_CL_KHR_KERNEL_CLOCK)
+  add_test_pocl(NAME "kernel/test_kernel_clock"
+                COMMAND "kernel" "test_kernel_clock")
+endif()
+
 add_test_pocl(NAME "kernel/test_halfs"
               COMMAND "kernel" "test_halfs")
 
@@ -141,6 +146,16 @@ foreach(VARIANT ${VARIANTS})
       PROCESSORS 1
       DEPENDS "pocl_version_check")
 endforeach()
+
+if(HOST_CPU_ENABLE_CL_KHR_KERNEL_CLOCK)
+  foreach(VARIANT ${VARIANTS})
+    set_tests_properties("kernel/test_kernel_clock_${VARIANT}"
+      PROPERTIES
+        COST 4.0
+        PROCESSORS 1
+        DEPENDS "pocl_version_check")
+  endforeach()
+endif()
 
 ######################################################################
 add_executable("sampler_address_clamp" "sampler_address_clamp.c")

--- a/tests/kernel/test_kernel_clock.cl
+++ b/tests/kernel/test_kernel_clock.cl
@@ -1,0 +1,40 @@
+#define HILO_TO_ULONG(v) ((ulong)(v).x | ((ulong)(v).y << 32))
+
+kernel void test_kernel_clock() {
+    ulong dev0 = clock_read_device();
+    ulong dev1 = clock_read_device();
+    ulong wg0 = clock_read_work_group();
+    ulong wg1 = clock_read_work_group();
+    ulong sg0 = clock_read_sub_group();
+    ulong sg1 = clock_read_sub_group();
+
+    ulong dev_hilo0 = HILO_TO_ULONG(clock_read_hilo_device());
+    ulong dev_hilo1 = HILO_TO_ULONG(clock_read_hilo_device());
+    ulong wg_hilo0 = HILO_TO_ULONG(clock_read_hilo_work_group());
+    ulong wg_hilo1 = HILO_TO_ULONG(clock_read_hilo_work_group());
+    ulong sg_hilo0 = HILO_TO_ULONG(clock_read_hilo_sub_group());
+    ulong sg_hilo1 = HILO_TO_ULONG(clock_read_hilo_sub_group());
+
+    if (dev0 > dev1) {
+        printf("Device clocks: FAIL (%lu > %lu)\n", dev0, dev1);
+    }
+    if (wg0 > wg1) {
+        printf("Work-group clocks: FAIL (%lu > %lu)\n", wg0, wg1);
+    }
+    if (sg0 > sg1) {
+        printf("Sub-group clocks: FAIL (%lu > %lu)\n", sg0, sg1);
+    }
+
+    if (dev_hilo0 > dev_hilo1) {
+        printf("Device hilo clocks: FAIL (%lu > %lu)\n",
+               dev_hilo0, dev_hilo1);
+    }
+    if (wg_hilo0 > wg_hilo1) {
+        printf("Work-group hilo clocks: FAIL (%lu > %lu)\n",
+               wg_hilo0, wg_hilo1);
+    }
+    if (sg_hilo0 > sg_hilo1) {
+        printf("Sub-group hilo clocks: FAIL (%lu > %lu)\n",
+               sg_hilo0, sg_hilo1);
+    }
+}


### PR DESCRIPTION
## Description
This PR implements the `cl_khr_kernel_clock` extension for PoCL's host (CPU) devices. This extension allows OpenCL kernels to sample high-resolution hardware clocks at different scopes (device, work-group, and sub-group), which is essential for fine-grained performance analysis and profiling within kernels.

## Key Changes

### 1. OpenCL C Built-ins Implementation
- Added 6 new built-in functions in `lib/kernel/kernel_clock.cl`:
    - Standard `ulong` variants: `clock_read_device()`, `clock_read_work_group()`, `clock_read_sub_group()`.
    - HiLo `uint2` variants: `clock_read_hilo_device()`, `clock_read_hilo_work_group()`, `clock_read_hilo_sub_group()`.
- These functions leverage Clang's `__builtin_readcyclecounter()` to provide high-precision hardware clock data on CPU backends.
- Updated `include/_clang_opencl.h` and `include/_builtin_renames.h` for proper function declaration and internal renaming.

### 2. Runtime & Device Info Support
- **Mandatory Query**: Implemented `CL_DEVICE_KERNEL_CLOCK_CAPABILITIES_KHR` in `clGetDeviceInfo.c` as required by the specification.
- **Initialization**: Updated `struct _cl_device_id` in `pocl_cl.h` and initialized the capabilities in `lib/CL/devices/common_utils.c`.
- **Feature Macros**: Enabled associated OpenCL C feature macros (`__opencl_c_kernel_clock_scope_*`) in `CMakeLists.txt` for host devices.

### 3. Testing & Validation
- **New Kernel Test**: Added `tests/kernel/test_kernel_clock.cl` to verify the functionality of all new built-ins.
- **Runtime Validation**: Enhanced `tests/runtime/test_clGetDeviceInfo.c` to ensure the new device capability query is correctly handled and reports valid data.
- **CI Integration**: Updated `tests/kernel/CMakeLists.txt` to include the new test in the standard test suite.

## Specification Reference
- [Khronos OpenCL SDK: cl_khr_kernel_clock](https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/cl_khr_kernel_clock.html)

## Checklist
- [x] Implementation follows the Khronos specification.
- [x] All 6 built-in functions (including HiLo variants) are implemented.
- [x] `clGetDeviceInfo` support for `CL_DEVICE_KERNEL_CLOCK_CAPABILITIES_KHR` is added.
- [x] Added/Updated tests to verify both Kernel and Runtime changes.
