### PR TITLE
Enhance macOS setup instructions for dual OpenCL devices

### DIFF
--- a/doc/sphinx/source/macos.rst
+++ b/doc/sphinx/source/macos.rst
@@ -43,12 +43,15 @@ homebrew and can be installed with::
     brew install pocl
 
 Note that this installs an ICD loader from KhronoGroup and the built-in OpenCL
-implementation will be invisible when your application is linked to this loader. To make it visible and having both GPU icd from Apple and CPU icd from PoCL, aka, dual devices. The steps are as follows (take Apple Silicon device as examples). Run these commands in a terminal::
+implementation will be invisible when your application is linked to this loader. 
+
+To make both the Apple GPU ICD and the PoCL CPU ICD visible—i.e., to enable dual devices—follow these steps (using an Apple Silicon device as an example). Run the following commands in a terminal::
 
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     xcode-select --install
     brew install autoconf automake libtool git
     brew install ocl-icd pocl
+
 After installing `ocl-icd`, create a symbolic link so that `/opt/homebrew/lib/libOpenCL.dylib` exists (needed for linking)::
 
     # Find the actual library version (e.g., 2.3.5)
@@ -98,12 +101,12 @@ Expected output::
     Platform #1: Portable Computing Language
      `-- Device #0: cpu
 
-Set Environment Variables (Required for Every Session): Add the following lines to your `~/.zshrc` (or `~/.bash_profile`) to make them permanent:
+Set Environment Variables (Required for Every Session): Add the following lines to your `~/.zshrc` (or `~/.bash_profile`) to make them permanent::
 
     export DYLD_LIBRARY_PATH=/opt/homebrew/lib
     export OCL_ICD_VENDORS=/opt/homebrew/etc/OpenCL/vendors
 
-Then apply:
+Then apply::
 
     source ~/.zshrc
 
@@ -119,19 +122,17 @@ Temporary fix (for one terminal session)::
 
     export CC=/usr/bin/clang
     export CXX=/usr/bin/clang++
-    export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
-    export LDFLAGS="-L$SDKROOT/usr/lib -lSystem"
-    export CPATH="$SDKROOT/usr/include"
-    export LIBRARY_PATH="$SDKROOT/usr/lib"
+    export LDFLAGS="-L/usr/lib -lSystem"
+    export CPATH="/usr/include"
+    export LIBRARY_PATH="/usr/lib"
 
 Permanent fix (add to `~/.zshrc`)::
 
     echo 'export CC=/usr/bin/clang' >> ~/.zshrc
     echo 'export CXX=/usr/bin/clang++' >> ~/.zshrc
-    echo 'export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)' >> ~/.zshrc
-    echo 'export LDFLAGS="-L$SDKROOT/usr/lib -lSystem"' >> ~/.zshrc
-    echo 'export CPATH="$SDKROOT/usr/include"' >> ~/.zshrc
-    echo 'export LIBRARY_PATH="$SDKROOT/usr/lib"' >> ~/.zshrc
+    echo 'export LDFLAGS="-L/usr/lib -lSystem"' >> ~/.zshrc
+    echo 'export CPATH="/usr/include"' >> ~/.zshrc
+    echo 'export LIBRARY_PATH="/usr/lib"' >> ~/.zshrc
     source ~/.zshrc
 
 After applying these environment variables, you can reinstall PoCL from source (if needed) or any other software that requires system libraries::

--- a/doc/sphinx/source/macos.rst
+++ b/doc/sphinx/source/macos.rst
@@ -43,7 +43,122 @@ homebrew and can be installed with::
     brew install pocl
 
 Note that this installs an ICD loader from KhronoGroup and the built-in OpenCL
-implementation will be invisible when your application is linked to this loader.
+implementation will be invisible when your application is linked to this loader. To make it visible and having both GPU icd from Apple and CPU icd from PoCL, aka, dual devices. The steps are as follows (take Apple Silicon device as examples). Run these commands in a terminal::
+
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    xcode-select --install
+    brew install autoconf automake libtool git
+    brew install ocl-icd pocl
+After installing `ocl-icd`, create a symbolic link so that `/opt/homebrew/lib/libOpenCL.dylib` exists (needed for linking)::
+
+    # Find the actual library version (e.g., 2.3.5)
+    ls /opt/homebrew/Cellar/ocl-icd/*/lib/libOpenCL*.dylib
+    # Create the symlink (adjust the version number if necessary)
+    sudo ln -sf /opt/homebrew/Cellar/ocl-icd/2.3.5/lib/libOpenCL.1.dylib /opt/homebrew/lib/libOpenCL.dylib
+
+Build and Install the Apple Wrapper::
+
+    git clone https://github.com/octaveoclx/ocl_icd_wrapper.git
+    cd ocl_icd_wrapper
+    autoreconf -ivf
+    ./configure
+    make LDFLAGS+="-framework OpenCL"
+
+If `/usr/local/lib` does not exist, create it::
+
+    sudo mkdir -p /usr/local/lib
+    sudo chmod 755 /usr/local/lib
+
+Then copy the wrapper libraries::
+
+    sudo cp .libs/libocl_icd_wrapper.0.dylib /usr/local/lib/
+    sudo cp .libs/libocl_icd_wrapper.dylib /usr/local/lib/
+
+Configure ICD Vendor Files (Critical Step), where the ICD loader (`ocl-icd`) searches `/opt/homebrew/etc/OpenCL/vendors/` by default (not `/etc/OpenCL/vendors/`)::
+
+    sudo mkdir -p /opt/homebrew/etc/OpenCL/vendors
+    echo "/usr/local/lib/libocl_icd_wrapper.dylib" | sudo tee /opt/homebrew/etc/OpenCL/vendors/apple.icd
+    echo "/opt/homebrew/lib/libpocl.2.dylib" | sudo tee /opt/homebrew/etc/OpenCL/vendors/pocl.icd
+    sudo chmod 644 /opt/homebrew/etc/OpenCL/vendors/*.icd
+
+Recompile `clinfo` to an ICD‑aware Version (Optional but Recommended): Clone the `clinfo` repository and compile it to link against the ICD loader::
+
+    git clone https://github.com/Oblomov/clinfo.git
+    cd clinfo
+    clang -I/opt/homebrew/include -o clinfo src/clinfo.c /opt/homebrew/lib/libOpenCL.dylib
+
+Now test that both platforms are visible::
+
+    ./clinfo -l
+
+Expected output::
+
+    Platform #0: Apple
+     `-- Device #0: Apple M2 Max
+    Platform #1: Portable Computing Language
+     `-- Device #0: cpu
+
+Set Environment Variables (Required for Every Session): Add the following lines to your `~/.zshrc` (or `~/.bash_profile`) to make them permanent:
+
+    export DYLD_LIBRARY_PATH=/opt/homebrew/lib
+    export OCL_ICD_VENDORS=/opt/homebrew/etc/OpenCL/vendors
+
+Then apply:
+
+    source ~/.zshrc
+
+Now any OpenCL program that links against `libOpenCL.dylib` will see both the Apple GPU and the PoCL CPU.
+
+Fix `ld: library 'System' not found` When Using Homebrew GCC: If you have previously used Homebrew’s `gcc` and `g++` (e.g., `gcc@11`), you may encounter the linker error::
+
+    ld: library 'System' not found
+
+This happens because Homebrew’s GCC cannot find the macOS system libraries by default. To solve it, **force the use of Apple’s Clang** and explicitly set the SDK path. This is especially important when compiling PoCL from source or any other OpenCL project that uses `-lOpenCL`.
+
+Temporary fix (for one terminal session)::
+
+    export CC=/usr/bin/clang
+    export CXX=/usr/bin/clang++
+    export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+    export LDFLAGS="-L$SDKROOT/usr/lib -lSystem"
+    export CPATH="$SDKROOT/usr/include"
+    export LIBRARY_PATH="$SDKROOT/usr/lib"
+
+Permanent fix (add to `~/.zshrc`)::
+
+    echo 'export CC=/usr/bin/clang' >> ~/.zshrc
+    echo 'export CXX=/usr/bin/clang++' >> ~/.zshrc
+    echo 'export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)' >> ~/.zshrc
+    echo 'export LDFLAGS="-L$SDKROOT/usr/lib -lSystem"' >> ~/.zshrc
+    echo 'export CPATH="$SDKROOT/usr/include"' >> ~/.zshrc
+    echo 'export LIBRARY_PATH="$SDKROOT/usr/lib"' >> ~/.zshrc
+    source ~/.zshrc
+
+After applying these environment variables, you can reinstall PoCL from source (if needed) or any other software that requires system libraries::
+
+    brew reinstall --build-from-source pocl
+
+All regular `brew install`, `brew reinstall`, and other commands will automatically inherit these settings.
+
+Verify the Dual‑Device Setup in your own OpenCL program (Optional): If you intend to compile your own OpenCL program, make sure to link against the ICD loader by using::
+
+    -L/opt/homebrew/lib -lOpenCL
+
+and **remove** any occurrence of `-framework OpenCL` from your build flags.
+
+For example, a minimal compilation command for a source file `my_program.c` would be::
+
+    clang -I/opt/homebrew/include -L/opt/homebrew/lib -lOpenCL my_program.c -o my_program
+
+Then run the program with the required environment variables::
+
+    export DYLD_LIBRARY_PATH=/opt/homebrew/lib
+    export OCL_ICD_VENDORS=/opt/homebrew/etc/OpenCL/vendors
+    ./my_program
+
+Your program should detect both the Apple GPU and the PoCL CPU as separate OpenCL platforms/devices.
+
+If you are using a build system (Makefile, CMake, etc.), ensure that `-L/opt/homebrew/lib -lOpenCL` is used instead of `-framework OpenCL`.
 
 **Conda**
 


### PR DESCRIPTION
Added detailed instructions for setting up dual OpenCL devices on macOS, including installation steps for PoCL, creating symbolic links, and configuring environment variables.

Please do polish the language.

To make it visible and enable both the Apple GPU ICD and the PoCL CPU ICD (i.e., dual devices), follow the steps below (using Apple Silicon as an example). Run these commands in a terminal: