### PR TITLE
core-math: provide missing FP16 host math overloads

### DIFF
--- a/lib/kernel/core-math/additionalf16.cl
+++ b/lib/kernel/core-math/additionalf16.cl
@@ -74,3 +74,14 @@ IMPLEMENT_FP16_FREXP_AS (global)
 #ifdef __opencl_c_generic_address_space
 IMPLEMENT_FP16_FREXP_AS (generic)
 #endif
+
+/* Vector frexp: recurse through lo/hi halves down to the scalar overload above,
+   plus the local/global/generic exponent-pointer forms. This is the same
+   expansion the vectorized frexp.cl produces via DEFINE_BUILTIN_V_VPJ;
+   additionalf16.cl is the non-vectorized-only file, so the half vector
+   overloads (missing from libclc-pocl/frexp.cl) are supplied here. */
+IMPLEMENT_BUILTIN_V_VPJ (frexp, half2, int2, int, int, lo, hi)
+IMPLEMENT_BUILTIN_V_VPJ (frexp, half3, int3, int2, int, lo, s2)
+IMPLEMENT_BUILTIN_V_VPJ (frexp, half4, int4, int2, int2, lo, hi)
+IMPLEMENT_BUILTIN_V_VPJ (frexp, half8, int8, int4, int4, lo, hi)
+IMPLEMENT_BUILTIN_V_VPJ (frexp, half16, int16, int8, int8, lo, hi)

--- a/lib/kernel/core-math/additionalf16.cl
+++ b/lib/kernel/core-math/additionalf16.cl
@@ -1,16 +1,76 @@
 #include "common_types.h"
 
+/* FP16 overloads for math builtins with a Clang/LLVM FP16 lowering: the
+   __builtin_elementwise_* intrinsics (scalar + @llvm.<op>.vNf16, so they
+   vectorize without SLEEF) plus fmod and frexp, which map to single LLVM
+   intrinsics.
+ *
+ * These supplement the kernel library only in the non-vectorized configuration
+ * (ENABLE_HOST_CPU_VECTORIZE_BUILTINS=OFF). When vectorization is ON the generic
+ * <fn>.cl files provide these same FP16 overloads via __builtin_<fn>f16, so this
+ * file is excluded then (see lib/kernel/host/CMakeLists.txt) to avoid multiple
+ * definitions.
+ *
+ * Functions without a native FP16 builtin (logb, ilogb, ldexp, rootn, pown,
+ * remainder, nextafter, powr, modf, remquo) are in promotedf16.cl. That file is
+ * compiled in both configurations because the vectorized generic path does not
+ * cover those overloads either. (sincos and lgamma_r half are provided by
+ * core-math/sincosf16.cl and lgammaf16.cl.) */
+
 #undef isfinite
 #undef isnormal
 #undef isinf
 #undef isnan
 
 DEFINE_FP16_BUILTIN_FPCLASS (isfinite, 504)
-
 DEFINE_FP16_BUILTIN_FPCLASS (isnormal, 264)
-
 DEFINE_FP16_BUILTIN_FPCLASS (isinf, 516)
-
 DEFINE_FP16_BUILTIN_FPCLASS (isnan, 3)
 
 DEFINE_FP16_BUILTIN_V_V (sqrt, __builtin_elementwise_sqrt)
+DEFINE_FP16_BUILTIN_V_V (ceil, __builtin_elementwise_ceil)
+DEFINE_FP16_BUILTIN_V_V (floor, __builtin_elementwise_floor)
+DEFINE_FP16_BUILTIN_V_V (trunc, __builtin_elementwise_trunc)
+DEFINE_FP16_BUILTIN_V_V (rint, __builtin_elementwise_rint)
+DEFINE_FP16_BUILTIN_V_V (round, __builtin_elementwise_round)
+DEFINE_FP16_BUILTIN_V_V (fabs, __builtin_elementwise_abs)
+
+/* __builtin_elementwise_max/min lower to @llvm.maxnum/minnum, matching the
+   OpenCL fmax/fmin NaN-quieting semantics. */
+DEFINE_FP16_BUILTIN_V_VV (fmax, __builtin_elementwise_max)
+DEFINE_FP16_BUILTIN_V_VV (fmin, __builtin_elementwise_min)
+DEFINE_FP16_BUILTIN_V_VVV (fma, __builtin_elementwise_fma)
+
+/* fdim(x, y) = (x > y) ? x - y : +0, returning NaN if either input is NaN.
+   No single builtin exists; build it from fmax (defined above), keeping the
+   isnan guards because fmax quiets NaNs. This file undefines isnan above so it
+   can define _cl_isnan, so call the prefixed overload directly. (maxmag/minmag
+   then resolve.) */
+#define IMPLEMENT_FP16_FDIM(TYPE)                                             \
+  TYPE _CL_OVERLOADABLE fdim (TYPE a, TYPE b)                                 \
+  {                                                                           \
+    return _cl_isnan (a) ? a : (_cl_isnan (b) ? b : fmax (a - b, (TYPE)0));   \
+  }
+
+IMPLEMENT_FP16_FDIM (half)
+IMPLEMENT_FP16_FDIM (half2)
+IMPLEMENT_FP16_FDIM (half3)
+IMPLEMENT_FP16_FDIM (half4)
+IMPLEMENT_FP16_FDIM (half8)
+IMPLEMENT_FP16_FDIM (half16)
+
+/* fmod -> @llvm.frem and frexp -> @llvm.frexp are single LLVM intrinsics (no
+   libm libcall), so they belong with the Clang-builtin-backed overloads. */
+half _CL_OVERLOADABLE fmod (half a, half b) { return (half)__builtin_fmodf ((float)a, (float)b); }
+DEFINE_FP16_EXPR_V_VV (fmod)
+
+half _CL_OVERLOADABLE
+frexp (half x, private int *e) { return (half)__builtin_frexpf ((float)x, e); }
+#define IMPLEMENT_FP16_FREXP_AS(AS)                                          \
+  half _CL_OVERLOADABLE frexp (half x, AS int *e)                            \
+  { int t; half r = frexp (x, &t); *e = t; return r; }
+IMPLEMENT_FP16_FREXP_AS (local)
+IMPLEMENT_FP16_FREXP_AS (global)
+#ifdef __opencl_c_generic_address_space
+IMPLEMENT_FP16_FREXP_AS (generic)
+#endif

