### PR TITLE
Fix null pointer & incomptatible type compile errors with  device_aux_functions

### DIFF
--- a/lib/llvmopencl/Flatten.cc
+++ b/lib/llvmopencl/Flatten.cc
@@ -70,6 +70,8 @@ static bool flattenAll(Module &M) {
       AuxFuncs.insert(token);
       DevAuxFunctionsList.erase(0, pos + 1);
     }
+    if (!DevAuxFunctionsList.empty())
+      AuxFuncs.insert(DevAuxFunctionsList);
   }
 
   for (llvm::Module::iterator i = M.begin(), e = M.end(); i != e; ++i) {

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -1563,7 +1563,7 @@ LLVMValueRef WorkgroupImpl::createAllocaMemcpyForStruct(
     args[1] = CARG1;
     args[2] = Size;
 
-    LLVMTypeRef FnTy = LLVMGetCalledFunctionType(MemCpy4);
+    LLVMTypeRef FnTy = LLVMGlobalGetValueType(MemCpy4);
     LLVMBuildCall2(Builder, FnTy, MemCpy4, args, 3, "");
   } else {
     LLVMTypeRef i8PtrAS0 = LLVMPointerType(Int8Type, 0);
@@ -1578,7 +1578,7 @@ LLVMValueRef WorkgroupImpl::createAllocaMemcpyForStruct(
     args[1] = CARG1;
     args[2] = Size;
 
-    LLVMTypeRef FnTy = LLVMGetCalledFunctionType(MemCpy1);
+    LLVMTypeRef FnTy = LLVMGlobalGetValueType(MemCpy1);
     LLVMBuildCall2(Builder, FnTy, MemCpy1, args, 3, "");
   }
 


### PR DESCRIPTION
Hi, i came across two compile errors regarding `Device->device_aux_functions` on tta/almaif drivers. 

Firstly, [pocl_llvm_wg.cc:870](https://github.com/pocl/pocl/blob/main/lib/CL/pocl_llvm_wg.cc#L870) doesn't append a `;` to the end of the final function, and because of that, a parser at [Flatten.cc:65](https://github.com/pocl/pocl/blob/main/lib/llvmopencl/Flatten.cc#L65) fails to add it to the AuxFuncs-list. I'm not sure which place is correct to fix, i just fixed the parsing.

Secondly, [Workgroup.cc:1566](https://github.com/pocl/pocl/blob/main/lib/llvmopencl/Workgroup.cc#L1566)'s `LLVMGetCalledFunctionType(MemCpy4);` would crash to an incompatible type error, changing the call to `LLVMGlobalGetValueType()` fixed it.

After these changes my program compiles and runs correctly.



First crash:
```
heartwall.out: /home/eetu/projects/temp/tcemc-merge/openasip/llvm-build-Release/release_21/llvm/include/llvm/Support/Casting.h:109: static bool llvm::isa_impl_cl<To, const From*>::doit(const From*) [with To = llvm::CallBase; From = llvm::Value]: Assertion `Val && "isa<> used on a null pointer"' failed.


bt:
#9  0x00007fb71b03b517 in __assert_fail
    (assertion=0x7fb713be0100 "Val && \"isa<> used on a null pointer\"", file=0x7fb713bcebb0 "/home/eetu/projects/temp/tcemc-merge/openasip/llvm-build-Release/release_21/llvm/include/llvm/Support/Casting.h", line=109, function=0x7fb713c35cd0 "static bool llvm::isa_impl_cl<To, const From*>::doit(const From*) [with To = llvm::CallBase; From = llvm::Value]") at ./assert/assert.c:105
#10 0x00007fb7102b459c in LLVMGetCalledFunctionType () at /home/eetu/tce_local/lib/libLLVMTCE.so.21.1
#11 0x00007fb71adfe066 in pocl::WorkgroupImpl::createAllocaMemcpyForStruct (this=0x7ffd7388da40, M=0x5bd422994ac0, Builder=0x5bd4229815a0, Arg=..., ArgByteOffset=0x5bd422981680) at /home/eetu/projects/pocl/lib/llvmopencl/Workgroup.cc:1566
#12 0x00007fb71adfe329 in pocl::WorkgroupImpl::createArgBufferLoad (this=0x7ffd7388da40, Builder=0x5bd4229815a0, ArgBufferPtr=0x5bd423c32bf0, ArgBufferOffsets=0x5bd423c164b0, Ctx=0x5bd4228d8bc0, F=0x5bd422af7458, ParamIndex=0, Name="kernel_arg_0")
    at /home/eetu/projects/pocl/lib/llvmopencl/Workgroup.cc:1629
#13 0x00007fb71adfeb56 in pocl::WorkgroupImpl::createArgBufferWorkgroupLauncher (this=0x7ffd7388da40, Func=0x5bd422af7458, KernName="kernel_gpu_opencl") at /home/eetu/projects/pocl/lib/llvmopencl/Workgroup.cc:1743
```

Second crash:
```
heartwall.out: /home/eetu/projects/temp/tcemc-merge/openasip/llvm-build-Release/release_21/llvm/include/llvm/Support/Casting.h:578: decltype(auto) llvm::cast(From*) [with To = CallBase; From = Value]: Assertion `isa<To>(Val) && "cast<Ty>() argument of incompatible type!"' failed.


bt:
#9  0x000070fccf83b517 in __assert_fail
    (assertion=0x70fcc83e01a0 "isa<To>(Val) && \"cast<Ty>() argument of incompatible type!\"", file=0x70fcc83cebb0 "/home/eetu/projects/temp/tcemc-merge/openasip/llvm-build-Release/release_21/llvm/include/llvm/Support/Casting.h", line=578, function=0x70fcc8435d48 "decltype(auto) llvm::cast(From*) [with To = CallBase; From = Value]") at ./assert/assert.c:105
#10 0x000070fcc4ab4551 in LLVMGetCalledFunctionType () at /home/eetu/tce_local/lib/libLLVMTCE.so.21.1
#11 0x000070fccf5fe090 in pocl::WorkgroupImpl::createAllocaMemcpyForStruct (this=0x7fff559449c0, M=0x61e4f7194120, Builder=0x61e4f72ea1c0, Arg=..., ArgByteOffset=0x61e4f72ea2a0) at /home/eetu/projects/pocl/lib/llvmopencl/Workgroup.cc:1566
#12 0x000070fccf5fe353 in pocl::WorkgroupImpl::createArgBufferLoad (this=0x7fff559449c0, Builder=0x61e4f72ea1c0, ArgBufferPtr=0x61e4f83e7090, ArgBufferOffsets=0x61e4f7804b10, Ctx=0x61e4f70cebc0, F=0x61e4f71976d8, ParamIndex=0, Name="kernel_arg_0")
    at /home/eetu/projects/pocl/lib/llvmopencl/Workgroup.cc:1629
#13 0x000070fccf5feb80 in pocl::WorkgroupImpl::createArgBufferWorkgroupLauncher (this=0x7fff559449c0, Func=0x61e4f71976d8, KernName="kernel_gpu_opencl") at /home/eetu/projects/pocl/lib/llvmopencl/Workgroup.cc:1743
```
