### PR TITLE
Fix LLVM 22 deprecations and unused-result build warnings

### DIFF
--- a/examples/EinsteinToolkit/EinsteinToolkit.c
+++ b/examples/EinsteinToolkit/EinsteinToolkit.c
@@ -1458,7 +1458,12 @@ int main(int argc, char** argv)
   size_t const source1_size = ftell(source1_file);
   fseek(source1_file, 0, SEEK_SET);
   char *source1 = malloc (source1_size + 1);
-  fread(source1, source1_size, 1, source1_file);
+  if (fread(source1, source1_size, 1, source1_file) != 1)
+    {
+      free (source1);
+      fclose (source1_file);
+      return EXIT_FAILURE;
+    }
   source1[source1_size] = '\0';
   fclose(source1_file);
 
@@ -1468,7 +1473,12 @@ int main(int argc, char** argv)
   size_t const source2_size = ftell(source2_file);
   fseek(source2_file, 0, SEEK_SET);
   char *source2 = malloc (source2_size + 1);
-  fread(source2, source2_size, 1, source2_file);
+  if (fread(source2, source2_size, 1, source2_file) != 1)
+    {
+      free (source2);
+      fclose (source2_file);
+      return EXIT_FAILURE;
+    }
   source2[source2_size] = '\0';
   fclose(source2_file);
   

--- a/examples/matrix1/matrix1.c
+++ b/examples/matrix1/matrix1.c
@@ -255,7 +255,7 @@ main (int argc, char **argv)
           "USE_FMA %i \n"
           "EXPLICIT BINARY: %s \n",
           spirv, poclbin, use_locals, use_2d_reg_block, use_fma,
-          explicit_binary_path);
+          explicit_binary_path ? explicit_binary_path : "(none)");
 
   if (explicit_binary_path && ((spirv + poclbin) == 0))
     {

--- a/examples/scalarwave/scalarwave.c
+++ b/examples/scalarwave/scalarwave.c
@@ -130,7 +130,12 @@ main(void)
   fseek(source_file, 0, SEEK_SET);
   
   char *source = (char*)malloc(source_size + 1);
-  fread(source, source_size, 1, source_file);
+  if (fread(source, source_size, 1, source_file) < 1)
+    {
+      free (source);
+      fclose (source_file);
+      return EXIT_FAILURE;
+    }
   source[source_size] = '\0';
   
   fclose(source_file);

--- a/examples/trig/trig.c
+++ b/examples/trig/trig.c
@@ -58,7 +58,12 @@ main (void)
   source = (char *) malloc (source_size + 1);
   assert (source != NULL);
 
-  fread (source, source_size, 1, source_file);
+  if (fread (source, source_size, 1, source_file) != 1)
+    {
+      free (source);
+      fclose (source_file);
+      return EXIT_FAILURE;
+    }
   source[source_size] = '\0';
 
   fclose (source_file);

--- a/lib/CL/devices/printf_buffer.c
+++ b/lib/CL/devices/printf_buffer.c
@@ -804,10 +804,15 @@ pocl_flush_printf_buffer (char *buffer, uint32_t buffer_size)
 
   if (p.printf_buffer_index > 0)
     {
+      /* Best-effort flush; ignore short writes / errors. */
 #ifdef _MSC_VER
-      write (_fileno (stdout), p.printf_buffer, p.printf_buffer_index);
+      if (write (_fileno (stdout), p.printf_buffer, p.printf_buffer_index) < 0)
+        {
+        }
 #else
-      write (STDOUT_FILENO, p.printf_buffer, p.printf_buffer_index);
+      if (write (STDOUT_FILENO, p.printf_buffer, p.printf_buffer_index) < 0)
+        {
+        }
 #endif
     }
 }