--- a/lib/kernel/core-math/lgammaf16.cl
+++ b/lib/kernel/core-math/lgammaf16.cl
@@ -249,4 +249,10 @@ _CL_OVERLOADABLE half lgamma (half xf16) {
 
 DEFINE_FP16_EXPR_V_V(lgamma)
 
-/* DEFINE_FP16_EXPR_V_VPI(lgamma) */
+/* Vector lgamma_r: recurse through lo/hi halves down to the scalar overload
+   above, plus the local/global/generic signp-pointer forms. */
+IMPLEMENT_BUILTIN_V_VPJ (lgamma_r, half2, int2, int, int, lo, hi)
+IMPLEMENT_BUILTIN_V_VPJ (lgamma_r, half3, int3, int2, int, lo, s2)
+IMPLEMENT_BUILTIN_V_VPJ (lgamma_r, half4, int4, int2, int2, lo, hi)
+IMPLEMENT_BUILTIN_V_VPJ (lgamma_r, half8, int8, int4, int4, lo, hi)
+IMPLEMENT_BUILTIN_V_VPJ (lgamma_r, half16, int16, int8, int8, lo, hi)

--- a/lib/kernel/core-math/powf16.cl
+++ b/lib/kernel/core-math/powf16.cl
@@ -308,40 +308,8 @@ Expected: -inf (half 0xfc00)
 Actual: inf (half 0x7c00) at index: 9
 */
 
-_CL_OVERLOADABLE half pown(half x, int y) {
-    float ret = pow(convert_float(x), y);
-    return convert_half(ret);
-}
-
-DEFINE_FP16_EXPR_V_VI(pown)
-/*
-
-ERROR: powr: nan ulp error at {-0x1.be8p-12 (0x8efa), 0x1.becp+12 (0x6efb)}
-Expected: nan  (half 0x7e00)
-Actual: 0x0p+0 (half 0x0000) at index: 0
-
-ERROR: powr: nan ulp error at {-0x1.728p+9 (0xe1ca), -0x1.4ap+14 (0xf528)}
-Expected: nan  (half 0x7e00)
-Actual: 0x0p+0 (half 0x0000) at index: 14
-
-ERROR: powr: nan ulp error at {-0x1.5dcp-10 (0x9577), -0x1.c84p+12 (0xef21)}
-Expected: nan  (half 0x7e00)
-Actual: inf (half 0x7c00) at index: 9
-
-ERROR: powr: nan ulp error at {-0x1.f24p+13 (0xf3c9), -0x1.e84p+10 (0xe7a1)}
-Expected: nan  (half 0x7e00)
-Actual: -0x0p+0 (half 0x8000) at index: 7
-
-*/
-
-_CL_OVERLOADABLE half powr(half x, half y) {
-    b16u16_u xx = { .f = x };
-    x = (xx.u == 0x8000) ? 0 : x;
-    half retval = pow(x, y);
-    retval = (xx.u > 0x8000) ? NAN : retval;
-    retval = isnan(x) ? NAN : retval;
-    retval = isnan(y) ? NAN : retval;
-    return retval;
-}
-
-DEFINE_FP16_EXPR_V_VV(powr)
+/* NOTE: pown(half) and powr(half) live in promotedf16.cl, not here. They have no
+   native FP16 builtin and are not provided by the vectorized generic pow.cl, so
+   they must be compiled in BOTH configurations -- whereas pow(half) above clashes
+   with the generic vectorized pow.cl when ENABLE_HOST_CPU_VECTORIZE_BUILTINS=ON,
+   so this file stays in the non-vectorized build only. */

--- a/lib/kernel/core-math/promotedf16.cl
+++ b/lib/kernel/core-math/promotedf16.cl
@@ -140,6 +140,11 @@ powr (half x, half y)
   x = (xu == (ushort)0x8000) ? (half)0 : x;       /* -0 -> +0 */
   half r = pow (x, y);
   r = (xu > (ushort)0x8000) ? (half)NAN : r;       /* x < 0 -> NaN */
+  /* pow() returns 1 for the indeterminate forms, but powr() must return NaN:
+     powr(1, +-inf), powr(+-0, +-0) and powr(+inf, +-0) are all NaN. */
+  r = (x == (half)1 && isinf (y)) ? (half)NAN : r;       /* 1^inf   */
+  r = (x == (half)0 && y == (half)0) ? (half)NAN : r;    /* 0^0     */
+  r = (isinf (x) && y == (half)0) ? (half)NAN : r;       /* inf^0   */
   r = isnan (x) ? (half)NAN : r;
   r = isnan (y) ? (half)NAN : r;
   return r;

--- a/lib/kernel/core-math/promotedf16.cl
+++ b/lib/kernel/core-math/promotedf16.cl
@@ -1,0 +1,180 @@
+#include "common_types.h"
+
+float _CL_OVERLOADABLE _cl_modf (float, private float *);
+float _CL_OVERLOADABLE _cl_remquo (float, float, private int *);
+
+/* FP16 overloads for math builtins without a native FP16 path -- neither a
+   Clang/LLVM FP16 builtin nor a SLEEF FP16 routine. Unlike additionalf16.cl
+   (the __builtin_elementwise_* overloads, which the vectorized generic <fn>.cl
+   files already provide via __builtin_<fn>f16 when
+   ENABLE_HOST_CPU_VECTORIZE_BUILTINS=ON), nothing else in the kernel library
+   supplies these in either configuration, so this file is compiled in both the
+   vectorized and non-vectorized builds.
+ *
+ * These overloads either promote to float and compute with pocl's own float
+ * builtin before rounding back to half, or, for nextafter, compute directly on
+ * the half bit pattern. This keeps the calls inside the kernel library instead
+ * of lowering to unresolved host libm symbols.
+ *
+ * The float computation calls the OpenCL builtin (e.g. `logb`), which the
+ * kernel-library rename (_builtin_renames.h) maps to pocl's own `_cl_logb`. It
+ * must not use `__builtin_logbf`: that has no LLVM intrinsic, so at the kernel
+ * library's -O0 it lowers to a call to the libm symbol `logbf`, which the
+ * kernel library does not provide -- producing
+ * "Cannot find symbol logbf in kernel library" when a half kernel is built.
+ * (The half overload below renames to `_cl_logb(half)`; the `logb((float)a)`
+ * call resolves by overload to `_cl_logb(float)`, so there is no recursion.) */
+
+/* logb : half -> half */
+half _CL_OVERLOADABLE logb (half a) { return (half)logb ((float)a); }
+DEFINE_FP16_EXPR_V_V (logb)
+
+/* ilogb : half -> int (scalar), halfN -> intN (vector) */
+int _CL_OVERLOADABLE ilogb (half a) { return ilogb ((float)a); }
+#define IMPLEMENT_FP16_ILOGB(ITYPE, HTYPE, NAMEN)                            \
+  ITYPE _CL_OVERLOADABLE ilogb (HTYPE a) { return (ITYPE)NAMEN (ilogb); }
+IMPLEMENT_FP16_ILOGB (int2, half2, NAME1_2)
+IMPLEMENT_FP16_ILOGB (int3, half3, NAME1_3)
+IMPLEMENT_FP16_ILOGB (int4, half4, NAME1_4)
+IMPLEMENT_FP16_ILOGB (int8, half8, NAME1_8)
+IMPLEMENT_FP16_ILOGB (int16, half16, NAME1_16)
+
+/* ldexp : (half, int) -> half */
+half _CL_OVERLOADABLE ldexp (half a, int b) { return (half)ldexp ((float)a, b); }
+DEFINE_FP16_EXPR_V_VI (ldexp)
+
+/* rootn : (half, int) -> half */
+half _CL_OVERLOADABLE rootn (half a, int b) { return (half)rootn ((float)a, b); }
+DEFINE_FP16_EXPR_V_VI (rootn)
+
+/* pown : (half, int) -> half. (Relocated from powf16.cl, which is compiled only
+   in the non-vectorized build; pown has no native FP16 builtin so it is needed
+   in both.) */
+half _CL_OVERLOADABLE pown (half a, int b) { return (half)pown ((float)a, b); }
+DEFINE_FP16_EXPR_V_VI (pown)
+
+/* remainder : (half, half) -> half */
+half _CL_OVERLOADABLE remainder (half a, half b) { return (half)remainder ((float)a, (float)b); }
+DEFINE_FP16_EXPR_V_VV (remainder)
+
+/* modf : (halfN, address-space halfN*) -> halfN */
+half _CL_OVERLOADABLE
+modf (half x, private half *iptr)
+{
+  float fip;
+  half r = (half)modf ((float)x, &fip);
+  *iptr = (half)fip;
+  return r;
+}
+
+#define IMPLEMENT_FP16_MODF_AS(TYPE, AS)                                     \
+  TYPE _CL_OVERLOADABLE modf (TYPE x, AS TYPE *iptr)                         \
+  { TYPE t; TYPE r = modf (x, &t); *iptr = t; return r; }
+
+#define IMPLEMENT_FP16_MODF_VECTOR(TYPE, LTYPE, HTYPE, LO, HI)               \
+  TYPE _CL_OVERLOADABLE modf (TYPE x, private TYPE *iptr)                    \
+  {                                                                          \
+    LTYPE l;                                                                 \
+    HTYPE h;                                                                 \
+    TYPE r = (TYPE)(modf (x.LO, &l), modf (x.HI, &h));                       \
+    iptr->LO = l;                                                            \
+    iptr->HI = h;                                                            \
+    return r;                                                                \
+  }                                                                          \
+  IMPLEMENT_FP16_MODF_AS (TYPE, local)                                       \
+  IMPLEMENT_FP16_MODF_AS (TYPE, global)                                      \
+  IF_GEN_AS (IMPLEMENT_FP16_MODF_AS (TYPE, generic))
+
+IMPLEMENT_FP16_MODF_AS (half, local)
+IMPLEMENT_FP16_MODF_AS (half, global)
+IF_GEN_AS (IMPLEMENT_FP16_MODF_AS (half, generic))
+IMPLEMENT_FP16_MODF_VECTOR (half2, half, half, lo, hi)
+IMPLEMENT_FP16_MODF_VECTOR (half3, half2, half, lo, s2)
+IMPLEMENT_FP16_MODF_VECTOR (half4, half2, half2, lo, hi)
+IMPLEMENT_FP16_MODF_VECTOR (half8, half4, half4, lo, hi)
+IMPLEMENT_FP16_MODF_VECTOR (half16, half8, half8, lo, hi)
+
+/* remquo : (halfN, halfN, address-space intN*) -> halfN */
+half _CL_OVERLOADABLE
+remquo (half x, half y, private int *quo)
+{
+  return (half)remquo ((float)x, (float)y, quo);
+}
+
+#define IMPLEMENT_FP16_REMQUO_AS(TYPE, ITYPE, AS)                            \
+  TYPE _CL_OVERLOADABLE remquo (TYPE x, TYPE y, AS ITYPE *quo)               \
+  { ITYPE t; TYPE r = remquo (x, y, &t); *quo = t; return r; }
+
+#define IMPLEMENT_FP16_REMQUO_VECTOR(TYPE, ITYPE, LITYPE, HITYPE, LO, HI)    \
+  TYPE _CL_OVERLOADABLE remquo (TYPE x, TYPE y, private ITYPE *quo)          \
+  {                                                                          \
+    LITYPE l;                                                                \
+    HITYPE h;                                                                \
+    TYPE r = (TYPE)(remquo (x.LO, y.LO, &l), remquo (x.HI, y.HI, &h));       \
+    quo->LO = l;                                                             \
+    quo->HI = h;                                                             \
+    return r;                                                                \
+  }                                                                          \
+  IMPLEMENT_FP16_REMQUO_AS (TYPE, ITYPE, local)                              \
+  IMPLEMENT_FP16_REMQUO_AS (TYPE, ITYPE, global)                             \
+  IF_GEN_AS (IMPLEMENT_FP16_REMQUO_AS (TYPE, ITYPE, generic))
+
+IMPLEMENT_FP16_REMQUO_AS (half, int, local)
+IMPLEMENT_FP16_REMQUO_AS (half, int, global)
+IF_GEN_AS (IMPLEMENT_FP16_REMQUO_AS (half, int, generic))
+IMPLEMENT_FP16_REMQUO_VECTOR (half2, int2, int, int, lo, hi)
+IMPLEMENT_FP16_REMQUO_VECTOR (half3, int3, int2, int, lo, s2)
+IMPLEMENT_FP16_REMQUO_VECTOR (half4, int4, int2, int2, lo, hi)
+IMPLEMENT_FP16_REMQUO_VECTOR (half8, int8, int4, int4, lo, hi)
+IMPLEMENT_FP16_REMQUO_VECTOR (half16, int16, int8, int8, lo, hi)
+
+/* powr : (half, half) -> half. powr(x,y) = pow(x,y) for x >= 0, NaN for x < 0.
+   Built on the half `pow` builtin -- which is available in both configurations
+   (CORE-Math powf16.cl when vectorization is off, the generic vectorized pow.cl
+   when it is on) -- so this works in both. (Relocated from powf16.cl, which is
+   compiled only in the non-vectorized build.) */
+half _CL_OVERLOADABLE
+powr (half x, half y)
+{
+  ushort xu = as_ushort (x);
+  x = (xu == (ushort)0x8000) ? (half)0 : x;       /* -0 -> +0 */
+  half r = pow (x, y);
+  r = (xu > (ushort)0x8000) ? (half)NAN : r;       /* x < 0 -> NaN */
+  r = isnan (x) ? (half)NAN : r;
+  r = isnan (y) ? (half)NAN : r;
+  return r;
+}
+DEFINE_FP16_EXPR_V_VV (powr)
+
+/* nextafter : (half, half) -> half. Computed directly on the half bit pattern;
+   float promotion is wrong here (it would step to the next float, not the next
+   half). Mirrors sleef-pocl/nextafter.cl (pocl#2210). */
+half _CL_OVERLOADABLE
+nextafter (half x, half y)
+{
+  const short sign_bit = as_short ((ushort)0x8000);
+  const short sign_bit_mask = 0x7fff;
+
+  short ix = as_short (x);
+  short ax = ix & sign_bit_mask;
+  short mx = sign_bit - ix;
+  mx = ix < (short)0 ? mx : ix;
+
+  short iy = as_short (y);
+  short ay = iy & sign_bit_mask;
+  short my = sign_bit - iy;
+  my = iy < (short)0 ? my : iy;
+
+  short t = mx + (mx < my ? 1 : -1);
+  short r = sign_bit - t;
+  r = t < (short)0 ? r : t;
+
+  if (t == 0 && ix < 0)
+    r = sign_bit;
+
+  r = isnan (x) ? ix : r;
+  r = isnan (y) ? iy : r;
+  r = (((ax | ay) == (short)0) | (ix == iy)) ? iy : r;
+  return as_half (r);
+}
+DEFINE_FP16_EXPR_V_VV (nextafter)

--- a/lib/kernel/core-math/sincosf16.cl
+++ b/lib/kernel/core-math/sincosf16.cl
@@ -2099,4 +2099,10 @@ _CL_OVERLOADABLE half sincos(half x, generic half *cosval){
 }
 #endif
 
-/* DEFINE_FP16_EXPR_V_VPV(sincos) */
+/* Vector sincos: recurse through lo/hi halves down to the scalar overload
+   above, plus the local/global/generic cosval-pointer forms. */
+IMPLEMENT_BUILTIN_V_VPV (sincos, half2, half, half, lo, hi)
+IMPLEMENT_BUILTIN_V_VPV (sincos, half3, half2, half, lo, s2)
+IMPLEMENT_BUILTIN_V_VPV (sincos, half4, half2, half2, lo, hi)
+IMPLEMENT_BUILTIN_V_VPV (sincos, half8, half4, half4, lo, hi)
+IMPLEMENT_BUILTIN_V_VPV (sincos, half16, half8, half8, lo, hi)

--- a/lib/kernel/host/CMakeLists.txt
+++ b/lib/kernel/host/CMakeLists.txt
@@ -356,7 +356,10 @@ if(HOST_CPU_ENABLE_CL_KHR_FP16)
         acoshf16.cl   atan2pif16.cl  exp10m1f16.cl   lgammaf16.cl    sinpif16.cl
         atanhf16.cl   cospif16.cl    exp2m1f16.cl    log10p1f16.cl   asinhf16.cl
         atanpif16.cl  erfcf16.cl     log1pf16.cl     sincosf16.cl    asinpif16.cl
-        cbrtf16.cl    erff16.cl      expm1f16.cl     tanpif16.cl)
+        cbrtf16.cl    erff16.cl      expm1f16.cl     tanpif16.cl
+        # FP16 ops with no native FP16 builtin and no SLEEF FP16 path: not
+        # covered by the vectorized generic builtins above, so needed here too.
+        promotedf16.cl)
       list(APPEND SOURCES_WITH_SLEEF "core-math/${FILE}")
     endforeach()
   else()
