### PR TITLE
Fix float-to-half rounding behavior in pocl_cl_half_util.c

### DIFF
--- a/lib/CL/pocl_cl_half_util.c
+++ b/lib/CL/pocl_cl_half_util.c
@@ -23,89 +23,17 @@
    IN THE SOFTWARE.
 */
 
-/**
- * TODO: see if this library can be dropped for the include/CL/cl_half.h
- *  library. The question is which rounding mode should be used in that
- *  case.
- */
-
 #include "pocl_cl_half_util.h"
-
-static int const shift = 13;
-static int const shiftSign = 16;
-
-static int32_t const infN = 0x7F800000;  /* flt32 infinity */
-static int32_t const maxN = 0x477FE000;  /* max flt16 normal as a flt32 */
-static int32_t const minN = 0x38800000;  /* min flt16 normal as a flt32 */
-static int32_t const signN = 0x80000000; /* flt32 sign bit */
-
-/* static int32_t const infC = infN >> shift;
- * static int32_t const infC = 0x3FC00;
- * static int32_t const nanN = (infC + 1) << shift; // minimum flt16 nan as a
- * flt32
- */
-static int32_t const nanN = 0x7f802000;
-/* static int32_t const maxC = maxN >> shift; */
-static int32_t const maxC = 0x23bff;
-/* static int32_t const minC = minN >> shift;
- * static int32_t const minC = 0x1c400;
- * static int32_t const signC = signN >> shiftSign; // flt16 sign bit
- */
-static int32_t const signC = 0x40000; /* flt16 sign bit */
-
-static int32_t const mulN = 0x52000000; /* (1 << 23) / minN */
-static int32_t const mulC = 0x33800000; /* minN / (1 << (23 - shift)) */
-
-static int32_t const subC = 0x003FF; /* max flt32 subnormal down shifted */
-static int32_t const norC = 0x00400; /* min flt32 normal down shifted */
-
-/* static int32_t const maxD = infC - maxC - 1; */
-static int32_t const maxD = 0x1c000;
-/* static int32_t const minD = minC - subC - 1; */
-static int32_t const minD = 0x1c000;
-
-typedef union
-{
-  float f;
-  int32_t si;
-  uint32_t ui;
-} H2F_Bits;
+#include <CL/cl_half.h>
 
 float
 pocl_half_to_float (uint16_t value)
 {
-  H2F_Bits v;
-  v.ui = value;
-  int32_t sign = v.si & signC;
-  v.si ^= sign;
-  sign <<= shiftSign;
-  v.si ^= ((v.si + minD) ^ v.si) & -(v.si > subC);
-  v.si ^= ((v.si + maxD) ^ v.si) & -(v.si > maxC);
-  H2F_Bits s;
-  s.si = mulC;
-  s.f *= v.si;
-  int32_t mask = -(norC > v.si);
-  v.si <<= shift;
-  v.si ^= (s.si ^ v.si) & mask;
-  v.si |= sign;
-  return v.f;
+  return cl_half_to_float (value);
 }
 
 uint16_t
 pocl_float_to_half (float value)
 {
-  H2F_Bits v, s;
-  v.f = value;
-  uint32_t sign = v.si & signN;
-  v.si ^= sign;
-  sign >>= shiftSign;
-  s.si = mulN;
-  s.f = s.f * v.f;
-  v.si ^= (s.si ^ v.si) & -(minN > v.si);
-  v.si ^= (infN ^ v.si) & -((infN > v.si) & (v.si > maxN));
-  v.si ^= (nanN ^ v.si) & -((nanN > v.si) & (v.si > infN));
-  v.ui >>= shift;
-  v.si ^= ((v.si - maxD) ^ v.si) & -(v.si > maxC);
-  v.si ^= ((v.si - minD) ^ v.si) & -(v.si > subC);
-  return v.ui | sign;
+  return cl_half_from_float (value, CL_HALF_RTE);
 }


### PR DESCRIPTION
This change fixes the buggy custom bitwise emulation logic in pocl_float_to_half to use standard, correct calls to the official Khronos cl_half.h library functions, enforcing proper round-to-nearest-even (RTE) rounding during float-to-half conversion.

The original bitwise helper truncated floating-point values instead of performing IEEE-754 rounding.

According to the OpenCL C Programming Language Specification:
- Conversions to floating-point types follow IEEE-754 rounding rules.
- If no rounding mode is specified, the default rounding mode is round-to-nearest-even (RTE). See Section "Explicit Conversions": https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_C.html#explicit-conversions