### PR TITLE
Fix floating point to normalized integer rounding in pocl_image_util.c

### DIFF
--- a/lib/CL/pocl_image_util.c
+++ b/lib/CL/pocl_image_util.c
@@ -25,6 +25,7 @@
 #include "assert.h"
 #include "pocl_cl.h"
 #include "pocl_cl_half_util.h"
+#include <math.h>
 
 cl_int pocl_opencl_image_type_to_index (cl_mem_object_type  image_type)
 {
@@ -369,6 +370,114 @@ convert_ushort_sat (cl_float x)
   return (cl_ushort)max (0, min (y, CL_USHRT_MAX));
 }
 
+static cl_char
+convert_char_sat_rte (cl_float x)
+{
+  cl_int y = (cl_int)rintf (x);
+  return (cl_char)max (CL_CHAR_MIN, min (y, CL_CHAR_MAX));
+}
+
+static cl_short
+convert_short_sat_rte (cl_float x)
+{
+  cl_int y = (cl_int)rintf (x);
+  return (cl_short)max (CL_SHRT_MIN, min (y, CL_SHRT_MAX));
+}
+
+static cl_uchar
+convert_uchar_sat_rte (cl_float x)
+{
+  cl_long y = (cl_long)rintf (x);
+  return (cl_uchar)max (0, min (y, CL_UCHAR_MAX));
+}
+
+static cl_ushort
+convert_ushort_sat_rte (cl_float x)
+{
+  cl_long y = (cl_long)rintf (x);
+  return (cl_ushort)max (0, min (y, CL_USHRT_MAX));
+}
+
+static cl_char2
+convert_char2_sat_rte (cl_float2 x)
+{
+  cl_char2 r;
+  unsigned i;
+  for (i = 0; i < 2; i++)
+    r.s[i] = convert_char_sat_rte (x.s[i]);
+  return r;
+}
+
+static cl_short2
+convert_short2_sat_rte (cl_float2 x)
+{
+  cl_short2 r;
+  unsigned i;
+  for (i = 0; i < 2; i++)
+    r.s[i] = convert_short_sat_rte (x.s[i]);
+  return r;
+}
+
+static cl_uchar2
+convert_uchar2_sat_rte (cl_float2 x)
+{
+  cl_uchar2 r;
+  unsigned i;
+  for (i = 0; i < 2; i++)
+    r.s[i] = convert_uchar_sat_rte (x.s[i]);
+  return r;
+}
+
+static cl_ushort2
+convert_ushort2_sat_rte (cl_float2 x)
+{
+  cl_ushort2 r;
+  unsigned i;
+  for (i = 0; i < 2; i++)
+    r.s[i] = convert_ushort_sat_rte (x.s[i]);
+  return r;
+}
+
+static cl_char4
+convert_char4_sat_rte (cl_float4 x)
+{
+  cl_char4 r;
+  unsigned i;
+  for (i = 0; i < 4; i++)
+    r.s[i] = convert_char_sat_rte (x.s[i]);
+  return r;
+}
+
+static cl_short4
+convert_short4_sat_rte (cl_float4 x)
+{
+  cl_short4 r;
+  unsigned i;
+  for (i = 0; i < 4; i++)
+    r.s[i] = convert_short_sat_rte (x.s[i]);
+  return r;
+}
+
+static cl_uchar4
+convert_uchar4_sat_rte (cl_float4 x)
+{
+  cl_uchar4 r;
+  unsigned i;
+  for (i = 0; i < 4; i++)
+    r.s[i] = convert_uchar_sat_rte (x.s[i]);
+  return r;
+}
+
+static cl_ushort4
+convert_ushort4_sat_rte (cl_float4 x)
+{
+  cl_ushort4 r;
+  unsigned i;
+  for (i = 0; i < 4; i++)
+    r.s[i] = convert_ushort_sat_rte (x.s[i]);
+  return r;
+}
+
 /****************************************************/
 
 cl_char4
@@ -546,7 +655,7 @@ write_float4_pixel (cl_float4 color, void *data, int type)
       unsigned i;
       for (i = 0; i < 4; i++)
         colorf.s[i] = color.s[i] * f127;
-      cl_char4 final_color = convert_char4_sat (colorf);
+      cl_char4 final_color = convert_char4_sat_rte (colorf);
       *((cl_char4 *)data) = final_color;
       return;
     }