@@ -368,7 +371,7 @@ if(HOST_CPU_ENABLE_CL_KHR_FP16)
         asinf16.cl    atanhf16.cl    cospif16.cl     exp2m1f16.cl   log10p1f16.cl  tanf16.cl
         asinhf16.cl   atanpif16.cl   erfcf16.cl      expf16.cl      log1pf16.cl    sincosf16.cl  tanhf16.cl
         asinpif16.cl  cbrtf16.cl     erff16.cl       expm1f16.cl    log2f16.cl     sinf16.cl     tanpif16.cl
-        additionalf16.cl)
+        additionalf16.cl  promotedf16.cl)
       list(APPEND SOURCES_WITH_SLEEF "core-math/${FILE}")
     endforeach()
   endif()

--- a/lib/kernel/templates.h
+++ b/lib/kernel/templates.h
@@ -2228,3 +2228,19 @@
   IMPLEMENT_FP16_EXPR_V_V (NAME, half4, BUILTIN (a))                          \
   IMPLEMENT_FP16_EXPR_V_V (NAME, half8, BUILTIN (a))                          \
   IMPLEMENT_FP16_EXPR_V_V (NAME, half16, BUILTIN (a))
+
+#define DEFINE_FP16_BUILTIN_V_VV(NAME, BUILTIN)                               \
+  IMPLEMENT_FP16_EXPR_V_VV (NAME, half, BUILTIN (a, b))                       \
+  IMPLEMENT_FP16_EXPR_V_VV (NAME, half2, BUILTIN (a, b))                      \
+  IMPLEMENT_FP16_EXPR_V_VV (NAME, half3, BUILTIN (a, b))                      \
+  IMPLEMENT_FP16_EXPR_V_VV (NAME, half4, BUILTIN (a, b))                      \
+  IMPLEMENT_FP16_EXPR_V_VV (NAME, half8, BUILTIN (a, b))                      \
+  IMPLEMENT_FP16_EXPR_V_VV (NAME, half16, BUILTIN (a, b))
+
+#define DEFINE_FP16_BUILTIN_V_VVV(NAME, BUILTIN)                              \
+  IMPLEMENT_FP16_EXPR_V_VVV (NAME, half, BUILTIN (a, b, c))                   \
+  IMPLEMENT_FP16_EXPR_V_VVV (NAME, half2, BUILTIN (a, b, c))                  \
+  IMPLEMENT_FP16_EXPR_V_VVV (NAME, half3, BUILTIN (a, b, c))                  \
+  IMPLEMENT_FP16_EXPR_V_VVV (NAME, half4, BUILTIN (a, b, c))                  \
+  IMPLEMENT_FP16_EXPR_V_VVV (NAME, half8, BUILTIN (a, b, c))                  \
+  IMPLEMENT_FP16_EXPR_V_VVV (NAME, half16, BUILTIN (a, b, c))

