### PR TITLE
Hide statically-linked LLVM symbols on macOS in the CMake-package setup

### DIFF
--- a/cmake/SetupLLVMviaCMake.cmake
+++ b/cmake/SetupLLVMviaCMake.cmake
@@ -291,3 +291,53 @@ if(LLVM_ENABLE_SHARED_LIBS OR STATIC_LLVM)
     endif()
   endforeach()
 endif()
+
+if(APPLE AND STATIC_LLVM AND VISIBILITY_HIDDEN)
+  # Mach-O ld has no --exclude-libs (which lib/CL/CMakeLists.txt uses on ELF to
+  # keep the statically-linked LLVM out of libpocl's exports), so symbols pulled
+  # from the LLVM/Clang static archives would be re-exported -- and their weak
+  # definitions (vtables, template instantiations) coalesced by dyld with any
+  # other LLVM copy in the process, which is fatal when the versions differ.
+  # Link the archives through ld64's -hidden-l instead, which marks every symbol
+  # they contribute private-extern, like SetupLLVMviaBinary.cmake already does.
+  # The component target names equal the archive base names (LLVMCore ->
+  # libLLVMCore.a), but the imported targets also carry the transitive system
+  # libraries (zstd, zlib, curses, xml2, ...) in their interface, so walk that
+  # interface and keep the non-LLVM/Clang entries on the regular link list.
+  set(_HIDDEN_LINK_FLAGS)
+  set(_HIDDEN_EXTERNAL_DEPS)
+  set(_HIDDEN_VISITED)
+  set(_HIDDEN_WORKLIST ${POCL_CLANG_LINK_TARGETS} ${POCL_LLVM_LINK_TARGETS})
+  while(_HIDDEN_WORKLIST)
+    list(POP_FRONT _HIDDEN_WORKLIST _ITEM)
+    if(_ITEM IN_LIST _HIDDEN_VISITED)
+      continue()
+    endif()
+    list(APPEND _HIDDEN_VISITED ${_ITEM})
+    # static library targets wrap their private deps in $<LINK_ONLY:...>;
+    # unwrap so LLVM components named that way are hidden, not relinked plainly
+    if(_ITEM MATCHES "^\\$<LINK_ONLY:(.+)>$")
+      list(APPEND _HIDDEN_WORKLIST ${CMAKE_MATCH_1})
+      continue()
+    endif()
+    # (exact "LLVM" is the dylib, which -hidden-l cannot apply to; the hack
+    # above strips it from the Clang targets, but be defensive)
+    if(_ITEM MATCHES "^(LLVM|clang|lld)" AND NOT _ITEM STREQUAL "LLVM" AND TARGET ${_ITEM})
+      list(APPEND _HIDDEN_LINK_FLAGS "-Wl,-hidden-l${_ITEM}")
+      get_target_property(_ITEM_IFACE ${_ITEM} INTERFACE_LINK_LIBRARIES)
+      if(_ITEM_IFACE)
+        list(APPEND _HIDDEN_WORKLIST ${_ITEM_IFACE})
+      endif()
+    else()
+      # a system library (m, dl, ...) or an imported target (ZLIB::ZLIB,
+      # zstd::libzstd_shared, ...): link as usual
+      list(APPEND _HIDDEN_EXTERNAL_DEPS ${_ITEM})
+    endif()
+  endwhile()
+  # -hidden-l only takes a library name, so the archive directory must be on
+  # the search path; LLVM_LDFLAGS ends up in libpocl's LINK_FLAGS.
+  set(LLVM_LDFLAGS "-L${LLVM_LIBDIR}")
+  set(POCL_CLANG_LINK_TARGETS)
+  set(POCL_LLVM_LINK_TARGETS ${_HIDDEN_LINK_FLAGS} ${_HIDDEN_EXTERNAL_DEPS})
+  message(STATUS "Hiding statically-linked LLVM/Clang symbols via -hidden-l: ${POCL_LLVM_LINK_TARGETS}")
+endif()

