### PR TITLE
Don't crash on an unparseable program.bc; report the error

### DIFF
--- a/lib/CL/pocl_llvm_build.cc
+++ b/lib/CL/pocl_llvm_build.cc
@@ -798,7 +798,11 @@ int pocl_llvm_build_program(cl_program program,
 
     program->llvm_irs[device_i] = mod =
         parseModuleIR(program_bc_path, llvm_ctx->Context);
-    assert(mod);
+    if (mod == nullptr) {
+      POCL_MSG_ERR("pocl: failed to parse program.bc '%s' (corrupt or stale "
+                   "kernel-cache entry)\n", program_bc_path);
+      return CL_BUILD_ERROR;
+    }
     ++llvm_ctx->number_of_IRs;
 
     parseModuleGVarSize(program, device_i, mod);

--- a/lib/CL/pocl_llvm_utils.cc
+++ b/lib/CL/pocl_llvm_utils.cc
@@ -80,11 +80,20 @@ using namespace llvm;
 
 llvm::Module *parseModuleIR(const char *path, llvm::LLVMContext *c) {
   SMDiagnostic Err;
-  return parseIRFile(path, Err, *c).release();
+  llvm::Module *M = parseIRFile(path, Err, *c).release();
+  if (M == nullptr) {
+    std::string Msg;
+    raw_string_ostream OS(Msg);
+    Err.print("pocl", OS);
+    POCL_MSG_ERR("parseModuleIR('%s') failed:\n%s\n", path, OS.str().c_str());
+  }
+  return M;
 }
 
 void parseModuleGVarSize(cl_program program, unsigned device_i,
                          llvm::Module *ProgramBC) {
+  if (ProgramBC == nullptr)
+    return;
 
   unsigned long TotalGVarBytes = 0;
   if (!getModuleIntMetadata(*ProgramBC, PoclGVarMDName, TotalGVarBytes))

--- a/lib/CL/pocl_llvm_wg.cc
+++ b/lib/CL/pocl_llvm_wg.cc
@@ -1117,7 +1117,12 @@ int pocl_llvm_read_program_llvm_irs(cl_program program, unsigned device_i,
     assert(program_bc_path);
     M = parseModuleIR(program_bc_path, llvm_ctx->Context);
   }
-  assert(M);
+  if (M == nullptr) {
+    POCL_MSG_ERR("pocl: failed to parse program IR for device %u; the cached "
+                 "program.bc may be corrupt (try clearing the kernel cache)\n",
+                 device_i);
+    return CL_BUILD_ERROR;
+  }
   program->llvm_irs[device_i] = M;
   if (dev->run_program_scope_variables_pass)
     parseModuleGVarSize(program, device_i, M);


### PR DESCRIPTION
parseModuleIR/parseModuleIRMem can return null for a corrupt or version-incompatible program.bc (e.g. a stale kernel-cache entry left by an older driver build). The callers only had asserts, compiled out in a release driver, so this dereferenced null in parseModuleGVarSize and crashed the whole process.