### PR TITLE
WorkitemLoops: share local memory across region replicas

### DIFF
--- a/lib/llvmopencl/WorkitemLoops.cc
+++ b/lib/llvmopencl/WorkitemLoops.cc
@@ -133,6 +133,8 @@ private:
   void fixMultiRegionVariables(ParallelRegion *Region);
   void addContextSaveRestore(llvm::Instruction *instruction);
   void releaseParallelRegions();
+  void shareReplicatedLocalMemAllocas(
+      ParallelRegion &Region, llvm::ValueToValueMapTy &ReferenceMap);
 
   // Returns an instruction in the entry block which computes the
   // total size of work-items in the work-group. If it doesn't
@@ -451,6 +453,29 @@ void WorkitemLoopsImpl::releaseParallelRegions() {
   }
 }
 
+void WorkitemLoopsImpl::shareReplicatedLocalMemAllocas(
+    ParallelRegion &Region, ValueToValueMapTy &ReferenceMap) {
+  for (BasicBlock *BB : Region) {
+    for (Instruction &I : *BB) {
+      auto *Original = dyn_cast<CallInst>(&I);
+      if (Original == nullptr || Original->getCalledFunction() == nullptr ||
+          (Original->getCalledFunction() != LocalMemAllocaFuncDecl &&
+           Original->getCalledFunction() != WorkGroupAllocaFuncDecl))
+        continue;
+
+      auto *Replica = dyn_cast_or_null<CallInst>(ReferenceMap.lookup(Original));
+      if (Replica == nullptr || Replica == Original)
+        continue;
+
+      // Region replicas execute different work-items of the same work group.
+      // They must share local memory originating from the same allocation.
+      Replica->replaceAllUsesWith(Original);
+      ReferenceMap[Original] = Original;
+      Replica->eraseFromParent();
+    }
+  }
+}
+
 bool WorkitemLoopsImpl::processFunction(Function &F) {
 
   releaseParallelRegions();
@@ -545,6 +570,7 @@ bool WorkitemLoopsImpl::processFunction(Function &F) {
       LLVM_DEBUG(dbgs() << "Conditional region, peeling the first iteration\n");
 
       ParallelRegion *replica = PRegion->replicate(reference_map, ".peeled_wi");
+      shareReplicatedLocalMemAllocas(*PRegion, reference_map);
       replica->chainAfter(PRegion);
       replica->purge();
 
@@ -586,6 +612,7 @@ bool WorkitemLoopsImpl::processFunction(Function &F) {
         for (unsigned c = 1; c < UnrollCount; ++c) {
           ParallelRegion *UnrolledPR =
               PRegion->replicate(reference_map, ".unrolled_wi");
+          shareReplicatedLocalMemAllocas(*PRegion, reference_map);
           UnrolledPR->chainAfter(prev);
           prev = UnrolledPR;
           lastBB = UnrolledPR->exitBB();

--- a/tests/regression/CMakeLists.txt
+++ b/tests/regression/CMakeLists.txt
@@ -31,6 +31,7 @@ set(C_PROGRAMS_TO_BUILD test_assign_loop_variable_to_privvar_makes_it_local
      test_issue_1711 test_issue_1794 test_issue_1747
      test_rematerialized_alloca_load_with_outside_pr_users
      test_peeled_wi_global_id
+     test_replicated_wi_subgroup_alloca
      test_usm_indirect_ptrs
 )
 foreach(PROG ${C_PROGRAMS_TO_BUILD})
@@ -156,6 +157,10 @@ add_test_pocl(NAME "regression/test_issue_1794b" COMMAND "test_issue_1794" "0" "
 add_test_pocl(NAME "regression/test_issue_1747" COMMAND "test_issue_1747" "0" "${CMAKE_CURRENT_SOURCE_DIR}/test_issue_1747.spv" LABELS ${SPIRV_LABELS})
 
 add_test_pocl(NAME "regression/peeled_wi_global_id" WORKITEM_HANDLER "loopvec;cbs;" COMMAND "test_peeled_wi_global_id" LABELS ${SPIRV_LABELS})
+
+add_test_pocl(NAME "regression/replicated_wi_subgroup_alloca" WORKITEM_HANDLER "loops;loopvec;cbs;" COMMAND "test_replicated_wi_subgroup_alloca")
+set_tests_properties("regression/replicated_wi_subgroup_alloca_loops" PROPERTIES ENVIRONMENT "POCL_WORK_GROUP_METHOD=loops;POCL_WILOOPS_MAX_UNROLL_COUNT=4")
+set_tests_properties("regression/replicated_wi_subgroup_alloca_loopvec" PROPERTIES ENVIRONMENT "POCL_WORK_GROUP_METHOD=loopvec;POCL_WILOOPS_MAX_UNROLL_COUNT=4")
 
 add_test_pocl(NAME "regression/test_usm_indirect_ptrs" COMMAND "test_usm_indirect_ptrs")
 

--- a/tests/regression/test_replicated_wi_subgroup_alloca.c
+++ b/tests/regression/test_replicated_wi_subgroup_alloca.c
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 PoCL developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/*
+  A static path bypasses the inner return check and still reaches the barrier
+  exposed by flattening sub_group_shuffle, so ImplicitConditionalBarriers must
+  not normalize the conditional region. At launch, both bounds equal the work
+  group size, so all work-items take the inner path and reach the source
+  barrier.
+
+  WorkitemLoops may replicate this barrier region when unrolling or peeling
+  work-items. Every copy must use the same work-group allocation backing the
+  shuffle.
+*/
+
+#include "pocl_opencl.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#define CHECK_ERROR(err)                                                       \
+  do {                                                                         \
+    if ((err) != CL_SUCCESS) {                                                 \
+      fprintf(stderr, "OpenCL error %d at %s:%d\n", (err), __FILE__,           \
+              __LINE__);                                                       \
+      goto error;                                                              \
+    }                                                                          \
+  } while (0)
+
+static const char KernelSource[] =
+    "#pragma OPENCL EXTENSION cl_khr_subgroups : enable\n"
+    "__kernel void test_kernel(__global int *out,\n"
+    "                          __global int *trace,\n"
+    "                          __global const int *input,\n"
+    "                          uint enter_n, uint logical_len) {\n"
+    "  uint i = get_sub_group_local_id();\n"
+    "  if (i < enter_n) {\n"
+    "    if (i >= logical_len) return;\n"
+    "    trace[i] = input[i] + 100;\n"
+    "  }\n"
+    "  uint j = get_sub_group_size() - i - 1;\n"
+    "  out[i] = sub_group_shuffle(input[i], j);\n"
+    "}\n";
+
+int main(void) {
+  const cl_int input[] = {0, 1, 2, 3, 4, 5, 6, 7};
+  cl_int output[8] = {-1, -1, -1, -1, -1, -1, -1, -1};
+  cl_int trace[8] = {-1, -1, -1, -1, -1, -1, -1, -1};
+  const cl_uint enter_n = 8;
+  const cl_uint logical_len = 8;
+  const size_t work_size = 8;
+  cl_int err;
+  cl_uint num_platforms;
+  cl_platform_id *platforms = NULL;
+  cl_context context = NULL;
+  cl_command_queue queue = NULL;
+  cl_program program = NULL;
+  cl_kernel kernel = NULL;
+  cl_mem output_buffer = NULL;
+  cl_mem trace_buffer = NULL;
+  cl_mem input_buffer = NULL;
+  int result = 1;
+
+  err = clGetPlatformIDs(0, NULL, &num_platforms);
+  CHECK_ERROR(err);
+  if (num_platforms == 0) {
+    puts("SKIP: no OpenCL platforms");
+    return 77;
+  }
+  platforms = malloc(num_platforms * sizeof(*platforms));
+  if (platforms == NULL)
+    goto error;
+  err = clGetPlatformIDs(num_platforms, platforms, NULL);
+  CHECK_ERROR(err);
+
+  cl_device_id device;
+  err = clGetDeviceIDs(platforms[0], CL_DEVICE_TYPE_ALL, 1, &device, NULL);
+  CHECK_ERROR(err);
+  if (!poclu_supports_extension(device, "cl_khr_subgroups")) {
+    puts("SKIP: The test requires cl_khr_subgroups");
+    free(platforms);
+    return 77;
+  }
+  context = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
+  CHECK_ERROR(err);
+  const cl_queue_properties properties[] = {0};
+  queue = clCreateCommandQueueWithProperties(context, device, properties, &err);
+  CHECK_ERROR(err);
+
+  const char *sources[] = {KernelSource};
+  program = clCreateProgramWithSource(context, 1, sources, NULL, &err);
+  CHECK_ERROR(err);
+  err = clBuildProgram(program, 1, &device, "-cl-std=CL3.0", NULL, NULL);
+  if (err != CL_SUCCESS) {
+    size_t log_size = 0;
+    clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, NULL,
+                          &log_size);
+    char *log = malloc(log_size);
+    if (log != NULL) {
+      clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size,
+                            log, NULL);
+      fprintf(stderr, "Build error:\n%s\n", log);
+      free(log);
+    }
+    goto error;
+  }
+  kernel = clCreateKernel(program, "test_kernel", &err);
+  CHECK_ERROR(err);
+  output_buffer =
+      clCreateBuffer(context, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+                     sizeof(output), output, &err);
+  CHECK_ERROR(err);
+  input_buffer =
+      clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+                     sizeof(input), (void *)input, &err);
+  CHECK_ERROR(err);
+  trace_buffer =
+      clCreateBuffer(context, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+                     sizeof(trace), trace, &err);
+  CHECK_ERROR(err);
+
+  CHECK_ERROR(clSetKernelArg(kernel, 0, sizeof(output_buffer), &output_buffer));
+  CHECK_ERROR(clSetKernelArg(kernel, 1, sizeof(trace_buffer), &trace_buffer));
+  CHECK_ERROR(clSetKernelArg(kernel, 2, sizeof(input_buffer), &input_buffer));
+  CHECK_ERROR(clSetKernelArg(kernel, 3, sizeof(enter_n), &enter_n));
+  CHECK_ERROR(clSetKernelArg(kernel, 4, sizeof(logical_len), &logical_len));
+  CHECK_ERROR(clEnqueueNDRangeKernel(queue, kernel, 1, NULL, &work_size,
+                                     &work_size, 0, NULL, NULL));
+  CHECK_ERROR(clEnqueueReadBuffer(queue, output_buffer, CL_TRUE, 0,
+                                  sizeof(output), output, 0, NULL, NULL));
+  CHECK_ERROR(clEnqueueReadBuffer(queue, trace_buffer, CL_TRUE, 0,
+                                  sizeof(trace), trace, 0, NULL, NULL));
+
+  for (size_t i = 0; i < work_size; ++i) {
+    if (output[i] != input[work_size - i - 1]) {
+      fprintf(stderr, "output[%zu] = %d, expected %d\n", i, output[i],
+              input[work_size - i - 1]);
+      goto error;
+    }
+    if (trace[i] != input[i] + 100) {
+      fprintf(stderr, "trace[%zu] = %d, expected %d\n", i, trace[i],
+              input[i] + 100);
+      goto error;
+    }
+  }
+  puts("OK");
+  result = 0;
+
+error:
+  free(platforms);
+  if (trace_buffer != NULL)
+    clReleaseMemObject(trace_buffer);
+  if (input_buffer != NULL)
+    clReleaseMemObject(input_buffer);
+  if (output_buffer != NULL)
+    clReleaseMemObject(output_buffer);
+  if (kernel != NULL)
+    clReleaseKernel(kernel);
+  if (program != NULL)
+    clReleaseProgram(program);
+  if (queue != NULL)
+    clReleaseCommandQueue(queue);
+  if (context != NULL)
+    clReleaseContext(context);
+  return result;
+}


### PR DESCRIPTION
AI-generated fix for what I observed in https://github.com/pocl/pocl/pull/2235#issuecomment-5006799743: simply avoiding certain implicit barriers (by checking `isUniform`) resulted in a miscompilation in `WorkitemLoops`.

---

Work-item loop unrolling and conditional barrier handling replicate parallel regions. If a region contains a compiler-expanded local-memory allocation, lowering the original and cloned calls independently gives each replica different storage. Subgroup operations then read incomplete data after their barrier.

Make peeled and unrolled replicas reuse the allocation call from the original region before local-memory calls are lowered. Add a regression that forces region unrolling around a subgroup shuffle and fails with both loops handlers before the fix.