### PR TITLE
remote: implement server-side barrier and marker commands

### DIFF
--- a/doc/sphinx/source/notes_7_3.rst
+++ b/doc/sphinx/source/notes_7_3.rst
@@ -27,3 +27,9 @@ CUDA driver
 
 * Initial bits for images support. Currently only the `IMAGE1D_BUFFER` image
   type is supported.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Remote driver
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Barriers and markers are now handled server-side.

--- a/include/messages.h
+++ b/include/messages.h
@@ -128,6 +128,7 @@ extern "C"
 
     MessageType_MigrateD2D,
 
+    MessageType_Marker,
     MessageType_Barrier,
 
     MessageType_ReadBuffer,
@@ -191,6 +192,9 @@ extern "C"
     // ***********************************************
 
     MessageType_MigrateD2DReply,
+
+    MessageType_BarrierReply,
+    MessageType_MarkerReply,
 
     MessageType_ReadBufferReply,
     MessageType_WriteBufferReply,

--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -824,6 +824,8 @@ finish_running_cmd (remote_server_data_t *server,
         case CL_COMMAND_NDRANGE_KERNEL:
         case CL_COMMAND_TASK:
         case CL_COMMAND_NATIVE_KERNEL:
+        case CL_COMMAND_MARKER:
+        case CL_COMMAND_BARRIER:
           e->time_queue = running_cmd->reply.server_read_end_timestamp_ns;
           e->time_submit = e->time_queue + ocl_in_host_queue;
           e->time_start = e->time_submit + ocl_in_dev_queue;
@@ -1748,6 +1750,8 @@ request_to_str (enum RequestMessageType type)
       return "MigrateD2D";
     case MessageType_Barrier:
       return "Barrier";
+    case MessageType_Marker:
+      return "Marker";
 
     case MessageType_ReadBuffer:
       return "ReadBuffer";
@@ -3760,6 +3764,27 @@ pocl_network_run_kernel (uint32_t cq_id, remote_device_data_t *ddata,
 
   TP_NDRANGE_KERNEL (req->msg_id, ddata->local_did, cq_id,
                      node->sync.event.event->id, kernel_id, kernel->name);
+
+  SEND_REQ_FAST;
+
+  return 0;
+}
+
+cl_int
+pocl_network_barrier_or_marker (uint32_t cq_id,
+                                remote_device_data_t *ddata,
+                                network_command_callback cb,
+                                void *arg,
+                                _cl_command_node *node)
+{
+  REMOTE_SERV_DATA2;
+
+  CREATE_ASYNC_NETCMD;
+
+  REQUEST (Marker);
+  if (node->type == CL_COMMAND_BARRIER)
+    req->message_type = MessageType_Barrier;
+  req->cq_id = node->sync.event.event->queue->id;
 
   SEND_REQ_FAST;
 

--- a/lib/CL/devices/remote/communication.h
+++ b/lib/CL/devices/remote/communication.h
@@ -523,6 +523,12 @@ cl_int pocl_network_run_command_buffer (remote_device_data_t *ddata,
                                         void *arg,
                                         _cl_command_node *node);
 
+cl_int pocl_network_barrier_or_marker (uint32_t cq_id,
+                                       remote_device_data_t *ddata,
+                                       network_command_callback cb,
+                                       void *arg,
+                                       _cl_command_node *node);
+
 /****************************************************************************/
 
 cl_int pocl_network_copy_image_rect (

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -1713,6 +1713,7 @@ remote_finish_command (void *arg, _cl_command_node *node,
       break;
     }
 
+  node->state = POCL_COMMAND_READY;
   POCL_LOCK (d->wq_lock);
   DL_APPEND (d->finished_list, node);
   POCL_SIGNAL_COND (d->wakeup_cond);
@@ -2747,6 +2748,32 @@ pocl_remote_async_fill_image (void *data, _cl_command_node *node,
   return r;
 }
 
+cl_int
+pocl_remote_async_barrier_or_marker (void *data, _cl_command_node *node)
+{
+  char *kind = NULL;
+  switch (node->type)
+    {
+    case CL_COMMAND_BARRIER:
+      kind = "BARRIER";
+      break;
+    case CL_COMMAND_MARKER:
+      kind = "MARKER";
+      break;
+    default:
+      return 1;
+    }
+  POCL_MSG_PRINT_REMOTE ("REMOTE %s EID: %lu\n", kind,
+                         (unsigned long)(node->sync.event.event->id));
+
+  uint32_t queue_id = (uint32_t)node->sync.event.event->queue->id;
+
+  int r = pocl_network_barrier_or_marker (queue_id, data,
+                                          remote_finish_command, data, node);
+
+  return r;
+}
+
 static void
 remote_start_command (remote_device_data_t *d, _cl_command_node *node)
 {
@@ -3013,7 +3040,9 @@ remote_start_command (remote_device_data_t *d, _cl_command_node *node)
 
     case CL_COMMAND_MARKER:
     case CL_COMMAND_BARRIER:
-      goto EARLY_FINISH;
+      if (pocl_remote_async_barrier_or_marker (d, node) > 0)
+        goto EARLY_FINISH;
+      return;
 
     case CL_COMMAND_COMMAND_BUFFER_KHR:
       pocl_remote_async_run_command_buffer (d, node);

--- a/pocld/cmd_queue.cc
+++ b/pocld/cmd_queue.cc
@@ -141,6 +141,14 @@ void CommandQueue::RunCommand(Request *request) {
     RunKernel(queue_id, request, reply);
     break;
 
+  case MessageType_Barrier:
+    Barrier(queue_id, request, reply);
+    break;
+
+  case MessageType_Marker:
+    Marker(queue_id, request, reply);
+    break;
+
   case MessageType_RunCommandBuffer:
     RunCommandBuffer(queue_id, request, reply);
     break;
@@ -462,6 +470,32 @@ void CommandQueue::RunKernel(uint32_t queue_id, Request *req, Reply *rep) {
                     CL_FINISHED);
 
   replyOK(rep, evt_timing, MessageType_RunKernelReply);
+}
+
+void CommandQueue::Barrier(uint32_t queue_id, Request *req, Reply *rep) {
+  RunKernelMsg_t &m = req->Body.m.run_kernel;
+  EventTiming_t evt_timing{};
+
+  TP_BARRIER(req->Body.msg_id, req->Body.client_did, queue_id, CL_RUNNING);
+  RETURN_IF_ERR_CODE(backend->barrier(req->Body.event_id, queue_id, evt_timing,
+                                      req->Body.waitlist_size,
+                                      req->Waitlist.data()));
+  TP_BARRIER(req->Body.msg_id, req->Body.client_did, queue_id, CL_FINISHED);
+
+  replyOK(rep, evt_timing, MessageType_BarrierReply);
+}
+
+void CommandQueue::Marker(uint32_t queue_id, Request *req, Reply *rep) {
+  RunKernelMsg_t &m = req->Body.m.run_kernel;
+  EventTiming_t evt_timing{};
+
+  TP_MARKER(req->Body.msg_id, req->Body.client_did, queue_id, CL_RUNNING);
+  RETURN_IF_ERR_CODE(backend->marker(req->Body.event_id, queue_id, evt_timing,
+                                     req->Body.waitlist_size,
+                                     req->Waitlist.data()));
+  TP_MARKER(req->Body.msg_id, req->Body.client_did, queue_id, CL_FINISHED);
+
+  replyOK(rep, evt_timing, MessageType_MarkerReply);
 }
 
 void CommandQueue::RunCommandBuffer(uint32_t queue_id, Request *req,

--- a/pocld/cmd_queue.hh
+++ b/pocld/cmd_queue.hh
@@ -76,6 +76,10 @@ private:
 
   void RunKernel(uint32_t queue_id, Request *req, Reply *rep);
 
+  void Barrier(uint32_t queue_id, Request *req, Reply *rep);
+
+  void Marker(uint32_t queue_id, Request *req, Reply *rep);
+
   void RunCommandBuffer(uint32_t queue_id, Request *req, Reply *rep);
 
   /******************/

--- a/pocld/daemon.cc
+++ b/pocld/daemon.cc
@@ -1028,8 +1028,10 @@ void PoclDaemon::readAllClientSocketsThread() {
                   case MessageType_ReadImageRect:
                   case MessageType_WriteImageRect:
                   case MessageType_FillImageRect:
-                  case MessageType_RunCommandBuffer:
-                  case MessageType_RunKernel: {
+                  case MessageType_RunKernel:
+                  case MessageType_Barrier:
+                  case MessageType_Marker:
+                  case MessageType_RunCommandBuffer: {
                     Ctx->queuedPush(R);
                     break;
                   }

--- a/pocld/pocld_lttng.h
+++ b/pocld/pocld_lttng.h
@@ -103,6 +103,25 @@ TRACEPOINT_EVENT (
                                    ctf_integer (int, event_status,
                                                 event_status)))
 
+/**
+ *  Synchronization commands
+ */
+// Command queue barrier
+TRACEPOINT_EVENT (
+    pocld_trace, barrier,
+    TP_ARGS (uint64_t, msg_id, uint32_t, queue_id, int, event_status),
+    TP_FIELDS (ctf_integer_hex (uint64_t, msg_id, msg_id)
+                   ctf_integer_hex (uint32_t, queue_id, queue_id)
+                       ctf_integer (int, event_status, event_status)))
+
+// Command queue marker
+TRACEPOINT_EVENT (
+    pocld_trace, marker,
+    TP_ARGS (uint64_t, msg_id, uint32_t, queue_id, int, event_status),
+    TP_FIELDS (ctf_integer_hex (uint64_t, msg_id, msg_id)
+                   ctf_integer_hex (uint32_t, queue_id, queue_id)
+                       ctf_integer (int, event_status, event_status)))
+
 /******************************************************************************
 *******************************************************************************
 ******************************************************************************/

--- a/pocld/reply_th.cc
+++ b/pocld/reply_th.cc
@@ -103,6 +103,10 @@ static const char *reply_to_str(ReplyMessageType type) {
 
   case MessageType_RunKernelReply:
     return "RunKernelReply";
+  case MessageType_BarrierReply:
+    return "BarrierReply";
+  case MessageType_MarkerReply:
+    return "MarkerReply";
   case MessageType_RunCommandBufferReply:
     return "RunCommandBufferReply";
 

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -356,6 +356,12 @@ public:
                         const sizet_vec3 &global,
                         const sizet_vec3 *local = nullptr) override;
 
+  virtual int barrier(uint64_t ev_id, uint32_t cq_id, EventTiming_t &evt,
+                      uint32_t waitlist_size, uint64_t *waitlist) override;
+
+  virtual int marker(uint64_t ev_id, uint32_t cq_id, EventTiming_t &evt,
+                     uint32_t waitlist_size, uint64_t *waitlist) override;
+
   virtual int runCommandBuffer(uint64_t ev_id, EventTiming_t &evt,
                                uint32_t CmdBufId, uint32_t NumQueues,
                                uint32_t *QueueIds, uint32_t waitlist_size,
@@ -3320,6 +3326,35 @@ int SharedCLContext::runKernel(
     return err;
   }
 
+  return err;
+}
+
+/***************************************************************************/
+
+int SharedCLContext::barrier(uint64_t ev_id, uint32_t cq_id, EventTiming_t &evt,
+                             uint32_t waitlist_size, uint64_t *waitlist) {
+  std::vector<cl::Event> Dependencies;
+  Dependencies = remapWaitlist(waitlist_size, waitlist, ev_id);
+  cl::CommandQueue *cq = nullptr;
+  {
+    FIND_QUEUE;
+  }
+
+  EVENT_TIMING("barrier",
+               cq->enqueueBarrierWithWaitList(&Dependencies, &event));
+  return err;
+}
+
+int SharedCLContext::marker(uint64_t ev_id, uint32_t cq_id, EventTiming_t &evt,
+                            uint32_t waitlist_size, uint64_t *waitlist) {
+  std::vector<cl::Event> Dependencies;
+  Dependencies = remapWaitlist(waitlist_size, waitlist, ev_id);
+  cl::CommandQueue *cq = nullptr;
+  {
+    FIND_QUEUE;
+  }
+
+  EVENT_TIMING("marker", cq->enqueueMarkerWithWaitList(&Dependencies, &event));
   return err;
 }
 

--- a/pocld/shared_cl_context.hh
+++ b/pocld/shared_cl_context.hh
@@ -185,6 +185,12 @@ public:
                         const sizet_vec3 &global,
                         const sizet_vec3 *local = nullptr) = 0;
 
+  virtual int barrier(uint64_t ev_id, uint32_t cq_id, EventTiming_t &evt,
+                      uint32_t waitlist_size, uint64_t *waitlist) = 0;
+
+  virtual int marker(uint64_t ev_id, uint32_t cq_id, EventTiming_t &evt,
+                     uint32_t waitlist_size, uint64_t *waitlist) = 0;
+
   virtual int runCommandBuffer(uint64_t ev_id, EventTiming_t &evt,
                                uint32_t CmdBufId, uint32_t NumQueues,
                                uint32_t *QueueIds, uint32_t waitlist_size,

--- a/pocld/tracing.h
+++ b/pocld/tracing.h
@@ -80,6 +80,11 @@
   tracepoint (pocld_trace, ndrange_setup, msg_id, dev_id, queue_id,           \
               kernel_id, stat);
 
+#define TP_BARRIER(msg_id, dev_id, queue_id, stat)                            \
+  tracepoint (pocld_trace, msg_id, queue_id, stat);
+#define TP_MARKER(msg_id, dev_id, queue_id, stat)                             \
+  tracepoint (pocld_trace, msg_id, queue_id, stat);
+
 #define TP_READ_IMAGE_RECT(msg_id, dev_id, queue_id, obj_id, x, y, z, stat)   \
   tracepoint (pocld_trace, read_image_rect, msg_id, dev_id, queue_id, obj_id, \
               x, y, z, stat);
@@ -143,6 +148,9 @@
 #define TP_FILL_BUFFER(msg_id, dev_id, queue_id, obj_id, size, stat)
 #define TP_NDRANGE_KERNEL(msg_id, dev_id, queue_id, kernel_id, stat)
 #define TP_NDRANGE_SETUP(msg_id, dev_id, queue_id, kernel_id, stat)
+
+#define TP_BARRIER(msg_id, dev_id, queue_id, stat)
+#define TP_MARKER(msg_id, dev_id, queue_id, stat)
 
 #define TP_READ_IMAGE_RECT(msg_id, dev_id, queue_id, obj_id, x, y, z, stat)
 #define TP_WRITE_IMAGE_RECT(msg_id, dev_id, queue_id, obj_id, x, y, z, stat)


### PR DESCRIPTION
Shorting these on the client was a handy shortcut earlier, but it's causing problems if servers receive commands that depend on the marker/barrier..