### PR TITLE
SPIRVParser: handle OpTypeUntypedPointerKHR

### DIFF
--- a/lib/CL/devices/spirv.hh
+++ b/lib/CL/devices/spirv.hh
@@ -1186,6 +1186,7 @@ enum class Op : unsigned {
   OpModuleProcessed = 330,
   OpExecutionModeId = 331,
   OpDecorateId = 332,
+  OpTypeUntypedPointerKHR = 4417,
   OpSubgroupBallotKHR = 4421,
   OpSubgroupFirstInvocationKHR = 4422,
   OpSubgroupAllKHR = 4428,

--- a/lib/CL/devices/spirv_parser.cc
+++ b/lib/CL/devices/spirv_parser.cc
@@ -381,8 +381,9 @@ public:
   bool isName() const { return Opcode_ == spv::Op::OpName; }
   bool isDecoration() const { return Opcode_ == spv::Op::OpDecorate; }
   bool isType() const {
-    return ((int32_t)Opcode_ >= (int32_t)spv::Op::OpTypeVoid) &&
-           ((int32_t)Opcode_ <= (int32_t)spv::Op::OpTypeForwardPointer);
+    return (((int32_t)Opcode_ >= (int32_t)spv::Op::OpTypeVoid) &&
+            ((int32_t)Opcode_ <= (int32_t)spv::Op::OpTypeForwardPointer)) ||
+           (Opcode_ == spv::Op::OpTypeUntypedPointerKHR);
   }
   bool isConstant() const { return Opcode_ == spv::Op::OpConstant; }
   bool isBitcast() const { return Opcode_ == spv::Op::OpBitcast; }
@@ -556,6 +557,11 @@ public:
 
       } else
         return new SPIRVtypePointer(Word1_, Word2_, PointerSize, Word3_);
+    }
+
+    if (Opcode_ == spv::Op::OpTypeUntypedPointerKHR) {
+      return new SPIRVtypePointer(Word1_, Word2_, PointerSize,
+                                  0 /* no pointee type */);
     }
 
     return nullptr;


### PR DESCRIPTION
The parser did not recognize OpTypeUntypedPointerKHR in kernel argument types, treat untyped pointers as regular pointers with no pointee type