@@ -556,7 +665,7 @@ write_float4_pixel (cl_float4 color, void *data, int type)
       unsigned i;
       for (i = 0; i < 4; i++)
         colorf.s[i] = color.s[i] * f32767;
-      cl_short4 final_color = convert_short4_sat (colorf);
+      cl_short4 final_color = convert_short4_sat_rte (colorf);
       *((cl_short4 *)data) = final_color;
       return;
     }
@@ -568,7 +677,7 @@ write_float4_pixel (cl_float4 color, void *data, int type)
       unsigned i;
       for (i = 0; i < 4; i++)
         colorf.s[i] = color.s[i] * f255;
-      cl_uchar4 final_color = convert_uchar4_sat (colorf);
+      cl_uchar4 final_color = convert_uchar4_sat_rte (colorf);
       *((cl_uchar4 *)data) = final_color;
       return;
     }
@@ -578,7 +687,7 @@ write_float4_pixel (cl_float4 color, void *data, int type)
       unsigned i;
       for (i = 0; i < 4; i++)
         colorf.s[i] = color.s[i] * f65535;
-      cl_ushort4 final_color = convert_ushort4_sat (colorf);
+      cl_ushort4 final_color = convert_ushort4_sat_rte (colorf);
       *((cl_ushort4 *)data) = final_color;
       return;
     }
@@ -616,7 +725,7 @@ write_float2_pixel (cl_float2 color, void *data, int type)
       cl_float2 colorf;
       for (i = 0; i < 2; i++)
         colorf.s[i] = color.s[i] * f127;
-      cl_char2 final_color = convert_char2_sat (colorf);
+      cl_char2 final_color = convert_char2_sat_rte (colorf);
       *((cl_char2 *)data) = final_color;
       return;
     }
@@ -625,7 +734,7 @@ write_float2_pixel (cl_float2 color, void *data, int type)
       cl_float2 colorf;
       for (i = 0; i < 2; i++)
         colorf.s[i] = color.s[i] * f32767;
-      cl_short2 final_color = convert_short2_sat (colorf);
+      cl_short2 final_color = convert_short2_sat_rte (colorf);
       *((cl_short2 *)data) = final_color;
       return;
     }
@@ -636,7 +745,7 @@ write_float2_pixel (cl_float2 color, void *data, int type)
       cl_float2 colorf;
       for (i = 0; i < 2; i++)
         colorf.s[i] = color.s[i] * f255;
-      cl_uchar2 final_color = convert_uchar2_sat (colorf);
+      cl_uchar2 final_color = convert_uchar2_sat_rte (colorf);
       *((cl_uchar2 *)data) = final_color;
       return;
     }
@@ -645,7 +754,7 @@ write_float2_pixel (cl_float2 color, void *data, int type)
       cl_float2 colorf;
       for (i = 0; i < 2; i++)
         colorf.s[i] = color.s[i] * f65535;
-      cl_ushort2 final_color = convert_ushort2_sat (colorf);
+      cl_ushort2 final_color = convert_ushort2_sat_rte (colorf);
       *((cl_ushort2 *)data) = final_color;
       return;
     }
@@ -677,14 +786,14 @@ write_float_pixel (cl_float color, void *data, int type)
     {
       /*  <-1.0, 1.0> to <I*_MIN, I*_MAX> */
       cl_float colorf = color * f127;
-      cl_char final_color = convert_char_sat (colorf);
+      cl_char final_color = convert_char_sat_rte (colorf);
       *((cl_char *)data) = final_color;
       return;
     }
   if (type == CL_SNORM_INT16)
     {
       cl_float colorf = color * f32767;
-      cl_short final_color = convert_short_sat (colorf);
+      cl_short final_color = convert_short_sat_rte (colorf);
       *((cl_short *)data) = final_color;
       return;
     }
@@ -693,14 +802,14 @@ write_float_pixel (cl_float color, void *data, int type)
       /* <0, I*_MAX> to <0.0, 1.0> */
       /*  <-1.0, 1.0> to <I*_MIN, I*_MAX> */
       cl_float colorf = color * f255;
