### PR TITLE
Minor (mostly AlmaIF driver related) fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,8 @@ cmake-build-*/
 
 # Visual Studio related files
 .vs
+.vscode
 
 # Cmake
 CMakeUserPresets.json
+CMakeFiles/*

--- a/include/pocl_types.h
+++ b/include/pocl_types.h
@@ -108,11 +108,11 @@ typedef uint8_t uchar;
 typedef uint16_t ushort;
 typedef uint32_t uint;
 
-#ifdef cl_khr_int64
+#if defined(cl_khr_int64) && defined(__UINT64_TYPE__)
 #if __APPLE__
 typedef unsigned long ulong;
 #else
-typedef uint64_t ulong;
+typedef __UINT64_TYPE__ ulong;
 #endif
 #else
 typedef uint32_t ulong;

--- a/lib/CL/devices/almaif/AlmaIFDevice.cc
+++ b/lib/CL/devices/almaif/AlmaIFDevice.cc
@@ -119,7 +119,7 @@ void AlmaIFDevice::discoverDeviceParameters() {
                         (void *)CQStart, (void *)ImemStart, (void *)DmemStart);
   POCL_MSG_PRINT_ALMAIF("CQSize=%u ImemSize=%u DmemSize=%u\n", CQSize, ImemSize,
                         DmemSize);
-  POCL_MSG_PRINT_ALMAIF("ControlMemory->PhysAddress=%zu\n",
+  POCL_MSG_PRINT_ALMAIF("ControlMemory->PhysAddress=%zx\n",
                         ControlMemory->PhysAddress());
   AllocRegions = (memory_region_t *)calloc(1, sizeof(memory_region_t));
   pocl_init_mem_region(AllocRegions,
@@ -181,7 +181,7 @@ void AlmaIFDevice::loadProgramToDevice(almaif_kernel_data_s *KernelData,
   InstructionMemory->CopyToMMAP(InstructionMemory->PhysAddress(),
                                 KernelData->imem_img,
                                 KernelData->imem_img_size);
-  POCL_MSG_PRINT_ALMAIF("IMEM image written: %zu / %zu B\n",
+  POCL_MSG_PRINT_ALMAIF("IMEM image written: %zx / %zu B\n",
                         InstructionMemory->PhysAddress(),
                         KernelData->imem_img_size);
 
@@ -203,7 +203,12 @@ void AlmaIFDevice::prereadImages(const std::string &KernelCacheDir,
     size = (size_t)temp;
     assert(res == 0);
     assert(size > 0);
-    assert(size < InstructionMemory->Size());
+    if (size > InstructionMemory->Size()) {
+      POCL_ABORT(
+          "ALMAIF: program image (0x%zx) too large to fit inside instruction "
+          "memory (0x%zx)!\n",
+          size, InstructionMemory->Size());
+    }
     KernelData->imem_img = content;
     KernelData->imem_img_size = size;
     content = NULL;
@@ -294,8 +299,9 @@ void AlmaIFDevice::readDataFromDevice(char *__restrict__ const Dst,
                                       size_t Size, size_t Offset) {
 
   chunk_info_t *chunk = (chunk_info_t *)SrcMemId->mem_ptr;
-  POCL_MSG_PRINT_ALMAIF("Reading data with chunk start %zu, and offset %zu\n",
-                        chunk->start_address, Offset);
+  POCL_MSG_PRINT_ALMAIF(
+      "Reading data with chunk start 0x%zx, and offset 0x%zx\n",
+      chunk->start_address, Offset);
   size_t Src = chunk->start_address + Offset;
   if (DataMemory->isInRange(Src)) {
     POCL_MSG_PRINT_ALMAIF("almaif: Copying %zu bytes from 0x%zx\n", Size, Src);
@@ -305,9 +311,9 @@ void AlmaIFDevice::readDataFromDevice(char *__restrict__ const Dst,
                           Size, Src);
     ExternalMemory->CopyFromMMAP(Dst, Src, Size);
   } else {
-    POCL_ABORT(
-        "Attempt to read data from outside the device memories. Address=%zu\n",
-        Src);
+    POCL_ABORT("Attempt to read data from outside the device memories. "
+               "Address=0x%zx\n",
+               Src);
   }
 }
 

--- a/lib/CL/devices/almaif/AlmaifCompile.cc
+++ b/lib/CL/devices/almaif/AlmaifCompile.cc
@@ -86,7 +86,6 @@ int pocl_almaif_compile_init(unsigned j, cl_device_id dev,
   dev->final_linkage_flags = NULL;
 
   d->compilationData->current_kernel = NULL;
-  SETUP_DEVICE_CL_VERSION(dev, 1, 2);
 
   d->Available = pocl_offline_compile ? CL_FALSE : CL_TRUE;
 
@@ -114,7 +113,7 @@ int pocl_almaif_compile_init(unsigned j, cl_device_id dev,
   SHA1_digest_t digest;
   pocl_almaif_openasip_device_hash(parameters.c_str(), dev->llvm_target_triplet,
                                    (char *)digest);
-  POCL_MSG_PRINT_ALMAIF("ALMAIF TCE DEVICE HASH=%s", (char *)digest);
+  POCL_MSG_PRINT_ALMAIF("ALMAIF TCE DEVICE HASH=%s\n", (char *)digest);
   adi->build_hash = strdup((char *)digest);
 
 #else
@@ -135,7 +134,7 @@ int pocl_almaif_compile_init(unsigned j, cl_device_id dev,
   dev->ops->build_poclbinary = pocl_driver_build_poclbinary;
   dev->ops->build_binary = pocl_almaif_build_binary;
 #ifdef ENABLE_COMPILER
-  dev->ops->compile_kernel = pocl_almaif_openasip_compile;
+  dev->ops->compile_kernel = pocl_almaif_compile_kernel;
   dev->ops->init_build = pocl_almaif_openasip_init_build;
   dev->ops->build_builtin = pocl_driver_build_opencl_builtins;
 #endif
@@ -192,6 +191,13 @@ int pocl_almaif_compile_kernel(_cl_command_node *cmd, cl_kernel kernel,
   if (pocl_offline_compile) {
     return CL_SUCCESS;
   }
+
+  // clCreateKernel may not have happened yet, in which case kernel->data is
+  // NULL
+  if (kernel->data == NULL || kernel->data[cmd->program_device_i] == NULL) {
+    return CL_SUCCESS;
+  }
+
   almaif_kernel_data_t *kd =
       (almaif_kernel_data_t *)kernel->data[cmd->program_device_i];
 

--- a/lib/CL/devices/almaif/AlmaifShared.hh
+++ b/lib/CL/devices/almaif/AlmaifShared.hh
@@ -128,7 +128,7 @@ struct AQLQueueInfo {
 #define ALMAIF_CQ_WRITE (offsetof(AQLQueueInfo, write_index))
 #define ALMAIF_CQ_LENGTH (offsetof(AQLQueueInfo, size))
 
-#define ALMAIF_DRIVER_SLEEP 200
+#define ALMAIF_DRIVER_SLEEP 10000
 
 enum ALMAIF_DEVICE_TYPE : size_t {
   POCL_ALMAIFDEVICE_XRT = 0xA,

--- a/lib/CL/devices/almaif/almaif.cc
+++ b/lib/CL/devices/almaif/almaif.cc
@@ -275,7 +275,7 @@ cl_int pocl_almaif_init(unsigned j, cl_device_id dev, const char *parameters) {
   dev->long_name = (char *)"memory mapped custom device";
   dev->short_name = "almaif";
   dev->vendor = "pocl";
-  dev->version = "1.2";
+  dev->version = "OpenCL 1.2 pocl";
   dev->extensions = "";
   dev->profile = "FULL_PROFILE";
 

--- a/lib/CL/devices/almaif/almaif.cc
+++ b/lib/CL/devices/almaif/almaif.cc
@@ -486,11 +486,11 @@ cl_int pocl_almaif_init(unsigned j, cl_device_id dev, const char *parameters) {
   chunk_info_t *chunk = NULL;
   chunk = pocl_alloc_buffer(D->Dev->AllocRegions, dev->printf_buffer_size);
   if (chunk == NULL) {
-    POCL_MSG_WARN("Almaif: Can't allocate %lu bytes for printf buffer\n",
+    POCL_MSG_WARN("Almaif: Can't allocate %lx bytes for printf buffer\n",
                   dev->printf_buffer_size);
     dev->device_side_printf = 0;
   } else {
-    POCL_MSG_PRINT_ALMAIF("Allocated printf buffer of size %lu from %lu\n",
+    POCL_MSG_PRINT_ALMAIF("Allocated printf buffer of size %lx from 0x%lx\n",
                           dev->printf_buffer_size, chunk->start_address);
     D->PrintfBuffer = chunk;
 
@@ -998,7 +998,7 @@ void scheduleNDRange(AlmaifData *data, _cl_command_node *cmd, size_t arg_size,
         (almaif_kernel_data_t *)run->kernel->data[cmd->program_device_i];
     packet.kernel_object = kd->kernel_address;
 
-    POCL_MSG_PRINT_ALMAIF("Kernel addresss=0x%" PRIu32 "\n", kd->kernel_address);
+    POCL_MSG_PRINT_ALMAIF("Kernel address=0x%" PRIx32 "\n", kd->kernel_address);
   }
 
   if (data->Dev->RelativeAddressing) {

--- a/lib/CL/devices/almaif/almaif.cc
+++ b/lib/CL/devices/almaif/almaif.cc
@@ -946,10 +946,19 @@ void scheduleNDRange(AlmaifData *data, _cl_command_node *cmd, size_t arg_size,
 
   pocl_context32 pc;
 
+  packet.grid_size_x = run->pc.local_size[0] * run->pc.num_groups[0];
+  packet.grid_size_y = run->pc.local_size[1] * run->pc.num_groups[1];
+  packet.grid_size_z = run->pc.local_size[2] * run->pc.num_groups[2];
+  POCL_MSG_PRINT_ALMAIF(
+      "almaif: NDRange kernel %s launched with %zu x %zu x %zu WGs (Total: "
+      "%zu), "
+      "WG size: %zu x %zu x %zu WIs (Total: %zu WIs/WG)\n",
+      k->name, run->pc.num_groups[0], run->pc.num_groups[1],
+      run->pc.num_groups[2],
+      run->pc.num_groups[0] * run->pc.num_groups[1] * run->pc.num_groups[2],
+      run->pc.local_size[0], run->pc.local_size[1], run->pc.local_size[2],
+      run->pc.local_size[0] * run->pc.local_size[1] * run->pc.local_size[2]);
   if (kernelID != -1) {
-    packet.grid_size_x = run->pc.local_size[0] * run->pc.num_groups[0];
-    packet.grid_size_y = run->pc.local_size[1] * run->pc.num_groups[1];
-    packet.grid_size_z = run->pc.local_size[2] * run->pc.num_groups[2];
     packet.kernel_object = kernelID;
   } else {
 
@@ -967,6 +976,7 @@ void scheduleNDRange(AlmaifData *data, _cl_command_node *cmd, size_t arg_size,
     pc.global_offset[1] = run->pc.global_offset[1];
     pc.global_offset[2] = run->pc.global_offset[2];
     pc.global_var_buffer = 0;
+    pc.execution_failed = 0;
 
     if (cmd->device->device_side_printf) {
       pc.printf_buffer = ((chunk_info_t *)data->PrintfBuffer)->start_address;

--- a/lib/CL/devices/almaif/openasip/AlmaifCompileOpenasip.cc
+++ b/lib/CL/devices/almaif/openasip/AlmaifCompileOpenasip.cc
@@ -674,6 +674,12 @@ void pocl_almaif_openasip_produce_standalone_program(AlmaifData *D,
       << run_cmd->pc.local_size[1] << ";\n"
       << "\tstandalone_packet.workgroup_size_z = " << std::hex << "(uint32_t)0x"
       << run_cmd->pc.local_size[2] << ";\n"
+      << "\tstandalone_packet.grid_size_x = " << std::hex << "(uint32_t)0x"
+      << run_cmd->pc.local_size[0] * run_cmd->pc.num_groups[0] << ";\n"
+      << "\tstandalone_packet.grid_size_y = " << std::hex << "(uint32_t)0x"
+      << run_cmd->pc.local_size[1] * run_cmd->pc.num_groups[1] << ";\n"
+      << "\tstandalone_packet.grid_size_z = " << std::hex << "(uint32_t)0x"
+      << run_cmd->pc.local_size[2] * run_cmd->pc.num_groups[2] << ";\n"
 
       << "\tstandalone_packet.reserved1 = (uint32_t)ctx_buffer"
       << ";\n"

--- a/lib/llvmopencl/LLVMUtils.cc
+++ b/lib/llvmopencl/LLVMUtils.cc
@@ -157,31 +157,39 @@ regenerate_kernel_metadata(llvm::Module &M, FunctionMapping &kernels)
   NamedMDNode *WGSizes = M.getNamedMetadata("opencl.kernel_wg_size_info");
   if (WGSizes != NULL && WGSizes->getNumOperands() > 0)
     {
-      for (std::size_t mni = 0; mni < WGSizes->getNumOperands(); ++mni)
-        {
-          MDNode *wgsizeMD = dyn_cast<MDNode>(WGSizes->getOperand(mni));
-          for (FunctionMapping::const_iterator i = kernels.begin(),
-                 e = kernels.end(); i != e; ++i)
-            {
-              Function *OldKernel = (*i).first;
-              Function *NewKernel = (*i).second;
-              Function *FuncFromMD;
-              FuncFromMD = dyn_cast<Function>(
-                dyn_cast<ValueAsMetadata>(wgsizeMD->getOperand(0))->getValue());
-              if (OldKernel == NewKernel || wgsizeMD->getNumOperands() == 0 ||
-                  FuncFromMD != OldKernel)
-                continue;
-              // found a wg size metadata that points to the old kernel, copy its
-              // operands except the first one to a new MDNode
-              SmallVector<Metadata*, 8> operands;
-              operands.push_back(llvm::ValueAsMetadata::get(NewKernel));
-              for (unsigned opr = 1; opr < wgsizeMD->getNumOperands(); ++opr) {
-                  operands.push_back(wgsizeMD->getOperand(opr));
-              }
-              MDNode *new_wg_md = MDNode::get(M.getContext(), operands);
-              WGSizes->addOperand(new_wg_md);
-            }
+    // metadata might contain references to deleted functions,
+    // which will be cleared as well
+    SmallVector<MDNode *, 8> ValidNodes;
+    for (std::size_t mni = 0; mni < WGSizes->getNumOperands(); ++mni) {
+      MDNode *wgsizeMD = dyn_cast<MDNode>(WGSizes->getOperand(mni));
+      for (FunctionMapping::const_iterator i = kernels.begin(),
+                                           e = kernels.end();
+           i != e; ++i) {
+        Function *OldKernel = (*i).first;
+        Function *NewKernel = (*i).second;
+        Function *FuncFromMD = nullptr;
+        if (wgsizeMD->getNumOperands() > 0) {
+          if (auto *VAM = dyn_cast_or_null<ValueAsMetadata>(
+                  wgsizeMD->getOperand(0).get()))
+            FuncFromMD = dyn_cast<Function>(VAM->getValue());
         }
+        if (OldKernel == NewKernel || wgsizeMD->getNumOperands() == 0 ||
+            FuncFromMD != OldKernel)
+          continue;
+        // found a wg size metadata that points to the old kernel, copy its
+        // operands except the first one to a new MDNode
+        SmallVector<Metadata *, 8> operands;
+        operands.push_back(llvm::ValueAsMetadata::get(NewKernel));
+        for (unsigned opr = 1; opr < wgsizeMD->getNumOperands(); ++opr) {
+          operands.push_back(wgsizeMD->getOperand(opr));
+        }
+        MDNode *new_wg_md = MDNode::get(M.getContext(), operands);
+        ValidNodes.push_back(new_wg_md);
+      }
+    }
+    WGSizes->clearOperands();
+    for (auto *N : ValidNodes)
+      WGSizes->addOperand(N);
     }
 
   // reproduce the opencl.kernels metadata, if it exists

--- a/lib/llvmopencl/Workgroup.cc
+++ b/lib/llvmopencl/Workgroup.cc
@@ -358,7 +358,7 @@ bool WorkgroupImpl::runOnModule(Module &M, llvm::FunctionAnalysisManager &FAM) {
     }
   }
 
-  if (!DeviceUsingArgBufferLauncher && DeviceIsSPMD) {
+  if (DeviceIsSPMD) {
     regenerate_kernel_metadata(M, KernelsMap);
   }
 


### PR DESCRIPTION
Hi, 

I was working on updated device driver for ttasim, and although there is little reason to merge it since the driver uses a private branch of OpenASIP, along the way I made some smaller changes that could be useful to other users.


Most of these are minor fixes in the AlmaIF driver (giving a struct a function ptr to wrong function, fixing up the version ID to match what OpenCL conformance test suite expects, changing debug prints to use base 16 for addresses, increasing polling interval so it isn't as spammy, etc.)


The broadest change touches `lib/llvmopencl/LLVMUtils.cc`, since `regenerate_kernel_metadata()` gets called by all SPMD devices now.  It fixes two crashes I had with kernel compilation running GROMACS.