--- a/lib/CL/pocl_run_command.c
+++ b/lib/CL/pocl_run_command.c
@@ -189,8 +189,14 @@ pocl_run_command_capture_output (char *capture_string,
 
   int in[2];
   int out[2];
-  pipe (in);
-  pipe (out);
+  if (pipe (in) == -1)
+    return EXIT_FAILURE;
+  if (pipe (out) == -1)
+    {
+      close (in[0]);
+      close (in[1]);
+      return EXIT_FAILURE;
+    }
 
   pid_t p = fork ();
   if (p == 0)

--- a/lib/CL/pocl_util.c
+++ b/lib/CL/pocl_util.c
@@ -31,7 +31,9 @@
 #ifndef _DEFAULT_SOURCE
 #define _DEFAULT_SOURCE
 #endif
+#ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
 
 #include <errno.h>
 #include <limits.h>

--- a/lib/llvmopencl/ParallelRegion.cc
+++ b/lib/llvmopencl/ParallelRegion.cc
@@ -620,7 +620,7 @@ ParallelRegion::InjectPrintF
   /* generated with help from https://llvm.org/demo/index.cgi */
   Function* printfFunc = M->getFunction("printf");
   if (printfFunc == NULL) {
-    PointerType* PointerTy_4 = PointerType::get(IntegerType::get(M->getContext(), 8), 0);
+    PointerType* PointerTy_4 = PointerType::get(M->getContext(), 0);
  
     std::vector<Type*> FuncTy_6_args;
     FuncTy_6_args.push_back(PointerTy_4);
@@ -655,9 +655,10 @@ ParallelRegion::InjectPrintF
   const_ptr_8_indices.push_back(const_int64_9);
   const_ptr_8_indices.push_back(const_int64_9);
   assert (isa<Constant>(stringArg));
+  auto *StrGV = cast<GlobalVariable>(stringArg);
   Constant* const_ptr_8 =
     ConstantExpr::getGetElementPtr
-    (PointerType::getUnqual(Type::getInt8Ty(M->getContext())), cast<Constant>(stringArg), const_ptr_8_indices);
+    (StrGV->getValueType(), StrGV, const_ptr_8_indices);
 
   std::vector<Value*> args;
   args.push_back(const_ptr_8);

--- a/lib/llvmopencl/ProgramScopeVariables.cc
+++ b/lib/llvmopencl/ProgramScopeVariables.cc
@@ -144,7 +144,8 @@ static Value *expandConstant(Constant *C, IRBuilder<> &Builder,
       if (GVar->getAddressSpace() != DeviceGlobalAS) {
         GVarPtrWithOffset = Builder.CreateAddrSpaceCast(
             GVarPtrWithOffset,
-            PointerType::get(GVarBufferTy, GVar->getAddressSpace()));
+            PointerType::get(GVarBufferTy->getContext(),
+                             GVar->getAddressSpace()));
       }
       Instruction *I = cast<Instruction>(GVarPtrWithOffset);
       InsnCache[GVar] = I;
@@ -219,7 +220,8 @@ static void addGlobalVarInitInstr(GlobalVariable *OriginalGVarDef,
   if (OrigGVarPTy->getAddressSpace() != DeviceGlobalAS)
     GVarPtrWithOffset = Builder.CreateAddrSpaceCast(
         GVarPtrWithOffset,
-        PointerType::get(GVarBufferTy, OrigGVarPTy->getAddressSpace()));
+        PointerType::get(GVarBufferTy->getContext(),
+                         OrigGVarPTy->getAddressSpace()));
 
   // Initializers are constant expressions. If they have references to a global
   // variables we are going to replace with load instructions we need to rewrite
@@ -310,7 +312,7 @@ static Value *loadGVarFromBuffer(Instruction *GVarBuffer,
     // AScast from DeviceGlobalAS to use's AS
     if (GVarPTy->getAddressSpace() != DeviceGlobalAS)
       V = Builder.CreateAddrSpaceCast(
-          V, PointerType::get(GVar->getType(), GVarPTy->getAddressSpace()));
+          V, PointerType::get(GVar->getContext(), GVarPTy->getAddressSpace()));
   } else {
     SmallVector<Value *, 2> Indices{ConstantInt::get(I64Ty, 0),
                                     ConstantInt::get(I64Ty, Offset)};
@@ -329,7 +331,7 @@ static Value *loadGVarFromBuffer(Instruction *GVarBuffer,
     // AScast from DeviceGlobalAS to use's AS
     if (GVarPTy->getAddressSpace() != DeviceGlobalAS)
       V = Builder.CreateAddrSpaceCast(
-          V, PointerType::get(GVar->getType(), GVarPTy->getAddressSpace()));
+          V, PointerType::get(GVar->getContext(), GVarPTy->getAddressSpace()));
   }
 
 #ifdef POCL_DEBUG_PROGVARS
@@ -474,7 +476,7 @@ int runProgramScopeVariablesPass(
 
   Type *GVarBufferArrayTy = ArrayType::get(Type::getInt8Ty(Ctx), TotalGVarSize);
   PointerType *GVarBufferTy =
-      PointerType::get(GVarBufferArrayTy, DeviceGlobalAS);
+      PointerType::get(Ctx, DeviceGlobalAS);
   Program->getOrInsertGlobal(PoclGVarBufferName, GVarBufferTy);
 
   GlobalVariable *GVarBuffer = Program->getNamedGlobal(PoclGVarBufferName);

--- a/lib/llvmopencl/SubCFGFormation.cc
+++ b/lib/llvmopencl/SubCFGFormation.cc
@@ -210,7 +210,8 @@ void copyDgbValues(llvm::Value *From, llvm::Value *To,
         *InsertBefore->getParent()->getParent()->getParent()};
     DbgBuilder.insertDbgValueIntrinsic(To, DbgValue->getVariable(),
                                        DbgValue->getExpression(),
-                                       DbgValue->getDebugLoc(), InsertBefore);
+                                       DbgValue->getDebugLoc(),
+                                       Inst2InsertPt(InsertBefore));
   }
 }
 