-      cl_uchar final_color = convert_uchar_sat (colorf);
+      cl_uchar final_color = convert_uchar_sat_rte (colorf);
       *((cl_uchar *)data) = final_color;
       return;
     }
   if (type == CL_UNORM_INT16)
     {
       cl_float colorf = color * f65535;
-      cl_ushort final_color = convert_ushort_sat (colorf);
+      cl_ushort final_color = convert_ushort_sat_rte (colorf);
       *((cl_ushort *)data) = final_color;
       return;
     }

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -47,7 +47,8 @@ set(C_PROGRAMS_TO_BUILD test_clFinish test_clGetDeviceInfo test_clGetEventInfo
   test_cl_pocl_content_size test_cl_pocl_content_size_migration
   test_deviceside_enqueue test_command_buffer test_command_buffer_images
   test_command_buffer_multi_device test_queue_creation_with_hints
-  test_remote_discovery test_dbk_color_convert test_subgroup_queries)
+  test_remote_discovery test_dbk_color_convert test_subgroup_queries
+  test_image_normalized_conv)
 
 if(HAVE_ONNXRT)
   list(APPEND C_PROGRAMS_TO_BUILD test_dbk_onnx_inference)
@@ -120,6 +121,8 @@ add_test_pocl(NAME "runtime/clSetEventCallback"
               WORKITEM_HANDLER "loopvec")
 
 add_test(NAME "runtime/clGetSupportedImageFormats" COMMAND "test_clGetSupportedImageFormats")
+
+add_test(NAME "runtime/test_image_normalized_conv" COMMAND "test_image_normalized_conv")
 
 add_test_pocl(NAME "runtime/clCreateKernelsInProgram" COMMAND "test_clCreateKernelsInProgram" WORKITEM_HANDLER "loopvec")
 
