### PR TITLE
cpu: enable cl_khr_fp16 on MinGW hosts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1645,10 +1645,14 @@ endif()
 # LLVM <15 doesn't support _Float16;
 # LLVM 15 crashes on some code; LLVM 16 seems to work but fails with ldexp; LLVM 18 fails with isinf
 # CONFORMANCE=ON disables FP16 b/c PoCL support is incomplete
+# The host check is on the *build* machine, not the target -- so Yggdrasil's
+# Linux cross-builds already ship working FP16 in the macOS/Windows binaries.
+# Linux and MinGW are validated; FreeBSD is kept out (native _Float16 build
+# failure, see #1776).
 if((LLVM_VERSION_MAJOR GREATER_EQUAL 19)
    AND (NOT ENABLE_CONFORMANCE)
    AND (NOT I386)
-   AND (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+   AND ((CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux") OR MINGW)
    AND CLANG_SUPPORTS_FLOAT16_ON_CPU
    AND HOST_COMPILER_SUPPORTS_FLOAT16)
   message(STATUS "CPU device support for cl_khr_fp16 enabled")

--- a/lib/CL/devices/printf_buffer.c
+++ b/lib/CL/devices/printf_buffer.c
@@ -118,11 +118,14 @@ DEFINE_PRINT_INTS (ulong, int64_t, uint64_t)
         memcpy (&val, vals, sizeof (FLOAT_TYPE));                             \
         vals = (char *)vals + sizeof (FLOAT_TYPE);                            \
         const char *other = NULL;                                             \
-        if (isnan (val))                                                      \
+        /* classify through double: exact for half/float, identity for double, \
+           and avoids a _Float16 isnan/isinf/signbit path that traps on some   \
+           runtimes (e.g. MinGW libgcc). */                                    \
+        if (isnan ((double)val))                                              \
           other = NANs[p->flags.uc];                                          \
-        if (isinf (val))                                                      \
+        if (isinf ((double)val))                                              \
           {                                                                   \
-            p->flags.sign = signbit (val) ? 1 : 0;                            \
+            p->flags.sign = signbit ((double)val) ? 1 : 0;                    \
             other = INFs[p->flags.uc];                                        \
           }                                                                   \
         if (other)                                                            \


### PR DESCRIPTION
FP16 host math support was gated to CMAKE_HOST_SYSTEM_NAME == "Linux" (commit 9de7551) to dodge a _Float16 build failure on FreeBSD.

Native MinGW satisfies every real requirement: clang codegens _Float16 for the host CPU target, libgcc provides the __extendhfsf2/__truncsfhf2 conversion helpers (so the FreeBSD failure mode does not occur), and the host compiler supports _Float16. Add MINGW to the host allowlist, keeping FreeBSD and other untested hosts gated off. Validated on native MinGW/MSYS2 (LLVM 22): full build plus the tests/kernel/test_fp16_* / test_halfs / test_shuffle_half / test_printf_vectors_halfn suite pass.

Also fix a latent crash this exposes: __pocl_print_floats_<T> classified values with isnan/isinf/signbit on the raw element type, and the _Float16 path traps at runtime under MinGW libgcc while printing half inf/nan. Classify through double instead (half->double and float->double are exact, double->double is a no-op), preserving nan/inf/sign for every type. Fixes test_printf_vectors_halfn.