### PR TITLE
Validate that memory objects passed to image kernel arguments are valid images

### DIFF
--- a/lib/CL/clSetKernelArg.c
+++ b/lib/CL/clSetKernelArg.c
@@ -370,6 +370,11 @@ POname(clSetKernelArg)(cl_kernel kernel,
               !IS_CL_OBJECT_VALID ((const cl_mem)ptr_value),
               CL_INVALID_ARG_VALUE,
               "Arg %u is not a valid CL object\n", arg_index);
+          POCL_RETURN_ERROR_ON (
+              (pi->type == POCL_ARG_TYPE_IMAGE
+               && ((const cl_mem)ptr_value)->is_image == CL_FALSE),
+              CL_INVALID_MEM_OBJECT,
+              "Arg %u is not a valid Image object\n", arg_index);
         }
       else
         {


### PR DESCRIPTION
When a memory object is passed to a kernel argument of type POCL_ARG_TYPE_IMAGE, PoCL checked IS_CL_OBJECT_VALID, but did not verify whether the memory object was actually an image (is_image == CL_TRUE). Consequently, passing a buffer object to an image argument returned CL_SUCCESS instead of CL_INVALID_MEM_OBJECT as required by the OpenCL specification:
https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#clSetKernelArg

This fixes the negative_set_kernel_arg_invalid_image test in CTS.

Co-authored-by: Gemini 3.5 Flash