### PR TITLE
Add half (fp16) dot built-in function overload support

### DIFF
--- a/lib/kernel/dot.cl
+++ b/lib/kernel/dot.cl
@@ -83,3 +83,36 @@ double _CL_OVERLOADABLE dot(double16 a, double16 b)
   return dot(a.lo, b.lo) + dot(a.hi, b.hi);
 }
 #endif
+
+#ifdef cl_khr_fp16
+half _CL_OVERLOADABLE dot(half a, half b)
+{
+  return a * b;
+}
+
+half _CL_OVERLOADABLE dot(half2 a, half2 b)
+{
+  return a.lo * b.lo + a.hi * b.hi;
+}
+
+half _CL_OVERLOADABLE dot(half3 a, half3 b)
+{
+  return dot(a.s01, b.s01) + a.s2 * b.s2;
+}
+
+half _CL_OVERLOADABLE dot(half4 a, half4 b)
+{
+  return dot(a.lo, b.lo) + dot(a.hi, b.hi);
+}
+
+half _CL_OVERLOADABLE dot(half8 a, half8 b)
+{
+  return dot(a.lo, b.lo) + dot(a.hi, b.hi);
+}
+
+half _CL_OVERLOADABLE dot(half16 a, half16 b)
+{
+  return dot(a.lo, b.lo) + dot(a.hi, b.hi);
+}
+#endif
+

--- a/tests/kernel/CMakeLists.txt
+++ b/tests/kernel/CMakeLists.txt
@@ -64,6 +64,9 @@ add_test_pocl(NAME "kernel/test_min_max"
 add_test_pocl(NAME "kernel/test_length_distance"
               COMMAND "kernel" "test_length_distance")
 
+add_test_pocl(NAME "kernel/test_dot"
+              COMMAND "kernel" "test_dot")
+
 add_test_pocl(NAME "kernel/test_fmin_fmax_fma"
               COMMAND "kernel" "test_fmin_fmax_fma")
 
@@ -140,7 +143,7 @@ foreach(VARIANT ${VARIANTS})
     "kernel/test_convert_sat_regression_${VARIANT}"   "kernel/test_fabs_${VARIANT}"
     "kernel/test_rotate_${VARIANT}" "kernel/test_copy_signbit_${VARIANT}" "kernel/test_ilogb_${VARIANT}"
     "kernel/test_ldexp_${VARIANT}" "kernel/test_isnan_${VARIANT}" "kernel/test_short16_${VARIANT}"
-    "kernel/test_frexp_modf_${VARIANT}" ${ENABLE_CPU_TESTS}
+    "kernel/test_frexp_modf_${VARIANT}" "kernel/test_dot_${VARIANT}" ${ENABLE_CPU_TESTS}
     PROPERTIES
       COST 4.0
       PROCESSORS 1

--- a/tests/kernel/test_dot.cl
+++ b/tests/kernel/test_dot.cl
@@ -1,0 +1,120 @@
+#ifdef cl_khr_fp16
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+#endif
+
+// Helper macros to check float/half values
+#define CHECK_VAL(typename, actual, expected, tol) \
+  do { \
+    if (fabs((float)(actual) - (float)(expected)) > (float)(tol)) { \
+      printf("FAIL: dot_%s actual %f expected %f\n", #typename, (float)(actual), (float)(expected)); \
+      return; \
+    } \
+  } while (0)
+
+kernel void test_dot_fp32()
+{
+  // Test float (scalar)
+  {
+    float a = 1.5f;
+    float b = 2.0f;
+    float res = dot(a, b);
+    CHECK_VAL(float, res, 3.0f, 1e-5f);
+  }
+
+  // Test float2
+  {
+    float2 a = (float2)(1.0f, 2.0f);
+    float2 b = (float2)(3.0f, 4.0f);
+    float res = dot(a, b);
+    CHECK_VAL(float2, res, 11.0f, 1e-5f);
+  }
+
+  // Test float3
+  {
+    float3 a = (float3)(1.0f, 2.0f, 3.0f);
+    float3 b = (float3)(4.0f, 5.0f, 6.0f);
+    float res = dot(a, b);
+    CHECK_VAL(float3, res, 32.0f, 1e-5f);
+  }
+
+  // Test float4
+  {
+    float4 a = (float4)(1.0f, 2.0f, 3.0f, 4.0f);
+    float4 b = (float4)(5.0f, 6.0f, 7.0f, 8.0f);
+    float res = dot(a, b);
+    CHECK_VAL(float4, res, 70.0f, 1e-5f);
+  }
+
+  // Test float8
+  {
+    float8 a = (float8)(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+    float8 b = (float8)(1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f);
+    float res = dot(a, b);
+    CHECK_VAL(float8, res, 36.0f, 1e-5f);
+  }
+
+  // Test float16
+  {
+    float16 a = (float16)(1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f,
+                          1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f);
+    float16 b = (float16)(2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f,
+                          2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f);
+    float res = dot(a, b);
+    CHECK_VAL(float16, res, 32.0f, 1e-5f);
+  }
+}
+
+#ifdef cl_khr_fp16
+kernel void test_dot_fp16()
+{
+  // Test half (scalar)
+  {
+    half a = (half)1.5f;
+    half b = (half)2.0f;
+    half res = dot(a, b);
+    CHECK_VAL(half, res, 3.0f, 1e-3f);
+  }
+
+  // Test half2
+  {
+    half2 a = (half2)(1.0f, 2.0f);
+    half2 b = (half2)(3.0f, 4.0f);
+    half res = dot(a, b);
+    CHECK_VAL(half2, res, 11.0f, 1e-3f);
+  }
+
+  // Test half3
+  {
+    half3 a = (half3)(1.0f, 2.0f, 3.0f);
+    half3 b = (half3)(4.0f, 5.0f, 6.0f);
+    half res = dot(a, b);
+    CHECK_VAL(half3, res, 32.0f, 1e-3f);
+  }
+
+  // Test half4
+  {
+    half4 a = (half4)(1.0f, 2.0f, 3.0f, 4.0f);
+    half4 b = (half4)(5.0f, 6.0f, 7.0f, 8.0f);
+    half res = dot(a, b);
+    CHECK_VAL(half4, res, 70.0f, 1e-3f);
+  }
+
+  // Test half8
+  {
+    half8 a = (half8)(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f);
+    half8 b = (half8)(1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f);
+    half res = dot(a, b);
+    CHECK_VAL(half8, res, 36.0f, 1e-3f);
+  }
+
+  // Test half16
+  {
+    half16 a = (half16)(1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f,
+                        1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f);
+    half16 b = (half16)(2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f,
+                        2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f, 2.0f);
+    half res = dot(a, b);
+    CHECK_VAL(half16, res, 32.0f, 1e-3f);
+  }
+}
+#endif


### PR DESCRIPTION
This change adds vector and scalar overloads for the OpenCL C built-in dot() function for half (fp16) types.

Without this patch, compiling a kernel using dot() with half arguments fails with link errors in clBuildProgram: 

Cannot find symbol _Z7_cl_dotDv4_DhS_ in kernel library
Cannot find symbol _Z7_cl_dotDhDh in kernel library
Cannot find symbol _Z7_cl_dotDv3_DhS_ in kernel library
Cannot find symbol _Z7_cl_dotDv2_DhS_ in kernel library
Cannot find symbol _Z7_cl_dotDv8_DhS_ in kernel library
Cannot find symbol _Z7_cl_dotDv16_DhS_ in kernel library