### PR TITLE
Fix float-to-half conversion overflow bug in pocl_float_to_half

### DIFF
--- a/lib/CL/pocl_cl_half_util.c
+++ b/lib/CL/pocl_cl_half_util.c
@@ -100,7 +100,7 @@ pocl_float_to_half (float value)
   v.si ^= sign;
   sign >>= shiftSign;
   s.si = mulN;
-  s.si = s.f * v.f;
+  s.f = s.f * v.f;
   v.si ^= (s.si ^ v.si) & -(minN > v.si);
   v.si ^= (infN ^ v.si) & -((infN > v.si) & (v.si > maxN));
   v.si ^= (nanN ^ v.si) & -((nanN > v.si) & (v.si > infN));


### PR DESCRIPTION
This change fixes an implicit float-to-int conversion overflow in pocl_float_to_half() which triggers a SIGILL under UBSan.

By changing the assignment from s.si to s.f, we store the raw float product in the union and read its bits later via s.si/s.ui, instead of converting the float value to integer (which overflows because s.f is ~1.1e11).