--- a/tests/kernel/CMakeLists.txt
+++ b/tests/kernel/CMakeLists.txt
@@ -100,6 +100,9 @@ add_test_pocl(NAME "kernel/test_short16"
 add_test_pocl(NAME "kernel/test_frexp_modf"
               COMMAND "kernel" "test_frexp_modf")
 
+add_test_pocl(NAME "kernel/test_fp16_math_builtins"
+              COMMAND "kernel" "test_fp16_math_builtins")
+
 if(HOST_CPU_ENABLE_CL_KHR_KERNEL_CLOCK)
   add_test_pocl(NAME "kernel/test_kernel_clock"
                 COMMAND "kernel" "test_kernel_clock")
@@ -143,7 +146,8 @@ foreach(VARIANT ${VARIANTS})
     "kernel/test_convert_sat_regression_${VARIANT}"   "kernel/test_fabs_${VARIANT}"
     "kernel/test_rotate_${VARIANT}" "kernel/test_copy_signbit_${VARIANT}" "kernel/test_ilogb_${VARIANT}"
     "kernel/test_ldexp_${VARIANT}" "kernel/test_isnan_${VARIANT}" "kernel/test_short16_${VARIANT}"
-    "kernel/test_frexp_modf_${VARIANT}" "kernel/test_dot_${VARIANT}" ${ENABLE_CPU_TESTS}
+    "kernel/test_frexp_modf_${VARIANT}" "kernel/test_fp16_math_builtins_${VARIANT}"
+    "kernel/test_dot_${VARIANT}" ${ENABLE_CPU_TESTS}
     PROPERTIES
       COST 4.0
       PROCESSORS 1
@@ -252,6 +256,7 @@ if(NOT HOST_CPU_ENABLE_CL_KHR_FP16)
   foreach(VARIANT ${VARIANTS})
   set_tests_properties("kernel/test_printf_vectors_halfn_${VARIANT}"
     "kernel/test_shuffle_half_${VARIANT}" "kernel/test_halfs_${VARIANT}"
+    "kernel/test_fp16_math_builtins_${VARIANT}"
     PROPERTIES
       PROCESSORS 1
       COST 120

--- a/tests/kernel/test_fp16_math_builtins.cl
+++ b/tests/kernel/test_fp16_math_builtins.cl
@@ -52,6 +52,7 @@ kernel void test_fp16_math_builtins ()
   int8 hvn = vn;
   half8 vip;
   int8 vquo;
+  int8 viexp;
 
   vsink = ceil (hvx);
   vsink = floor (hvx);
@@ -66,6 +67,7 @@ kernel void test_fp16_math_builtins ()
   vsink = maxmag (hvx, hvy);
   vsink = minmag (hvx, hvy);
   vsink = fmod (hvy, hvx);
+  vsink = frexp (hvx, &viexp);
   vsink = logb (hvx);
   visink = ilogb (hvx);
   vsink = ldexp (hvx, hvn);

--- a/tests/kernel/test_fp16_math_builtins.cl
+++ b/tests/kernel/test_fp16_math_builtins.cl
@@ -21,6 +21,7 @@ kernel void test_fp16_math_builtins ()
   int iexp;
   int quo;
   half hcos;
+  int isign;
 
   hsink = ceil (hx);
   hsink = floor (hx);
@@ -47,6 +48,7 @@ kernel void test_fp16_math_builtins ()
   isink = iexp + quo;
   hsink = powr (hy, hx);
   hsink = sincos (hx, &hcos);
+  hsink = lgamma_r (hx, &isign);
   hsink = nextafter (hx, hy);
 
   half8 hvx = vx;
@@ -56,6 +58,7 @@ kernel void test_fp16_math_builtins ()
   int8 vquo;
   int8 viexp;
   half8 vcos;
+  int8 visign;
 
   vsink = ceil (hvx);
   vsink = floor (hvx);
@@ -82,5 +85,6 @@ kernel void test_fp16_math_builtins ()
   visink = vquo;
   vsink = powr (hvy, hvx);
   vsink = sincos (hvx, &vcos);
+  vsink = lgamma_r (hvx, &visign);
   vsink = nextafter (hvx, hvy);
 }

--- a/tests/kernel/test_fp16_math_builtins.cl
+++ b/tests/kernel/test_fp16_math_builtins.cl
@@ -1,0 +1,80 @@
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+volatile global half x = 1.5h;
+volatile global half y = 2.0h;
+volatile global int n = 3;
+volatile global half8 vx = (half8)(1.5h);
+volatile global half8 vy = (half8)(2.0h);
+volatile global int8 vn = (int8)(3);
+
+volatile global half hsink;
+volatile global int isink;
+volatile global half8 vsink;
+volatile global int8 visink;
+
+kernel void test_fp16_math_builtins ()
+{
+  half hx = x;
+  half hy = y;
+  int hn = n;
+  half hip;
+  int iexp;
+  int quo;
+
+  hsink = ceil (hx);
+  hsink = floor (hx);
+  hsink = trunc (hx);
+  hsink = rint (hx);
+  hsink = round (hx);
+  hsink = fabs (hx);
+  hsink = fmax (hx, hy);
+  hsink = fmin (hx, hy);
+  hsink = fma (hx, hy, hx);
+  hsink = fdim (hy, hx);
+  hsink = maxmag (hx, hy);
+  hsink = minmag (hx, hy);
+  hsink = fmod (hy, hx);
+  hsink = frexp (hx, &iexp);
+  hsink = logb (hx);
+  isink = ilogb (hx);
+  hsink = ldexp (hx, hn);
+  hsink = rootn (hy, hn);
+  hsink = pown (hx, hn);
+  hsink = remainder (hy, hx);
+  hsink = modf (hx, &hip);
+  hsink = remquo (hy, hx, &quo);
+  isink = iexp + quo;
+  hsink = powr (hy, hx);
+  hsink = nextafter (hx, hy);
+
+  half8 hvx = vx;
+  half8 hvy = vy;
+  int8 hvn = vn;
+  half8 vip;
+  int8 vquo;
+
+  vsink = ceil (hvx);
+  vsink = floor (hvx);
+  vsink = trunc (hvx);
+  vsink = rint (hvx);
+  vsink = round (hvx);
+  vsink = fabs (hvx);
+  vsink = fmax (hvx, hvy);
+  vsink = fmin (hvx, hvy);
+  vsink = fma (hvx, hvy, hvx);
+  vsink = fdim (hvy, hvx);
+  vsink = maxmag (hvx, hvy);
+  vsink = minmag (hvx, hvy);
+  vsink = fmod (hvy, hvx);
+  vsink = logb (hvx);
+  visink = ilogb (hvx);
+  vsink = ldexp (hvx, hvn);
+  vsink = rootn (hvy, hvn);
+  vsink = pown (hvx, hvn);
+  vsink = remainder (hvy, hvx);
+  vsink = modf (hvx, &vip);
+  vsink = remquo (hvy, hvx, &vquo);
+  visink = vquo;
+  vsink = powr (hvy, hvx);
+  vsink = nextafter (hvx, hvy);
+}

--- a/tests/kernel/test_fp16_math_builtins.cl
+++ b/tests/kernel/test_fp16_math_builtins.cl
@@ -20,6 +20,7 @@ kernel void test_fp16_math_builtins ()
   half hip;
   int iexp;
   int quo;
+  half hcos;
 
   hsink = ceil (hx);
   hsink = floor (hx);
@@ -45,6 +46,7 @@ kernel void test_fp16_math_builtins ()
   hsink = remquo (hy, hx, &quo);
   isink = iexp + quo;
   hsink = powr (hy, hx);
+  hsink = sincos (hx, &hcos);
   hsink = nextafter (hx, hy);
 
   half8 hvx = vx;
@@ -53,6 +55,7 @@ kernel void test_fp16_math_builtins ()
   half8 vip;
   int8 vquo;
   int8 viexp;
+  half8 vcos;
 
   vsink = ceil (hvx);
   vsink = floor (hvx);
@@ -78,5 +81,6 @@ kernel void test_fp16_math_builtins ()
   vsink = remquo (hvy, hvx, &vquo);
   visink = vquo;
   vsink = powr (hvy, hvx);
+  vsink = sincos (hvx, &vcos);
   vsink = nextafter (hvx, hvy);
 }


