### PR TITLE
Fix EmitPrintf.cc compilation with LLVM 23.0

### DIFF
--- a/lib/llvmopencl/EmitPrintf.cc
+++ b/lib/llvmopencl/EmitPrintf.cc
@@ -399,7 +399,11 @@ static void processConstantStringArg(StringData *SD, IRBuilder<> &Builder,
                                      SmallVectorImpl<Value *> &WhatToStore) {
   std::string Str(SD->Str.str() + '\0');
 
+#if LLVM_MAJOR >= 23
+  DataExtractor Extractor(Str, /*IsLittleEndian=*/true);
+#else
   DataExtractor Extractor(Str, /*IsLittleEndian=*/true, 8);
+#endif
   DataExtractor::Cursor Offset(0);
   while (Offset && Offset.tell() < Str.size()) {
     const uint64_t ReadSize = 4;


### PR DESCRIPTION
This change fixes a compilation error in EmitPrintf.cc due to a constructor signature change for llvm::DataExtractor in the modern LLVM project (which added the 2-argument constructor and removed the 3-argument one): https://github.com/llvm/llvm-project/commit/7319a3c

An LLVM version guard is added in EmitPrintf.cc because LLVM versions before 23 do not have a 2-argument constructor for llvm::DataExtractor (see https://github.com/llvm/llvm-project/blob/release/17.x/llvm/include/llvm/Support/DataExtractor.h). The 2-argument constructor is supported in LLVM 23.0 (see https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/Support/DataExtractor.h).