@@ -274,17 +275,19 @@ getLocalSizeValues(llvm::Function &F, llvm::ArrayRef<unsigned long> LocalSizes,
 
       if (I->getParent() != &F.getEntryBlock()) {
         // must be in entry block. move.
-// TODO for some reason, moveAfter(InsertionPoint) exists in the header, but
-// linking fails with undefined symbol
-//#if LLVM_MAJOR < 20
-          auto InsPt = F.getEntryBlock().getFirstNonPHI();
-//#else
-//          BasicBlock::iterator InsPt = F.getEntryBlock().getFirstInsertionPt();
-//#endif
+#if LLVM_MAJOR < 20
+        auto InsPt = F.getEntryBlock().getFirstNonPHI();
         if (F.getEntryBlock().size() == 1)
           I->moveBefore(InsPt);
         else
           I->moveAfter(InsPt);
+#else
+        auto InsPt = F.getEntryBlock().getFirstNonPHIIt();
+        if (F.getEntryBlock().size() == 1)
+          I->moveBefore(InsPt);
+        else
+          I->moveBefore(std::next(InsPt));
+#endif
       }
     } else
       LocalSize[D] = llvm::ConstantInt::get(
@@ -1395,7 +1398,8 @@ void SubCFGFormation::formSubCfgs(llvm::Function &F, llvm::LoopInfo &LI,
   auto *IndVarT =
       getLoadForGlobalVariable(F, LocalIdGlobalNames[Dim - 1])->getType();
   llvm::Instruction *IndVar = Builder.CreateLoad(
-      IndVarT, llvm::UndefValue::get(llvm::PointerType::get(IndVarT, 0)));
+      IndVarT,
+      llvm::UndefValue::get(llvm::PointerType::get(F.getContext(), 0)));
   // kept for simple reenabling of more advanced uniformity analysis
 #if 0
   VecInfo.setPinnedShape(*IndVar, pocl::VectorShape::cont());

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -283,23 +283,21 @@ bool WorkgroupImpl::runOnModule(Module &M, llvm::FunctionAnalysisManager &FAM) {
   SizeT = pocl::SizeT(&M);
 
   llvm::Type *Int32T = Type::getInt32Ty(*C);
-  llvm::Type *Int8T = Type::getInt8Ty(*C);
   PoclContextT = StructType::get(
       ArrayType::get(SizeT, 3),                   // NUM_GROUPS
       ArrayType::get(SizeT, 3),                   // GLOBAL_OFFSET
       ArrayType::get(SizeT, 3),                   // LOCAL_SIZE
-      PointerType::get(Int8T, DeviceGlobalASid),  // PRINTF_BUFFER
-      PointerType::get(Int32T, DeviceGlobalASid), // PRINTF_BUFFER_POSITION
-      Int32T,                                     // PRINTF_BUFFER_CAPACITY
-      PointerType::get(Int8T, DeviceGlobalASid),  // GLOBAL_VAR_BUFFER
-      Int32T,                                     // WORK_DIM
-      Int32T);                                    // EXECUTION_FAILED
+      PointerType::get(*C, DeviceGlobalASid),  // PRINTF_BUFFER
+      PointerType::get(*C, DeviceGlobalASid),  // PRINTF_BUFFER_POSITION
+      Int32T,                                  // PRINTF_BUFFER_CAPACITY
+      PointerType::get(*C, DeviceGlobalASid),  // GLOBAL_VAR_BUFFER
+      Int32T,                                  // WORK_DIM
+      Int32T);                                 // EXECUTION_FAILED
 
   LauncherFuncT = FunctionType::get(
       Type::getVoidTy(*C),
-      {PointerType::get(PointerType::get(Type::getInt8Ty(*C), 0),
-                        DeviceArgsASid),
-       PointerType::get(PoclContextT, DeviceContextASid), SizeT, SizeT, SizeT},
+      {PointerType::get(*C, DeviceArgsASid),
+       PointerType::get(*C, DeviceContextASid), SizeT, SizeT, SizeT},
       false);
 
   assert ((SizeTWidth == 64 || SizeTWidth == 32) &&
@@ -928,11 +926,11 @@ Function *WorkgroupImpl::createWrapper(Function *F,
     FuncParams.push_back(i->getType());
 
   if (!DeviceUsingArgBufferLauncher && DeviceIsSPMD) {
-    FuncParams.push_back(PointerType::get(PoclContextT, DeviceContextASid));
+    FuncParams.push_back(PointerType::get(C, DeviceContextASid));
     HiddenArgs = 1;
   } else {
     // pocl_context
-    FuncParams.push_back(PointerType::get(PoclContextT, DeviceContextASid));
+    FuncParams.push_back(PointerType::get(C, DeviceContextASid));
     // group_x
     FuncParams.push_back(SizeT);
     // group_y
@@ -1391,7 +1389,7 @@ void WorkgroupImpl::createDefaultWorkgroupLauncher(llvm::Function *F) {
     Type* I32Ty = Type::getInt32Ty(M->getContext());
 
     Type *I8Ty = Type::getInt8Ty(M->getContext());
-    Type *I8PtrTy = I8Ty->getPointerTo(0);
+    Type *I8PtrTy = PointerType::get(M->getContext(), 0);
     Value *GEP = Builder.CreateGEP(I8PtrTy, AI, ConstantInt::get(I32Ty, i));
     Value *Pointer = Builder.CreateLoad(I8PtrTy, GEP);
 

--- a/poclu/misc.c
+++ b/poclu/misc.c
@@ -259,7 +259,12 @@ poclu_read_binfile (const char *filename, size_t *len)
     }
 
   fseek (file, 0, SEEK_SET);
-  fread (src, *len, 1, file);
+  if (fread (src, *len, 1, file) < 1)
+    {
+      free (src);
+      fclose (file);
+      return NULL;
+    }
   fclose (file);
 
   return src;

--- a/tests/regression/test_issue_1711.c
+++ b/tests/regression/test_issue_1711.c
@@ -131,7 +131,12 @@ int main(int argc, char** argv) {
     fseek(f, 0, SEEK_SET);
 
     unsigned char* binary = (unsigned char*)malloc(size);
-    fread(binary, 1, size, f);
+    if (fread(binary, 1, size, f) != size) {
+        printf("Failed to read SPIR-V at %s:%d\n", __FILE__, __LINE__);
+        free(binary);
+        fclose(f);
+        return 1;
+    }
     fclose(f);
 
     cl_program program = clCreateProgramWithIL(context, binary, size, &err);

--- a/tests/regression/test_issue_1747.c
+++ b/tests/regression/test_issue_1747.c
@@ -177,7 +177,13 @@ main (int argc, char **argv)
   fseek (f, 0, SEEK_SET);
 
   unsigned char *binary = (unsigned char *)malloc (size);
-  fread (binary, 1, size, f);
+  if (fread (binary, 1, size, f) != size)
+    {
+      printf ("Failed to read SPIR-V at %s:%d\n", __FILE__, __LINE__);
+      free (binary);
+      fclose (f);
+      return 1;
+    }
   fclose (f);
 
   cl_program program = clCreateProgramWithIL (context, binary, size, &err);

--- a/tests/regression/test_issue_1794.c
+++ b/tests/regression/test_issue_1794.c
@@ -179,7 +179,13 @@ main (int argc, char **argv)
   fseek (f, 0, SEEK_SET);
 
   unsigned char *binary = (unsigned char *)malloc (size);
-  fread (binary, 1, size, f);
+  if (fread (binary, 1, size, f) != size)
+    {
+      printf ("Failed to read SPIR-V at %s:%d\n", __FILE__, __LINE__);
+      free (binary);
+      fclose (f);
+      return 1;
+    }
   fclose (f);
 
   cl_program program = clCreateProgramWithIL (context, binary, size, &err);

--- a/tests/regression/test_peeled_wi_global_id.c
+++ b/tests/regression/test_peeled_wi_global_id.c
@@ -108,7 +108,12 @@ int main(int argc, char **argv) {
   size_t size = ftell(f);
   fseek(f, 0, SEEK_SET);
   unsigned char *binary = malloc(size);
-  fread(binary, 1, size, f);
+  if (fread(binary, 1, size, f) != size) {
+    printf("Failed to read SPIR-V\n");
+    free(binary);
+    fclose(f);
+    return 1;
+  }
   fclose(f);
 
   cl_program program = clCreateProgramWithIL(context, binary, size, &err);

--- a/tests/regression/test_rematerialized_alloca_load_with_outside_pr_users.c
+++ b/tests/regression/test_rematerialized_alloca_load_with_outside_pr_users.c
@@ -170,7 +170,13 @@ main (int argc, char **argv)
   fseek (f, 0, SEEK_SET);
 
   unsigned char *binary = (unsigned char *)malloc (size);
-  fread (binary, 1, size, f);
+  if (fread (binary, 1, size, f) != size)
+    {
+      printf ("Failed to read SPIR-V at %s:%d\n", __FILE__, __LINE__);
+      free (binary);
+      fclose (f);
+      return 1;
+    }
   fclose (f);
 
   cl_program program = clCreateProgramWithIL (context, binary, size, &err);


### PR DESCRIPTION
## Summary
- Update LLVM IR helpers to Context-based `PointerType` APIs and iterator insert points required by LLVM 22.
- Check `fread`/`pipe`/`write` return values and guard `_POSIX_C_SOURCE` so RelWithDebInfo builds stay warning-clean.
- Verified with `tools/scripts/run_cpu_tests` on LLVM 21 and 22 (SPIR-V enabled): 324/324 passed.

## Test plan
- [x] Build against LLVM 22 with SPIR-V (`build-llvm22`)
- [x] `../tools/scripts/run_cpu_tests -j$(nproc) --output-on-failure` on LLVM 22
- [x] Build against LLVM 21 with SPIR-V (`build-llvm21`)
- [x] Same CPU test script on LLVM 21


Made with [Cursor](https://cursor.com)