### PR TITLE
Migrate to CondBrInst/UncondBrInst and update DIBuilder usage for LLVM 24

### DIFF
--- a/lib/llvmopencl/DebugHelpers.cc
+++ b/lib/llvmopencl/DebugHelpers.cc
@@ -134,7 +134,11 @@ static void printBasicBlock(
       } else if (isa<Barrier>(Instr)) {
         s << "BARRIER\\n";
         PreviousNonHighlighted = 0;
+#if LLVM_MAJOR >= 23
+      } else if (isa<UncondBrInst>(Instr) || isa<CondBrInst>(Instr)) {
+#else
       } else if (isa<BranchInst>(Instr)) {
+#endif
         s << "branch\\n";
         PreviousNonHighlighted = 0;
       } else if (isa<PHINode>(Instr)) {

--- a/lib/llvmopencl/EmitPrintf.cc
+++ b/lib/llvmopencl/EmitPrintf.cc
@@ -158,7 +158,11 @@ static Value *getStrlenWithNull(IRBuilder<> &Builder, Value *Str, unsigned Nativ
   Len = Builder.CreateAdd(Len, One);
 
   // Final join.
+#if LLVM_MAJOR >= 23
+  UncondBrInst::Create(Join, WhileDone);
+#else
   BranchInst::Create(Join, WhileDone);
+#endif
   Builder.SetInsertPoint(Join, Join->begin());
   auto LenPhi = Builder.CreatePHI(Len->getType(), 2);
   LenPhi->addIncoming(Len, WhileDone);
@@ -607,7 +611,11 @@ Value *pocl::emitPrintfCall(IRBuilder<> &Builder,
         Ctx, "argpush.block", Builder.GetInsertBlock()->getParent());
 
     // if the allocation returned null, jump to end BB
+#if LLVM_MAJOR >= 23
+    CondBrInst::Create(Cmp, ArgPush, End, LastBB);
+#else
     BranchInst::Create(ArgPush, End, Cmp, LastBB);
+#endif
 
     Builder.SetInsertPoint(ArgPush);
 
@@ -709,7 +717,11 @@ Value *pocl::emitPrintfCall(IRBuilder<> &Builder,
     }
 
     // End block, returns -1 on failure
+#if LLVM_MAJOR >= 23
+    UncondBrInst::Create(End, ArgPush);
+#else
     BranchInst::Create(End, ArgPush);
+#endif
     Builder.SetInsertPoint(End->getFirstInsertionPt());
     return Builder.CreateSExt(Builder.CreateNot(Cmp), Int32Ty, "printf_result");
   }

--- a/lib/llvmopencl/ImplicitLoopBarriers.cc
+++ b/lib/llvmopencl/ImplicitLoopBarriers.cc
@@ -110,9 +110,15 @@ static bool addInnerLoopBarrier(llvm::Loop &L,
 
   /* Check the branch condition predicate. If it is uniform, we know the loop 
      is  executed the same number of times for all WIs. */
+#if LLVM_MAJOR >= 23
+  llvm::CondBrInst *br = dyn_cast<llvm::CondBrInst>(brexit->getTerminator());  
+  if (br &&
+      VUA.isUniform(f, br->getCondition())) {
+#else
   llvm::BranchInst *br = dyn_cast<llvm::BranchInst>(brexit->getTerminator());  
   if (br && br->isConditional() &&
       VUA.isUniform(f, br->getCondition())) {
+#endif
 
     /* Add a barrier both to the beginning of the entry and to the very end
        to nicely isolate the parallel region. */
@@ -125,7 +131,11 @@ static bool addInnerLoopBarrier(llvm::Loop &L,
     return true;
   } else {
 #ifdef DEBUG_ILOOP_BARRIERS
+#if LLVM_MAJOR >= 23
+    if (br && !VUA.isUniform(f, br->getCondition())) {
+#else
     if (br && br->isConditional() && !VUA.isUniform(f, br->getCondition())) {
+#endif
       std::cerr << "### loop condition not uniform" << std::endl;
       br->getCondition()->dump();
     }

--- a/lib/llvmopencl/SubCFGFormation.cc
+++ b/lib/llvmopencl/SubCFGFormation.cc
@@ -208,10 +208,17 @@ void copyDgbValues(llvm::Value *From, llvm::Value *To,
     auto *DbgValue = DbgValues.back();
     llvm::DIBuilder DbgBuilder{
         *InsertBefore->getParent()->getParent()->getParent()};
+#if LLVM_MAJOR < 24
     DbgBuilder.insertDbgValueIntrinsic(To, DbgValue->getVariable(),
                                        DbgValue->getExpression(),
                                        DbgValue->getDebugLoc(),
                                        Inst2InsertPt(InsertBefore));
+#else
+    DbgBuilder.insertDbgValue(To, DbgValue->getVariable(),
+                              DbgValue->getExpression(),
+                              DbgValue->getDebugLoc(),
+                              Inst2InsertPt(InsertBefore));
+#endif
   }
 }
 

--- a/lib/llvmopencl/UnreachablesToReturns.cc
+++ b/lib/llvmopencl/UnreachablesToReturns.cc
@@ -177,6 +177,28 @@ static void detachBBFromPredecessor(BasicBlock &BB,
     assert(Pred != nullptr);
     Instruction *I = Pred->getTerminator();
     assert(I != nullptr);
+#if LLVM_MAJOR >= 23
+    if (auto *BI = dyn_cast<UncondBrInst>(I)) {
+      LLVM_DEBUG(dbgs() << "The predecessor " << Pred->getName().str()
+                        << " is unconditionally branching to it\n");
+      LLVM_DEBUG(Pred->dump());
+      // The predecessor has an unconditional branch to the unreachable BB,
+      // remove that in a next call.
+      NewUnreachableBBs.insert(Pred);
+    } else if (auto *CBI = dyn_cast<CondBrInst>(I)) {
+      LLVM_DEBUG(
+          dbgs() << "The predecessor is conditionally branching to it\n");
+      LLVM_DEBUG(Pred->dump());
+
+      BasicBlock *Other = nullptr;
+      if (CBI->getSuccessor(0) == &BB)
+        Other = CBI->getSuccessor(1);
+      else
+        Other = CBI->getSuccessor(0);
+      UncondBrInst *NewBI = UncondBrInst::Create(Other);
+      Replacements.insert(std::make_pair(CBI, NewBI));
+    }
+#else
     if (BranchInst *BI = dyn_cast<BranchInst>(I)) {
       if (BI->isUnconditional()) {
         LLVM_DEBUG(dbgs() << "The predecessor " << Pred->getName().str()
@@ -198,7 +220,9 @@ static void detachBBFromPredecessor(BasicBlock &BB,
         BranchInst *NewBI = BranchInst::Create(Other);
         Replacements.insert(std::make_pair(BI, NewBI));
       }
-    } else if (SwitchInst *PredSwitch = dyn_cast<SwitchInst>(I)) {
+    }
+#endif
+    else if (SwitchInst *PredSwitch = dyn_cast<SwitchInst>(I)) {
       LLVM_DEBUG(dbgs() << "The predecessor is a switch case in "
                         << Pred->getName().str() << "\n");
       PredSwitches.push_back(PredSwitch);

--- a/lib/llvmopencl/VariableUniformityAnalysis.cc
+++ b/lib/llvmopencl/VariableUniformityAnalysis.cc
@@ -184,21 +184,35 @@ void VariableUniformityAnalysisResult::analyzeBBDivergence(
     return;
   }
 
+#if LLVM_MAJOR >= 23
+  UncondBrInst *UncondBr = dyn_cast<UncondBrInst>(Term);
+  CondBrInst *CondBr = dyn_cast<CondBrInst>(Term);
+#else
   llvm::BranchInst *BrInst = dyn_cast<llvm::BranchInst>(Term);
+#endif
   llvm::SwitchInst *SwInst = dyn_cast<llvm::SwitchInst>(Term);
 
+#if LLVM_MAJOR >= 23
+  if (UncondBr == nullptr && CondBr == nullptr && SwInst == nullptr) {
+#else
   if (BrInst == nullptr && SwInst == nullptr) {
+#endif
     // Can only handle branches and switches for now.
     return;
   }
 
   // The BBs that were found uniform.
-  std::vector<llvm::BasicBlock *> FoundUniforms;
+  std::vector<BasicBlock *> FoundUniforms;
 
   // Condition c)
+#if LLVM_MAJOR >= 23
+  if (UncondBr || (CondBr && isUniform(F, CondBr->getCondition())) ||
+      (SwInst && isUniform(F, SwInst->getCondition()))) {
+#else
   if ((BrInst && (!BrInst->isConditional() ||
                   isUniform(F, BrInst->getCondition()))) ||
       (SwInst && isUniform(F, SwInst->getCondition()))) {
+#endif
     // This is a branch with a uniform condition, propagate the uniformity
     // to the BB of interest.
     for (unsigned suc = 0, end = Term->getNumSuccessors(); suc < end; ++suc) {

--- a/lib/llvmopencl/WorkitemLoops.cc
+++ b/lib/llvmopencl/WorkitemLoops.cc
@@ -1279,7 +1279,11 @@ void WorkitemLoopsImpl::addContextSaveRestore(llvm::Instruction *Def) {
 
 bool WorkitemLoopsImpl::shouldNotBeContextSaved(llvm::Instruction *Instr) {
 
+#if LLVM_MAJOR >= 23
+  if (isa<UncondBrInst>(Instr) || isa<CondBrInst>(Instr)) return true;
+#else
   if (isa<BranchInst>(Instr)) return true;
+#endif
 
   // The local memory allocation call is uniform, the same pointer to the
   // work-group shared memory area is returned to all work-items. It must


### PR DESCRIPTION
LLVM 23 split BranchInst into CondBrInst and UncondBrInst, and legacy
BranchInst creation APIs were subsequently removed in LLVM 24. This change
migrates usages in PoCL to the new APIs when compiling with LLVM 23 or newer.
(See LLVM Discourse RFC: https://discourse.llvm.org/t/rfc-split-branchinst-into-uncondbr-and-condbr/90022)

Additionally, DIBuilder::insertDbgValueIntrinsic was renamed to insertDbgValue
and the old signature was removed in LLVM 24. Updated SubCFGFormation.cc to
use DIBuilder::insertDbgValue for LLVM 24+.
(See LLVM Commit: https://github.com/llvm/llvm-project/commit/bd3551611ea19adae70a744be8d4f4ec096a114a)

Backward compatibility with older LLVM versions is maintained using
LLVM_MAJOR version guards.

Co-authored-by: Gemini 3.5 Flash