### PR TITLE
Return program upon CL_LINK_PROGRAM_FAILURE in clLinkProgram

### DIFF
--- a/lib/CL/clLinkProgram.c
+++ b/lib/CL/clLinkProgram.c
@@ -109,7 +109,7 @@ ERROR:
   if (errcode_ret)
     *errcode_ret = errcode;
 
-  if (errcode == CL_SUCCESS)
+  if (errcode == CL_SUCCESS || errcode == CL_LINK_PROGRAM_FAILURE)
     {
       return program;
     }


### PR DESCRIPTION
According to the OpenCL specification (Section 5.6.2), clLinkProgram must return a valid non-zero cl_program object when a linker failure occurs (setting errcode_ret to CL_LINK_PROGRAM_FAILURE). The specification states: "The application should query the linker status of this program object to check if the link was successful or not." This allows the application to query the build logs to diagnose the linker errors via clGetProgramBuildInfo. PoCL's original implementation incorrectly released the program and returned NULL, preventing build log extraction.

See: https://registry.khronos.org/OpenCL/specs/unified/refpages/man/html/clLinkProgram.html