### PR TITLE
Apply #1929 to `main`

### DIFF
--- a/lib/CL/pocl_networking.c
+++ b/lib/CL/pocl_networking.c
@@ -164,13 +164,14 @@ pocl_freeaddrinfo (struct addrinfo *ai)
 {
   if (ai)
     {
+#ifdef HAVE_LINUX_VSOCK_H
       if (ai->ai_family == AF_VSOCK)
         {
           free (ai->ai_canonname);
           free (ai);
           return;
         }
-
+#endif
       freeaddrinfo (ai);
     }
 }

--- a/pocld/connection.cc
+++ b/pocld/connection.cc
@@ -47,9 +47,11 @@ void Connection::configure(bool LowLatency) {
     // function only actually checks whether ai_family is AF_VSOCK
     pocl_remote_client_set_socket_options(Fd, BufSize, LowLatency, AF_UNSPEC);
     break;
+#ifdef HAVE_LINUX_VSOCK_H
   case TransportDomain_Vsock:
     pocl_remote_client_set_socket_options(Fd, BufSize, LowLatency, AF_VSOCK);
     break;
+#endif
   default:
     break;
   }

--- a/pocld/daemon.cc
+++ b/pocld/daemon.cc
@@ -580,18 +580,25 @@ int PoclDaemon::launch(std::string ListenAddress, struct ServerPorts &Ports,
   addrinfo *ai = ResolvedAddress;
   NumListenFds = 0;
   for (addrinfo *ai = ResolvedAddress; ai; ai = ai->ai_next) {
+#ifdef HAVE_LINUX_VSOCK_H
     if (ai->ai_family != AF_INET && ai->ai_family != AF_INET6 &&
         ai->ai_family != AF_VSOCK)
       continue;
+#else
+    if (ai->ai_family != AF_INET && ai->ai_family != AF_INET6)
+      continue;
+#endif
     struct sockaddr *base_addr = ai->ai_addr;
     int base_addrlen = ai->ai_addrlen;
     std::string addr_string = describe_sockaddr(base_addr, base_addrlen);
+#ifdef HAVE_LINUX_VSOCK_H
     if (UseVsock && ai->ai_family != AF_VSOCK) {
       POCL_MSG_ERR("Using vsock requires using the correct address "
                    "vsock:<cid>, instead of %s\n",
                    addr_string.c_str());
       break;
     }
+#endif
     int FdCommand = -1;
     int FdStream = -1;
     transport_domain_t Domain =

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -700,7 +700,7 @@ SharedCLContext::SharedCLContext(cl::Platform *p, unsigned pid,
     if (MaxMemAllocSize < MaxSVMAllocSize)
       MaxSVMAllocSize = MaxMemAllocSize;
 
-    MaxTotalAllocatableSVM = std::min(MaxTotalAllocatableSVM,
+    MaxTotalAllocatableSVM = std::min(MaxTotalAllocatableSVM, (size_t)
                                       Dev.getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>());
   }
 


### PR DESCRIPTION
https://github.com/pocl/pocl/pull/1929 was only applied to `release_7_0`, and in Julia we've been carrying this patch for our 7.1 build. Is there a reason it was not applied to `main`?