### PR TITLE
WorkitemHandlerChooser: keep the chosen handler stable

### DIFF
--- a/lib/llvmopencl/WorkitemHandlerChooser.cc
+++ b/lib/llvmopencl/WorkitemHandlerChooser.cc
@@ -109,12 +109,18 @@ WorkitemHandlerChooser::run(llvm::Function &F,
 }
 
 bool WorkitemHandlerResult::invalidate(
-    llvm::Function &F, const llvm::PreservedAnalyses PA,
-    llvm::AnalysisManager<llvm::Function>::Invalidator &Inv) {
-  // Check whether the analysis has been explicitly invalidated.
-  // Otherwise, it stays valid
-  auto PAC = PA.getChecker<WorkitemHandlerChooser>();
-  return !PAC.preservedWhenStateless();
+    llvm::Function &, const llvm::PreservedAnalyses,
+    llvm::AnalysisManager<llvm::Function>::Invalidator &) {
+  // The work-item handler is chosen once, up front (the pipeline requires this
+  // analysis before any kernel transformation runs), and the whole work-group
+  // pipeline commits to that one choice. Never invalidate it: later passes add
+  // *implicit* barriers -- e.g. ImplicitLoopBarriers, for the work-item-loops
+  // path -- which flip hasWorkgroupBarriers(). Recomputing the choice then can
+  // pick CBS for a kernel originally classified LOOPS; whether that happens
+  // depends on incidental analysis-cache invalidation, so the choice (and thus
+  // which handler runs, and whether SubCFGFormation aborts on an exit-less
+  // kernel) becomes environment-dependent. Keep the result stable.
+  return false;
 }
 
 REGISTER_NEW_FANALYSIS(PASS_NAME, PASS_CLASS, PASS_DESC);


### PR DESCRIPTION
The work-item handler is chosen once, before any kernel transformation, and the whole work-group pipeline commits to it. As a plain cached analysis it could be recomputed mid-pipeline: ImplicitLoopBarriers adds implicit barriers (for the work-item-loops path) that flip hasWorkgroupBarriers(), so a recompute picks CBS for a kernel originally classified LOOPS. Whether that recompute happens is incidental, environment-dependent cache invalidation -- which surfaced regressions on some hosts but not others. Pin the result so it is never invalidated.

I think this is the reason https://github.com/pocl/pocl/pull/2196 happened on https://github.com/pocl/pocl/pull/2194 but not on main.