### PR TITLE
Add half (fp16) conversion functions

### DIFF
--- a/lib/kernel/convert_type.cl
+++ b/lib/kernel/convert_type.cl
@@ -53937,3 +53937,6069 @@ double16 convert_double16_rtn(double16 x)
   return res;
 }
 #endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtz(char x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rte(char x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtp(char x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtn(char x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtz(char2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rte(char2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtp(char2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtn(char2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtz(char3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rte(char3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtp(char3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtn(char3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtz(char4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rte(char4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtp(char4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtn(char4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtz(char8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rte(char8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtp(char8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtn(char8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtz(char16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rte(char16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtp(char16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtn(char16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtz(uchar x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rte(uchar x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtp(uchar x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtn(uchar x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtz(uchar2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rte(uchar2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtp(uchar2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtn(uchar2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtz(uchar3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rte(uchar3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtp(uchar3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtn(uchar3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtz(uchar4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rte(uchar4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtp(uchar4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtn(uchar4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtz(uchar8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rte(uchar8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtp(uchar8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtn(uchar8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtz(uchar16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rte(uchar16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtp(uchar16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtn(uchar16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtz(short x)
+{
+  half r = convert_half(x);
+  short y = convert_short(r);
+  ushort abs_x = abs(x);
+  ushort abs_y = abs(y);
+  half res = select(r, nextafter(r, sign(r) * (half)-INFINITY), convert_short(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rte(short x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtp(short x)
+{
+  half r = convert_half(x);
+  short y = convert_short(r);
+  half res = select(r, nextafter(r, (half)INFINITY), convert_short(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtn(short x)
+{
+  half r = convert_half(x);
+  short y = convert_short(r);
+  half res = select(r, nextafter(r, (half)-INFINITY), convert_short(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtz(short2 x)
+{
+  half2 r = convert_half2(x);
+  short2 y = convert_short2(r);
+  ushort2 abs_x = abs(x);
+  ushort2 abs_y = abs(y);
+  half2 res = select(r, nextafter(r, sign(r) * (half2)-INFINITY), convert_short2(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rte(short2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtp(short2 x)
+{
+  half2 r = convert_half2(x);
+  short2 y = convert_short2(r);
+  half2 res = select(r, nextafter(r, (half2)INFINITY), convert_short2(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtn(short2 x)
+{
+  half2 r = convert_half2(x);
+  short2 y = convert_short2(r);
+  half2 res = select(r, nextafter(r, (half2)-INFINITY), convert_short2(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtz(short3 x)
+{
+  half3 r = convert_half3(x);
+  short3 y = convert_short3(r);
+  ushort3 abs_x = abs(x);
+  ushort3 abs_y = abs(y);
+  half3 res = select(r, nextafter(r, sign(r) * (half3)-INFINITY), convert_short3(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rte(short3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtp(short3 x)
+{
+  half3 r = convert_half3(x);
+  short3 y = convert_short3(r);
+  half3 res = select(r, nextafter(r, (half3)INFINITY), convert_short3(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtn(short3 x)
+{
+  half3 r = convert_half3(x);
+  short3 y = convert_short3(r);
+  half3 res = select(r, nextafter(r, (half3)-INFINITY), convert_short3(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtz(short4 x)
+{
+  half4 r = convert_half4(x);
+  short4 y = convert_short4(r);
+  ushort4 abs_x = abs(x);
+  ushort4 abs_y = abs(y);
+  half4 res = select(r, nextafter(r, sign(r) * (half4)-INFINITY), convert_short4(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rte(short4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtp(short4 x)
+{
+  half4 r = convert_half4(x);
+  short4 y = convert_short4(r);
+  half4 res = select(r, nextafter(r, (half4)INFINITY), convert_short4(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtn(short4 x)
+{
+  half4 r = convert_half4(x);
+  short4 y = convert_short4(r);
+  half4 res = select(r, nextafter(r, (half4)-INFINITY), convert_short4(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtz(short8 x)
+{
+  half8 r = convert_half8(x);
+  short8 y = convert_short8(r);
+  ushort8 abs_x = abs(x);
+  ushort8 abs_y = abs(y);
+  half8 res = select(r, nextafter(r, sign(r) * (half8)-INFINITY), convert_short8(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rte(short8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtp(short8 x)
+{
+  half8 r = convert_half8(x);
+  short8 y = convert_short8(r);
+  half8 res = select(r, nextafter(r, (half8)INFINITY), convert_short8(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtn(short8 x)
+{
+  half8 r = convert_half8(x);
+  short8 y = convert_short8(r);
+  half8 res = select(r, nextafter(r, (half8)-INFINITY), convert_short8(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtz(short16 x)
+{
+  half16 r = convert_half16(x);
+  short16 y = convert_short16(r);
+  ushort16 abs_x = abs(x);
+  ushort16 abs_y = abs(y);
+  half16 res = select(r, nextafter(r, sign(r) * (half16)-INFINITY), convert_short16(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rte(short16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtp(short16 x)
+{
+  half16 r = convert_half16(x);
+  short16 y = convert_short16(r);
+  half16 res = select(r, nextafter(r, (half16)INFINITY), convert_short16(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtn(short16 x)
+{
+  half16 r = convert_half16(x);
+  short16 y = convert_short16(r);
+  half16 res = select(r, nextafter(r, (half16)-INFINITY), convert_short16(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtz(ushort x)
+{
+  half r = convert_half(x);
+  ushort y = convert_ushort(r);
+  ushort abs_x = abs(x);
+  ushort abs_y = abs(y);
+  half res = select(r, nextafter(r, sign(r) * (half)-INFINITY), convert_short(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rte(ushort x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtp(ushort x)
+{
+  half r = convert_half(x);
+  ushort y = convert_ushort(r);
+  half res = select(r, nextafter(r, (half)INFINITY), convert_short(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtn(ushort x)
+{
+  half r = convert_half(x);
+  ushort y = convert_ushort(r);
+  half res = select(r, nextafter(r, (half)-INFINITY), convert_short(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtz(ushort2 x)
+{
+  half2 r = convert_half2(x);
+  ushort2 y = convert_ushort2(r);
+  ushort2 abs_x = abs(x);
+  ushort2 abs_y = abs(y);
+  half2 res = select(r, nextafter(r, sign(r) * (half2)-INFINITY), convert_short2(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rte(ushort2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtp(ushort2 x)
+{
+  half2 r = convert_half2(x);
+  ushort2 y = convert_ushort2(r);
+  half2 res = select(r, nextafter(r, (half2)INFINITY), convert_short2(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtn(ushort2 x)
+{
+  half2 r = convert_half2(x);
+  ushort2 y = convert_ushort2(r);
+  half2 res = select(r, nextafter(r, (half2)-INFINITY), convert_short2(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtz(ushort3 x)
+{
+  half3 r = convert_half3(x);
+  ushort3 y = convert_ushort3(r);
+  ushort3 abs_x = abs(x);
+  ushort3 abs_y = abs(y);
+  half3 res = select(r, nextafter(r, sign(r) * (half3)-INFINITY), convert_short3(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rte(ushort3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtp(ushort3 x)
+{
+  half3 r = convert_half3(x);
+  ushort3 y = convert_ushort3(r);
+  half3 res = select(r, nextafter(r, (half3)INFINITY), convert_short3(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtn(ushort3 x)
+{
+  half3 r = convert_half3(x);
+  ushort3 y = convert_ushort3(r);
+  half3 res = select(r, nextafter(r, (half3)-INFINITY), convert_short3(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtz(ushort4 x)
+{
+  half4 r = convert_half4(x);
+  ushort4 y = convert_ushort4(r);
+  ushort4 abs_x = abs(x);
+  ushort4 abs_y = abs(y);
+  half4 res = select(r, nextafter(r, sign(r) * (half4)-INFINITY), convert_short4(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rte(ushort4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtp(ushort4 x)
+{
+  half4 r = convert_half4(x);
+  ushort4 y = convert_ushort4(r);
+  half4 res = select(r, nextafter(r, (half4)INFINITY), convert_short4(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtn(ushort4 x)
+{
+  half4 r = convert_half4(x);
+  ushort4 y = convert_ushort4(r);
+  half4 res = select(r, nextafter(r, (half4)-INFINITY), convert_short4(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtz(ushort8 x)
+{
+  half8 r = convert_half8(x);
+  ushort8 y = convert_ushort8(r);
+  ushort8 abs_x = abs(x);
+  ushort8 abs_y = abs(y);
+  half8 res = select(r, nextafter(r, sign(r) * (half8)-INFINITY), convert_short8(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rte(ushort8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtp(ushort8 x)
+{
+  half8 r = convert_half8(x);
+  ushort8 y = convert_ushort8(r);
+  half8 res = select(r, nextafter(r, (half8)INFINITY), convert_short8(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtn(ushort8 x)
+{
+  half8 r = convert_half8(x);
+  ushort8 y = convert_ushort8(r);
+  half8 res = select(r, nextafter(r, (half8)-INFINITY), convert_short8(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtz(ushort16 x)
+{
+  half16 r = convert_half16(x);
+  ushort16 y = convert_ushort16(r);
+  ushort16 abs_x = abs(x);
+  ushort16 abs_y = abs(y);
+  half16 res = select(r, nextafter(r, sign(r) * (half16)-INFINITY), convert_short16(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rte(ushort16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtp(ushort16 x)
+{
+  half16 r = convert_half16(x);
+  ushort16 y = convert_ushort16(r);
+  half16 res = select(r, nextafter(r, (half16)INFINITY), convert_short16(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtn(ushort16 x)
+{
+  half16 r = convert_half16(x);
+  ushort16 y = convert_ushort16(r);
+  half16 res = select(r, nextafter(r, (half16)-INFINITY), convert_short16(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtz(int x)
+{
+  half r = convert_half(x);
+  int y = convert_int(r);
+  uint abs_x = abs(x);
+  uint abs_y = abs(y);
+  half res = select(r, nextafter(r, sign(r) * (half)-INFINITY), convert_short(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rte(int x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtp(int x)
+{
+  half r = convert_half(x);
+  int y = convert_int(r);
+  half res = select(r, nextafter(r, (half)INFINITY), convert_short(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtn(int x)
+{
+  half r = convert_half(x);
+  int y = convert_int(r);
+  half res = select(r, nextafter(r, (half)-INFINITY), convert_short(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtz(int2 x)
+{
+  half2 r = convert_half2(x);
+  int2 y = convert_int2(r);
+  uint2 abs_x = abs(x);
+  uint2 abs_y = abs(y);
+  half2 res = select(r, nextafter(r, sign(r) * (half2)-INFINITY), convert_short2(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rte(int2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtp(int2 x)
+{
+  half2 r = convert_half2(x);
+  int2 y = convert_int2(r);
+  half2 res = select(r, nextafter(r, (half2)INFINITY), convert_short2(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtn(int2 x)
+{
+  half2 r = convert_half2(x);
+  int2 y = convert_int2(r);
+  half2 res = select(r, nextafter(r, (half2)-INFINITY), convert_short2(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtz(int3 x)
+{
+  half3 r = convert_half3(x);
+  int3 y = convert_int3(r);
+  uint3 abs_x = abs(x);
+  uint3 abs_y = abs(y);
+  half3 res = select(r, nextafter(r, sign(r) * (half3)-INFINITY), convert_short3(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rte(int3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtp(int3 x)
+{
+  half3 r = convert_half3(x);
+  int3 y = convert_int3(r);
+  half3 res = select(r, nextafter(r, (half3)INFINITY), convert_short3(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtn(int3 x)
+{
+  half3 r = convert_half3(x);
+  int3 y = convert_int3(r);
+  half3 res = select(r, nextafter(r, (half3)-INFINITY), convert_short3(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtz(int4 x)
+{
+  half4 r = convert_half4(x);
+  int4 y = convert_int4(r);
+  uint4 abs_x = abs(x);
+  uint4 abs_y = abs(y);
+  half4 res = select(r, nextafter(r, sign(r) * (half4)-INFINITY), convert_short4(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rte(int4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtp(int4 x)
+{
+  half4 r = convert_half4(x);
+  int4 y = convert_int4(r);
+  half4 res = select(r, nextafter(r, (half4)INFINITY), convert_short4(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtn(int4 x)
+{
+  half4 r = convert_half4(x);
+  int4 y = convert_int4(r);
+  half4 res = select(r, nextafter(r, (half4)-INFINITY), convert_short4(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtz(int8 x)
+{
+  half8 r = convert_half8(x);
+  int8 y = convert_int8(r);
+  uint8 abs_x = abs(x);
+  uint8 abs_y = abs(y);
+  half8 res = select(r, nextafter(r, sign(r) * (half8)-INFINITY), convert_short8(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rte(int8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtp(int8 x)
+{
+  half8 r = convert_half8(x);
+  int8 y = convert_int8(r);
+  half8 res = select(r, nextafter(r, (half8)INFINITY), convert_short8(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtn(int8 x)
+{
+  half8 r = convert_half8(x);
+  int8 y = convert_int8(r);
+  half8 res = select(r, nextafter(r, (half8)-INFINITY), convert_short8(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtz(int16 x)
+{
+  half16 r = convert_half16(x);
+  int16 y = convert_int16(r);
+  uint16 abs_x = abs(x);
+  uint16 abs_y = abs(y);
+  half16 res = select(r, nextafter(r, sign(r) * (half16)-INFINITY), convert_short16(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rte(int16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtp(int16 x)
+{
+  half16 r = convert_half16(x);
+  int16 y = convert_int16(r);
+  half16 res = select(r, nextafter(r, (half16)INFINITY), convert_short16(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtn(int16 x)
+{
+  half16 r = convert_half16(x);
+  int16 y = convert_int16(r);
+  half16 res = select(r, nextafter(r, (half16)-INFINITY), convert_short16(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtz(uint x)
+{
+  half r = convert_half(x);
+  uint y = convert_uint(r);
+  uint abs_x = abs(x);
+  uint abs_y = abs(y);
+  half res = select(r, nextafter(r, sign(r) * (half)-INFINITY), convert_short(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rte(uint x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtp(uint x)
+{
+  half r = convert_half(x);
+  uint y = convert_uint(r);
+  half res = select(r, nextafter(r, (half)INFINITY), convert_short(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtn(uint x)
+{
+  half r = convert_half(x);
+  uint y = convert_uint(r);
+  half res = select(r, nextafter(r, (half)-INFINITY), convert_short(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtz(uint2 x)
+{
+  half2 r = convert_half2(x);
+  uint2 y = convert_uint2(r);
+  uint2 abs_x = abs(x);
+  uint2 abs_y = abs(y);
+  half2 res = select(r, nextafter(r, sign(r) * (half2)-INFINITY), convert_short2(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rte(uint2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtp(uint2 x)
+{
+  half2 r = convert_half2(x);
+  uint2 y = convert_uint2(r);
+  half2 res = select(r, nextafter(r, (half2)INFINITY), convert_short2(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtn(uint2 x)
+{
+  half2 r = convert_half2(x);
+  uint2 y = convert_uint2(r);
+  half2 res = select(r, nextafter(r, (half2)-INFINITY), convert_short2(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtz(uint3 x)
+{
+  half3 r = convert_half3(x);
+  uint3 y = convert_uint3(r);
+  uint3 abs_x = abs(x);
+  uint3 abs_y = abs(y);
+  half3 res = select(r, nextafter(r, sign(r) * (half3)-INFINITY), convert_short3(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rte(uint3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtp(uint3 x)
+{
+  half3 r = convert_half3(x);
+  uint3 y = convert_uint3(r);
+  half3 res = select(r, nextafter(r, (half3)INFINITY), convert_short3(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtn(uint3 x)
+{
+  half3 r = convert_half3(x);
+  uint3 y = convert_uint3(r);
+  half3 res = select(r, nextafter(r, (half3)-INFINITY), convert_short3(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtz(uint4 x)
+{
+  half4 r = convert_half4(x);
+  uint4 y = convert_uint4(r);
+  uint4 abs_x = abs(x);
+  uint4 abs_y = abs(y);
+  half4 res = select(r, nextafter(r, sign(r) * (half4)-INFINITY), convert_short4(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rte(uint4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtp(uint4 x)
+{
+  half4 r = convert_half4(x);
+  uint4 y = convert_uint4(r);
+  half4 res = select(r, nextafter(r, (half4)INFINITY), convert_short4(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtn(uint4 x)
+{
+  half4 r = convert_half4(x);
+  uint4 y = convert_uint4(r);
+  half4 res = select(r, nextafter(r, (half4)-INFINITY), convert_short4(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtz(uint8 x)
+{
+  half8 r = convert_half8(x);
+  uint8 y = convert_uint8(r);
+  uint8 abs_x = abs(x);
+  uint8 abs_y = abs(y);
+  half8 res = select(r, nextafter(r, sign(r) * (half8)-INFINITY), convert_short8(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rte(uint8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtp(uint8 x)
+{
+  half8 r = convert_half8(x);
+  uint8 y = convert_uint8(r);
+  half8 res = select(r, nextafter(r, (half8)INFINITY), convert_short8(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtn(uint8 x)
+{
+  half8 r = convert_half8(x);
+  uint8 y = convert_uint8(r);
+  half8 res = select(r, nextafter(r, (half8)-INFINITY), convert_short8(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtz(uint16 x)
+{
+  half16 r = convert_half16(x);
+  uint16 y = convert_uint16(r);
+  uint16 abs_x = abs(x);
+  uint16 abs_y = abs(y);
+  half16 res = select(r, nextafter(r, sign(r) * (half16)-INFINITY), convert_short16(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rte(uint16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtp(uint16 x)
+{
+  half16 r = convert_half16(x);
+  uint16 y = convert_uint16(r);
+  half16 res = select(r, nextafter(r, (half16)INFINITY), convert_short16(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtn(uint16 x)
+{
+  half16 r = convert_half16(x);
+  uint16 y = convert_uint16(r);
+  half16 res = select(r, nextafter(r, (half16)-INFINITY), convert_short16(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtz(long x)
+{
+  half r = convert_half(x);
+  long y = convert_long(r);
+  ulong abs_x = abs(x);
+  ulong abs_y = abs(y);
+  half res = select(r, nextafter(r, sign(r) * (half)-INFINITY), convert_short(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rte(long x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtp(long x)
+{
+  half r = convert_half(x);
+  long y = convert_long(r);
+  half res = select(r, nextafter(r, (half)INFINITY), convert_short(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtn(long x)
+{
+  half r = convert_half(x);
+  long y = convert_long(r);
+  half res = select(r, nextafter(r, (half)-INFINITY), convert_short(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtz(long2 x)
+{
+  half2 r = convert_half2(x);
+  long2 y = convert_long2(r);
+  ulong2 abs_x = abs(x);
+  ulong2 abs_y = abs(y);
+  half2 res = select(r, nextafter(r, sign(r) * (half2)-INFINITY), convert_short2(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rte(long2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtp(long2 x)
+{
+  half2 r = convert_half2(x);
+  long2 y = convert_long2(r);
+  half2 res = select(r, nextafter(r, (half2)INFINITY), convert_short2(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtn(long2 x)
+{
+  half2 r = convert_half2(x);
+  long2 y = convert_long2(r);
+  half2 res = select(r, nextafter(r, (half2)-INFINITY), convert_short2(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtz(long3 x)
+{
+  half3 r = convert_half3(x);
+  long3 y = convert_long3(r);
+  ulong3 abs_x = abs(x);
+  ulong3 abs_y = abs(y);
+  half3 res = select(r, nextafter(r, sign(r) * (half3)-INFINITY), convert_short3(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rte(long3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtp(long3 x)
+{
+  half3 r = convert_half3(x);
+  long3 y = convert_long3(r);
+  half3 res = select(r, nextafter(r, (half3)INFINITY), convert_short3(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtn(long3 x)
+{
+  half3 r = convert_half3(x);
+  long3 y = convert_long3(r);
+  half3 res = select(r, nextafter(r, (half3)-INFINITY), convert_short3(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtz(long4 x)
+{
+  half4 r = convert_half4(x);
+  long4 y = convert_long4(r);
+  ulong4 abs_x = abs(x);
+  ulong4 abs_y = abs(y);
+  half4 res = select(r, nextafter(r, sign(r) * (half4)-INFINITY), convert_short4(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rte(long4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtp(long4 x)
+{
+  half4 r = convert_half4(x);
+  long4 y = convert_long4(r);
+  half4 res = select(r, nextafter(r, (half4)INFINITY), convert_short4(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtn(long4 x)
+{
+  half4 r = convert_half4(x);
+  long4 y = convert_long4(r);
+  half4 res = select(r, nextafter(r, (half4)-INFINITY), convert_short4(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtz(long8 x)
+{
+  half8 r = convert_half8(x);
+  long8 y = convert_long8(r);
+  ulong8 abs_x = abs(x);
+  ulong8 abs_y = abs(y);
+  half8 res = select(r, nextafter(r, sign(r) * (half8)-INFINITY), convert_short8(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rte(long8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtp(long8 x)
+{
+  half8 r = convert_half8(x);
+  long8 y = convert_long8(r);
+  half8 res = select(r, nextafter(r, (half8)INFINITY), convert_short8(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtn(long8 x)
+{
+  half8 r = convert_half8(x);
+  long8 y = convert_long8(r);
+  half8 res = select(r, nextafter(r, (half8)-INFINITY), convert_short8(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtz(long16 x)
+{
+  half16 r = convert_half16(x);
+  long16 y = convert_long16(r);
+  ulong16 abs_x = abs(x);
+  ulong16 abs_y = abs(y);
+  half16 res = select(r, nextafter(r, sign(r) * (half16)-INFINITY), convert_short16(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rte(long16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtp(long16 x)
+{
+  half16 r = convert_half16(x);
+  long16 y = convert_long16(r);
+  half16 res = select(r, nextafter(r, (half16)INFINITY), convert_short16(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtn(long16 x)
+{
+  half16 r = convert_half16(x);
+  long16 y = convert_long16(r);
+  half16 res = select(r, nextafter(r, (half16)-INFINITY), convert_short16(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtz(ulong x)
+{
+  half r = convert_half(x);
+  ulong y = convert_ulong(r);
+  ulong abs_x = abs(x);
+  ulong abs_y = abs(y);
+  half res = select(r, nextafter(r, sign(r) * (half)-INFINITY), convert_short(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rte(ulong x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtp(ulong x)
+{
+  half r = convert_half(x);
+  ulong y = convert_ulong(r);
+  half res = select(r, nextafter(r, (half)INFINITY), convert_short(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtn(ulong x)
+{
+  half r = convert_half(x);
+  ulong y = convert_ulong(r);
+  half res = select(r, nextafter(r, (half)-INFINITY), convert_short(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtz(ulong2 x)
+{
+  half2 r = convert_half2(x);
+  ulong2 y = convert_ulong2(r);
+  ulong2 abs_x = abs(x);
+  ulong2 abs_y = abs(y);
+  half2 res = select(r, nextafter(r, sign(r) * (half2)-INFINITY), convert_short2(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rte(ulong2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtp(ulong2 x)
+{
+  half2 r = convert_half2(x);
+  ulong2 y = convert_ulong2(r);
+  half2 res = select(r, nextafter(r, (half2)INFINITY), convert_short2(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtn(ulong2 x)
+{
+  half2 r = convert_half2(x);
+  ulong2 y = convert_ulong2(r);
+  half2 res = select(r, nextafter(r, (half2)-INFINITY), convert_short2(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtz(ulong3 x)
+{
+  half3 r = convert_half3(x);
+  ulong3 y = convert_ulong3(r);
+  ulong3 abs_x = abs(x);
+  ulong3 abs_y = abs(y);
+  half3 res = select(r, nextafter(r, sign(r) * (half3)-INFINITY), convert_short3(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rte(ulong3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtp(ulong3 x)
+{
+  half3 r = convert_half3(x);
+  ulong3 y = convert_ulong3(r);
+  half3 res = select(r, nextafter(r, (half3)INFINITY), convert_short3(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtn(ulong3 x)
+{
+  half3 r = convert_half3(x);
+  ulong3 y = convert_ulong3(r);
+  half3 res = select(r, nextafter(r, (half3)-INFINITY), convert_short3(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtz(ulong4 x)
+{
+  half4 r = convert_half4(x);
+  ulong4 y = convert_ulong4(r);
+  ulong4 abs_x = abs(x);
+  ulong4 abs_y = abs(y);
+  half4 res = select(r, nextafter(r, sign(r) * (half4)-INFINITY), convert_short4(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rte(ulong4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtp(ulong4 x)
+{
+  half4 r = convert_half4(x);
+  ulong4 y = convert_ulong4(r);
+  half4 res = select(r, nextafter(r, (half4)INFINITY), convert_short4(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtn(ulong4 x)
+{
+  half4 r = convert_half4(x);
+  ulong4 y = convert_ulong4(r);
+  half4 res = select(r, nextafter(r, (half4)-INFINITY), convert_short4(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtz(ulong8 x)
+{
+  half8 r = convert_half8(x);
+  ulong8 y = convert_ulong8(r);
+  ulong8 abs_x = abs(x);
+  ulong8 abs_y = abs(y);
+  half8 res = select(r, nextafter(r, sign(r) * (half8)-INFINITY), convert_short8(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rte(ulong8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtp(ulong8 x)
+{
+  half8 r = convert_half8(x);
+  ulong8 y = convert_ulong8(r);
+  half8 res = select(r, nextafter(r, (half8)INFINITY), convert_short8(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtn(ulong8 x)
+{
+  half8 r = convert_half8(x);
+  ulong8 y = convert_ulong8(r);
+  half8 res = select(r, nextafter(r, (half8)-INFINITY), convert_short8(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtz(ulong16 x)
+{
+  half16 r = convert_half16(x);
+  ulong16 y = convert_ulong16(r);
+  ulong16 abs_x = abs(x);
+  ulong16 abs_y = abs(y);
+  half16 res = select(r, nextafter(r, sign(r) * (half16)-INFINITY), convert_short16(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rte(ulong16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtp(ulong16 x)
+{
+  half16 r = convert_half16(x);
+  ulong16 y = convert_ulong16(r);
+  half16 res = select(r, nextafter(r, (half16)INFINITY), convert_short16(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtn(ulong16 x)
+{
+  half16 r = convert_half16(x);
+  ulong16 y = convert_ulong16(r);
+  half16 res = select(r, nextafter(r, (half16)-INFINITY), convert_short16(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtz(half x)
+{
+  half r = convert_half(x);
+  half y = convert_half(r);
+  half abs_x = fabs(x);
+  half abs_y = fabs(y);
+  half res = select(r, nextafter(r, sign(r) * (half)-INFINITY), convert_short(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rte(half x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtp(half x)
+{
+  half r = convert_half(x);
+  half y = convert_half(r);
+  half res = select(r, nextafter(r, (half)INFINITY), convert_short(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtn(half x)
+{
+  half r = convert_half(x);
+  half y = convert_half(r);
+  half res = select(r, nextafter(r, (half)-INFINITY), convert_short(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtz(half2 x)
+{
+  half2 r = convert_half2(x);
+  half2 y = convert_half2(r);
+  half2 abs_x = fabs(x);
+  half2 abs_y = fabs(y);
+  half2 res = select(r, nextafter(r, sign(r) * (half2)-INFINITY), convert_short2(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rte(half2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtp(half2 x)
+{
+  half2 r = convert_half2(x);
+  half2 y = convert_half2(r);
+  half2 res = select(r, nextafter(r, (half2)INFINITY), convert_short2(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtn(half2 x)
+{
+  half2 r = convert_half2(x);
+  half2 y = convert_half2(r);
+  half2 res = select(r, nextafter(r, (half2)-INFINITY), convert_short2(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtz(half3 x)
+{
+  half3 r = convert_half3(x);
+  half3 y = convert_half3(r);
+  half3 abs_x = fabs(x);
+  half3 abs_y = fabs(y);
+  half3 res = select(r, nextafter(r, sign(r) * (half3)-INFINITY), convert_short3(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rte(half3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtp(half3 x)
+{
+  half3 r = convert_half3(x);
+  half3 y = convert_half3(r);
+  half3 res = select(r, nextafter(r, (half3)INFINITY), convert_short3(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtn(half3 x)
+{
+  half3 r = convert_half3(x);
+  half3 y = convert_half3(r);
+  half3 res = select(r, nextafter(r, (half3)-INFINITY), convert_short3(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtz(half4 x)
+{
+  half4 r = convert_half4(x);
+  half4 y = convert_half4(r);
+  half4 abs_x = fabs(x);
+  half4 abs_y = fabs(y);
+  half4 res = select(r, nextafter(r, sign(r) * (half4)-INFINITY), convert_short4(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rte(half4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtp(half4 x)
+{
+  half4 r = convert_half4(x);
+  half4 y = convert_half4(r);
+  half4 res = select(r, nextafter(r, (half4)INFINITY), convert_short4(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtn(half4 x)
+{
+  half4 r = convert_half4(x);
+  half4 y = convert_half4(r);
+  half4 res = select(r, nextafter(r, (half4)-INFINITY), convert_short4(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtz(half8 x)
+{
+  half8 r = convert_half8(x);
+  half8 y = convert_half8(r);
+  half8 abs_x = fabs(x);
+  half8 abs_y = fabs(y);
+  half8 res = select(r, nextafter(r, sign(r) * (half8)-INFINITY), convert_short8(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rte(half8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtp(half8 x)
+{
+  half8 r = convert_half8(x);
+  half8 y = convert_half8(r);
+  half8 res = select(r, nextafter(r, (half8)INFINITY), convert_short8(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtn(half8 x)
+{
+  half8 r = convert_half8(x);
+  half8 y = convert_half8(r);
+  half8 res = select(r, nextafter(r, (half8)-INFINITY), convert_short8(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtz(half16 x)
+{
+  half16 r = convert_half16(x);
+  half16 y = convert_half16(r);
+  half16 abs_x = fabs(x);
+  half16 abs_y = fabs(y);
+  half16 res = select(r, nextafter(r, sign(r) * (half16)-INFINITY), convert_short16(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rte(half16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtp(half16 x)
+{
+  half16 r = convert_half16(x);
+  half16 y = convert_half16(r);
+  half16 res = select(r, nextafter(r, (half16)INFINITY), convert_short16(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtn(half16 x)
+{
+  half16 r = convert_half16(x);
+  half16 y = convert_half16(r);
+  half16 res = select(r, nextafter(r, (half16)-INFINITY), convert_short16(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtz(float x)
+{
+  half r = convert_half(x);
+  float y = convert_float(r);
+  float abs_x = fabs(x);
+  float abs_y = fabs(y);
+  half res = select(r, nextafter(r, sign(r) * (half)-INFINITY), convert_short(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rte(float x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtp(float x)
+{
+  half r = convert_half(x);
+  float y = convert_float(r);
+  half res = select(r, nextafter(r, (half)INFINITY), convert_short(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtn(float x)
+{
+  half r = convert_half(x);
+  float y = convert_float(r);
+  half res = select(r, nextafter(r, (half)-INFINITY), convert_short(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtz(float2 x)
+{
+  half2 r = convert_half2(x);
+  float2 y = convert_float2(r);
+  float2 abs_x = fabs(x);
+  float2 abs_y = fabs(y);
+  half2 res = select(r, nextafter(r, sign(r) * (half2)-INFINITY), convert_short2(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rte(float2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtp(float2 x)
+{
+  half2 r = convert_half2(x);
+  float2 y = convert_float2(r);
+  half2 res = select(r, nextafter(r, (half2)INFINITY), convert_short2(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtn(float2 x)
+{
+  half2 r = convert_half2(x);
+  float2 y = convert_float2(r);
+  half2 res = select(r, nextafter(r, (half2)-INFINITY), convert_short2(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtz(float3 x)
+{
+  half3 r = convert_half3(x);
+  float3 y = convert_float3(r);
+  float3 abs_x = fabs(x);
+  float3 abs_y = fabs(y);
+  half3 res = select(r, nextafter(r, sign(r) * (half3)-INFINITY), convert_short3(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rte(float3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtp(float3 x)
+{
+  half3 r = convert_half3(x);
+  float3 y = convert_float3(r);
+  half3 res = select(r, nextafter(r, (half3)INFINITY), convert_short3(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtn(float3 x)
+{
+  half3 r = convert_half3(x);
+  float3 y = convert_float3(r);
+  half3 res = select(r, nextafter(r, (half3)-INFINITY), convert_short3(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtz(float4 x)
+{
+  half4 r = convert_half4(x);
+  float4 y = convert_float4(r);
+  float4 abs_x = fabs(x);
+  float4 abs_y = fabs(y);
+  half4 res = select(r, nextafter(r, sign(r) * (half4)-INFINITY), convert_short4(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rte(float4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtp(float4 x)
+{
+  half4 r = convert_half4(x);
+  float4 y = convert_float4(r);
+  half4 res = select(r, nextafter(r, (half4)INFINITY), convert_short4(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtn(float4 x)
+{
+  half4 r = convert_half4(x);
+  float4 y = convert_float4(r);
+  half4 res = select(r, nextafter(r, (half4)-INFINITY), convert_short4(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtz(float8 x)
+{
+  half8 r = convert_half8(x);
+  float8 y = convert_float8(r);
+  float8 abs_x = fabs(x);
+  float8 abs_y = fabs(y);
+  half8 res = select(r, nextafter(r, sign(r) * (half8)-INFINITY), convert_short8(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rte(float8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtp(float8 x)
+{
+  half8 r = convert_half8(x);
+  float8 y = convert_float8(r);
+  half8 res = select(r, nextafter(r, (half8)INFINITY), convert_short8(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtn(float8 x)
+{
+  half8 r = convert_half8(x);
+  float8 y = convert_float8(r);
+  half8 res = select(r, nextafter(r, (half8)-INFINITY), convert_short8(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtz(float16 x)
+{
+  half16 r = convert_half16(x);
+  float16 y = convert_float16(r);
+  float16 abs_x = fabs(x);
+  float16 abs_y = fabs(y);
+  half16 res = select(r, nextafter(r, sign(r) * (half16)-INFINITY), convert_short16(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rte(float16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtp(float16 x)
+{
+  half16 r = convert_half16(x);
+  float16 y = convert_float16(r);
+  half16 res = select(r, nextafter(r, (half16)INFINITY), convert_short16(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtn(float16 x)
+{
+  half16 r = convert_half16(x);
+  float16 y = convert_float16(r);
+  half16 res = select(r, nextafter(r, (half16)-INFINITY), convert_short16(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtz(double x)
+{
+  half r = convert_half(x);
+  double y = convert_double(r);
+  double abs_x = fabs(x);
+  double abs_y = fabs(y);
+  half res = select(r, nextafter(r, sign(r) * (half)-INFINITY), convert_short(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rte(double x)
+{
+  return convert_half(x);
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtp(double x)
+{
+  half r = convert_half(x);
+  double y = convert_double(r);
+  half res = select(r, nextafter(r, (half)INFINITY), convert_short(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half convert_half_rtn(double x)
+{
+  half r = convert_half(x);
+  double y = convert_double(r);
+  half res = select(r, nextafter(r, (half)-INFINITY), convert_short(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtz(double2 x)
+{
+  half2 r = convert_half2(x);
+  double2 y = convert_double2(r);
+  double2 abs_x = fabs(x);
+  double2 abs_y = fabs(y);
+  half2 res = select(r, nextafter(r, sign(r) * (half2)-INFINITY), convert_short2(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rte(double2 x)
+{
+  return convert_half2(x);
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtp(double2 x)
+{
+  half2 r = convert_half2(x);
+  double2 y = convert_double2(r);
+  half2 res = select(r, nextafter(r, (half2)INFINITY), convert_short2(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half2 convert_half2_rtn(double2 x)
+{
+  half2 r = convert_half2(x);
+  double2 y = convert_double2(r);
+  half2 res = select(r, nextafter(r, (half2)-INFINITY), convert_short2(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtz(double3 x)
+{
+  half3 r = convert_half3(x);
+  double3 y = convert_double3(r);
+  double3 abs_x = fabs(x);
+  double3 abs_y = fabs(y);
+  half3 res = select(r, nextafter(r, sign(r) * (half3)-INFINITY), convert_short3(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rte(double3 x)
+{
+  return convert_half3(x);
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtp(double3 x)
+{
+  half3 r = convert_half3(x);
+  double3 y = convert_double3(r);
+  half3 res = select(r, nextafter(r, (half3)INFINITY), convert_short3(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half3 convert_half3_rtn(double3 x)
+{
+  half3 r = convert_half3(x);
+  double3 y = convert_double3(r);
+  half3 res = select(r, nextafter(r, (half3)-INFINITY), convert_short3(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtz(double4 x)
+{
+  half4 r = convert_half4(x);
+  double4 y = convert_double4(r);
+  double4 abs_x = fabs(x);
+  double4 abs_y = fabs(y);
+  half4 res = select(r, nextafter(r, sign(r) * (half4)-INFINITY), convert_short4(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rte(double4 x)
+{
+  return convert_half4(x);
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtp(double4 x)
+{
+  half4 r = convert_half4(x);
+  double4 y = convert_double4(r);
+  half4 res = select(r, nextafter(r, (half4)INFINITY), convert_short4(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half4 convert_half4_rtn(double4 x)
+{
+  half4 r = convert_half4(x);
+  double4 y = convert_double4(r);
+  half4 res = select(r, nextafter(r, (half4)-INFINITY), convert_short4(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtz(double8 x)
+{
+  half8 r = convert_half8(x);
+  double8 y = convert_double8(r);
+  double8 abs_x = fabs(x);
+  double8 abs_y = fabs(y);
+  half8 res = select(r, nextafter(r, sign(r) * (half8)-INFINITY), convert_short8(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rte(double8 x)
+{
+  return convert_half8(x);
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtp(double8 x)
+{
+  half8 r = convert_half8(x);
+  double8 y = convert_double8(r);
+  half8 res = select(r, nextafter(r, (half8)INFINITY), convert_short8(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half8 convert_half8_rtn(double8 x)
+{
+  half8 r = convert_half8(x);
+  double8 y = convert_double8(r);
+  half8 res = select(r, nextafter(r, (half8)-INFINITY), convert_short8(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtz(double16 x)
+{
+  half16 r = convert_half16(x);
+  double16 y = convert_double16(r);
+  double16 abs_x = fabs(x);
+  double16 abs_y = fabs(y);
+  half16 res = select(r, nextafter(r, sign(r) * (half16)-INFINITY), convert_short16(abs_y > abs_x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rte(double16 x)
+{
+  return convert_half16(x);
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtp(double16 x)
+{
+  half16 r = convert_half16(x);
+  double16 y = convert_double16(r);
+  half16 res = select(r, nextafter(r, (half16)INFINITY), convert_short16(y < x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+half16 convert_half16_rtn(double16 x)
+{
+  half16 r = convert_half16(x);
+  double16 y = convert_double16(r);
+  half16 res = select(r, nextafter(r, (half16)-INFINITY), convert_short16(y > x));
+  return res;
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char convert_char_rtz(half x)
+{
+  return convert_char(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char convert_char_sat_rtz(half x)
+{
+  return convert_char_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char convert_char_rte(half x)
+{
+  x = rint(x);
+  return convert_char(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char convert_char_sat_rte(half x)
+{
+  x = rint(x);
+  return convert_char_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char convert_char_rtp(half x)
+{
+  x = ceil(x);
+  return convert_char(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char convert_char_sat_rtp(half x)
+{
+  x = ceil(x);
+  return convert_char_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char convert_char_rtn(half x)
+{
+  x = floor(x);
+  return convert_char(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char convert_char_sat_rtn(half x)
+{
+  x = floor(x);
+  return convert_char_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char2 convert_char2_rtz(half2 x)
+{
+  return convert_char2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char2 convert_char2_sat_rtz(half2 x)
+{
+  return convert_char2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char2 convert_char2_rte(half2 x)
+{
+  x = rint(x);
+  return convert_char2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char2 convert_char2_sat_rte(half2 x)
+{
+  x = rint(x);
+  return convert_char2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char2 convert_char2_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_char2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char2 convert_char2_sat_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_char2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char2 convert_char2_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_char2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char2 convert_char2_sat_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_char2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtz(half3 x)
+{
+  return convert_char3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_sat_rtz(half3 x)
+{
+  return convert_char3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rte(half3 x)
+{
+  x = rint(x);
+  return convert_char3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_sat_rte(half3 x)
+{
+  x = rint(x);
+  return convert_char3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_char3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_sat_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_char3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_char3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char3 convert_char3_sat_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_char3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtz(half4 x)
+{
+  return convert_char4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_sat_rtz(half4 x)
+{
+  return convert_char4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rte(half4 x)
+{
+  x = rint(x);
+  return convert_char4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_sat_rte(half4 x)
+{
+  x = rint(x);
+  return convert_char4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_char4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_sat_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_char4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_char4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char4 convert_char4_sat_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_char4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtz(half8 x)
+{
+  return convert_char8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_sat_rtz(half8 x)
+{
+  return convert_char8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rte(half8 x)
+{
+  x = rint(x);
+  return convert_char8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_sat_rte(half8 x)
+{
+  x = rint(x);
+  return convert_char8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_char8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_sat_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_char8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_char8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char8 convert_char8_sat_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_char8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtz(half16 x)
+{
+  return convert_char16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_sat_rtz(half16 x)
+{
+  return convert_char16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rte(half16 x)
+{
+  x = rint(x);
+  return convert_char16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_sat_rte(half16 x)
+{
+  x = rint(x);
+  return convert_char16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_char16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_sat_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_char16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_char16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+char16 convert_char16_sat_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_char16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar convert_uchar_rtz(half x)
+{
+  return convert_uchar(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar convert_uchar_sat_rtz(half x)
+{
+  return convert_uchar_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar convert_uchar_rte(half x)
+{
+  x = rint(x);
+  return convert_uchar(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar convert_uchar_sat_rte(half x)
+{
+  x = rint(x);
+  return convert_uchar_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar convert_uchar_rtp(half x)
+{
+  x = ceil(x);
+  return convert_uchar(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar convert_uchar_sat_rtp(half x)
+{
+  x = ceil(x);
+  return convert_uchar_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar convert_uchar_rtn(half x)
+{
+  x = floor(x);
+  return convert_uchar(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar convert_uchar_sat_rtn(half x)
+{
+  x = floor(x);
+  return convert_uchar_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar2 convert_uchar2_rtz(half2 x)
+{
+  return convert_uchar2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar2 convert_uchar2_sat_rtz(half2 x)
+{
+  return convert_uchar2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar2 convert_uchar2_rte(half2 x)
+{
+  x = rint(x);
+  return convert_uchar2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar2 convert_uchar2_sat_rte(half2 x)
+{
+  x = rint(x);
+  return convert_uchar2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar2 convert_uchar2_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_uchar2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar2 convert_uchar2_sat_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_uchar2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar2 convert_uchar2_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_uchar2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar2 convert_uchar2_sat_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_uchar2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtz(half3 x)
+{
+  return convert_uchar3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_sat_rtz(half3 x)
+{
+  return convert_uchar3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rte(half3 x)
+{
+  x = rint(x);
+  return convert_uchar3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_sat_rte(half3 x)
+{
+  x = rint(x);
+  return convert_uchar3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_uchar3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_sat_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_uchar3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_uchar3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar3 convert_uchar3_sat_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_uchar3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtz(half4 x)
+{
+  return convert_uchar4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_sat_rtz(half4 x)
+{
+  return convert_uchar4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rte(half4 x)
+{
+  x = rint(x);
+  return convert_uchar4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_sat_rte(half4 x)
+{
+  x = rint(x);
+  return convert_uchar4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_uchar4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_sat_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_uchar4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_uchar4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar4 convert_uchar4_sat_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_uchar4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtz(half8 x)
+{
+  return convert_uchar8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_sat_rtz(half8 x)
+{
+  return convert_uchar8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rte(half8 x)
+{
+  x = rint(x);
+  return convert_uchar8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_sat_rte(half8 x)
+{
+  x = rint(x);
+  return convert_uchar8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_uchar8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_sat_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_uchar8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_uchar8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar8 convert_uchar8_sat_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_uchar8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtz(half16 x)
+{
+  return convert_uchar16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_sat_rtz(half16 x)
+{
+  return convert_uchar16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rte(half16 x)
+{
+  x = rint(x);
+  return convert_uchar16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_sat_rte(half16 x)
+{
+  x = rint(x);
+  return convert_uchar16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_uchar16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_sat_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_uchar16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_uchar16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uchar16 convert_uchar16_sat_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_uchar16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short convert_short_rtz(half x)
+{
+  return convert_short(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short convert_short_sat_rtz(half x)
+{
+  return convert_short_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short convert_short_rte(half x)
+{
+  x = rint(x);
+  return convert_short(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short convert_short_sat_rte(half x)
+{
+  x = rint(x);
+  return convert_short_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short convert_short_rtp(half x)
+{
+  x = ceil(x);
+  return convert_short(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short convert_short_sat_rtp(half x)
+{
+  x = ceil(x);
+  return convert_short_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short convert_short_rtn(half x)
+{
+  x = floor(x);
+  return convert_short(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short convert_short_sat_rtn(half x)
+{
+  x = floor(x);
+  return convert_short_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short2 convert_short2_rtz(half2 x)
+{
+  return convert_short2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short2 convert_short2_sat_rtz(half2 x)
+{
+  return convert_short2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short2 convert_short2_rte(half2 x)
+{
+  x = rint(x);
+  return convert_short2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short2 convert_short2_sat_rte(half2 x)
+{
+  x = rint(x);
+  return convert_short2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short2 convert_short2_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_short2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short2 convert_short2_sat_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_short2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short2 convert_short2_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_short2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short2 convert_short2_sat_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_short2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtz(half3 x)
+{
+  return convert_short3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_sat_rtz(half3 x)
+{
+  return convert_short3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rte(half3 x)
+{
+  x = rint(x);
+  return convert_short3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_sat_rte(half3 x)
+{
+  x = rint(x);
+  return convert_short3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_short3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_sat_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_short3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_short3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short3 convert_short3_sat_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_short3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtz(half4 x)
+{
+  return convert_short4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_sat_rtz(half4 x)
+{
+  return convert_short4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rte(half4 x)
+{
+  x = rint(x);
+  return convert_short4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_sat_rte(half4 x)
+{
+  x = rint(x);
+  return convert_short4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_short4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_sat_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_short4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_short4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short4 convert_short4_sat_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_short4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtz(half8 x)
+{
+  return convert_short8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_sat_rtz(half8 x)
+{
+  return convert_short8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rte(half8 x)
+{
+  x = rint(x);
+  return convert_short8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_sat_rte(half8 x)
+{
+  x = rint(x);
+  return convert_short8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_short8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_sat_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_short8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_short8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short8 convert_short8_sat_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_short8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtz(half16 x)
+{
+  return convert_short16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_sat_rtz(half16 x)
+{
+  return convert_short16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rte(half16 x)
+{
+  x = rint(x);
+  return convert_short16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_sat_rte(half16 x)
+{
+  x = rint(x);
+  return convert_short16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_short16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_sat_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_short16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_short16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+short16 convert_short16_sat_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_short16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort convert_ushort_rtz(half x)
+{
+  return convert_ushort(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort convert_ushort_sat_rtz(half x)
+{
+  return convert_ushort_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort convert_ushort_rte(half x)
+{
+  x = rint(x);
+  return convert_ushort(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort convert_ushort_sat_rte(half x)
+{
+  x = rint(x);
+  return convert_ushort_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort convert_ushort_rtp(half x)
+{
+  x = ceil(x);
+  return convert_ushort(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort convert_ushort_sat_rtp(half x)
+{
+  x = ceil(x);
+  return convert_ushort_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort convert_ushort_rtn(half x)
+{
+  x = floor(x);
+  return convert_ushort(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort convert_ushort_sat_rtn(half x)
+{
+  x = floor(x);
+  return convert_ushort_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort2 convert_ushort2_rtz(half2 x)
+{
+  return convert_ushort2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort2 convert_ushort2_sat_rtz(half2 x)
+{
+  return convert_ushort2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort2 convert_ushort2_rte(half2 x)
+{
+  x = rint(x);
+  return convert_ushort2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort2 convert_ushort2_sat_rte(half2 x)
+{
+  x = rint(x);
+  return convert_ushort2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort2 convert_ushort2_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_ushort2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort2 convert_ushort2_sat_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_ushort2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort2 convert_ushort2_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_ushort2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort2 convert_ushort2_sat_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_ushort2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtz(half3 x)
+{
+  return convert_ushort3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_sat_rtz(half3 x)
+{
+  return convert_ushort3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rte(half3 x)
+{
+  x = rint(x);
+  return convert_ushort3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_sat_rte(half3 x)
+{
+  x = rint(x);
+  return convert_ushort3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_ushort3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_sat_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_ushort3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_ushort3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort3 convert_ushort3_sat_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_ushort3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtz(half4 x)
+{
+  return convert_ushort4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_sat_rtz(half4 x)
+{
+  return convert_ushort4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rte(half4 x)
+{
+  x = rint(x);
+  return convert_ushort4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_sat_rte(half4 x)
+{
+  x = rint(x);
+  return convert_ushort4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_ushort4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_sat_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_ushort4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_ushort4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort4 convert_ushort4_sat_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_ushort4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtz(half8 x)
+{
+  return convert_ushort8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_sat_rtz(half8 x)
+{
+  return convert_ushort8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rte(half8 x)
+{
+  x = rint(x);
+  return convert_ushort8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_sat_rte(half8 x)
+{
+  x = rint(x);
+  return convert_ushort8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_ushort8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_sat_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_ushort8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_ushort8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort8 convert_ushort8_sat_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_ushort8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtz(half16 x)
+{
+  return convert_ushort16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_sat_rtz(half16 x)
+{
+  return convert_ushort16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rte(half16 x)
+{
+  x = rint(x);
+  return convert_ushort16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_sat_rte(half16 x)
+{
+  x = rint(x);
+  return convert_ushort16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_ushort16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_sat_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_ushort16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_ushort16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ushort16 convert_ushort16_sat_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_ushort16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int convert_int_rtz(half x)
+{
+  return convert_int(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int convert_int_sat_rtz(half x)
+{
+  return convert_int_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int convert_int_rte(half x)
+{
+  x = rint(x);
+  return convert_int(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int convert_int_sat_rte(half x)
+{
+  x = rint(x);
+  return convert_int_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int convert_int_rtp(half x)
+{
+  x = ceil(x);
+  return convert_int(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int convert_int_sat_rtp(half x)
+{
+  x = ceil(x);
+  return convert_int_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int convert_int_rtn(half x)
+{
+  x = floor(x);
+  return convert_int(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int convert_int_sat_rtn(half x)
+{
+  x = floor(x);
+  return convert_int_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int2 convert_int2_rtz(half2 x)
+{
+  return convert_int2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int2 convert_int2_sat_rtz(half2 x)
+{
+  return convert_int2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int2 convert_int2_rte(half2 x)
+{
+  x = rint(x);
+  return convert_int2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int2 convert_int2_sat_rte(half2 x)
+{
+  x = rint(x);
+  return convert_int2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int2 convert_int2_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_int2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int2 convert_int2_sat_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_int2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int2 convert_int2_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_int2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int2 convert_int2_sat_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_int2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtz(half3 x)
+{
+  return convert_int3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_sat_rtz(half3 x)
+{
+  return convert_int3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rte(half3 x)
+{
+  x = rint(x);
+  return convert_int3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_sat_rte(half3 x)
+{
+  x = rint(x);
+  return convert_int3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_int3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_sat_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_int3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_int3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int3 convert_int3_sat_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_int3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtz(half4 x)
+{
+  return convert_int4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_sat_rtz(half4 x)
+{
+  return convert_int4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rte(half4 x)
+{
+  x = rint(x);
+  return convert_int4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_sat_rte(half4 x)
+{
+  x = rint(x);
+  return convert_int4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_int4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_sat_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_int4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_int4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int4 convert_int4_sat_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_int4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtz(half8 x)
+{
+  return convert_int8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_sat_rtz(half8 x)
+{
+  return convert_int8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rte(half8 x)
+{
+  x = rint(x);
+  return convert_int8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_sat_rte(half8 x)
+{
+  x = rint(x);
+  return convert_int8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_int8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_sat_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_int8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_int8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int8 convert_int8_sat_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_int8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtz(half16 x)
+{
+  return convert_int16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_sat_rtz(half16 x)
+{
+  return convert_int16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rte(half16 x)
+{
+  x = rint(x);
+  return convert_int16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_sat_rte(half16 x)
+{
+  x = rint(x);
+  return convert_int16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_int16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_sat_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_int16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_int16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+int16 convert_int16_sat_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_int16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint convert_uint_rtz(half x)
+{
+  return convert_uint(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint convert_uint_sat_rtz(half x)
+{
+  return convert_uint_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint convert_uint_rte(half x)
+{
+  x = rint(x);
+  return convert_uint(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint convert_uint_sat_rte(half x)
+{
+  x = rint(x);
+  return convert_uint_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint convert_uint_rtp(half x)
+{
+  x = ceil(x);
+  return convert_uint(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint convert_uint_sat_rtp(half x)
+{
+  x = ceil(x);
+  return convert_uint_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint convert_uint_rtn(half x)
+{
+  x = floor(x);
+  return convert_uint(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint convert_uint_sat_rtn(half x)
+{
+  x = floor(x);
+  return convert_uint_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint2 convert_uint2_rtz(half2 x)
+{
+  return convert_uint2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint2 convert_uint2_sat_rtz(half2 x)
+{
+  return convert_uint2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint2 convert_uint2_rte(half2 x)
+{
+  x = rint(x);
+  return convert_uint2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint2 convert_uint2_sat_rte(half2 x)
+{
+  x = rint(x);
+  return convert_uint2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint2 convert_uint2_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_uint2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint2 convert_uint2_sat_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_uint2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint2 convert_uint2_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_uint2(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint2 convert_uint2_sat_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_uint2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtz(half3 x)
+{
+  return convert_uint3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_sat_rtz(half3 x)
+{
+  return convert_uint3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rte(half3 x)
+{
+  x = rint(x);
+  return convert_uint3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_sat_rte(half3 x)
+{
+  x = rint(x);
+  return convert_uint3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_uint3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_sat_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_uint3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_uint3(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint3 convert_uint3_sat_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_uint3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtz(half4 x)
+{
+  return convert_uint4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_sat_rtz(half4 x)
+{
+  return convert_uint4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rte(half4 x)
+{
+  x = rint(x);
+  return convert_uint4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_sat_rte(half4 x)
+{
+  x = rint(x);
+  return convert_uint4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_uint4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_sat_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_uint4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_uint4(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint4 convert_uint4_sat_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_uint4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtz(half8 x)
+{
+  return convert_uint8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_sat_rtz(half8 x)
+{
+  return convert_uint8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rte(half8 x)
+{
+  x = rint(x);
+  return convert_uint8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_sat_rte(half8 x)
+{
+  x = rint(x);
+  return convert_uint8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_uint8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_sat_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_uint8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_uint8(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint8 convert_uint8_sat_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_uint8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtz(half16 x)
+{
+  return convert_uint16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_sat_rtz(half16 x)
+{
+  return convert_uint16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rte(half16 x)
+{
+  x = rint(x);
+  return convert_uint16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_sat_rte(half16 x)
+{
+  x = rint(x);
+  return convert_uint16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_uint16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_sat_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_uint16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_uint16(x);
+}
+#endif
+
+#if defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+uint16 convert_uint16_sat_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_uint16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long convert_long_rtz(half x)
+{
+  return convert_long(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long convert_long_sat_rtz(half x)
+{
+  return convert_long_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long convert_long_rte(half x)
+{
+  x = rint(x);
+  return convert_long(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long convert_long_sat_rte(half x)
+{
+  x = rint(x);
+  return convert_long_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long convert_long_rtp(half x)
+{
+  x = ceil(x);
+  return convert_long(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long convert_long_sat_rtp(half x)
+{
+  x = ceil(x);
+  return convert_long_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long convert_long_rtn(half x)
+{
+  x = floor(x);
+  return convert_long(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long convert_long_sat_rtn(half x)
+{
+  x = floor(x);
+  return convert_long_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long2 convert_long2_rtz(half2 x)
+{
+  return convert_long2(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long2 convert_long2_sat_rtz(half2 x)
+{
+  return convert_long2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long2 convert_long2_rte(half2 x)
+{
+  x = rint(x);
+  return convert_long2(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long2 convert_long2_sat_rte(half2 x)
+{
+  x = rint(x);
+  return convert_long2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long2 convert_long2_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_long2(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long2 convert_long2_sat_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_long2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long2 convert_long2_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_long2(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long2 convert_long2_sat_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_long2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtz(half3 x)
+{
+  return convert_long3(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_sat_rtz(half3 x)
+{
+  return convert_long3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rte(half3 x)
+{
+  x = rint(x);
+  return convert_long3(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_sat_rte(half3 x)
+{
+  x = rint(x);
+  return convert_long3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_long3(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_sat_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_long3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_long3(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long3 convert_long3_sat_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_long3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtz(half4 x)
+{
+  return convert_long4(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_sat_rtz(half4 x)
+{
+  return convert_long4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rte(half4 x)
+{
+  x = rint(x);
+  return convert_long4(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_sat_rte(half4 x)
+{
+  x = rint(x);
+  return convert_long4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_long4(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_sat_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_long4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_long4(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long4 convert_long4_sat_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_long4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtz(half8 x)
+{
+  return convert_long8(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_sat_rtz(half8 x)
+{
+  return convert_long8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rte(half8 x)
+{
+  x = rint(x);
+  return convert_long8(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_sat_rte(half8 x)
+{
+  x = rint(x);
+  return convert_long8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_long8(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_sat_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_long8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_long8(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long8 convert_long8_sat_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_long8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtz(half16 x)
+{
+  return convert_long16(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_sat_rtz(half16 x)
+{
+  return convert_long16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rte(half16 x)
+{
+  x = rint(x);
+  return convert_long16(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_sat_rte(half16 x)
+{
+  x = rint(x);
+  return convert_long16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_long16(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_sat_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_long16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_long16(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+long16 convert_long16_sat_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_long16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong convert_ulong_rtz(half x)
+{
+  return convert_ulong(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong convert_ulong_sat_rtz(half x)
+{
+  return convert_ulong_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong convert_ulong_rte(half x)
+{
+  x = rint(x);
+  return convert_ulong(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong convert_ulong_sat_rte(half x)
+{
+  x = rint(x);
+  return convert_ulong_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong convert_ulong_rtp(half x)
+{
+  x = ceil(x);
+  return convert_ulong(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong convert_ulong_sat_rtp(half x)
+{
+  x = ceil(x);
+  return convert_ulong_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong convert_ulong_rtn(half x)
+{
+  x = floor(x);
+  return convert_ulong(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong convert_ulong_sat_rtn(half x)
+{
+  x = floor(x);
+  return convert_ulong_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong2 convert_ulong2_rtz(half2 x)
+{
+  return convert_ulong2(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong2 convert_ulong2_sat_rtz(half2 x)
+{
+  return convert_ulong2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong2 convert_ulong2_rte(half2 x)
+{
+  x = rint(x);
+  return convert_ulong2(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong2 convert_ulong2_sat_rte(half2 x)
+{
+  x = rint(x);
+  return convert_ulong2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong2 convert_ulong2_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_ulong2(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong2 convert_ulong2_sat_rtp(half2 x)
+{
+  x = ceil(x);
+  return convert_ulong2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong2 convert_ulong2_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_ulong2(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong2 convert_ulong2_sat_rtn(half2 x)
+{
+  x = floor(x);
+  return convert_ulong2_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtz(half3 x)
+{
+  return convert_ulong3(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_sat_rtz(half3 x)
+{
+  return convert_ulong3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rte(half3 x)
+{
+  x = rint(x);
+  return convert_ulong3(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_sat_rte(half3 x)
+{
+  x = rint(x);
+  return convert_ulong3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_ulong3(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_sat_rtp(half3 x)
+{
+  x = ceil(x);
+  return convert_ulong3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_ulong3(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong3 convert_ulong3_sat_rtn(half3 x)
+{
+  x = floor(x);
+  return convert_ulong3_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtz(half4 x)
+{
+  return convert_ulong4(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_sat_rtz(half4 x)
+{
+  return convert_ulong4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rte(half4 x)
+{
+  x = rint(x);
+  return convert_ulong4(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_sat_rte(half4 x)
+{
+  x = rint(x);
+  return convert_ulong4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_ulong4(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_sat_rtp(half4 x)
+{
+  x = ceil(x);
+  return convert_ulong4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_ulong4(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong4 convert_ulong4_sat_rtn(half4 x)
+{
+  x = floor(x);
+  return convert_ulong4_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtz(half8 x)
+{
+  return convert_ulong8(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_sat_rtz(half8 x)
+{
+  return convert_ulong8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rte(half8 x)
+{
+  x = rint(x);
+  return convert_ulong8(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_sat_rte(half8 x)
+{
+  x = rint(x);
+  return convert_ulong8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_ulong8(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_sat_rtp(half8 x)
+{
+  x = ceil(x);
+  return convert_ulong8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_ulong8(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong8 convert_ulong8_sat_rtn(half8 x)
+{
+  x = floor(x);
+  return convert_ulong8_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtz(half16 x)
+{
+  return convert_ulong16(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_sat_rtz(half16 x)
+{
+  return convert_ulong16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rte(half16 x)
+{
+  x = rint(x);
+  return convert_ulong16(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_sat_rte(half16 x)
+{
+  x = rint(x);
+  return convert_ulong16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_ulong16(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_sat_rtp(half16 x)
+{
+  x = ceil(x);
+  return convert_ulong16_sat(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_ulong16(x);
+}
+#endif
+
+#if defined(cl_khr_int64) && defined(cl_khr_fp16)
+_CL_ALWAYSINLINE _CL_OVERLOADABLE _CL_READNONE
+ulong16 convert_ulong16_sat_rtn(half16 x)
+{
+  x = floor(x);
+  return convert_ulong16_sat(x);
+}
+#endif

--- a/lib/kernel/convert_type.py
+++ b/lib/kernel/convert_type.py
@@ -53,7 +53,7 @@ bool_type = {'char'  : 'char',
              'uint'  : 'int',
              'long'  : 'long',
              'ulong' : 'long',
-             'half'  : 'int',
+             'half'  : 'short',
              'float'  : 'int',
              'double' : 'long'}
 
@@ -467,3 +467,18 @@ for src in types:
     for size in vector_sizes:
       for mode in rounding_modes:
         generate_float_conversion(src, dst, size, mode, '')
+
+# Rounding conversions involving half (fp16)
+for src in types:
+  for dst in float16_types:
+    for size in vector_sizes:
+      for mode in rounding_modes:
+        generate_float_conversion(src, dst, size, mode, '')
+
+for src in float16_types:
+  for dst in int_types:
+    for size in vector_sizes:
+      for mode in rounding_modes:
+        for sat in saturation:
+          generate_float_conversion(src, dst, size, mode, sat)
+

--- a/tests/kernel/test_halfs.cl
+++ b/tests/kernel/test_halfs.cl
@@ -1,12 +1,15 @@
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
+#ifdef cl_khr_fp16
 volatile global half a = INFINITY;
 volatile global half b = 1.0h;
 volatile global half8 va = (half8)(INFINITY);
 volatile global half8 vb = (half8)(1.0h);
+#endif
 
 kernel
 void test_halfs() {
+#ifdef cl_khr_fp16
   if (!isinf(a))
     printf("FAIL at line %d\n", __LINE__ - 1);
   if (isinf(b))
@@ -15,4 +18,48 @@ void test_halfs() {
     printf("FAIL at line %d\n", __LINE__ - 1);
   if (!all(isinf(vb) == (short8)(0)))
     printf("FAIL at line %d\n", __LINE__ - 1);
+
+  // Test conversions involving half
+  {
+    float f = 2.5f;
+    half h = convert_half(f);
+    if ((float)h != 2.5f) {
+      printf("FAIL: convert_half(float) got %f\n", (float)h);
+    }
+  }
+
+  {
+    float4 f4 = (float4)(1.0f, 2.0f, 3.0f, 4.0f);
+    half4 h4 = convert_half4(f4);
+    if ((float)h4.x != 1.0f || (float)h4.y != 2.0f || (float)h4.z != 3.0f || (float)h4.w != 4.0f) {
+      printf("FAIL: convert_half4(float4) got %f %f %f %f\n", (float)h4.x, (float)h4.y, (float)h4.z, (float)h4.w);
+    }
+  }
+
+  {
+    half h = 1.6h;
+    int i = convert_int_rtz(h);
+    if (i != 1) {
+      printf("FAIL: convert_int_rtz(half) got %d\n", i);
+    }
+
+    int i_rte = convert_int_rte(h);
+    if (i_rte != 2) {
+      printf("FAIL: convert_int_rte(half) got %d\n", i_rte);
+    }
+  }
+
+  {
+    half4 h4 = (half4)(-129.5h, 127.5h, 128.5h, 0.0h);
+    char4 c4 = convert_char4_sat_rte(h4);
+    // sat char range is [-128, 127]
+    // -129.5 -> rounds to even -130 -> clamps to -128
+    // 127.5 -> rounds to even 128 -> clamps to 127
+    // 128.5 -> rounds to even 128 -> clamps to 127
+    if (c4.x != -128 || c4.y != 127 || c4.z != 127 || c4.w != 0) {
+      printf("FAIL: convert_char4_sat_rte(half4) got %d %d %d %d\n", c4.x, c4.y, c4.z, c4.w);
+    }
+  }
+#endif
 }
+


### PR DESCRIPTION
Add explicit type conversion functions (e.g. convert_halfN, convert_typeN(halfN)) between half (fp16) types and other OpenCL C types.

Why this patch is needed:
1. convert_type.py needs to map OpenCL C 'half' vector boolean comparisons to 'shortN' (16-bit signed vector types) instead of 'intN' (32-bit vector types) to comply with the OpenCL C specification for relational operators on 16-bit float vectors.
   See: https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_C.html#relational-and-logical-operators
2. It generates explicit convert_half*() and convert_*_sat_*(half*) conversion functions.
   See: https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_C.html#explicit-conversions
