### PR TITLE
llvmopencl: guard implicit barriers by source dominance

### DIFF
--- a/lib/llvmopencl/ImplicitConditionalBarriers.cc
+++ b/lib/llvmopencl/ImplicitConditionalBarriers.cc
@@ -34,8 +34,6 @@ IGNORE_COMPILER_WARNING("-Wmaybe-uninitialized")
 #include "DebugHelpers.h"
 #include "ImplicitConditionalBarriers.h"
 #include "LLVMUtils.h"
-#include "VariableUniformityAnalysis.h"
-#include "VariableUniformityAnalysisResult.hh"
 #include "Workgroup.h"
 #include "WorkitemHandlerChooser.h"
 POP_COMPILER_DIAGS
@@ -95,7 +93,6 @@ ImplicitConditionalBarriers::run(llvm::Function &F,
   llvm::LoopInfo &LI = FAM.getResult<LoopAnalysis>(F);
 
   PreservedAnalyses PAChanged = PreservedAnalyses::none();
-  PAChanged.preserve<VariableUniformityAnalysis>();
   PAChanged.preserve<WorkitemHandlerChooser>();
   PAChanged.preserve<LoopAnalysis>();
 
@@ -155,7 +152,12 @@ ImplicitConditionalBarriers::run(llvm::Function &F,
       if (Pred == BB) break; // Traced across a loop edge, skip this case.
     }
 
-    if (Barrier::hasOnlyBarrier(Pos)) continue;
+    if (Barrier::hasOnlyBarrier(Pos) || !DT.dominates(Pos, BB))
+      continue;
+
+    // Let the source barrier's all-or-none execution guarantee apply to the
+    // implicit barrier only when every path to the source crosses Pos.
+
     // Inject a barrier at the beginning of the BB and let the
     // CanonicalizeBarrier to clean it up (split to a separate BB).
 

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -31,6 +31,8 @@ set(C_PROGRAMS_TO_BUILD test_assign_loop_variable_to_privvar_makes_it_local
      test_issue_1711 test_issue_1794 test_issue_1747
      test_rematerialized_alloca_load_with_outside_pr_users
      test_peeled_wi_global_id
+     test_divergent_implicit_barrier_entry
+     test_uniform_implicit_barrier_entry
      test_usm_indirect_ptrs
 )
 foreach(PROG ${C_PROGRAMS_TO_BUILD})
@@ -156,6 +158,10 @@ add_test_pocl(NAME "regression/test_issue_1794b" COMMAND "test_issue_1794" "0" "
 add_test_pocl(NAME "regression/test_issue_1747" COMMAND "test_issue_1747" "0" "${CMAKE_CURRENT_SOURCE_DIR}/test_issue_1747.spv" LABELS ${SPIRV_LABELS})
 
 add_test_pocl(NAME "regression/peeled_wi_global_id" WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_peeled_wi_global_id" LABELS ${SPIRV_LABELS})
+
+add_test_pocl(NAME "regression/divergent_implicit_barrier_entry" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_divergent_implicit_barrier_entry")
+
+add_test_pocl(NAME "regression/uniform_implicit_barrier_entry" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_uniform_implicit_barrier_entry")
 
 add_test_pocl(NAME "regression/test_usm_indirect_ptrs" COMMAND "test_usm_indirect_ptrs")
 

--- a/tests/regression/test_divergent_implicit_barrier_entry.c
+++ b/tests/regression/test_divergent_implicit_barrier_entry.c
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 PoCL developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "pocl_opencl.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define CHECK_ERROR(err)                                                       \
+  do {                                                                         \
+    if ((err) != CL_SUCCESS) {                                                 \
+      fprintf(stderr, "OpenCL error %d at %s:%d\\n", (err), __FILE__,          \
+              __LINE__);                                                       \
+      goto error;                                                              \
+    }                                                                          \
+  } while (0)
+
+static const char KernelSource[] =
+    "__kernel void test_kernel(__global int *out,\n"
+    "                          __global const int *input,\n"
+    "                          uint active_n, uint logical_len) {\n"
+    "  __local int temp;\n"
+    "  size_t i = get_local_id(0);\n"
+    "  if (i == 0) temp = 0;\n"
+    "  barrier(CLK_LOCAL_MEM_FENCE);\n"
+    "  if (i < active_n) {\n"
+    "    if (i >= logical_len) return;\n"
+    "    if (input[i] < 0) temp = 1;\n"
+    "  }\n"
+    "  barrier(CLK_LOCAL_MEM_FENCE);\n"
+    "  if (i == 0) out[0] = temp;\n"
+    "}\n";
+
+int main(void) {
+  const cl_int input[] = {0, 0, -1, 0, 0, 0, 0, 0};
+  const cl_uint active_n = 2;
+  const cl_uint logical_len = 2;
+  cl_int output = -1;
+  const size_t work_size = 8;
+  cl_int err;
+  cl_uint num_platforms;
+  cl_platform_id *platforms = NULL;
+  cl_context context = NULL;
+  cl_command_queue queue = NULL;
+  cl_program program = NULL;
+  cl_kernel kernel = NULL;
+  cl_mem output_buffer = NULL;
+  cl_mem input_buffer = NULL;
+  int result = 1;
+
+  err = clGetPlatformIDs(0, NULL, &num_platforms);
+  CHECK_ERROR(err);
+  if (num_platforms == 0) {
+    puts("SKIP: no OpenCL platforms");
+    return 77;
+  }
+  platforms = malloc(num_platforms * sizeof(*platforms));
+  if (platforms == NULL)
+    goto error;
+  err = clGetPlatformIDs(num_platforms, platforms, NULL);
+  CHECK_ERROR(err);
+
+  cl_device_id device;
+  err = clGetDeviceIDs(platforms[0], CL_DEVICE_TYPE_ALL, 1, &device, NULL);
+  CHECK_ERROR(err);
+  context = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
+  CHECK_ERROR(err);
+  const cl_queue_properties properties[] = {0};
+  queue = clCreateCommandQueueWithProperties(context, device, properties, &err);
+  CHECK_ERROR(err);
+
+  const char *sources[] = {KernelSource};
+  program = clCreateProgramWithSource(context, 1, sources, NULL, &err);
+  CHECK_ERROR(err);
+  err = clBuildProgram(program, 1, &device, NULL, NULL, NULL);
+  if (err != CL_SUCCESS) {
+    size_t log_size = 0;
+    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, NULL,
+                          &log_size);
+    char *log = malloc(log_size);
+    if (log != NULL) {
+      clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size,
+                            log, NULL);
+      fprintf(stderr, "Build error:\\n%s\\n", log);
+      free(log);
+    }
+    goto error;
+  }
+  kernel = clCreateKernel(program, "test_kernel", &err);
+  CHECK_ERROR(err);
+  output_buffer =
+      clCreateBuffer(context, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+                     sizeof(output), &output, &err);
+  CHECK_ERROR(err);
+  input_buffer =
+      clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+                     sizeof(input), (void *)input, &err);
+  CHECK_ERROR(err);
+
+  CHECK_ERROR(clSetKernelArg(kernel, 0, sizeof(output_buffer), &output_buffer));
+  CHECK_ERROR(clSetKernelArg(kernel, 1, sizeof(input_buffer), &input_buffer));
+  CHECK_ERROR(clSetKernelArg(kernel, 2, sizeof(active_n), &active_n));
+  CHECK_ERROR(clSetKernelArg(kernel, 3, sizeof(logical_len), &logical_len));
+  CHECK_ERROR(clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &work_size,
+                                     &work_size, 0, NULL, NULL));
+  CHECK_ERROR(clEnqueueReadBuffer(queue, output_buffer, CL_TRUE, 0,
+                                  sizeof(output), &output, 0, NULL, NULL));
+
+  if (output != 0) {
+    fprintf(stderr, "output = %d, expected 0\\n", output);
+    goto error;
+  }
+  puts("OK");
+  result = 0;
+
+error:
+  free(platforms);
+  if (input_buffer != NULL)
+    clReleaseMemObject(input_buffer);
+  if (output_buffer != NULL)
+    clReleaseMemObject(output_buffer);
+  if (kernel != NULL)
+    clReleaseKernel(kernel);
+  if (program != NULL)
+    clReleaseProgram(program);
+  if (queue != NULL)
+    clReleaseCommandQueue(queue);
+  if (context != NULL)
+    clReleaseContext(context);
+  return result;
+}

--- a/tests/regression/test_divergent_implicit_barrier_entry.c
+++ b/tests/regression/test_divergent_implicit_barrier_entry.c
@@ -23,10 +23,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/*
+  Before the fix, ImplicitConditionalBarriers inserted the two barriers marked
+  below around the inner return check. Both are inside i < active_n, so inactive
+  work-items bypass them but still reach the second source barrier. After the
+  fix, the block after the return check does not dominate the source barrier,
+  and neither implicit barrier is inserted.
+*/
+
 #define CHECK_ERROR(err)                                                       \
   do {                                                                         \
     if ((err) != CL_SUCCESS) {                                                 \
-      fprintf(stderr, "OpenCL error %d at %s:%d\\n", (err), __FILE__,          \
+      fprintf(stderr, "OpenCL error %d at %s:%d\n", (err), __FILE__,           \
               __LINE__);                                                       \
       goto error;                                                              \
     }                                                                          \
@@ -41,7 +49,9 @@ static const char KernelSource[] =
     "  if (i == 0) temp = 0;\n"
     "  barrier(CLK_LOCAL_MEM_FENCE);\n"
     "  if (i < active_n) {\n"
+    "    /* pre-fix: implicit_barrier(); */\n"
     "    if (i >= logical_len) return;\n"
+    "    /* pre-fix: implicit_barrier(); */\n"
     "    if (input[i] < 0) temp = 1;\n"
     "  }\n"
     "  barrier(CLK_LOCAL_MEM_FENCE);\n"
@@ -98,7 +108,7 @@ int main(void) {
     if (log != NULL) {
       clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size,
                             log, NULL);
-      fprintf(stderr, "Build error:\\n%s\\n", log);
+      fprintf(stderr, "Build error:\n%s\n", log);
       free(log);
     }
     goto error;
@@ -124,7 +134,7 @@ int main(void) {
                                   sizeof(output), &output, 0, NULL, NULL));
 
   if (output != 0) {
-    fprintf(stderr, "output = %d, expected 0\\n", output);
+    fprintf(stderr, "output = %d, expected 0\n", output);
     goto error;
   }
   puts("OK");

--- a/tests/regression/test_uniform_implicit_barrier_entry.c
+++ b/tests/regression/test_uniform_implicit_barrier_entry.c
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 PoCL developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/*
+  The bounds check depends on the work-item id, but logical_len equals the
+  work-group size at launch, so every work-item reaches sub_group_shuffle.
+  The builtin is flattened before ImplicitConditionalBarriers and contains a
+  barrier. Its normal path dominates that barrier, so an implicit barrier is
+  legal even though VariableUniformityAnalysis cannot prove the condition
+  uniform.
+*/
+
+#include "pocl_opencl.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define CHECK_ERROR(err)                                                       \
+  do {                                                                         \
+    if ((err) != CL_SUCCESS) {                                                 \
+      fprintf(stderr, "OpenCL error %d at %s:%d\n", (err), __FILE__,           \
+              __LINE__);                                                       \
+      goto error;                                                              \
+    }                                                                          \
+  } while (0)
+
+static const char KernelSource[] =
+    "#pragma OPENCL EXTENSION cl_khr_subgroups : enable\n"
+    "__kernel void test_kernel(__global int *out,\n"
+    "                          __global const int *input,\n"
+    "                          uint logical_len) {\n"
+    "  uint i = get_sub_group_local_id();\n"
+    "  if (i >= logical_len) return;\n"
+    "  uint j = get_sub_group_size() - i - 1;\n"
+    "  out[i] = sub_group_shuffle(input[i], j);\n"
+    "}\n";
+
+int main(void) {
+  const cl_int input[] = {0, 1, 2, 3, 4, 5, 6, 7};
+  cl_int output[8] = {-1, -1, -1, -1, -1, -1, -1, -1};
+  const cl_uint logical_len = 8;
+  const size_t work_size = 8;
+  cl_int err;
+  cl_uint num_platforms;
+  cl_platform_id *platforms = NULL;
+  cl_context context = NULL;
+  cl_command_queue queue = NULL;
+  cl_program program = NULL;
+  cl_kernel kernel = NULL;
+  cl_mem output_buffer = NULL;
+  cl_mem input_buffer = NULL;
+  int result = 1;
+
+  err = clGetPlatformIDs(0, NULL, &num_platforms);
+  CHECK_ERROR(err);
+  if (num_platforms == 0) {
+    puts("SKIP: no OpenCL platforms");
+    return 77;
+  }
+  platforms = malloc(num_platforms * sizeof(*platforms));
+  if (platforms == NULL)
+    goto error;
+  err = clGetPlatformIDs(num_platforms, platforms, NULL);
+  CHECK_ERROR(err);
+
+  cl_device_id device;
+  err = clGetDeviceIDs(platforms[0], CL_DEVICE_TYPE_ALL, 1, &device, NULL);
+  CHECK_ERROR(err);
+  context = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
+  CHECK_ERROR(err);
+  const cl_queue_properties properties[] = {0};
+  queue = clCreateCommandQueueWithProperties(context, device, properties, &err);
+  CHECK_ERROR(err);
+
+  const char *sources[] = {KernelSource};
+  program = clCreateProgramWithSource(context, 1, sources, NULL, &err);
+  CHECK_ERROR(err);
+  err = clBuildProgram(program, 1, &device, "-cl-std=CL3.0", NULL, NULL);
+  if (err != CL_SUCCESS) {
+    size_t log_size = 0;
+    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, NULL,
+                          &log_size);
+    char *log = malloc(log_size);
+    if (log != NULL) {
+      clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size,
+                            log, NULL);
+      fprintf(stderr, "Build error:\n%s\n", log);
+      free(log);
+    }
+    goto error;
+  }
+  kernel = clCreateKernel(program, "test_kernel", &err);
+  CHECK_ERROR(err);
+  output_buffer =
+      clCreateBuffer(context, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+                     sizeof(output), output, &err);
+  CHECK_ERROR(err);
+  input_buffer =
+      clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+                     sizeof(input), (void *)input, &err);
+  CHECK_ERROR(err);
+
+  CHECK_ERROR(clSetKernelArg(kernel, 0, sizeof(output_buffer), &output_buffer));
+  CHECK_ERROR(clSetKernelArg(kernel, 1, sizeof(input_buffer), &input_buffer));
+  CHECK_ERROR(clSetKernelArg(kernel, 2, sizeof(logical_len), &logical_len));
+  CHECK_ERROR(clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &work_size,
+                                     &work_size, 0, NULL, NULL));
+  CHECK_ERROR(clEnqueueReadBuffer(queue, output_buffer, CL_TRUE, 0,
+                                  sizeof(output), output, 0, NULL, NULL));
+
+  for (size_t i = 0; i < work_size; ++i) {
+    if (output[i] != input[work_size - i - 1]) {
+      fprintf(stderr, "output[%zu] = %d, expected %d\n", i, output[i],
+              input[work_size - i - 1]);
+      goto error;
+    }
+  }
+  puts("OK");
+  result = 0;
+
+error:
+  free(platforms);
+  if (input_buffer != NULL)
+    clReleaseMemObject(input_buffer);
+  if (output_buffer != NULL)
+    clReleaseMemObject(output_buffer);
+  if (kernel != NULL)
+    clReleaseKernel(kernel);
+  if (program != NULL)
+    clReleaseProgram(program);
+  if (queue != NULL)
+    clReleaseCommandQueue(queue);
+  if (context != NULL)
+    clReleaseContext(context);
+  return result;
+}

