### PR TITLE
Fix out-of-bounds heap read in vload3

### DIFF
--- a/lib/kernel/vload.cl
+++ b/lib/kernel/vload.cl
@@ -36,7 +36,7 @@
   TYPE##3 _CL_OVERLOADABLE vload3 (size_t offset, const MOD TYPE *p)          \
   {                                                                           \
     TYPE##3 retval;                                                           \
-    __builtin_memcpy_inline (&retval, &p[offset * 3], sizeof (TYPE##3));      \
+    __builtin_memcpy_inline (&retval, &p[offset * 3], sizeof (TYPE) * 3);      \
     return retval;                                                            \
   }                                                                           \
                                                                               \


### PR DESCRIPTION
According to the OpenCL C Specification, vload3 reads exactly 3 * sizeof(gentype) bytes from memory.

However, the PoCL implementation of vload3 was copying sizeof(TYPE##3) bytes. In OpenCL C, 3-component vector types (gentype3) are padded and aligned to the size of 4-component vectors (gentype4), meaning sizeof(gentype3) is 4 * sizeof(gentype).

This caused vload3 to read 4 elements instead of 3. When reading the last element of a buffer (where only 3 elements remain), this resulted in an out-of-bounds read of 1 extra element. If this read crossed a page boundary, it caused a segmentation fault.

This fixes flaky CTS geometrics/geom_cross failure.