--- a/lib/CL/CMakeLists.txt
+++ b/lib/CL/CMakeLists.txt
@@ -390,7 +390,18 @@ if(ENABLE_LLVM)
     list(APPEND POCL_PRIVATE_LINK_LIST ${CLANG_LINK_LIBRARIES} ${LLVM_LINK_LIBRARIES} ${LLVM_SYSLIBS})
   endif()
   if (ENABLE_SPIRV AND HAVE_LLVM_SPIRV_LIB)
-    list(PREPEND POCL_PRIVATE_LINK_LIST ${LLVM_SPIRV_LIB})
+    if(APPLE AND VISIBILITY_HIDDEN AND LLVM_SPIRV_LIB MATCHES "\\.a$")
+      # like the LLVM/Clang archives (see SetupLLVMviaCMake.cmake), keep the
+      # translator's symbols (including weak LLVM template instantiations from
+      # its objects) out of libpocl's exports; ld64 has no --exclude-libs, so
+      # load the archive with -hidden-l instead.
+      get_filename_component(LLVM_SPIRV_LIB_DIR "${LLVM_SPIRV_LIB}" DIRECTORY)
+      get_filename_component(LLVM_SPIRV_LIB_NAME "${LLVM_SPIRV_LIB}" NAME_WE)
+      string(REGEX REPLACE "^lib" "" LLVM_SPIRV_LIB_NAME "${LLVM_SPIRV_LIB_NAME}")
+      list(PREPEND POCL_PRIVATE_LINK_LIST "-L${LLVM_SPIRV_LIB_DIR}" "-Wl,-hidden-l${LLVM_SPIRV_LIB_NAME}")
+    else()
+      list(PREPEND POCL_PRIVATE_LINK_LIST ${LLVM_SPIRV_LIB})
+    endif()
   endif()
 
   if (ENABLE_MLIR)


### PR DESCRIPTION
When LLVM is found through `LLVMConfig.cmake`, the LLVM and Clang static archives are linked into libpocl as plain imported targets, so every LLVM symbol gets re-exported. On ELF that's harmless because libpocl links with `--exclude-libs,ALL`. ld64 has no such flag, however, and the ~19k exported LLVM symbols include thousands of weak definitions: `cl::opt` vtables, template instantiations, and so on. dyld coalesces weak definitions across images, so any host that brings along a different LLVM ends up resolving libpocl's weak references against the host's copy, and the first virtual call jumps into the wrong vtable.

For example, Julia loads its own libLLVM 18, and its libraries contain weak instantiations of the same LLVM header templates. Observed locally: libpocl statically linked against LLVM 20 dies with a bus error inside `InitializeLLVM` on `clCreateContext` call.

The llvm-config path (`SetupLLVMviaBinary.cmake`) already handles this: it loads the archives with ld64's `-hidden-l`, which makes every symbol they contribute private-extern. This PR teaches the CMake-package path the same trick. On `APPLE` with `STATIC_LLVM` and `VISIBILITY_HIDDEN`, the component targets become `-Wl,-hidden-l<name>` flags (component target names equal the archive base names). Since dropping the imported targets would also drop their transitive system libraries, the conversion walks `INTERFACE_LINK_LIBRARIES` and keeps non-LLVM dependencies (`m`, `ZLIB::ZLIB`, `zstd::libzstd_*`, ...) on the regular link list; `$<LINK_ONLY:...>` entries are unwrapped so those components get hidden too rather than relinked plainly. A static `libLLVMSPIRVLib.a` is also loaded through `-hidden-l`, as its objects carry the same weak LLVM template instantiations.

A macOS libpocl built via the CMake-package path now exports the same minimal symbol set as the llvm-config path: 417 symbols instead of 54539, none of them LLVM, no weak externals. I verified this by building with `LLVM_DIR` against LLVM 20 on macOS arm64 and running OpenCL.jl inside Julia: context creation no longer crashes, and kernels compile and run correctly.