### PR TITLE
`clSetKernelExecInfo`: fix out-of-bounds read of the USM indirect pointer list.

### DIFF
--- a/doc/sphinx/source/notes_7_2.rst
+++ b/doc/sphinx/source/notes_7_2.rst
@@ -22,6 +22,10 @@ Notable bugfixes
   (some corner-cases in clSetKernelArg, clSetKernelExecInfo, clCreateContext,
    clCreateContextFromType, clGetDeviceIDs, clSetKernelArgSVMPointer,
    clEnqueueNDRange with local_size == NULL and nonzero reqq-wg-size)
+* Fixed an out-of-bounds read in `clSetKernelExecInfo` when registering
+  indirect USM pointers (`CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL`): the size of
+  the pointer list was passed on in bytes where a pointer count was expected,
+  causing the runtime to read past the end of the user-provided list.
 * `clGetKernelArgInfo(CL_KERNEL_ARG_NAME)` now returns the source
   argument names for SPIR/SPIR-V binaries on the CPU driver (previously
   returned `CL_KERNEL_ARG_INFO_NOT_AVAILABLE` even when the binary

--- a/lib/CL/clSetKernelExecInfo.c
+++ b/lib/CL/clSetKernelExecInfo.c
@@ -105,7 +105,7 @@ POname(clSetKernelExecInfo)(cl_kernel kernel,
         if (param_name == CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL
             && ret_val == CL_SUCCESS)
           pocl_reset_indirect_ptrs (kernel, (void **)param_value,
-                                    param_value_size);
+                                    param_value_size / sizeof (void *));
         return ret_val;
       }
 

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -31,6 +31,7 @@ set(C_PROGRAMS_TO_BUILD test_assign_loop_variable_to_privvar_makes_it_local
      test_issue_1711 test_issue_1794 test_issue_1747
      test_rematerialized_alloca_load_with_outside_pr_users
      test_peeled_wi_global_id
+     test_usm_indirect_ptrs
 )
 foreach(PROG ${C_PROGRAMS_TO_BUILD})
   add_executable("${PROG}" "${PROG}.c")
@@ -148,6 +149,8 @@ add_test_pocl(NAME "regression/test_issue_1794b" COMMAND "test_issue_1794" "0" "
 add_test_pocl(NAME "regression/test_issue_1747" COMMAND "test_issue_1747" "0" "${CMAKE_CURRENT_SOURCE_DIR}/test_issue_1747.spv" LABELS ${SPIRV_LABELS})
 
 add_test_pocl(NAME "regression/peeled_wi_global_id" WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_peeled_wi_global_id" LABELS ${SPIRV_LABELS})
+
+add_test_pocl(NAME "regression/test_usm_indirect_ptrs" COMMAND "test_usm_indirect_ptrs")
 
 add_test_pocl(NAME "regression/test_issue_893" COMMAND "test_issue_893")
 

--- a/tests/regression/test_usm_indirect_ptrs.c
+++ b/tests/regression/test_usm_indirect_ptrs.c
@@ -1,0 +1,113 @@
+/* Regression test for the clSetKernelExecInfo(CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL)
+   out-of-bounds read (reported downstream as JuliaGPU/OpenCL.jl#317).
+
+   clSetKernelExecInfo passed the parameter's *byte size* to pocl_reset_indirect_ptrs(),
+   which expects an *element count*, so it read 8x past the caller's pointer array. With a
+   large indirect-USM-pointer list the over-read runs off the mapping and segfaults; with a
+   small one it merely reads uninitialized memory. This test passes a large list and simply
+   checks that the call returns without crashing.
+
+   Copyright (c) 2026 Tim Besard
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#include "pocl_opencl.h"
+
+#include <CL/cl_ext.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CHECK_ERROR(err)                                                      \
+  if (err != CL_SUCCESS)                                                      \
+    {                                                                         \
+      printf ("OpenCL error %d at %s:%d\n", err, __FILE__, __LINE__);         \
+      return EXIT_FAILURE;                                                    \
+    }
+
+static const char *kernel_source = "__kernel void foo (void) { }";
+
+int
+main (void)
+{
+  cl_context context;
+  cl_device_id device;
+  cl_command_queue queue;
+  cl_platform_id platform;
+
+  cl_int err = poclu_get_any_device2 (&context, &device, &queue, &platform);
+  CHECK_ERROR (err);
+
+  /* Requires the USM extension. */
+  char exts[4096] = { 0 };
+  clGetDeviceInfo (device, CL_DEVICE_EXTENSIONS, sizeof (exts), exts, NULL);
+  if (strstr (exts, "cl_intel_unified_shared_memory") == NULL)
+    {
+      printf ("SKIP: device does not support cl_intel_unified_shared_memory\n");
+      return 77;
+    }
+
+  void *(*clDeviceMemAllocINTEL) (cl_context, cl_device_id,
+                                  const cl_mem_properties_intel *, size_t,
+                                  cl_uint, cl_int *)
+    = clGetExtensionFunctionAddressForPlatform (platform,
+                                                "clDeviceMemAllocINTEL");
+  cl_int (*clMemFreeINTEL) (cl_context, void *)
+    = clGetExtensionFunctionAddressForPlatform (platform, "clMemFreeINTEL");
+  if (clDeviceMemAllocINTEL == NULL || clMemFreeINTEL == NULL)
+    {
+      printf ("SKIP: USM allocation entry points not found\n");
+      return 77;
+    }
+
+  cl_program program
+    = clCreateProgramWithSource (context, 1, &kernel_source, NULL, &err);
+  CHECK_ERROR (err);
+  err = clBuildProgram (program, 1, &device, NULL, NULL, NULL);
+  CHECK_ERROR (err);
+  cl_kernel kernel = clCreateKernel (program, "foo", &err);
+  CHECK_ERROR (err);
+
+  void *usm = clDeviceMemAllocINTEL (context, device, NULL, 64, 0, &err);
+  CHECK_ERROR (err);
+
+  /* A large indirect-pointer list: an 8x over-read (8 MiB -> 64 MiB) is sure to
+     run off the array's mapping. The pointers are all valid USM pointers; only
+     the length of the read decides whether the call faults. */
+  const size_t n = 1 << 20;
+  void **ptrs = (void **)malloc (n * sizeof (void *));
+  for (size_t i = 0; i < n; ++i)
+    ptrs[i] = usm;
+
+  err = clSetKernelExecInfo (kernel, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL,
+                             n * sizeof (void *), ptrs);
+  CHECK_ERROR (err);
+
+  free (ptrs);
+  err = clMemFreeINTEL (context, usm);
+  CHECK_ERROR (err);
+  clReleaseKernel (kernel);
+  clReleaseProgram (program);
+  clReleaseCommandQueue (queue);
+  clReleaseContext (context);
+
+  printf ("OK\n");
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The `CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL` branch of `clSetKernelExecInfo` passes `param_value_size` (a byte count) to `pocl_reset_indirect_ptrs()`, which expects an element count. It therefore iterates past the end of the application's pointer array, reading uninitialized/unmapped memory. With a large indirect-pointer list this runs off the allocation and segfaults; with a small one it silently reads garbage (and can spuriously register stray words as indirect USM pointers).

The SVM branch a few lines up already divides by `sizeof(void*)` correctly; this just brings the USM branch in line.

Introduced in 588c6cc8a (#1876); affects v7.0, v7.1 and main.

Reported downstream as JuliaGPU/OpenCL.jl#317 (frequent crashes in Windows CI when launching kernels with USM buffers; the heap layout there makes the over-read fault, whereas it usually stays within mapped memory on Linux).