### PR TITLE
Add fp16 support for ldexp and add kernel tests

### DIFF
--- a/lib/kernel/ldexp.cl
+++ b/lib/kernel/ldexp.cl
@@ -24,9 +24,14 @@
 
 #include "templates.h"
 
-// there is no Clang builtin ldexp for fp16 type
+#ifdef cl_khr_fp16
+#ifndef __builtin_ldexpf16
+#define __builtin_ldexpf16(a, b) ((half)__builtin_ldexpf((float)(a), (b)))
+#endif
+#else
 #undef __IF_FP16
 #define __IF_FP16(X)
+#endif
 
 DEFINE_BUILTIN_V_VJ(ldexp)
 

--- a/tests/kernel/common.cl
+++ b/tests/kernel/common.cl
@@ -1186,6 +1186,30 @@ typedef constant char *string;
   __IF_FP64 (NAME##_double (); NAME##_double2 (); NAME##_double3 ();          \
              NAME##_double4 (); NAME##_double8 (); NAME##_double16 ();)
 
+#ifdef cl_khr_fp16
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+#define DEFINE_BODY_V_FP16(NAME, EXPR) \
+  IMPLEMENT_BODY_V (NAME, EXPR, 1, half, half, int, int, int, int) \
+  IMPLEMENT_BODY_V (NAME, EXPR, 2, half2, half, int2, int, int2, int) \
+  IMPLEMENT_BODY_V (NAME, EXPR, 3, half3, half, int3, int, int3, int) \
+  IMPLEMENT_BODY_V (NAME, EXPR, 4, half4, half, int4, int, int4, int) \
+  IMPLEMENT_BODY_V (NAME, EXPR, 8, half8, half, int8, int, int8, int) \
+  IMPLEMENT_BODY_V (NAME, EXPR, 16, half16, half, int16, int, int16, int)
+
+#define CALL_FUNC_V_FP16(NAME) \
+  NAME##_half (); \
+  NAME##_half2 (); \
+  NAME##_half3 (); \
+  NAME##_half4 (); \
+  NAME##_half8 (); \
+  NAME##_half16 ();
+
+#else
+#define DEFINE_BODY_V_FP16(NAME, EXPR)
+#define CALL_FUNC_V_FP16(NAME)
+#endif
+
 
 #define IMPLEMENT_BODY_G(NAME, BODY, SIZE, GTYPE, SGTYPE, UGTYPE, SUGTYPE)  \
   void NAME##_##GTYPE()                                                     \

--- a/tests/kernel/test_ldexp.cl
+++ b/tests/kernel/test_ldexp.cl
@@ -1,84 +1,87 @@
 #include "common.cl"
 
-DEFINE_BODY_V (
-    test_ldexp, ({
-      /* ldexp */
-      Ivec ival2;
-      ival2.v = (itype)4;
-      res.v = ldexp (val.v, ival2.v);
-      Tvec goodres;
-      equal = true;
-      for (int n = 0; n < vecsize; ++n)
-        {
-          if (ISNAN (val.s[n]))
-            {
-              goodres.s[n] = NAN;
-            }
-          else if (val.s[n] == (stype)0)
-            {
-              goodres.s[n] = val.s[n];
-            }
-          else if (isinf (val.s[n]))
-            {
-              goodres.s[n] = val.s[n];
-            }
-          else
-            {
-              goodres.s[n] = val.s[n] * (stype) (16.0f);
-            }
-          equal = equal && ISEQ (res.s[n], goodres.s[n]);
-        }
-      if (!equal)
-        {
-          for (int n = 0; n < vecsize; ++n)
-            {
-              printf ("FAIL: ldexp type=%s val=%.17g val2=%d res=%.17g "
-                      "good=%.17g\n",
-                      typename, val.s[n], (int)ival2.s[n], res.s[n],
-                      goodres.s[n]);
-            }
-          return;
-        }
+#define TEST_LDEXP_BODY \
+  ({ \
+      /* ldexp */ \
+      Ivec ival2; \
+      ival2.v = (itype)4; \
+      res.v = ldexp (val.v, ival2.v); \
+      Tvec goodres; \
+      equal = true; \
+      for (int n = 0; n < vecsize; ++n) \
+        { \
+          if (ISNAN (val.s[n])) \
+            { \
+              goodres.s[n] = NAN; \
+            } \
+          else if (val.s[n] == (stype)0) \
+            { \
+              goodres.s[n] = val.s[n]; \
+            } \
+          else if (isinf (val.s[n])) \
+            { \
+              goodres.s[n] = val.s[n]; \
+            } \
+          else \
+            { \
+              goodres.s[n] = val.s[n] * (stype) (16.0f); \
+            } \
+          equal = equal && ISEQ (res.s[n], goodres.s[n]); \
+        } \
+      if (!equal) \
+        { \
+          for (int n = 0; n < vecsize; ++n) \
+            { \
+              printf ("FAIL: ldexp type=%s val=%.17g val2=%d res=%.17g " \
+                      "good=%.17g\n", \
+                      typename, val.s[n], (int)ival2.s[n], res.s[n], \
+                      goodres.s[n]); \
+            } \
+          return; \
+        } \
+\
+      /* ldexp vector-scalar */ \
+      res.v = ldexp (val.v, 4); \
+      equal = true; \
+      for (int n = 0; n < vecsize; ++n) \
+        { \
+          if (ISNAN (val.s[n])) \
+            { \
+              goodres.s[n] = NAN; \
+            } \
+          else if (val.s[n] == (stype)0) \
+            { \
+              goodres.s[n] = val.s[n]; \
+            } \
+          else if (isinf (val.s[n])) \
+            { \
+              goodres.s[n] = val.s[n]; \
+            } \
+          else \
+            { \
+              goodres.s[n] = val.s[n] * (stype) (16.0f); \
+            } \
+          equal = equal && ISEQ (res.s[n], goodres.s[n]); \
+        } \
+      if (!equal) \
+        { \
+          for (int n = 0; n < vecsize; ++n) \
+            { \
+              printf ("FAIL: ldexp_scalar type=%s val=%.17g res=%.17g " \
+                      "good=%.17g\n", \
+                      typename, val.s[n], res.s[n], \
+                      goodres.s[n]); \
+            } \
+          return; \
+        } \
+  })
 
-      /* ldexp vector-scalar */
-      res.v = ldexp (val.v, 4);
-      equal = true;
-      for (int n = 0; n < vecsize; ++n)
-        {
-          if (ISNAN (val.s[n]))
-            {
-              goodres.s[n] = NAN;
-            }
-          else if (val.s[n] == (stype)0)
-            {
-              goodres.s[n] = val.s[n];
-            }
-          else if (isinf (val.s[n]))
-            {
-              goodres.s[n] = val.s[n];
-            }
-          else
-            {
-              goodres.s[n] = val.s[n] * (stype) (16.0f);
-            }
-          equal = equal && ISEQ (res.s[n], goodres.s[n]);
-        }
-      if (!equal)
-        {
-          for (int n = 0; n < vecsize; ++n)
-            {
-              printf ("FAIL: ldexp_scalar type=%s val=%.17g res=%.17g "
-                      "good=%.17g\n",
-                      typename, val.s[n], res.s[n],
-                      goodres.s[n]);
-            }
-          return;
-        }
-    }))
-
+DEFINE_BODY_V (test_ldexp, TEST_LDEXP_BODY)
+DEFINE_BODY_V_FP16 (test_ldexp, TEST_LDEXP_BODY)
 
 kernel void
 test_ldexp ()
 {
   CALL_FUNC_V (test_ldexp)
+  CALL_FUNC_V_FP16 (test_ldexp)
 }


### PR DESCRIPTION
This fixes a failure in the OpenCL Conformance Test Suite (CTS) 'bruteforce/ldexp' test. When compiling for fp16-enabled devices, the test would fail to load due to missing 'half' overloads of '_cl_ldexp' (e.g., unresolved symbol '_Z9_cl_ldexpDv4_DhDv4_i').

This patch:
1. Adds a fallback macro for '__builtin_ldexpf16' in 'lib/kernel/ldexp.cl' that casts inputs to 'float', calls '__builtin_ldexpf', and casts the result back to 'half'.
2. Defines fp16 test harness helper macros ('DEFINE_BODY_V_FP16' and 'CALL_FUNC_V_FP16') in 'tests/kernel/common.cl'.
3. Adds test cases for 'half' precision scalar and vector variants of 'ldexp' to 'tests/kernel/test_ldexp.cl'.

Co-authored-by: Gemini 3.5 Flash