### PR TITLE
cpu: disable AArch64 outline-atomics for in-process-linked kernels

### DIFF
--- a/lib/CL/pocl_llvm_wg.cc
+++ b/lib/CL/pocl_llvm_wg.cc
@@ -1231,6 +1231,21 @@ int pocl_llvm_codegen2(const char* TTriple, const char* MCPU,
   *Output = nullptr;
   std::unique_ptr<llvm::TargetLibraryInfoImpl> TLIIPtr;
 
+  // Outline-atomics lowers integer atomicrmw to libgcc __aarch64_* helpers that
+  // are static-only (absent from any dlopen-able lib), so in-process-linked
+  // kernels leave them unresolved and the atomics silently no-op. Emit inline.
+  if (llvm::Triple(TTriple).isAArch64()) {
+    for (llvm::Function &F : *Input) {
+      llvm::Attribute A = F.getFnAttribute("target-features");
+      std::string TF = A.isValid() ? A.getValueAsString().str() : std::string();
+      // A trailing "-outline-atomics" wins: LLVM applies features left-to-right.
+      if (!TF.empty())
+        TF += ",";
+      TF += "-outline-atomics";
+      F.addFnAttr("target-features", TF);
+    }
+  }
+
   std::unique_ptr<llvm::TargetMachine> TM(GetTargetMachine(TTriple, MCPU, Features));
   llvm::TargetMachine *Target = TM.get();
 

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -55,6 +55,7 @@ set(PROGRAMS_TO_BUILD test_barrier_between_for_loops test_early_return
   test_workitem_func_outside_kernel test_program_scope_vars test_issue_1548
   test_issue_1525 test_issue_1608 test_issue_1826 test_builtin_regression
   test_mem_host_ptr_issue test_issue_1962 test_issue_2005
+  test_global_atomics
 )
 if(UNIX)
   list(APPEND PROGRAMS_TO_BUILD test_issue_2174)
@@ -85,6 +86,8 @@ endif()
 ######################################################################
 
 add_test_pocl(NAME "regression/test_issue_231" COMMAND "test_issue_231")
+
+add_test_pocl(NAME "regression/test_global_atomics" COMMAND "test_global_atomics")
 
 add_test_pocl(NAME "regression/test_issue_445" COMMAND "test_issue_445")
 

--- a/tests/regression/test_global_atomics.cpp
+++ b/tests/regression/test_global_atomics.cpp
@@ -1,0 +1,69 @@
+// Regression test for integer global atomics on CPU devices.
+//
+// On AArch64 the "generic" subtarget enables outline-atomics, which lowers
+// integer atomicrmw (add/sub/and/or/xor/xchg/cmpxchg) to calls to libgcc
+// helpers (__aarch64_ldadd4_acq_rel, ...). When kernels are linked in-process
+// with lld, those helpers (static-only in libgcc.a, not exported by any loaded
+// library) are left unresolved and the atomics silently no-op -- e.g. an
+// atomic_add accumulator stays at its initial value. atomic_max/min have no
+// LSE/outline form and are always inlined, so they kept working. This test
+// checks that the read-modify-write actually lands in memory.
+
+#include "pocl_opencl.h"
+
+#define CL_HPP_ENABLE_EXCEPTIONS
+
+#include <CL/opencl.hpp>
+#include <iostream>
+
+const char *SOURCE = R"RAW(
+  __kernel void add_one(__global int *p) { atomic_add(p, 1); }
+  __kernel void sub_one(__global int *p) { atomic_sub(p, 1); }
+  __kernel void or_bits(__global int *p) { atomic_or(p, 1 << (get_global_id(0) & 31)); }
+)RAW";
+
+int main(int, char **) {
+  try {
+    cl::Device device = cl::Device::getDefault();
+    cl::Context context = cl::Context::getDefault();
+    cl::CommandQueue queue = cl::CommandQueue::getDefault();
+
+    cl::Program program(context, SOURCE);
+    program.build();
+
+    const int N = 4096;
+    auto run = [&](const char *name, cl_int init) -> cl_int {
+      cl_int v = init;
+      cl::Buffer buf(context, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+                     sizeof(cl_int), &v);
+      cl::Kernel kernel(program, name);
+      kernel.setArg(0, buf);
+      queue.enqueueNDRangeKernel(kernel, cl::NullRange, cl::NDRange(N),
+                                 cl::NullRange);
+      queue.enqueueReadBuffer(buf, CL_TRUE, 0, sizeof(cl_int), &v);
+      return v;
+    };
+
+    cl_int add = run("add_one", 0);                 // expect N
+    cl_int sub = run("sub_one", N);                 // expect 0
+    cl_int orr = run("or_bits", 0);                 // N>=32 sets all 32 bits -> 0xFFFFFFFF
+    cl_int orr_expected = -1;
+
+    bool ok = (add == N) && (sub == 0) && (orr == orr_expected);
+    std::cout << "atomic_add=" << add << " (expect " << N << "), "
+              << "atomic_sub=" << sub << " (expect 0), "
+              << "atomic_or=0x" << std::hex << orr << std::dec
+              << " (expect 0xffffffff)\n";
+
+    if (ok) {
+      std::cout << "OK\n";
+      return EXIT_SUCCESS;
+    }
+    std::cout << "FAIL\n";
+    return EXIT_FAILURE;
+  } catch (cl::Error &err) {
+    std::cout << "FAIL with OpenCL error = " << err.what() << " (" << err.err()
+              << ")\n";
+    return EXIT_FAILURE;
+  }
+}


### PR DESCRIPTION
Outline-atomics lowers integer atomicrmw to static-only libgcc __aarch64_* helpers; in-process-linked kernels leave them unresolved at dlopen time and the atomics silently no-op. Disable it in codegen (so both the lld and ORC backends benefit) to emit atomics inline.

Fixes a regression introduced by #2194 