@@ -245,6 +248,7 @@ set_tests_properties( "runtime/clGetDeviceInfo" "runtime/clEnqueueNativeKernel"
   "runtime/clGetKernelArgInfo"
   "runtime/clCreateSubDevices"
   "runtime/test_subgroup_queries"
+  "runtime/test_image_normalized_conv"
   PROPERTIES
     COST 2.0
     PROCESSORS 1
@@ -264,6 +268,7 @@ set_tests_properties(
   "runtime/test_device_address"
   "runtime/test_svm"
   "runtime/test_large_buf"
+  "runtime/test_image_normalized_conv"
   PROPERTIES SKIP_RETURN_CODE 77)
 
 if(ENABLE_REMOTE_CLIENT AND ENABLE_REMOTE_SERVER AND ENABLE_HOST_CPU_DEVICES)

--- a/tests/runtime/test_image_normalized_conv.c
+++ b/tests/runtime/test_image_normalized_conv.c
@@ -1,0 +1,152 @@
+/* Test float-to-normalized-integer rounding behavior for images.
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <CL/opencl.h>
+#include "poclu.h"
+
+static int
+test_format(cl_context context, cl_command_queue queue,
+            cl_channel_type data_type, size_t type_size,
+            cl_float color_val, int expected_val)
+{
+  cl_int err;
+  cl_image_format format = {
+    .image_channel_order = CL_R,
+    .image_channel_data_type = data_type
+  };
+
+  cl_image_desc desc = {
+    .image_type = CL_MEM_OBJECT_IMAGE2D,
+    .image_width = 1,
+    .image_height = 1,
+  };
+
+  cl_mem img = clCreateImage (context, CL_MEM_READ_WRITE, &format, &desc, NULL, &err);
+  if (err == CL_INVALID_OPERATION || err == CL_INVALID_IMAGE_FORMAT_DESCRIPTOR || err == CL_IMAGE_FORMAT_NOT_SUPPORTED)
+    {
+      printf ("Format 0x%X not supported (error %d), skipping test. SKIP\n", data_type, err);
+      return 77;
+    }
+  CHECK_OPENCL_ERROR_IN ("clCreateImage");
+
+  cl_float color[4] = { color_val, 0.0f, 0.0f, 0.0f };
+  size_t origin[3] = { 0, 0, 0 };
+  size_t region[3] = { 1, 1, 1 };
+
+  err = clEnqueueFillImage (queue, img, color, origin, region, 0, NULL, NULL);
+  CHECK_OPENCL_ERROR_IN ("clEnqueueFillImage");
+
+  err = clFinish (queue);
+  CHECK_OPENCL_ERROR_IN ("clFinish");
+
+  // Read back
+  long long readback = 0;
+  err = clEnqueueReadImage (queue, img, CL_TRUE, origin, region, 0, 0, &readback, 0, NULL, NULL);
+  CHECK_OPENCL_ERROR_IN ("clEnqueueReadImage");
+
+  long long masked_val = 0;
+  if (type_size == 1)
+    {
+      if (data_type == CL_SNORM_INT8)
+        masked_val = *(char *)&readback;
+      else
+        masked_val = *(unsigned char *)&readback;
+    }
+  else if (type_size == 2)
+    {
+      if (data_type == CL_SNORM_INT16)
+        masked_val = *(short *)&readback;
+      else
+        masked_val = *(unsigned short *)&readback;
+    }
+
+  printf ("Format 0x%X (input: %f) readback value: %lld (expected %d)\n", data_type, color_val, masked_val, expected_val);
+  TEST_ASSERT (masked_val == expected_val);
+
+  CHECK_CL_ERROR (clReleaseMemObject (img));
+  return EXIT_SUCCESS;
+}
+
+int
+main(void)
+{
+  cl_int err;
+  cl_context context = NULL;
+  cl_device_id device = NULL;
+  cl_command_queue queue = NULL;
+  cl_platform_id platform = NULL;
+
+  CHECK_CL_ERROR (
+    poclu_get_any_device2 (&context, &device, &queue, &platform));
+  TEST_ASSERT (context);
+  TEST_ASSERT (device);
+  TEST_ASSERT (queue);
+
+  cl_bool SupportsImgs = CL_FALSE;
+  err = clGetDeviceInfo (device, CL_DEVICE_IMAGE_SUPPORT, sizeof (cl_bool),
+                         &SupportsImgs, NULL);
+  CHECK_OPENCL_ERROR_IN ("clGetDeviceInfo CL_DEVICE_IMAGE_SUPPORT\n");
+  if (SupportsImgs == CL_FALSE)
+    {
+      puts ("Selected device doesn't support images, skipping test. SKIP");
+      return 77;
+    }
+
+#define RUN_TEST_FORMAT(data_type, type_size, color_val, expected_val) \
+  do { \
+    int res = test_format (context, queue, data_type, type_size, color_val, expected_val); \
+    if (res == 77) return 77; \
+    TEST_ASSERT (res == EXIT_SUCCESS); \
+  } while (0)
+
+  // Test all normalized image formats supported by OpenCL (signed/unsigned 8 and 16-bit integers)
+  // For each format, we test:
+  // 1. Case A: rounds UP to nearest even value (halfway from odd value)
+  // 2. Case B: rounds DOWN to nearest even value (halfway from even value)
+
+  // CL_SNORM_INT8 (max 127)
+  RUN_TEST_FORMAT (CL_SNORM_INT8, 1, 63.5f / 127.0f, 64);
+  RUN_TEST_FORMAT (CL_SNORM_INT8, 1, 62.5f / 127.0f, 62);
+
+  // CL_UNORM_INT8 (max 255)
+  RUN_TEST_FORMAT (CL_UNORM_INT8, 1, 127.5f / 255.0f, 128);
+  RUN_TEST_FORMAT (CL_UNORM_INT8, 1, 126.5f / 255.0f, 126);
+
+  // CL_SNORM_INT16 (max 32767)
+  RUN_TEST_FORMAT (CL_SNORM_INT16, 2, 16383.5f / 32767.0f, 16384);
+  RUN_TEST_FORMAT (CL_SNORM_INT16, 2, 16382.5f / 32767.0f, 16382);
+
+  // CL_UNORM_INT16 (max 65535)
+  RUN_TEST_FORMAT (CL_UNORM_INT16, 2, 32767.5f / 65535.0f, 32768);
+  RUN_TEST_FORMAT (CL_UNORM_INT16, 2, 32766.5f / 65535.0f, 32766);
+
+#undef RUN_TEST_FORMAT
+
+  CHECK_CL_ERROR (clReleaseCommandQueue (queue));
+  CHECK_CL_ERROR (clReleaseContext (context));
+
+  printf ("OK\n");
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This change implements true round-to-nearest-even (RTE) rounding for float-to-normalized-integer image conversions in pocl_image_util.c by using rintf instead of truncation (which was performed via direct integer casts). See: https://registry.khronos.org/OpenCL/specs/unified/html/OpenCL_C.html#converting-floating-point-values-to-normalized-integer-channel-data-types

A comprehensive unit test is added to test both round-up-to-even and round-down-to-even halfway cases across all OpenCL-supported normalized formats (signed/unsigned 8 and 16-bit integers).