### PR TITLE
SubCFGFormation: fall back to work-item loops when a kernel has no exit

### DIFF
--- a/lib/llvmopencl/SubCFGFormation.cc
+++ b/lib/llvmopencl/SubCFGFormation.cc
@@ -1279,7 +1279,19 @@ llvm::Instruction *SubCFGFormation::getLocalIdInRegion(llvm::Instruction *Instr,
 /// CBS does not handle kernels without barriers.
 bool SubCFGFormation::canHandleKernel(llvm::Function &K,
                                       llvm::FunctionAnalysisManager &AM) {
-  return hasWorkgroupBarriers(K);
+  if (!hasWorkgroupBarriers(K))
+    return false;
+
+  // formSubCfgs() builds sub-CFGs between the entry barrier and the kernel's
+  // exit (0-successor) blocks. A kernel with no exit block, such as one with an
+  // infinite loop, gives it nothing to work with and trips the "No kernel
+  // exits!" abort. The work-item loops handler compiles these kernels (see
+  // regression/infinite_loop), so decline here and let the chooser fall back to
+  // it, as it already does for kernels without barriers.
+  for (llvm::BasicBlock &BB : K)
+    if (BB.getTerminator()->getNumSuccessors() == 0)
+      return true;
+  return false;
 }
 
 void moveAllocasToEntry(llvm::Function &F,

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -44,7 +44,8 @@ set(PROGRAMS_TO_BUILD test_barrier_between_for_loops test_early_return
   test_for_with_var_iteration_count test_id_dependent_computation
   test_locals test_multi_level_loops_with_barriers
   test_simple_for_with_a_barrier test_structs_as_args test_vectors_as_args
-  test_barrier_before_return test_infinite_loop test_constant_array
+  test_barrier_before_return test_infinite_loop test_infinite_loop_with_barrier
+  test_constant_array
   test_undominated_variable test_setargs test_null_arg
   test_fors_with_var_iteration_counts test_issue_231 test_issue_445
   test_autolocals_in_constexprs test_issue_553 test_issue_577 test_issue_757
@@ -174,6 +175,8 @@ add_test_pocl(NAME "regression/barrier_just_before_return" WORKITEM_HANDLER "loo
 
 add_test_pocl(NAME "regression/infinite_loop" WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_infinite_loop")
 
+add_test_pocl(NAME "regression/infinite_loop_with_barrier" WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_infinite_loop_with_barrier")
+
 add_test_pocl(NAME "regression/undominated_variable_from_conditional_barrier_handling"
   WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_undominated_variable")
 
@@ -204,6 +207,7 @@ set_tests_properties(
   "regression/id-dependent_computation_before_kernel_exit_${VARIANT}"
   "regression/barrier_just_before_return_${VARIANT}"
   "regression/infinite_loop_${VARIANT}"
+  "regression/infinite_loop_with_barrier_${VARIANT}"
   "regression/undominated_variable_from_conditional_barrier_handling_${VARIANT}"
   "regression/assigning_a_loop_iterator_variable_to_a_private_makes_it_local_${VARIANT}"
   "regression/assigning_a_loop_iterator_variable_to_a_private_makes_it_local_2_${VARIANT}"
@@ -330,6 +334,8 @@ set_property(TEST
   "regression/test_flatten_barrier_subs_cbs"
   "regression/infinite_loop_loopvec"
   "regression/infinite_loop_cbs"
+  "regression/infinite_loop_with_barrier_loopvec"
+  "regression/infinite_loop_with_barrier_cbs"
   APPEND PROPERTY LABELS "mingw_fail")
 
 # Label tests that work with CUDA backend

--- a/tests/regression/test_infinite_loop_with_barrier.cpp
+++ b/tests/regression/test_infinite_loop_with_barrier.cpp
@@ -1,0 +1,154 @@
+/* Tests a kernel with a work-group barrier followed by an infinite loop.
+
+   This deterministically exercises the CBS (sub-group) work-group handler on a
+   kernel that has no exit block: the barrier makes the handler chooser pick
+   CBS, and the infinite loop leaves the function with no return. CBS used to
+   abort such kernels in SubCFGFormation ("Invalid kernel! No kernel exits!");
+   it must instead fall back gracefully (to the work-item loops handler) as it
+   already does for barrier-free kernels. Unlike regression/infinite_loop, the
+   explicit barrier triggers the CBS path on every platform rather than relying
+   on an implicit barrier being inserted, which is build/target dependent.
+
+   Copyright (c) 2012 Pekka Jääskeläinen / Tampere University of Technology
+                 2026 PoCL developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+*/
+
+#include "pocl_opencl.h"
+
+// Enable OpenCL C++ exceptions
+#define CL_HPP_ENABLE_EXCEPTIONS
+
+#include <CL/opencl.hpp>
+
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+
+#ifndef _MSC_VER
+#  include <unistd.h>
+#else
+#  include "vccompat.hpp"
+#endif
+
+#include <thread>
+#include <chrono>
+
+#define WORK_ITEMS 4
+
+static char
+kernelSourceCode[] =
+"kernel void test_kernel(global int *input, global int* output)\n"
+"{\n"
+"  size_t lid = get_local_id(0);\n"
+"  output[lid] = input[lid] + 1;\n"
+"  barrier(CLK_GLOBAL_MEM_FENCE | CLK_LOCAL_MEM_FENCE);\n"
+"  for (;;);                       /* never returns: no kernel exit */\n"
+"}\n";
+
+int
+main(void)
+{
+    int output[WORK_ITEMS];
+    int input[WORK_ITEMS];
+    for (int i = 0; i < WORK_ITEMS; ++i) {
+        input[i] = i;
+        output[i] = 0;
+    }
+
+    try {
+        std::vector<cl::Platform> platformList;
+
+        // Pick platform
+        cl::Platform::get(&platformList);
+
+        // Pick first platform
+        cl_context_properties cprops[] = {
+            CL_CONTEXT_PLATFORM, (cl_context_properties)(platformList[0])(), 0};
+        cl::Context context(CL_DEVICE_TYPE_ALL, cprops);
+
+        // Query the set of devices attched to the context
+        std::vector<cl::Device> devices = context.getInfo<CL_CONTEXT_DEVICES>();
+
+        // Create and program from source
+        cl::Program::Sources sources({kernelSourceCode});
+        cl::Program program(context, sources);
+
+        // Build program
+        program.build(devices);
+
+        cl::Buffer outBuffer = cl::Buffer(
+            context,
+            CL_MEM_WRITE_ONLY | CL_MEM_USE_HOST_PTR,
+            WORK_ITEMS * sizeof(int),
+            (void *) &output[0]);
+
+        cl::Buffer inBuffer = cl::Buffer(
+            context,
+            CL_MEM_READ_ONLY | CL_MEM_USE_HOST_PTR,
+            WORK_ITEMS * sizeof(int),
+            (void *) &input[0]);
+
+        // Create kernel object
+        cl::Kernel kernel(program, "test_kernel");
+
+        // Set kernel args
+        kernel.setArg(0, inBuffer);
+        kernel.setArg(1, outBuffer);
+
+        // Create command queue
+        cl::CommandQueue queue(context, devices[0], 0);
+
+        // Do the work: one work-group of WORK_ITEMS so the barrier is real.
+        queue.enqueueNDRangeKernel(
+            kernel,
+            cl::NullRange,
+            cl::NDRange(WORK_ITEMS),
+            cl::NDRange(WORK_ITEMS));
+
+        /* The kernel build/specialization should not crash the compiler. */
+
+        std::cout << "OK" << std::endl;
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+
+        // Force exit of the process regardless of the running kernel thread
+        // by replacing the process with a dummy process.
+#if __cplusplus >= 201103L && /* C++11 */                                      \
+    !defined(__APPLE__) && !(defined(__MINGW64__))
+        std::quick_exit(EXIT_SUCCESS);
+#else
+        execlp("true", "true", NULL);
+#endif
+    }
+    catch (cl::Error &err) {
+         std::cerr
+             << "ERROR: "
+             << err.what()
+             << "("
+             << err.err()
+             << ")"
+             << std::endl;
+         return EXIT_FAILURE;
+    }
+    std::cerr << "UNREACHABLE. Perhaps there was an uncaught STL exception."
+              << std::endl;
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
canHandleKernel() only checked for barriers, so a kernel that has a barrier but no exit block (an infinite loop like for(;;)) was still handed to CBS. formSubCfgs() then takes the "Invalid kernel! No kernel exits!" path and calls llvm_unreachable, which lowers to a trap without assertions.

The work-item loops generator already compiles these kernels (the regression/infinite_loop test relies on it), and the chooser already sends barrier-free kernels there. Send kernels with no exit block there too.

Fixes the failure seen in https://github.com/pocl/pocl/pull/2194