### PR DESCRIPTION
When `cl_khr_fp16` is enabled, the host CPU kernel library advertises half support but several `_cl_*` half math entry points are absent in vectorized builtin configurations, because the SLEEF/libmvec wrappers only cover float and double. SPIR wrappers and OpenCL C kernels can then fail at program creation or link time with unresolved half math symbols.

Add the missing FP16 overloads to the host core-math library. Operations that have native LLVM half support stay in `additionalf16.cl`; the remaining builtins live in `promotedf16.cl` and are implemented by promoting through float, handling vector forms and pointer address spaces explicitly. Include the new source in both vectorized and non-vectorized host builds, and add the needed FP16 builtin declaration helpers.

Without this, the added tests fails on a build like:

```
CMAKE_GENERATOR=Ninja
CMAKE_BUILD_TYPE=Debug
ENABLE_TESTS=ON
ENABLE_SLEEF=ON
ENABLE_HOST_CPU_VECTORIZE_SVML=ON
ENABLE_HOST_CPU_VECTORIZE_LIBMVEC=OFF
ENABLE_HOST_CPU_VECTORIZE_SLEEF=OFF
ENABLE_HOST_CPU_VECTORIZE_BUILTINS=ON
KERNELLIB_HOST_CPU_VARIANTS=distro
LLVM_VERSION_FULL=20.1.8jl
LLVM_LIBS=-lLLVM-20jl
CPU_USE_LLD_LINK=defined
HOST_CPU_ENABLE_SPIRV=defined
OCL_KERNEL_TARGET_CPU="znver5"
HOST_LD_FLAGS="-shared -nostartfiles /opt/intel/oneapi/compiler/latest/lib/libsvml.a /opt/intel/oneapi/compiler/latest/lib/libirc.a"
```

