### PR TITLE
Fix return value of scalar FP16 relational built-ins

### DIFF
--- a/lib/kernel/templates.h
+++ b/lib/kernel/templates.h
@@ -2206,20 +2206,19 @@
   IMPLEMENT_FP16_EXPR_V_VI (NAME, half16, int16, NAME2_16 (NAME))
 
 /* __builtin_isfpclass() returns 1 / 0, not -1 that we need */
-#define IMPLEMENT_FP16_BUILTIN_FPCLASS(NAME, CLASSNUM, FLTTYPE, INTTYPE)          \
+#define IMPLEMENT_FP16_BUILTIN_FPCLASS(NAME, CLASSNUM, FLTTYPE, INTTYPE, RETVAL)  \
   INTTYPE _CL_OVERLOADABLE _CL_READNONE _cl_##NAME (FLTTYPE a)                \
   {                                                                           \
-    return (__builtin_isfpclass (a, CLASSNUM) > (INTTYPE)0) ? (INTTYPE)(-1)   \
-                                                            : (INTTYPE)(0);   \
-  }
+    return (__builtin_isfpclass (a, CLASSNUM) > (INTTYPE)0) ? (INTTYPE)(RETVAL)   \
+                                                            : (INTTYPE)(0);     }
 
 #define DEFINE_FP16_BUILTIN_FPCLASS(NAME, CLASSNUM)                               \
-  IMPLEMENT_FP16_BUILTIN_FPCLASS (NAME, CLASSNUM, half, int)                      \
-  IMPLEMENT_FP16_BUILTIN_FPCLASS (NAME, CLASSNUM, half2, short2)                  \
-  IMPLEMENT_FP16_BUILTIN_FPCLASS (NAME, CLASSNUM, half3, short3)                  \
-  IMPLEMENT_FP16_BUILTIN_FPCLASS (NAME, CLASSNUM, half4, short4)                  \
-  IMPLEMENT_FP16_BUILTIN_FPCLASS (NAME, CLASSNUM, half8, short8)                  \
-  IMPLEMENT_FP16_BUILTIN_FPCLASS (NAME, CLASSNUM, half16, short16)
+  IMPLEMENT_FP16_BUILTIN_FPCLASS (NAME, CLASSNUM, half, int, 1)                   \
+  IMPLEMENT_FP16_BUILTIN_FPCLASS (NAME, CLASSNUM, half2, short2, -1)              \
+  IMPLEMENT_FP16_BUILTIN_FPCLASS (NAME, CLASSNUM, half3, short3, -1)              \
+  IMPLEMENT_FP16_BUILTIN_FPCLASS (NAME, CLASSNUM, half4, short4, -1)              \
+  IMPLEMENT_FP16_BUILTIN_FPCLASS (NAME, CLASSNUM, half8, short8, -1)              \
+  IMPLEMENT_FP16_BUILTIN_FPCLASS (NAME, CLASSNUM, half16, short16, -1)
 
 #define DEFINE_FP16_BUILTIN_V_V(NAME, BUILTIN)                                \
   IMPLEMENT_FP16_EXPR_V_V (NAME, half, BUILTIN (a))                           \


### PR DESCRIPTION
According to the OpenCL C specification, relational built-in functions (such as isfinite, isnormal, isinf, and isnan) must return:
- 1 (true) or 0 (false) for scalar inputs.
- -1 (all bits set to 1, i.e., signed -1) or 0 for vector inputs.

The DEFINE_FP16_BUILTIN_FPCLASS macro in templates.h (which wraps the __builtin_isfpclass clang builtin) was incorrectly returning -1 for both scalar and vector overloads.

Co-authored-by: Gemini 3.5 Flash