### PR TITLE
Fix compilation of SubCFGFormation.cc in C++20

### DIFF
--- a/lib/llvmopencl/SubCFGFormation.cc
+++ b/lib/llvmopencl/SubCFGFormation.cc
@@ -1132,16 +1132,6 @@ void fillUserHull(llvm::AllocaInst *Alloca,
   }
 }
 
-template <class PtrSet> struct PtrSetWrapper {
-  explicit PtrSetWrapper(PtrSet &PtrSetArg) : Set(PtrSetArg) {}
-  PtrSet &Set;
-  using iterator = typename PtrSet::iterator;
-  using value_type = typename PtrSet::value_type;
-  template <class IT, class ValueT> IT insert(IT, const ValueT &Value) {
-    return Set.insert(Value).first;
-  }
-};
-
 // checks if all uses of an alloca are in just a single subcfg (doesn't have to
 // be arrayified!).
 // TO CLEAN: merge with WorkitemLoopsImpl::shouldNotBeContextSaved().
@@ -1152,10 +1142,9 @@ bool isAllocaSubCfgInternal(llvm::AllocaInst *Alloca,
   {
     llvm::SmallVector<llvm::Instruction *, 32> Users;
     fillUserHull(Alloca, Users);
-    PtrSetWrapper<decltype(UserBlocks)> Wrapper{UserBlocks};
-    std::transform(Users.begin(), Users.end(),
-                   std::inserter(Wrapper, UserBlocks.end()),
-                   [](auto *I) { return I->getParent(); });
+    for (auto *I : Users) {
+      UserBlocks.insert(I->getParent());
+    }
   }
 
   for (auto &SubCfg : SubCfgs) {


### PR DESCRIPTION
Using std::inserter with PtrSetWrapper fails to compile because std::insert_iterator requires the container to be a range (supporting std::ranges::begin). PtrSetWrapper does not support std::ranges::begin (it only has iterator typedefs and an insert helper), causing template substitution to fail under C++20.

This replaces the std::transform and std::inserter usage with a clean range-based for loop. This removes the need for PtrSetWrapper entirely, making the code simpler and compatible across standard versions.

Co-authored-by: Gemini 3.5 Flash