... with:

```
Running test test_fp16_math_builtins...

Unknown OpenCL error 1 in clCreateProgram call failed
 on line 42
FAIL

Error(s) while linking:
Cannot find symbol _Z9_cl_rootnDv8_DhDv8_i in kernel library
Cannot find symbol _Z9_cl_rootnDhi in kernel library
Cannot find symbol _Z9_cl_ldexpDhi in kernel library
Cannot find symbol _Z10_cl_remquoDhDhPU9CLgenerici in kernel library
Cannot find symbol _Z8_cl_powrDv8_DhS_ in kernel library
Cannot find symbol _Z9_cl_ilogbDv8_Dh in kernel library
Cannot find symbol _Z13_cl_nextafterDv8_DhS_ in kernel library
Cannot find symbol _Z8_cl_modfDhPU9CLgenericDh in kernel library
Cannot find symbol _Z8_cl_logbDv8_Dh in kernel library
Cannot find symbol _Z8_cl_powrDhDh in kernel library
Cannot find symbol _Z8_cl_logbDh in kernel library
Cannot find symbol _Z10_cl_remquoDv8_DhS_PU9CLgenericDv8_i in kernel library
Cannot find symbol _Z8_cl_pownDhi in kernel library
Cannot find symbol _Z13_cl_remainderDv8_DhS_ in kernel library
Cannot find symbol _Z13_cl_nextafterDhDh in kernel library
Cannot find symbol _Z9_cl_ilogbDh in kernel library
Cannot find symbol _Z9_cl_ldexpDv8_DhDv8_i in kernel library
Cannot find symbol _Z8_cl_modfDv8_DhPU9CLgenericS_ in kernel library
Cannot find symbol _Z13_cl_remainderDhDh in kernel library
Cannot find symbol _Z8_cl_pownDv8_DhDv8_i in kernel library

Device cpu-skylake-avx512-AMD Ryzen 9 9950X 16-Core Processor failed to build the program
CL_BUILD_PROGRAM_FAILURE in clBuildProgram on line 686A
```

Reduced from an existing failure in OpenCL.jl