### PR TITLE
Guard pocl_update_event_finished against concurrent double-finish

### DIFF
--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -1665,6 +1665,37 @@ pocl_update_event_finished (cl_int status, const char *func, unsigned line,
   cl_command_queue cq = event->queue;
   POCL_LOCK_OBJ (cq);
   POCL_LOCK_OBJ (event);
+  /* Idempotency guard: an event can be driven to a terminal state twice,
+   * concurrently, from two different pocl_broadcast threads. This affects ANY
+   * command with more than one wait-list dependency, not just markers/barriers.
+   * Two interleavings produce it on a failing chain:
+   *
+   *   - Two dependencies finish in ERROR concurrently. Each pocl_broadcast
+   *     calls notify(), which takes the finished->status < CL_COMPLETE branch
+   *     and fails the waiter via pocl_update_event_finished -- twice.
+   *   - One dependency FAILS (failing the waiter) while another dependency's
+   *     COMPLETION drives the waiter terminal too (for a marker/barrier that is
+   *     completion-as-termination; for a regular command it can additionally
+   *     race the submit/execute path).
+   *
+   * These transitions are not mutually exclusive because pocl_broadcast tests
+   * the waiter's "still pending" gate (status == CL_QUEUED/SUBMITTED) BEFORE
+   * calling notify, and notify drops the event lock (a lock-order dance with
+   * the command queue) before the new status is written -- so a second
+   * broadcast can read the stale pre-terminal status and call in here on an
+   * event the first finisher is already terminating.
+   *
+   * OpenCL event state is monotonic: once terminal (CL_COMPLETE or a negative
+   * error) it never changes again, so a second finish is a no-op. The check is
+   * taken under the event lock, so exactly one caller finishes the event and
+   * the other returns cleanly. Bail under the locks we already hold
+   * (reverse-order unlock). */
+  if (event->status <= CL_COMPLETE)
+    {
+      POCL_UNLOCK_OBJ (event);
+      POCL_UNLOCK_OBJ (cq);
+      return;
+    }
   assert (event->status > CL_COMPLETE);
   if ((cq->properties & CL_QUEUE_PROFILING_ENABLE)
       && (cq->device->has_own_timer == 0))


### PR DESCRIPTION

[pocl-double-finish-repro.zip](https://github.com/user-attachments/files/29316780/pocl-double-finish-repro.zip)
## Problem

An event can be driven to a terminal state **twice, concurrently, from two `pocl_broadcast` threads**, tripping:

```
pocl_util.c:1690: pocl_update_event_finished:
  Assertion `event->status > CL_COMPLETE' failed.
```

(With the assert compiled out, the second finisher instead mutates/re-lists/releases an event the first already terminated and may have recycled — an intermittent `SIGSEGV`/`SIGABRT` in `clReleaseEvent` on a nearby thread.)

This affects **any command with more than one wait-list dependency** — it is not specific to markers/barriers. Two interleavings produce it on a failing chain:

- **Two dependencies finish in error concurrently.** Each `pocl_broadcast` calls the device `notify()`, which takes the `finished->status < CL_COMPLETE` branch and fails the waiter via `pocl_update_event_finished` — twice.
- **One dependency fails the waiter while another dependency's completion drives it terminal too.** For a marker/barrier that is completion-as-termination; for a regular command the failed-dependency path can also race the submit/execute path.

## Why the transitions race

`pocl_broadcast` tests the waiter's "still pending" gate (`status == CL_SUBMITTED || CL_QUEUED`) **before** calling `notify`, and `notify` drops the event lock (a lock-order dance with the command queue) **before** the new status is written. So a second broadcast can read the stale pre-terminal status, pass the gate, and call into `pocl_update_event_finished` on an event the first finisher is already terminating.

## Root cause

`pocl_update_event_finished` assumes it is the sole finisher of an event. That holds for a single terminating transition, but not when two dependency broadcasts converge on the same multi-dependency waiter. The `assert (event->status > CL_COMPLETE)` is asserting the very invariant the function does not enforce on entry.

## Fix

OpenCL event execution state is **monotonic**: once terminal (`CL_COMPLETE` or a negative error) it never changes again, so a second finish is a no-op. Enforce that on entry — under the `cq` + `event` locks the function already takes, return if the event is already terminal:

```c
POCL_LOCK_OBJ (cq);
POCL_LOCK_OBJ (event);
if (event->status <= CL_COMPLETE)
  {
    POCL_UNLOCK_OBJ (event);
    POCL_UNLOCK_OBJ (cq);
    return;
  }
assert (event->status > CL_COMPLETE);
```

The check is under the event lock, so it is atomic against the other finisher: exactly one caller finishes the event, the other returns cleanly.

(The guard is intentionally unconditional, not scoped to a command type. Re-enabling the assert for "unaffected" types and re-testing showed there are none — a plain `clEnqueueReadBuffer` with two concurrently-failed dependencies double-finishes just like a marker does.)

## Testing

Two reproducers on a Debug build (assert active):
- a plain `clEnqueueReadBuffer` whose wait list holds two user events both set to a negative status (the pure two-errors case), and
- a marker depending on an `Unmap` completion plus a failed host-gate user event.

Both aborted at `pocl_util.c:1690` before the guard; **0 asserts after** (40/40 and 30/30 clean). pocl runtime + event test suites pass with no regressions.
