### PR TITLE
CMake: handle required flags with CMake 4.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -870,7 +870,7 @@ if(UNIX OR MINGW)
   include(CheckSymbolExists)
 
   # don't allow implicit function declarations
-  set(CMAKE_REQUIRED_FLAGS "-std=c99 ${FORBID_IMPLICIT_FUNCTIONS}")
+  string(JOIN " " CMAKE_REQUIRED_FLAGS "-std=c99" ${FORBID_IMPLICIT_FUNCTIONS})
   if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     set(CMAKE_REQUIRED_LIBRARIES "rt")
   endif ()


### PR DESCRIPTION
CMAKE_REQUIRED_FLAGS must be a single space-separated string for try_compile. Passing FORBID_IMPLICIT_FUNCTIONS as an expanded CMake list makes CMake 4.4 interpret -Werror=incompatible-pointer-types as its own warning-control option instead of forwarding it to the C compiler, aborting the fork probe during configuration. Join the flags before assigning the variable so both checks reach the compiler.