### PR TITLE
Prefer RequirePassInfoMixin

### DIFF
--- a/lib/llvmopencl/AllocasToEntry.h
+++ b/lib/llvmopencl/AllocasToEntry.h
@@ -33,11 +33,19 @@
 
 namespace pocl {
 
-class AllocasToEntry : public llvm::RequiredPassInfoMixin<AllocasToEntry> {
+class AllocasToEntry
+#if LLVM_MAJOR >= 23
+    : public llvm::RequiredPassInfoMixin<AllocasToEntry> {
+#else
+    : public llvm::PassInfoMixin<AllocasToEntry> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
   } // namespace pocl

--- a/lib/llvmopencl/AllocasToEntry.h
+++ b/lib/llvmopencl/AllocasToEntry.h
@@ -33,14 +33,12 @@
 
 namespace pocl {
 
-class AllocasToEntry : public llvm::PassInfoMixin<AllocasToEntry> {
+class AllocasToEntry : public llvm::RequiredPassInfoMixin<AllocasToEntry> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
-
 
   } // namespace pocl
 

--- a/lib/llvmopencl/AutomaticLocals.h
+++ b/lib/llvmopencl/AutomaticLocals.h
@@ -32,11 +32,10 @@
 
 namespace pocl {
 
-class AutomaticLocals : public llvm::PassInfoMixin<AutomaticLocals> {
+class AutomaticLocals : public llvm::RequiredPassInfoMixin<AutomaticLocals> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/AutomaticLocals.h
+++ b/lib/llvmopencl/AutomaticLocals.h
@@ -32,10 +32,18 @@
 
 namespace pocl {
 
-class AutomaticLocals : public llvm::RequiredPassInfoMixin<AutomaticLocals> {
+class AutomaticLocals
+#if LLVM_MAJOR >= 23
+    : public llvm::RequiredPassInfoMixin<AutomaticLocals> {
+#else
+    : public llvm::PassInfoMixin<AutomaticLocals> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/BarrierTailReplication.h
+++ b/lib/llvmopencl/BarrierTailReplication.h
@@ -34,12 +34,11 @@
 namespace pocl {
 
 class BarrierTailReplication
-    : public llvm::PassInfoMixin<BarrierTailReplication> {
+    : public llvm::RequiredPassInfoMixin<BarrierTailReplication> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/BarrierTailReplication.h
+++ b/lib/llvmopencl/BarrierTailReplication.h
@@ -34,11 +34,18 @@
 namespace pocl {
 
 class BarrierTailReplication
+#if LLVM_MAJOR >= 23
     : public llvm::RequiredPassInfoMixin<BarrierTailReplication> {
+#else
+    : public llvm::PassInfoMixin<BarrierTailReplication> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/CanonicalizeBarriers.h
+++ b/lib/llvmopencl/CanonicalizeBarriers.h
@@ -39,11 +39,18 @@ namespace pocl {
 /// only the barrier and the terminator, with just one predecessor. This allows
 /// us to use those BBs as markers only, they will not be replicated.
 class CanonicalizeBarriers
+#if LLVM_MAJOR >= 23
     : public llvm::RequiredPassInfoMixin<CanonicalizeBarriers> {
+#else
+    : public llvm::PassInfoMixin<CanonicalizeBarriers> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/CanonicalizeBarriers.h
+++ b/lib/llvmopencl/CanonicalizeBarriers.h
@@ -38,12 +38,12 @@ namespace pocl {
 /// Canonical form means that the barriers are in their separate BB containing
 /// only the barrier and the terminator, with just one predecessor. This allows
 /// us to use those BBs as markers only, they will not be replicated.
-class CanonicalizeBarriers : public llvm::PassInfoMixin<CanonicalizeBarriers> {
+class CanonicalizeBarriers
+    : public llvm::RequiredPassInfoMixin<CanonicalizeBarriers> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/DebugHelpers.h
+++ b/lib/llvmopencl/DebugHelpers.h
@@ -60,23 +60,21 @@ void viewCFG(llvm::Function &F);
 // @return True in case the function was changed.
 bool chopBBs (llvm::Function &F, llvm::Pass &P);
 
-  class PoCLCFGPrinter : public llvm::PassInfoMixin<PoCLCFGPrinter> {
-  public:
-    explicit PoCLCFGPrinter(llvm::raw_ostream &OutS, llvm::StringRef Pref = "")
-        : OS(OutS) {
-      Prefix = Pref.str();
-      Prefix += "_";
-    }
-    static void registerWithPB(llvm::PassBuilder &B);
-    llvm::PreservedAnalyses run(llvm::Module &M,
-                                llvm::ModuleAnalysisManager &AM);
-    static bool isRequired() { return true; }
+class PoCLCFGPrinter : public llvm::RequiredPassInfoMixin<PoCLCFGPrinter> {
+public:
+  explicit PoCLCFGPrinter(llvm::raw_ostream &OutS, llvm::StringRef Pref = "")
+      : OS(OutS) {
+    Prefix = Pref.str();
+    Prefix += "_";
+  }
+  static void registerWithPB(llvm::PassBuilder &B);
+  llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
 
-  private:
-    std::string Prefix;
-    llvm::raw_ostream &OS;
-    void dumpModule(llvm::Module &M);
-  };
+private:
+  std::string Prefix;
+  llvm::raw_ostream &OS;
+  void dumpModule(llvm::Module &M);
+};
 };
 
 // Controls the debug output from BarrierTailReplication.cc.

--- a/lib/llvmopencl/DebugHelpers.h
+++ b/lib/llvmopencl/DebugHelpers.h
@@ -60,7 +60,12 @@ void viewCFG(llvm::Function &F);
 // @return True in case the function was changed.
 bool chopBBs (llvm::Function &F, llvm::Pass &P);
 
-class PoCLCFGPrinter : public llvm::RequiredPassInfoMixin<PoCLCFGPrinter> {
+class PoCLCFGPrinter
+#if LLVM_MAJOR >= 23
+    : public llvm::RequiredPassInfoMixin<PoCLCFGPrinter> {
+#else
+    : public llvm::PassInfoMixin<PoCLCFGPrinter> {
+#endif
 public:
   explicit PoCLCFGPrinter(llvm::raw_ostream &OutS, llvm::StringRef Pref = "")
       : OS(OutS) {
@@ -69,6 +74,9 @@ public:
   }
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 
 private:
   std::string Prefix;

--- a/lib/llvmopencl/Flatten.hh
+++ b/lib/llvmopencl/Flatten.hh
@@ -34,11 +34,10 @@
 
 namespace pocl {
 
-class FlattenAll : public llvm::PassInfoMixin<FlattenAll> {
+class FlattenAll : public llvm::RequiredPassInfoMixin<FlattenAll> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/Flatten.hh
+++ b/lib/llvmopencl/Flatten.hh
@@ -34,10 +34,18 @@
 
 namespace pocl {
 
-class FlattenAll : public llvm::RequiredPassInfoMixin<FlattenAll> {
+class FlattenAll
+#if LLVM_MAJOR >= 23
+    : public llvm::RequiredPassInfoMixin<FlattenAll> {
+#else
+    : public llvm::PassInfoMixin<FlattenAll> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/FlattenBarrierSubs.hh
+++ b/lib/llvmopencl/FlattenBarrierSubs.hh
@@ -34,10 +34,17 @@
 namespace pocl {
 
 class FlattenBarrierSubs
+#if LLVM_MAJOR >= 23
     : public llvm::RequiredPassInfoMixin<FlattenBarrierSubs> {
+#else
+    : public llvm::PassInfoMixin<FlattenBarrierSubs> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/FlattenBarrierSubs.hh
+++ b/lib/llvmopencl/FlattenBarrierSubs.hh
@@ -33,12 +33,11 @@
 
 namespace pocl {
 
-
-class FlattenBarrierSubs : public llvm::PassInfoMixin<FlattenBarrierSubs> {
+class FlattenBarrierSubs
+    : public llvm::RequiredPassInfoMixin<FlattenBarrierSubs> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/FlattenGlobals.hh
+++ b/lib/llvmopencl/FlattenGlobals.hh
@@ -34,10 +34,18 @@
 
 namespace pocl {
 
-class FlattenGlobals : public llvm::RequiredPassInfoMixin<FlattenGlobals> {
+class FlattenGlobals
+#if LLVM_MAJOR >= 23
+    : public llvm::RequiredPassInfoMixin<FlattenGlobals> {
+#else
+    : public llvm::PassInfoMixin<FlattenGlobals> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/FlattenGlobals.hh
+++ b/lib/llvmopencl/FlattenGlobals.hh
@@ -34,14 +34,11 @@
 
 namespace pocl {
 
-
-class FlattenGlobals : public llvm::PassInfoMixin<FlattenGlobals> {
+class FlattenGlobals : public llvm::RequiredPassInfoMixin<FlattenGlobals> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
-
 
 } // namespace pocl
 

--- a/lib/llvmopencl/HandleSamplerInitialization.h
+++ b/lib/llvmopencl/HandleSamplerInitialization.h
@@ -37,11 +37,18 @@ namespace pocl {
 // per-target handling of samplers.
 
 class HandleSamplerInitialization
+#if LLVM_MAJOR >= 23
     : public llvm::RequiredPassInfoMixin<HandleSamplerInitialization> {
+#else
+    : public llvm::PassInfoMixin<HandleSamplerInitialization> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/HandleSamplerInitialization.h
+++ b/lib/llvmopencl/HandleSamplerInitialization.h
@@ -37,12 +37,11 @@ namespace pocl {
 // per-target handling of samplers.
 
 class HandleSamplerInitialization
-    : public llvm::PassInfoMixin<HandleSamplerInitialization> {
+    : public llvm::RequiredPassInfoMixin<HandleSamplerInitialization> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/ImplicitConditionalBarriers.h
+++ b/lib/llvmopencl/ImplicitConditionalBarriers.h
@@ -66,14 +66,12 @@
 namespace pocl {
 
 class ImplicitConditionalBarriers
-    : public llvm::PassInfoMixin<ImplicitConditionalBarriers> {
+    : public llvm::RequiredPassInfoMixin<ImplicitConditionalBarriers> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
-
 }
 
 #endif

--- a/lib/llvmopencl/ImplicitConditionalBarriers.h
+++ b/lib/llvmopencl/ImplicitConditionalBarriers.h
@@ -66,11 +66,18 @@
 namespace pocl {
 
 class ImplicitConditionalBarriers
+#if LLVM_MAJOR >= 23
     : public llvm::RequiredPassInfoMixin<ImplicitConditionalBarriers> {
+#else
+    : public llvm::PassInfoMixin<ImplicitConditionalBarriers> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 }
 

--- a/lib/llvmopencl/ImplicitLoopBarriers.h
+++ b/lib/llvmopencl/ImplicitLoopBarriers.h
@@ -36,12 +36,19 @@
 namespace pocl {
 
 class ImplicitLoopBarriers
+#if LLVM_MAJOR >= 23
     : public llvm::RequiredPassInfoMixin<ImplicitLoopBarriers> {
+#else
+    : public llvm::PassInfoMixin<ImplicitLoopBarriers> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Loop &L, llvm::LoopAnalysisManager &AM,
                               llvm::LoopStandardAnalysisResults &AR,
                               llvm::LPMUpdater &U);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/ImplicitLoopBarriers.h
+++ b/lib/llvmopencl/ImplicitLoopBarriers.h
@@ -35,14 +35,13 @@
 
 namespace pocl {
 
-
-class ImplicitLoopBarriers : public llvm::PassInfoMixin<ImplicitLoopBarriers> {
+class ImplicitLoopBarriers
+    : public llvm::RequiredPassInfoMixin<ImplicitLoopBarriers> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Loop &L, llvm::LoopAnalysisManager &AM,
                               llvm::LoopStandardAnalysisResults &AR,
                               llvm::LPMUpdater &U);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/InlineKernels.hh
+++ b/lib/llvmopencl/InlineKernels.hh
@@ -23,6 +23,8 @@
 #ifndef POCL_INLINE_KERNELS_H
 #define POCL_INLINE_KERNELS_H
 
+#include "config.h"
+
 #include <llvm/IR/Function.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Pass.h>
@@ -30,11 +32,19 @@
 
 namespace pocl {
 
-class InlineKernels : public llvm::RequiredPassInfoMixin<InlineKernels> {
+class InlineKernels
+#if LLVM_MAJOR >= 23
+    : public llvm::RequiredPassInfoMixin<InlineKernels> {
+#else
+    : public llvm::PassInfoMixin<InlineKernels> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/InlineKernels.hh
+++ b/lib/llvmopencl/InlineKernels.hh
@@ -30,12 +30,11 @@
 
 namespace pocl {
 
-class InlineKernels : public llvm::PassInfoMixin<InlineKernels> {
+class InlineKernels : public llvm::RequiredPassInfoMixin<InlineKernels> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/IsolateRegions.h
+++ b/lib/llvmopencl/IsolateRegions.h
@@ -33,11 +33,19 @@
 
 namespace pocl {
 
-class IsolateRegions : public llvm::RequiredPassInfoMixin<IsolateRegions> {
+class IsolateRegions
+#if LLVM_MAJOR >= 23
+    : public llvm::RequiredPassInfoMixin<IsolateRegions> {
+#else
+    : public llvm::PassInfoMixin<IsolateRegions> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/IsolateRegions.h
+++ b/lib/llvmopencl/IsolateRegions.h
@@ -33,13 +33,11 @@
 
 namespace pocl {
 
-
-class IsolateRegions : public llvm::PassInfoMixin<IsolateRegions> {
+class IsolateRegions : public llvm::RequiredPassInfoMixin<IsolateRegions> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/LoopBarriers.h
+++ b/lib/llvmopencl/LoopBarriers.h
@@ -35,12 +35,20 @@ namespace pocl {
 #include <llvm/Analysis/LoopAnalysisManager.h>
 #include <llvm/Transforms/Scalar/LoopPassManager.h>
 
-class LoopBarriers : public llvm::RequiredPassInfoMixin<LoopBarriers> {
+class LoopBarriers
+#if LLVM_MAJOR >= 23
+    : public llvm::RequiredPassInfoMixin<LoopBarriers> {
+#else
+    : public llvm::PassInfoMixin<LoopBarriers> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Loop &L, llvm::LoopAnalysisManager &AM,
                               llvm::LoopStandardAnalysisResults &AR,
                               llvm::LPMUpdater &U);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/LoopBarriers.h
+++ b/lib/llvmopencl/LoopBarriers.h
@@ -35,13 +35,12 @@ namespace pocl {
 #include <llvm/Analysis/LoopAnalysisManager.h>
 #include <llvm/Transforms/Scalar/LoopPassManager.h>
 
-class LoopBarriers : public llvm::PassInfoMixin<LoopBarriers> {
+class LoopBarriers : public llvm::RequiredPassInfoMixin<LoopBarriers> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Loop &L, llvm::LoopAnalysisManager &AM,
                               llvm::LoopStandardAnalysisResults &AR,
                               llvm::LPMUpdater &U);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/MinLegalVecSize.hh
+++ b/lib/llvmopencl/MinLegalVecSize.hh
@@ -24,6 +24,8 @@
 #ifndef POCL_MIN_VEC_SIZE_H
 #define POCL_MIN_VEC_SIZE_H
 
+#include "config.h"
+
 #include <llvm/IR/Module.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Pass.h>
@@ -31,10 +33,18 @@
 
 namespace pocl {
 
-class FixMinVecSize : public llvm::RequiredPassInfoMixin<FixMinVecSize> {
+class FixMinVecSize
+#if LLVM_MAJOR >= 23
+    : public llvm::RequiredPassInfoMixin<FixMinVecSize> {
+#else
+    : public llvm::PassInfoMixin<FixMinVecSize> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/MinLegalVecSize.hh
+++ b/lib/llvmopencl/MinLegalVecSize.hh
@@ -31,11 +31,10 @@
 
 namespace pocl {
 
-class FixMinVecSize : public llvm::PassInfoMixin<FixMinVecSize> {
+class FixMinVecSize : public llvm::RequiredPassInfoMixin<FixMinVecSize> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/OptimizeWorkItemGVars.h
+++ b/lib/llvmopencl/OptimizeWorkItemGVars.h
@@ -23,6 +23,8 @@
 #ifndef POCL_OPTIMIZE_WI_GVARS_H
 #define POCL_OPTIMIZE_WI_GVARS_H
 
+#include "config.h"
+
 #include <llvm/IR/Function.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Pass.h>
@@ -31,11 +33,18 @@
 namespace pocl {
 
 class OptimizeWorkItemGVars
+#if LLVM_MAJOR >= 23
     : public llvm::RequiredPassInfoMixin<OptimizeWorkItemGVars> {
+#else
+    : public llvm::PassInfoMixin<OptimizeWorkItemGVars> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/OptimizeWorkItemGVars.h
+++ b/lib/llvmopencl/OptimizeWorkItemGVars.h
@@ -31,14 +31,12 @@
 namespace pocl {
 
 class OptimizeWorkItemGVars
-    : public llvm::PassInfoMixin<OptimizeWorkItemGVars> {
+    : public llvm::RequiredPassInfoMixin<OptimizeWorkItemGVars> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
-
 
 } // namespace pocl
 

--- a/lib/llvmopencl/PHIsToAllocas.h
+++ b/lib/llvmopencl/PHIsToAllocas.h
@@ -31,12 +31,11 @@
 
 namespace pocl {
 
-class PHIsToAllocas : public llvm::PassInfoMixin<PHIsToAllocas> {
+class PHIsToAllocas : public llvm::RequiredPassInfoMixin<PHIsToAllocas> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/PHIsToAllocas.h
+++ b/lib/llvmopencl/PHIsToAllocas.h
@@ -24,6 +24,8 @@
 #ifndef POCL_PHIS_TO_ALLOCAS_H
 #define POCL_PHIS_TO_ALLOCAS_H
 
+#include "config.h"
+
 #include <llvm/IR/Function.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Pass.h>
@@ -31,11 +33,19 @@
 
 namespace pocl {
 
-class PHIsToAllocas : public llvm::RequiredPassInfoMixin<PHIsToAllocas> {
+class PHIsToAllocas
+#if LLVM_MAJOR >= 23
+    : public llvm::RequiredPassInfoMixin<PHIsToAllocas> {
+#else
+    : public llvm::PassInfoMixin<PHIsToAllocas> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/RemoveBarrierCalls.h
+++ b/lib/llvmopencl/RemoveBarrierCalls.h
@@ -34,12 +34,12 @@
 
 namespace pocl {
 
-class RemoveBarrierCalls : public llvm::PassInfoMixin<RemoveBarrierCalls> {
+class RemoveBarrierCalls
+    : public llvm::RequiredPassInfoMixin<RemoveBarrierCalls> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/RemoveBarrierCalls.h
+++ b/lib/llvmopencl/RemoveBarrierCalls.h
@@ -23,6 +23,8 @@
 #ifndef POCL_REMOVE_BARRIER_CALLS_H
 #define POCL_REMOVE_BARRIER_CALLS_H
 
+#include "config.h"
+
 #include <llvm/IR/Function.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Pass.h>
@@ -35,11 +37,18 @@
 namespace pocl {
 
 class RemoveBarrierCalls
+#if LLVM_MAJOR >= 23
     : public llvm::RequiredPassInfoMixin<RemoveBarrierCalls> {
+#else
+    : public llvm::PassInfoMixin<RemoveBarrierCalls> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/SVMOffset.hh
+++ b/lib/llvmopencl/SVMOffset.hh
@@ -33,11 +33,10 @@
 
 namespace pocl {
 
-class SVMOffset : public llvm::PassInfoMixin<SVMOffset> {
+class SVMOffset : public llvm::RequiredPassInfoMixin<SVMOffset> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/SVMOffset.hh
+++ b/lib/llvmopencl/SVMOffset.hh
@@ -33,10 +33,18 @@
 
 namespace pocl {
 
-class SVMOffset : public llvm::RequiredPassInfoMixin<SVMOffset> {
+class SVMOffset
+#if LLVM_MAJOR >= 23
+    : public llvm::RequiredPassInfoMixin<SVMOffset> {
+#else
+    : public llvm::PassInfoMixin<SVMOffset> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/SanitizeUBofDivRem.h
+++ b/lib/llvmopencl/SanitizeUBofDivRem.h
@@ -33,12 +33,12 @@
 
 namespace pocl {
 
-class SanitizeUBofDivRem : public llvm::PassInfoMixin<SanitizeUBofDivRem> {
+class SanitizeUBofDivRem
+    : public llvm::RequiredPassInfoMixin<SanitizeUBofDivRem> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/SanitizeUBofDivRem.h
+++ b/lib/llvmopencl/SanitizeUBofDivRem.h
@@ -34,11 +34,18 @@
 namespace pocl {
 
 class SanitizeUBofDivRem
+#if LLVM_MAJOR >= 23
     : public llvm::RequiredPassInfoMixin<SanitizeUBofDivRem> {
+#else
+    : public llvm::PassInfoMixin<SanitizeUBofDivRem> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/SubCFGFormation.h
+++ b/lib/llvmopencl/SubCFGFormation.h
@@ -37,10 +37,10 @@
 #include <llvm/Pass.h>
 #include <llvm/Passes/PassBuilder.h>
 
-#include "config.h"
 #include "VariableUniformityAnalysis.h"
 #include "VariableUniformityAnalysisResult.hh"
 #include "WorkitemHandler.h"
+#include "config.h"
 
 namespace pocl {
 
@@ -148,10 +148,10 @@ private:
 class SubCFGFormation
 #if LLVM_MAJOR >= 23
     : public llvm::RequiredPassInfoMixin<SubCFGFormation>,
-                        WorkitemHandler {
+      WorkitemHandler {
 #else
     : public llvm::PassInfoMixin<SubCFGFormation>,
-                        WorkitemHandler {
+      WorkitemHandler {
 #endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);

--- a/lib/llvmopencl/SubCFGFormation.h
+++ b/lib/llvmopencl/SubCFGFormation.h
@@ -144,13 +144,12 @@ private:
   llvm::BasicBlock *createUniformLoadBB(llvm::BasicBlock *OuterMostHeader);
 };
 
-class SubCFGFormation : public llvm::PassInfoMixin<SubCFGFormation>,
+class SubCFGFormation : public llvm::RequiredPassInfoMixin<SubCFGFormation>,
                         WorkitemHandler {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
-  static bool isRequired() { return true; }
 
   static bool canHandleKernel(llvm::Function &K,
                               llvm::FunctionAnalysisManager &AM);

--- a/lib/llvmopencl/SubCFGFormation.h
+++ b/lib/llvmopencl/SubCFGFormation.h
@@ -37,6 +37,7 @@
 #include <llvm/Pass.h>
 #include <llvm/Passes/PassBuilder.h>
 
+#include "config.h"
 #include "VariableUniformityAnalysis.h"
 #include "VariableUniformityAnalysisResult.hh"
 #include "WorkitemHandler.h"
@@ -144,12 +145,21 @@ private:
   llvm::BasicBlock *createUniformLoadBB(llvm::BasicBlock *OuterMostHeader);
 };
 
-class SubCFGFormation : public llvm::RequiredPassInfoMixin<SubCFGFormation>,
+class SubCFGFormation
+#if LLVM_MAJOR >= 23
+    : public llvm::RequiredPassInfoMixin<SubCFGFormation>,
                         WorkitemHandler {
+#else
+    : public llvm::PassInfoMixin<SubCFGFormation>,
+                        WorkitemHandler {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 
   static bool canHandleKernel(llvm::Function &K,
                               llvm::FunctionAnalysisManager &AM);

--- a/lib/llvmopencl/UnreachablesToReturns.h
+++ b/lib/llvmopencl/UnreachablesToReturns.h
@@ -23,6 +23,8 @@
 #ifndef POCL_FIX_UNREACHABLE_H
 #define POCL_FIX_UNREACHABLE_H
 
+#include "config.h"
+
 #include <llvm/IR/Function.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Pass.h>
@@ -31,11 +33,18 @@
 namespace pocl {
 
 class ConvertUnreachablesToReturns
+#if LLVM_MAJOR >= 23
     : public llvm::RequiredPassInfoMixin<ConvertUnreachablesToReturns> {
+#else
+    : public llvm::PassInfoMixin<ConvertUnreachablesToReturns> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/UnreachablesToReturns.h
+++ b/lib/llvmopencl/UnreachablesToReturns.h
@@ -31,12 +31,11 @@
 namespace pocl {
 
 class ConvertUnreachablesToReturns
-    : public llvm::PassInfoMixin<ConvertUnreachablesToReturns> {
+    : public llvm::RequiredPassInfoMixin<ConvertUnreachablesToReturns> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/Workgroup.h
+++ b/lib/llvmopencl/Workgroup.h
@@ -34,10 +34,18 @@
 
 namespace pocl {
 
-class Workgroup : public llvm::RequiredPassInfoMixin<Workgroup> {
+class Workgroup
+#if LLVM_MAJOR >= 23
+    : public llvm::RequiredPassInfoMixin<Workgroup> {
+#else
+    : public llvm::PassInfoMixin<Workgroup> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/Workgroup.h
+++ b/lib/llvmopencl/Workgroup.h
@@ -34,11 +34,10 @@
 
 namespace pocl {
 
-class Workgroup : public llvm::PassInfoMixin<Workgroup> {
+class Workgroup : public llvm::RequiredPassInfoMixin<Workgroup> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &AM);
-  static bool isRequired() { return true; }
 };
 
 } // namespace pocl

--- a/lib/llvmopencl/WorkitemLoops.h
+++ b/lib/llvmopencl/WorkitemLoops.h
@@ -33,11 +33,19 @@
 
 namespace pocl {
 
-class WorkitemLoops : public llvm::RequiredPassInfoMixin<WorkitemLoops> {
+class WorkitemLoops
+#if LLVM_MAJOR >= 23
+    : public llvm::RequiredPassInfoMixin<WorkitemLoops> {
+#else
+    : public llvm::PassInfoMixin<WorkitemLoops> {
+#endif
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
+#if LLVM_MAJOR < 23
+  static bool isRequired() { return true; }
+#endif
 
   // Returns false in case the WG generator can or should not handle the given
   // kernel. It might refuse to handle trickiest of conditional barrier

--- a/lib/llvmopencl/WorkitemLoops.h
+++ b/lib/llvmopencl/WorkitemLoops.h
@@ -33,13 +33,11 @@
 
 namespace pocl {
 
-
-class WorkitemLoops : public llvm::PassInfoMixin<WorkitemLoops> {
+class WorkitemLoops : public llvm::RequiredPassInfoMixin<WorkitemLoops> {
 public:
   static void registerWithPB(llvm::PassBuilder &B);
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &AM);
-  static bool isRequired() { return true; }
 
   // Returns false in case the WG generator can or should not handle the given
   // kernel. It might refuse to handle trickiest of conditional barrier
@@ -47,7 +45,6 @@ public:
   static bool canHandleKernel(llvm::Function &K,
                               llvm::FunctionAnalysisManager &AM);
 };
-
 
 } // namespace pocl
 


### PR DESCRIPTION
LLVM 23 made this preferred over normal PassInfoMixin and setting isRequired to return true. LLVM 24 will move PassInfoMixin to a detail namespace, causing a compilation error without this patch.