### PR TITLE
[llvmopencl] Fix LoopInfo::verify() call for LLVM 24

### DIFF
--- a/lib/llvmopencl/BarrierTailReplication.cc
+++ b/lib/llvmopencl/BarrierTailReplication.cc
@@ -102,7 +102,11 @@ bool BarrierTailReplicationImpl::runOnFunction(Function &F) {
 
   bool changed = ProcessFunction(F);
 
+#if LLVM_MAJOR >= 24
+  LI.verify();
+#else
   LI.verify(DT);
+#endif
   /* The created tails might contain PHI nodes with operands
      referring to the non-predecessor (split point) BB.
      These must be cleaned to avoid breakage later on.


### PR DESCRIPTION
In LLVM 24, LoopInfo::verify(const DominatorTreeBase<BlockT, false> &DomTree) const was changed to LoopInfo::verify() const, removing the DominatorTree argument: https://github.com/llvm/llvm-project/commit/022bf7ba97fa1897bf52cf3db2e3fa42cd19b29f (PR https://github.com/llvm/llvm-project/pull/212414)

Add an #if LLVM_MAJOR >= 24 guard around LI.verify() in BarrierTailReplication.cc to support LLVM 24 while preserving backward compatibility with older LLVM versions.

Co-authored-by: Gemini 3.5 Flash