--- a/tests/regression/test_uniform_implicit_barrier_entry.c
+++ b/tests/regression/test_uniform_implicit_barrier_entry.c
@@ -83,6 +83,11 @@ int main(void) {
   cl_device_id device;
   err = clGetDeviceIDs(platforms[0], CL_DEVICE_TYPE_ALL, 1, &device, NULL);
   CHECK_ERROR(err);
+  if (!poclu_supports_extension(device, "cl_khr_subgroups")) {
+    puts("SKIP: The test requires cl_khr_subgroups");
+    free(platforms);
+    return 77;
+  }
   context = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
   CHECK_ERROR(err);
   const cl_queue_properties properties[] = {0};

--- a/tests/regression/test_uniform_implicit_barrier_entry.c
+++ b/tests/regression/test_uniform_implicit_barrier_entry.c
@@ -19,12 +19,13 @@
 // THE SOFTWARE.
 
 /*
-  The bounds check depends on the work-item id, but logical_len equals the
-  work-group size at launch, so every work-item reaches sub_group_shuffle.
-  The builtin is flattened before ImplicitConditionalBarriers and contains a
-  barrier. Its normal path dominates that barrier, so an implicit barrier is
-  legal even though VariableUniformityAnalysis cannot prove the condition
-  uniform.
+  Flattening sub_group_shuffle exposes a source barrier after the return check.
+  Both before and after the fix, ImplicitConditionalBarriers inserts the two
+  barriers marked below. The block after the check dominates the source barrier,
+  so the source barrier's all-or-none execution guarantee makes both insertions
+  legal. VariableUniformityAnalysis cannot prove this because the bounds check
+  depends on the work-item id. At launch, logical_len equals the work-group size,
+  so every work-item takes the normal path.
 */
 
 #include "pocl_opencl.h"
@@ -47,7 +48,9 @@ static const char KernelSource[] =
     "                          __global const int *input,\n"
     "                          uint logical_len) {\n"
     "  uint i = get_sub_group_local_id();\n"
+    "  /* implicit_barrier(); */\n"
     "  if (i >= logical_len) return;\n"
+    "  /* implicit_barrier(); */\n"
     "  uint j = get_sub_group_size() - i - 1;\n"
     "  out[i] = sub_group_shuffle(input[i], j);\n"
     "}\n";


### PR DESCRIPTION
ImplicitConditionalBarriers can choose an insertion block nested below a divergent guard. If another control-flow path bypasses that block and still reaches the source barrier, work-item-loop lowering can execute the guarded path for non-participating work-items.

Require the insertion block to dominate the source barrier. This lets the source barrier's all-or-none execution guarantee apply to the implicit barrier, while retaining valid dynamically uniform cases such as lane-indexed bounds checks before flattened subgroup shuffles.

Add two OpenCL C regressions: one where a bypass makes insertion unsafe, and one where every work-item dynamically passes a lane-dependent bounds check before `sub_group_shuffle`.

Related: #1747, #1794, #1971, #2113.

Implemented with the help of GPT 5.6