### PR TITLE
remote: Thread reorganization

### DIFF
--- a/include/messages.h
+++ b/include/messages.h
@@ -237,6 +237,7 @@ extern "C"
     uint16_t peer_port;
     uint8_t use_rdma;
     uint8_t fast_socket;
+    uint8_t reply_socket;
   } CreateOrAttachSessionMsg_t;
 
   typedef struct __attribute__ ((packed))

--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -74,7 +74,6 @@
 /* https://eklitzke.org/the-caveats-of-tcp-nodelay */
 /* to be used with TCP_NODELAY:
  * ssize_t writev(int fildes, const struct iovec *iov, int iovcnt); */
-#include <poll.h>
 #include <sys/uio.h>
 
 #ifdef HAVE_LTTNG_UST
@@ -135,16 +134,15 @@ static const char *tracefile_path = NULL;
             continue;                                                         \
           else                                                                \
             {                                                                 \
-              POCL_MSG_PRINT_REMOTE ("error %i on read() call at " __FILE__   \
-                                     ":%i, trying to reconnect\n",            \
-                                     e, __LINE__);                            \
+              POCL_MSG_PRINT_REMOTE (                                         \
+                "error %i on read() call at " __FILE__ ":%i\n", e, __LINE__); \
               goto TRY_RECONNECT;                                             \
             }                                                                 \
         }                                                                     \
       if (readb == 0)                                                         \
         {                                                                     \
           POCL_MSG_PRINT_REMOTE ("Filedescriptor closed (server "             \
-                                 "disconnect). Trying to reconnect\n");       \
+                                 "disconnect)\n");                            \
           goto TRY_RECONNECT;                                                 \
         }                                                                     \
     }                                                                         \
@@ -160,9 +158,8 @@ static const char *tracefile_path = NULL;
       if (res < 0)                                                            \
         {                                                                     \
           int e = errno;                                                      \
-          POCL_MSG_PRINT_REMOTE ("error %i on write() call at " __FILE__      \
-                                 ":%i, trying to reconnect\n",                \
-                                 e, __LINE__);                                \
+          POCL_MSG_PRINT_REMOTE (                                             \
+            "error %i on write() call at " __FILE__ ":%i\n", e, __LINE__);    \
           goto TRY_RECONNECT;                                                 \
         }                                                                     \
     }                                                                         \
@@ -267,34 +264,6 @@ SMALL_VECTOR_HELPERS (sampler_ids, remote_server_data_t, uint32_t, sampler_ids)
 #define PKT_THRESHOLD 1200
 
 #define NUM_SERVER_SOCKET_THREADS 4
-
-/*
- * # A note on socket error handling
- *
- * The socket reconnection code may look intimidatingly all over the place, but
- * its logic is fairly straightforward:
- * - If the current fd is not a valid handle (i.e. < 0), jump to reconnect
- * - If the writer thread has encountered an I/O error[1], jump to reconnect
- * - If poll() reports that the socket is closed or unusable, jump to reconnect
- * - If a read() call has an error other than EAGAIN, jump to reconnect
- *
- * All possible jumps to the reconnection code happen before a netcmd is
- * removed from its work queue, so commands are not lost on reconnect.
- * Interrupted write and read results are discarded and the command is
- * retransmitted in its entirety after reconnecting.
- *
- * If the writer notices an error it will notify the reader via a pipe and
- * proceed to wait on the socket's setup_cond to avoid busy looping and
- * interfering with the handshake performed in the reconnection process. Once
- * reconnecting has succeeded and handshakes have been exchanged, the reader
- * signals the writer to resume normal operation (sleep on the work queue's
- * condition variable until a new command arrives from the application).
- *
- * [1]: Linux *aggressively* reuses fd numbers, so in order to avoid race
- * conditions, only the reader thread actually reconnects. The writer holds the
- * socket's setup_mutex during writes to ensure it does not get changed between
- * the check whether it has changed fd and the actual write.
- */
 
 /* Functions for manipulating a remote connection */
 
@@ -402,31 +371,22 @@ connection_writev_full (remote_connection_t *connection,
 static cl_int
 connection_init (remote_connection_t *connection,
                  transport_domain_t domain,
-                 int is_fast)
+                 int is_fast,
+                 int is_reader)
 {
   connection->domain = domain;
   connection->fd = -1;
-  POCL_INIT_LOCK (connection->setup_guard.mutex);
-  POCL_INIT_COND (connection->setup_guard.cond);
   connection->reconnect_count = 0;
-  int pipe_pair[2];
-  int pipe_res = pipe (pipe_pair);
   connection->is_fast = is_fast;
+  connection->is_reader = is_reader;
   connection->reconnect_attempts = 0;
 
-  if (pipe_res != 0)
-    POCL_MSG_ERR ("Failed to open socket notification pipe: %s\n",
-                  strerror (errno));
-  connection->notify_pipe_r = pipe_pair[0];
-  connection->notify_pipe_w = pipe_pair[1];
-
-  return pipe_res;
+  return CL_SUCCESS;
 }
 
 static cl_int
 connection_connect (remote_server_data_t *data,
                     remote_connection_t *connection,
-                    unsigned port,
                     int bufsize,
                     ReplyMsg_t *reply_out)
 {
@@ -445,7 +405,7 @@ connection_connect (remote_server_data_t *data,
 
   if (connection->domain != TransportDomain_Unix)
     {
-      ai = pocl_resolve_address (data->address, port, &err);
+      ai = pocl_resolve_address (data->address, data->client_port, &err);
       if (err)
         {
           POCL_MSG_ERR ("Failed to resolve address: %s\n", gai_strerror (err));
@@ -520,6 +480,7 @@ connection_connect (remote_server_data_t *data,
   hs.m.get_session.peer_id = data->peer_id;
   hs.session = data->session;
   hs.m.get_session.fast_socket = connection->is_fast;
+  hs.m.get_session.reply_socket = connection->is_reader;
   memcpy (hs.authkey, data->authkey, AUTHKEY_LENGTH);
   ssize_t readb, writeb;
   uint32_t req_len = request_size (hs.message_type);
@@ -557,10 +518,7 @@ connection_disconnect (remote_connection_t *connection)
 static void
 connection_release (remote_connection_t *connection)
 {
-  close (connection->notify_pipe_w);
-  close (connection->notify_pipe_r);
-  POCL_DESTROY_COND (connection->setup_guard.cond);
-  POCL_DESTROY_LOCK (connection->setup_guard.mutex);
+  connection_disconnect (connection);
 }
 
 /** Helper function for reconnecting a socket that has become unusable
@@ -582,17 +540,15 @@ pocl_remote_reconnect_socket (remote_server_data_t *remote,
       connection_disconnect (connection);
     }
 
-  POCL_MSG_PRINT_REMOTE (
-    "Attempting to connect to session %" PRIu64 " on %s:%d (%s)\n",
-    remote->session, remote->address,
-    connection->is_fast ? remote->fast_port : remote->slow_port,
-    connection->is_fast ? "fast" : "slow");
+  POCL_MSG_PRINT_REMOTE ("Attempting to connect to session %" PRIu64
+                         " on %s:%d (%s)\n",
+                         remote->session, remote->address, remote->client_port,
+                         connection->is_fast ? "fast" : "slow");
 
   connection->reconnect_attempts += 1;
 
   int res = connection_connect (
     remote, connection,
-    connection->is_fast ? remote->fast_port : remote->slow_port,
     connection->is_fast ? NETWORK_BUF_SIZE_FAST : NETWORK_BUF_SIZE_SLOW, NULL);
   if (res == CL_SUCCESS)
     {
@@ -641,13 +597,23 @@ pocl_remote_reconnect_rediscover (const char *address_with_port)
 
   free (addr);
 
-  POCL_LOCK (d->slow_connection.discovery_reconnect_guard.mutex);
-  POCL_BROADCAST_COND (d->slow_connection.discovery_reconnect_guard.cond);
-  POCL_UNLOCK (d->slow_connection.discovery_reconnect_guard.mutex);
+  POCL_LOCK (d->slow_read_connection.discovery_reconnect_guard.mutex);
+  POCL_BROADCAST_COND (d->slow_read_connection.discovery_reconnect_guard.cond);
+  POCL_UNLOCK (d->slow_read_connection.discovery_reconnect_guard.mutex);
 
-  POCL_LOCK (d->fast_connection.discovery_reconnect_guard.mutex);
-  POCL_BROADCAST_COND (d->fast_connection.discovery_reconnect_guard.cond);
-  POCL_UNLOCK (d->fast_connection.discovery_reconnect_guard.mutex);
+  POCL_LOCK (d->slow_write_connection.discovery_reconnect_guard.mutex);
+  POCL_BROADCAST_COND (
+    d->slow_write_connection.discovery_reconnect_guard.cond);
+  POCL_UNLOCK (d->slow_write_connection.discovery_reconnect_guard.mutex);
+
+  POCL_LOCK (d->fast_read_connection.discovery_reconnect_guard.mutex);
+  POCL_BROADCAST_COND (d->fast_read_connection.discovery_reconnect_guard.cond);
+  POCL_UNLOCK (d->fast_read_connection.discovery_reconnect_guard.mutex);
+
+  POCL_LOCK (d->fast_write_connection.discovery_reconnect_guard.mutex);
+  POCL_BROADCAST_COND (
+    d->fast_write_connection.discovery_reconnect_guard.cond);
+  POCL_UNLOCK (d->fast_write_connection.discovery_reconnect_guard.mutex);
 
   return CL_SUCCESS;
 }
@@ -937,94 +903,18 @@ pocl_remote_reader_pthread (void *aa)
   POCL_MEM_FREE (a);
 
   ssize_t readb;
-  struct pollfd pfd[2];
-  pfd[0].events = POLLIN;
-  pfd[1].events = POLLIN;
-  pfd[1].fd = connection->notify_pipe_r;
   int nevs;
   unsigned writer_reconnects;
   unsigned reader_reconnects;
-#ifdef SIGPIPE
-  /* Don't kill the thread on I/O errors */
-  POCL_IGNORE_SIGNAL_IN_THREAD (SIGPIPE);
-#endif
 
   while (!this->exit_requested)
     {
-      POCL_LOCK (connection->setup_guard.mutex);
       int fd = connection->fd;
-      reader_reconnects = POCL_ATOMIC_LOAD (connection->reconnect_count);
-      POCL_UNLOCK (connection->setup_guard.mutex);
       if (fd < 0)
         {
-          POCL_LOCK (connection->setup_guard.mutex);
-          int reconnected;
         TRY_RECONNECT:
-
-          reconnected = pocl_remote_reconnect_socket (remote, connection);
-          if (reconnected != CL_SUCCESS)
-            {
-              if (connection->reconnect_attempts
-                  >= POCL_REMOTE_RECONNECT_MAX_ATTEMPTS)
-                {
-                  network_command *cmd = NULL, *tmp = NULL;
-                  POCL_LOCK (inflight->mutex);
-                  /* Each command in the inflight queue of the failed server
-                   * has to be handled and marked as failed to prevent
-                   * deadlock. */
-                  DL_FOREACH_SAFE (inflight->queue, cmd, tmp)
-                    {
-                      DL_DELETE (inflight->queue, cmd);
-                      finish_running_cmd (remote, cmd, NETCMD_FAILED);
-                    }
-                  POCL_UNLOCK (inflight->mutex);
-
-#if defined(ENABLE_REMOTE_DISCOVERY_AVAHI)                                    \
-  || defined(ENABLE_REMOTE_DISCOVERY_DHT)                                     \
-  || defined(ENABLE_REMOTE_DISCOVERY_ANDROID)
-                  POCL_LOCK (connection->discovery_reconnect_guard.mutex);
-                  POCL_WAIT_COND (connection->discovery_reconnect_guard.cond,
-                                  connection->discovery_reconnect_guard.mutex);
-                  POCL_UNLOCK (connection->discovery_reconnect_guard.mutex);
-#endif
-                }
-              goto TRY_RECONNECT;
-            }
-          else
-            {
-              fd = connection->fd;
-              reader_reconnects
-                = POCL_ATOMIC_LOAD (connection->reconnect_count);
-              POCL_ATOMIC_STORE (connection->reconnect_attempts, 0);
-              POCL_BROADCAST_COND (connection->setup_guard.cond);
-              POCL_UNLOCK (connection->setup_guard.mutex);
-            }
-        }
-
-      /* Block until there is something to read. This is especially needed to
-       * get accurate profiling timestamps for read commands */
-      pfd[0].fd = fd;
-      nevs = poll (pfd, 2, -1);
-      if (nevs < 1)
-          continue;
-      else
-        {
-          if (pfd[1].revents & POLLIN)
-            {
-              /* If woken up by the writer pipe, reconnect iff the writer's
-               * reconnect count is still up to date (writer noticed an I/O
-               * error before poll did). If the writer's reconnect count is
-               * behind, this was a stale notification and no further action is
-               * needed. In that case proceed to checking events of the socket
-               * fd. */
-              read (pfd[1].fd, &writer_reconnects, sizeof (writer_reconnects));
-              if (writer_reconnects == reader_reconnects)
-                goto TRY_RECONNECT;
-            }
-          if (pfd[0].revents & POLLFD_ERROR_BITS)
-            goto TRY_RECONNECT;
-          if (!(pfd[0].revents & POLLIN))
-            continue;
+          connection->fd = -1;
+          break;
         }
 
       /* READ MSG */
@@ -1102,6 +992,9 @@ pocl_remote_reader_pthread (void *aa)
       POCL_SIGNAL_COND (remote->finalize_queue->cond);
       POCL_UNLOCK (remote->finalize_queue->mutex);
     }
+
+  POCL_ATOMIC_CAS (&this->exit_requested, 0, 1);
+  POCL_MSG_PRINT_REMOTE ("READER THREAD EXITING\n");
   return NULL;
 }
 
@@ -1194,7 +1087,7 @@ pocl_remote_rdma_reader_pthread (void *aa)
       POCL_UNLOCK (this->mutex);
 
       POCL_LOCK (remote->finalize_queue->mutex);
-      DL_APPEND (remote->finalize_queue->queue, running_cmd);
+      DL_APPEND (remote->finalize_queue->queue, cmd);
       POCL_SIGNAL_COND (remote->finalize_queue->cond);
       POCL_UNLOCK (remote->finalize_queue->mutex);
 
@@ -1364,14 +1257,6 @@ pocl_remote_writer_pthread (void *aa)
   remote_server_data_t *remote = a->remote;
   remote_connection_t *connection = a->connection;
   POCL_MEM_FREE (a);
-  unsigned reconnect_count = 0;
-#ifdef SIGPIPE
-  /* Don't kill the thread on I/O errors */
-  POCL_IGNORE_SIGNAL_IN_THREAD (SIGPIPE);
-#endif
-  POCL_LOCK (connection->setup_guard.mutex);
-  reconnect_count = POCL_ATOMIC_LOAD (connection->reconnect_count);
-  POCL_UNLOCK (connection->setup_guard.mutex);
 
   network_command *cmd;
   POCL_LOCK (this->mutex);
@@ -1417,31 +1302,12 @@ pocl_remote_writer_pthread (void *aa)
           DL_APPEND (cmd->receiver->queue, cmd);
           POCL_UNLOCK (cmd->receiver->mutex);
 
-          POCL_LOCK (connection->setup_guard.mutex);
-
           if (0)
             {
             /* This is only hit if there is an error from CHECK_WRITE */
             TRY_RECONNECT:
-              /* Only sleep if the reader thread has *not* reconnected yet */
-              if (reconnect_count
-                  == POCL_ATOMIC_LOAD (connection->reconnect_count))
-                {
-                  POCL_MSG_PRINT_REMOTE (
-                    "(%s) writer waiting for reader to reconnect\n",
-                    connection->is_fast ? "fast" : "slow");
-                  /* In synthetic benchmarks poll() would sometimes not notice
-                   * the socket getting closed from under it, leading to
-                   * deadlocks (poll has no time limit). To avoid this, there
-                   * is now a pipe that is part of the poll so the writer can
-                   * force the reader to wake up. */
-                  write (connection->notify_pipe_w, &reconnect_count,
-                         sizeof (reconnect_count));
-                  POCL_WAIT_COND (connection->setup_guard.cond,
-                                  connection->setup_guard.mutex);
-                }
+              return NULL;
             }
-          reconnect_count = POCL_ATOMIC_LOAD (connection->reconnect_count);
 
           /* WRITE DATA */
           if (cmd->req_extra_data2)
@@ -1489,8 +1355,6 @@ pocl_remote_writer_pthread (void *aa)
                                                   msg_size, remote));
             }
 
-          POCL_UNLOCK (connection->setup_guard.mutex);
-
           POCL_ATOMIC_STORE (cmd->client_write_end_timestamp_ns,
                              pocl_gettimemono_ns ());
 
@@ -1508,6 +1372,8 @@ pocl_remote_writer_pthread (void *aa)
 
   POCL_UNLOCK (this->mutex);
 
+  POCL_ATOMIC_CAS (&this->exit_requested, 0, 1);
+  POCL_MSG_PRINT_REMOTE ("WRITER THREAD EXITING\n");
   return NULL;
 }
 
@@ -1635,25 +1501,25 @@ start_engines (remote_server_data_t *d, remote_device_data_t *devd,
 
   d->slow_read_queue = calloc (1, sizeof (network_queue));
   SETUP_NETW_Q (d->slow_read_queue);
-  SETUP_NETW_Q_ARG (a, d, d->slow_read_queue, &d->slow_connection);
+  SETUP_NETW_Q_ARG (a, d, d->slow_read_queue, &d->slow_read_connection);
   POCL_CREATE_THREAD (d->slow_read_queue->thread_id,
                       pocl_remote_reader_pthread, a);
 
   d->fast_read_queue = calloc (1, sizeof (network_queue));
   SETUP_NETW_Q (d->fast_read_queue);
-  SETUP_NETW_Q_ARG (a, d, d->fast_read_queue, &d->fast_connection);
+  SETUP_NETW_Q_ARG (a, d, d->fast_read_queue, &d->fast_read_connection);
   POCL_CREATE_THREAD (d->fast_read_queue->thread_id,
                       pocl_remote_reader_pthread, a);
 
   d->slow_write_queue = calloc (1, sizeof (network_queue));
   SETUP_NETW_Q (d->slow_write_queue);
-  SETUP_NETW_Q_ARG (a, d, d->slow_write_queue, &d->slow_connection);
+  SETUP_NETW_Q_ARG (a, d, d->slow_write_queue, &d->slow_write_connection);
   POCL_CREATE_THREAD (d->slow_write_queue->thread_id,
                       pocl_remote_writer_pthread, a);
 
   d->fast_write_queue = calloc (1, sizeof (network_queue));
   SETUP_NETW_Q (d->fast_write_queue);
-  SETUP_NETW_Q_ARG (a, d, d->fast_write_queue, &d->fast_connection);
+  SETUP_NETW_Q_ARG (a, d, d->fast_write_queue, &d->fast_write_connection);
   POCL_CREATE_THREAD (d->fast_write_queue->thread_id,
                       pocl_remote_writer_pthread, a);
 
@@ -1991,30 +1857,29 @@ find_or_create_server (const char *address_with_port, unsigned port,
   d->threads_awaiting_reconnect = 0;
   POCL_INIT_LOCK (d->profiling_lock);
 
-  connection_init (&d->fast_connection, TransportDomain_Unset, 1);
-  connection_init (&d->slow_connection, TransportDomain_Unset, 0);
-
   /* pocl_network_init_device ensures address_with_port actually contains
    * port */
+  transport_domain_t server_domain;
   if (address_with_port[0] == '/')
     {
-      d->fast_connection.domain = TransportDomain_Unix;
-      d->slow_connection.domain = TransportDomain_Unix;
+      server_domain = TransportDomain_Unix;
     }
   else if (strncmp (address_with_port, "vsock:", strlen ("vsock:")) == 0)
     {
       strncpy (d->address, address_with_port,
                strrchr (address_with_port, ':') - address_with_port);
-      d->fast_connection.domain = TransportDomain_Vsock;
-      d->slow_connection.domain = TransportDomain_Vsock;
+      server_domain = TransportDomain_Vsock;
     }
   else
     {
       strncpy (d->address, address_with_port,
                strchr (address_with_port, ':') - address_with_port);
-      d->fast_connection.domain = TransportDomain_Inet;
-      d->slow_connection.domain = TransportDomain_Inet;
+      server_domain = TransportDomain_Inet;
     }
+  connection_init (&d->fast_read_connection, server_domain, 1, 1);
+  connection_init (&d->fast_write_connection, server_domain, 1, 0);
+  connection_init (&d->slow_read_connection, server_domain, 0, 1);
+  connection_init (&d->slow_write_connection, server_domain, 0, 0);
 
   char *tmp2 = strdup (parameters);
   char *peer_address = strtok (tmp2, "#");
@@ -2035,8 +1900,7 @@ find_or_create_server (const char *address_with_port, unsigned port,
   d->address_with_port[MAX_ADDRESS_PORT_SIZE - 1] = 0;
   POCL_MSG_PRINT_REMOTE ("using host %s with port %u\n", d->address, port);
 
-  d->fast_port = port;
-  d->slow_port = port + 1;
+  d->client_port = port;
 
 #ifdef ENABLE_RDMA
   /* TODO: re-enable once client RDMA has been reworked to match server
@@ -2053,8 +1917,8 @@ find_or_create_server (const char *address_with_port, unsigned port,
 #endif
 
   ReplyMsg_t hsr;
-  if (connection_connect (d, &d->fast_connection, d->fast_port,
-                          NETWORK_BUF_SIZE_FAST, &hsr))
+  if (connection_connect (d, &d->fast_read_connection, NETWORK_BUF_SIZE_FAST,
+                          &hsr))
     {
       POCL_MSG_ERR ("Could not connect to server\n");
       POCL_MEM_FREE (d);
@@ -2074,8 +1938,22 @@ find_or_create_server (const char *address_with_port, unsigned port,
 
   d->peer_port = hsr.m.get_session.peer_port;
 
-  if (connection_connect (d, &d->slow_connection, d->slow_port,
-                          NETWORK_BUF_SIZE_SLOW, NULL))
+  if (connection_connect (d, &d->fast_write_connection, NETWORK_BUF_SIZE_SLOW,
+                          NULL))
+    {
+      POCL_MSG_ERR ("Could not connect to server\n");
+      POCL_MEM_FREE (d);
+      return NULL;
+    }
+  if (connection_connect (d, &d->slow_read_connection, NETWORK_BUF_SIZE_SLOW,
+                          NULL))
+    {
+      POCL_MSG_ERR ("Could not connect to server\n");
+      POCL_MEM_FREE (d);
+      return NULL;
+    }
+  if (connection_connect (d, &d->slow_write_connection, NETWORK_BUF_SIZE_SLOW,
+                          NULL))
     {
       POCL_MSG_ERR ("Could not connect to server\n");
       POCL_MEM_FREE (d);
@@ -2209,19 +2087,20 @@ find_or_create_server (const char *address_with_port, unsigned port,
   uint32_t msg_size = request_size (req.message_type);
 
   ssize_t writeb, readb;
-  writeb = write (d->fast_connection.fd, &msg_size, sizeof (msg_size));
+  writeb = write (d->fast_write_connection.fd, &msg_size, sizeof (msg_size));
   assert ((size_t)(writeb) == sizeof (msg_size));
-  writeb = write (d->fast_connection.fd, &req, msg_size);
+  writeb = write (d->fast_write_connection.fd, &req, msg_size);
   assert ((size_t)(writeb) == msg_size);
 
   ReplyMsg_t rep;
-  readb = read (d->fast_connection.fd, &rep, sizeof (ReplyMsg_t));
+  readb = read (d->fast_read_connection.fd, &rep, sizeof (ReplyMsg_t));
   assert ((size_t)(readb) == sizeof (ReplyMsg_t));
   assert (rep.message_type == MessageType_ServerInfoReply);
 
   d->num_platforms = rep.obj_id;
   d->platform_devices = malloc (rep.data_size);
-  readb = read (d->fast_connection.fd, d->platform_devices, rep.data_size);
+  readb
+    = read (d->fast_read_connection.fd, d->platform_devices, rep.data_size);
   assert ((size_t)(readb) == rep.data_size);
   /****************************************/
   size_t num_plat_devs
@@ -2232,7 +2111,7 @@ find_or_create_server (const char *address_with_port, unsigned port,
     d->num_devices += d->platform_devices[i];
 
   POCL_MSG_PRINT_REMOTE ("Connected to %s:%d which has %d devices\n",
-                         d->address, d->fast_port, d->num_devices);
+                         d->address, d->client_port, d->num_devices);
 
   /****************************************/
 
@@ -2276,10 +2155,10 @@ release_server (remote_server_data_t *d)
   SMALL_VECTOR_DESTROY (d, sampler_ids, INITIAL_ARRAY_CAP);
 
   /* disconnect sockets */
-  connection_disconnect (&d->fast_connection);
-  connection_release (&d->fast_connection);
-  connection_disconnect (&d->slow_connection);
-  connection_release (&d->slow_connection);
+  connection_release (&d->fast_write_connection);
+  connection_release (&d->fast_read_connection);
+  connection_release (&d->slow_write_connection);
+  connection_release (&d->slow_read_connection);
 
 #ifdef ENABLE_RDMA
   rdma_uninitialize (&d->rdma_data);

--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -894,6 +894,37 @@ finish_running_cmd (remote_server_data_t *server,
     }
 }
 
+static void *
+pocl_remote_finalizer_pthread (void *aa)
+{
+  network_queue_arg *a = aa;
+  remote_server_data_t *remote = a->remote;
+  network_queue *inflight = a->in_flight;
+  network_queue *this = a->ours;
+  POCL_MEM_FREE (a);
+
+  network_command *cmd;
+  POCL_LOCK (this->mutex);
+  while (!this->exit_requested)
+    {
+      cmd = this->queue;
+      if (cmd)
+        {
+          DL_DELETE (this->queue, cmd);
+          POCL_UNLOCK (this->mutex);
+          assert (cmd->status == NETCMD_READ);
+          finish_running_cmd (remote, cmd, NETCMD_FINISHED);
+          POCL_LOCK (this->mutex);
+        }
+      else
+        {
+          POCL_WAIT_COND (this->cond, this->mutex);
+        }
+    }
+
+  return NULL;
+}
+
 /** Main function for the socket reader thread */
 static void *
 pocl_remote_reader_pthread (void *aa)
@@ -1066,7 +1097,10 @@ pocl_remote_reader_pthread (void *aa)
       POCL_LOCK (inflight->mutex);
       DL_DELETE (inflight->queue, running_cmd);
       POCL_UNLOCK (inflight->mutex);
-      finish_running_cmd (remote, running_cmd, NETCMD_FINISHED);
+      POCL_LOCK (remote->finalize_queue->mutex);
+      DL_APPEND (remote->finalize_queue->queue, running_cmd);
+      POCL_SIGNAL_COND (remote->finalize_queue->cond);
+      POCL_UNLOCK (remote->finalize_queue->mutex);
     }
   return NULL;
 }
@@ -1159,7 +1193,10 @@ pocl_remote_rdma_reader_pthread (void *aa)
       DL_DELETE (this->queue, cmd);
       POCL_UNLOCK (this->mutex);
 
-      finish_running_cmd (remote, cmd, NETCMD_FINISHED);
+      POCL_LOCK (remote->finalize_queue->mutex);
+      DL_APPEND (remote->finalize_queue->queue, running_cmd);
+      POCL_SIGNAL_COND (remote->finalize_queue->cond);
+      POCL_UNLOCK (remote->finalize_queue->mutex);
 
       POCL_LOCK (this->mutex);
     }
@@ -1577,6 +1614,12 @@ start_engines (remote_server_data_t *d, remote_device_data_t *devd,
   d->inflight_queue = calloc (1, sizeof (network_queue));
   SETUP_NETW_Q (d->inflight_queue);
 
+  d->finalize_queue = calloc (1, sizeof (network_queue));
+  SETUP_NETW_Q (d->finalize_queue);
+  SETUP_NETW_Q_ARG (a, d, d->finalize_queue, NULL);
+  POCL_CREATE_THREAD (d->finalize_queue->thread_id,
+                      pocl_remote_finalizer_pthread, a);
+
   d->traffic_monitor = calloc (1, sizeof (network_queue));
   SETUP_NETW_Q (d->traffic_monitor);
   SETUP_NETW_Q_ARG (a, d, d->traffic_monitor, NULL);
@@ -1672,6 +1715,9 @@ stop_engines (remote_server_data_t *d)
   POCL_JOIN_THREAD (d->rdma_read_queue->thread_id);
   POCL_JOIN_THREAD (d->rdma_write_queue->thread_id);
 #endif
+
+  NOTIFY_SHUTDOWN (d->finalize_queue);
+  POCL_JOIN_THREAD (d->finalize_queue->thread_id);
 
   NOTIFY_SHUTDOWN (d->traffic_monitor);
   POCL_JOIN_THREAD (d->traffic_monitor->thread_id);

--- a/lib/CL/devices/remote/communication.h
+++ b/lib/CL/devices/remote/communication.h
@@ -182,8 +182,6 @@ typedef struct remote_connection_s
 {
   transport_domain_t domain;
   int fd;
-  /* Sync objects for avoiding races in reconnect procedures */
-  sync_t setup_guard;
   /* Sync objects for avoiding a race condition between a writer picking up
    * the connection fd, the reader closing it and the writer trying to perform
    * a write with the now incorrect value of the fd. */
@@ -191,14 +189,11 @@ typedef struct remote_connection_s
   /* Running counter so threads can detect a connection change even if the new
    * fd has the same value as the old one. */
   unsigned reconnect_count;
-  /* Pipe endpoint that the reader should include when polling the connection
-   * fd so the writer can wake it up if a reconnect becomes necessary. */
-  int notify_pipe_r;
-  /* Pipe endpoint that the writer should write a single byte to if it detects
-   * the need for reconnecting. */
-  int notify_pipe_w;
   /* Flag for determining the socket options to use when (re)connecting */
   int is_fast;
+  /* Flag indicating whether this connection is used for sending requests or
+   * receiving responses */
+  int is_reader;
   /* Counter to track attempts made for reconnection. Variable is used to be
    * able to give-up after POCL_REMOTE_RECONNECT_MAX_ATTEMPTS. */
   int reconnect_attempts;
@@ -236,8 +231,7 @@ typedef struct remote_server_data_s
   char address_with_port[MAX_ADDRESS_PORT_SIZE];
   char peer_address[MAX_ADDRESS_SIZE];
   uint64_t peer_id;
-  unsigned slow_port;
-  unsigned fast_port;
+  unsigned client_port;
   unsigned peer_port;
 
   unsigned refcount;
@@ -254,10 +248,12 @@ typedef struct remote_server_data_s
    * purposes: */
   /** Connection optimized for large bulk data transfers, mainly intended for
    * transferring buffer contents */
-  remote_connection_t slow_connection;
+  remote_connection_t slow_read_connection;
+  remote_connection_t slow_write_connection;
   /** Connection optimized for low latency with small messages, used for
    * commands that are not expected to carry large amounts of data */
-  remote_connection_t fast_connection;
+  remote_connection_t fast_read_connection;
+  remote_connection_t fast_write_connection;
 
   uint32_t num_platforms;
   uint32_t num_devices;

--- a/lib/CL/devices/remote/communication.h
+++ b/lib/CL/devices/remote/communication.h
@@ -271,6 +271,7 @@ typedef struct remote_server_data_s
   network_queue *inflight_queue;
   network_queue *slow_write_queue;
   network_queue *fast_write_queue;
+  network_queue *finalize_queue;
 #ifdef ENABLE_RDMA
   network_queue *rdma_read_queue;
   network_queue *rdma_write_queue;

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -3183,7 +3183,7 @@ pocl_remote_get_device_info_ext (cl_device_id device,
       {
         remote_device_data_t *dev_data = (remote_device_data_t *)device->data;
         remote_server_data_t *server = dev_data->server;
-        POCL_RETURN_GETINFO (unsigned, server->fast_port);
+        POCL_RETURN_GETINFO (unsigned, server->client_port);
       }
     }
 

--- a/pocld/common.hh
+++ b/pocld/common.hh
@@ -285,8 +285,6 @@ struct PeerConnection {
 };
 
 struct ClientConnections_t {
-  std::shared_ptr<Connection> low_latency;
-  std::shared_ptr<Connection> bulk_throughput;
   std::mutex *incoming_peer_mutex;
   std::pair<std::condition_variable, std::vector<PeerConnection>>
       *incoming_peer_queue;

--- a/pocld/daemon.cc
+++ b/pocld/daemon.cc
@@ -61,7 +61,6 @@
 #endif
 #define POLLFD_ERROR_BITS (POLLHUP | POLLERR | POLLNVAL | POLLRDHUP)
 
-
 #define PERROR_CHECK(cond, str)                                                \
   do {                                                                         \
     if (cond) {                                                                \
@@ -474,8 +473,8 @@ void StartDHTAdvert(PoclDaemon *d, addrinfo *RA, struct ServerPorts &Ports) {
 PoclDaemon::~PoclDaemon() {
   if (ClientPoller.joinable())
     ClientPoller.join();
-  if (peer_listener_th.joinable())
-    peer_listener_th.join();
+  if (PeerListenerThread.joinable())
+    PeerListenerThread.join();
 #ifdef ENABLE_REMOTE_ADVERTISEMENT_AVAHI
   delete avahiAdvertiseP;
 #endif
@@ -489,6 +488,8 @@ PoclDaemon::~PoclDaemon() {
   if (pl_rdma_event_th.joinable())
     pl_rdma_event_th.join();
 #endif
+  if (ContextDeleter.joinable())
+    ContextDeleter.join();
 }
 
 VirtualContextBase *createVirtualContext(PoclDaemon *d,
@@ -712,22 +713,25 @@ int PoclDaemon::launch(std::string ListenAddress, struct ServerPorts &Ports,
   }
 
   if (!UseVsock) {
-    peer_listener_data.port = ListenPorts.peer;
+    PeerListenerData.port = ListenPorts.peer;
 #ifdef ENABLE_RDMA
-  peer_listener_data.peer_rdma_port = ListenPorts.peer_rdma;
-  peer_listener_data.rdma_listener.reset(new RdmaListener);
-  pl_rdma_event_th = std::move(
-      std::thread(listen_rdmacm_events<VirtualContextBase *>,
-                  peer_listener_data.rdma_listener->eventChannel(),
-                  std::ref(peer_listener_data.peer_cm_id_to_vctx),
-                  std::ref(peer_listener_data.peer_cm_id_to_vctx_mutex)));
+    PeerListenerData.peer_rdma_port = ListenPorts.peer_rdma;
+    PeerListenerData.rdma_listener.reset(new RdmaListener);
+    pl_rdma_event_th = std::move(
+        std::thread(listen_rdmacm_events<VirtualContextBase *>,
+                    PeerListenerData.rdma_listener->eventChannel(),
+                    std::ref(PeerListenerData.peer_cm_id_to_vctx),
+                    std::ref(PeerListenerData.peer_cm_id_to_vctx_mutex)));
 #endif
-  peer_listener_th =
-      std::move(std::thread(listen_peers, (void *)&peer_listener_data));
+    PeerListenerThread =
+        std::move(std::thread(listen_peers, (void *)&PeerListenerData));
   }
 
   ClientPoller = std::move(
       std::thread(std::bind(&PoclDaemon::readAllClientSocketsThread, this)));
+
+  ContextDeleter = std::move(
+      std::thread(std::bind(&PoclDaemon::contextDeleterThread, this)));
 
   return 0;
 }
@@ -749,10 +753,6 @@ PoclDaemon::performSessionSetup(std::shared_ptr<Connection> Conn, Request *R) {
   session = ++LastSessionId;
   SessionKeys.insert(std::make_pair(session, authkey));
   Conn->configure(R->Body.m.get_session.fast_socket);
-  if (R->Body.m.get_session.fast_socket)
-    connections.low_latency = Conn;
-  else
-    connections.bulk_throughput = Conn;
 
   ReplyMsg_t Reply = {};
   Reply.message_type = MessageType_CreateOrAttachSessionReply;
@@ -763,13 +763,13 @@ PoclDaemon::performSessionSetup(std::shared_ptr<Connection> Conn, Request *R) {
   authkey_hex =
       std::accumulate(authkey.begin(), authkey.end(), std::string(), hexdigits);
 
-  std::unique_lock<std::mutex> l(peer_listener_data.mutex);
+  std::unique_lock<std::mutex> l(PeerListenerData.mutex);
   auto p =
       new std::pair<std::condition_variable, std::vector<PeerConnection>>();
-  connections.incoming_peer_mutex = &peer_listener_data.mutex;
+  connections.incoming_peer_mutex = &PeerListenerData.mutex;
   connections.incoming_peer_queue = p;
-  peer_listener_data.incoming_peers.insert({session, p});
-  peer_listener_data.SessionPeerId.insert(
+  PeerListenerData.incoming_peers.insert({session, p});
+  PeerListenerData.SessionPeerId.insert(
       {session, uint64_t(R->Body.m.get_session.peer_id)});
   POCL_MSG_PRINT_INFO("Registered new client session %" PRIu64 " %s\n", session,
                       authkey_hex.c_str());
@@ -793,6 +793,8 @@ PoclDaemon::performSessionSetup(std::shared_ptr<Connection> Conn, Request *R) {
 
   // Start virtual_cl_context thread
   ctx = createVirtualContext(this, connections, session, R->Body.m.get_session);
+  ctx->setConnection(Conn, R->Body.m.get_session.fast_socket,
+                     R->Body.m.get_session.reply_socket);
 #ifdef ENABLE_RDMA
   if (Reply.m.get_session.use_rdma) {
     {
@@ -801,14 +803,14 @@ PoclDaemon::performSessionSetup(std::shared_ptr<Connection> Conn, Request *R) {
     }
     {
       std::unique_lock<std::mutex> l(
-          peer_listener_data.peer_cm_id_to_vctx_mutex);
-      peer_listener_data.peer_cm_id_to_vctx.insert(
+          PeerListenerData.peer_cm_id_to_vctx_mutex);
+      PeerListenerData.peer_cm_id_to_vctx.insert(
           {*connections.rdma->id(), ctx});
     }
   }
   {
-    std::unique_lock<std::mutex> l(peer_listener_data.vctx_map_mutex);
-    peer_listener_data.vctx_map.insert({session, ctx});
+    std::unique_lock<std::mutex> l(PeerListenerData.vctx_map_mutex);
+    PeerListenerData.vctx_map.insert({session, ctx});
   }
 #endif
   ClientSessions.insert({session, ctx});
@@ -825,9 +827,6 @@ void PoclDaemon::readAllClientSocketsThread() {
   std::vector<std::shared_ptr<Connection>> DroppedConnections;
   bool ConnectionsChanged = true;
   std::vector<struct pollfd> pfds;
-
-  SocketContexts.clear();
-  SocketContexts.resize(NumListenFds, nullptr);
 
   while (!exit_helper.exit_requested()) {
     /* Changes to the list of sockets should be relatively rare so let's
@@ -846,7 +845,6 @@ void PoclDaemon::readAllClientSocketsThread() {
 
     /* These *really* ought to stay consistent */
     assert(pfds.size() == OpenClientConnections.size() &&
-           SocketContexts.size() == OpenClientConnections.size() &&
            IncompleteRequests.size() == OpenClientConnections.size());
 
     /* Just block forever. If/when a socket is closed - including the client
@@ -885,7 +883,6 @@ void PoclDaemon::readAllClientSocketsThread() {
           if (NewFd >= 0) {
             OpenClientConnections.push_back(std::shared_ptr<Connection>(
                 new Connection(Transport->domain(), NewFd, nullptr)));
-            SocketContexts.push_back(nullptr);
             IncompleteRequests.push_back(new Request());
             ConnectionsChanged = true;
             std::string client_address_string = describe_sockaddr(
@@ -934,16 +931,11 @@ void PoclDaemon::readAllClientSocketsThread() {
           if (R->read(OpenClientConnections.at(i).get())) {
             if (R->IsFullyRead) {
               if (R->Body.message_type == MessageType_CreateOrAttachSession) {
-                int Fast = R->Body.m.get_session.fast_socket;
                 uint64_t Session = R->Body.session;
                 if (Session == 0) {
                   VirtualContextBase *ctx =
                       performSessionSetup(OpenClientConnections.at(i), R);
-                  if (ctx == nullptr) {
-                    DroppedConnections.push_back(OpenClientConnections.at(i));
-                  } else {
-                    SocketContexts.at(i) = ctx;
-                  }
+                  DroppedConnections.push_back(OpenClientConnections.at(i));
                 } else {
                   std::unique_lock<std::mutex> L(SessionListMtx);
                   auto it = SessionKeys.find(Session);
@@ -952,14 +944,6 @@ void PoclDaemon::readAllClientSocketsThread() {
                                     AUTHKEY_LENGTH) == 0) {
                       auto cit = ClientSessions.find(Session);
                       assert(cit != ClientSessions.end());
-                      if (Fast)
-                        cit->second->replaceConnections(
-                            OpenClientConnections.at(i), nullptr);
-                      else
-                        cit->second->replaceConnections(
-                            nullptr, OpenClientConnections.at(i));
-                      SocketContexts.at(i) = cit->second;
-                      L.unlock();
 
                       ReplyMsg_t Reply = {};
                       Reply.message_type =
@@ -969,6 +953,12 @@ void PoclDaemon::readAllClientSocketsThread() {
                              AUTHKEY_LENGTH);
                       OpenClientConnections.at(i)->writeFull(&Reply,
                                                              sizeof(Reply));
+
+                      cit->second->setConnection(
+                          OpenClientConnections.at(i),
+                          R->Body.m.get_session.fast_socket,
+                          R->Body.m.get_session.reply_socket);
+                      DroppedConnections.push_back(OpenClientConnections.at(i));
                     } else {
                       POCL_MSG_ERR(
                           "Client attempted to connect with invalid key\n");
@@ -976,90 +966,11 @@ void PoclDaemon::readAllClientSocketsThread() {
                     }
                   }
                 }
-                delete R;
               } else {
-                std::unique_lock<std::mutex> LSessions(SessionListMtx);
-                auto it = ClientSessions.find(R->Body.session);
-                VirtualContextBase *Ctx =
-                    it == ClientSessions.end() ? nullptr : it->second;
-                LSessions.unlock();
-                if (Ctx) {
-                  switch (R->Body.message_type) {
-                  case MessageType_ServerInfo:
-                  case MessageType_ConnectPeer:
-                  case MessageType_DeviceInfo:
-                  case MessageType_CreateBuffer:
-                  case MessageType_FreeBuffer:
-                  case MessageType_CreateCommandQueue:
-                  case MessageType_FreeCommandQueue:
-                  case MessageType_CreateSampler:
-                  case MessageType_FreeSampler:
-                  case MessageType_CreateImage:
-                  case MessageType_FreeImage:
-                  case MessageType_CreateCommandBuffer:
-                  case MessageType_FreeCommandBuffer:
-                  case MessageType_CreateKernel:
-                  case MessageType_FreeKernel:
-                  case MessageType_BuildProgramFromSource:
-                  case MessageType_BuildProgramFromBinary:
-                  case MessageType_BuildProgramFromSPIRV:
-                  case MessageType_CompileProgramFromSource:
-                  case MessageType_CompileProgramFromSPIRV:
-                  case MessageType_BuildProgramWithBuiltins:
-                  case MessageType_BuildProgramWithDefinedBuiltins:
-                  case MessageType_LinkProgram:
-                  case MessageType_FreeProgram:
-                  case MessageType_MigrateD2D:
-                  case MessageType_RdmaBufferRegistration:
-                  case MessageType_Shutdown: {
-                    Ctx->nonQueuedPush(R);
-                    break;
-                  }
-                  case MessageType_ReadBuffer:
-                  case MessageType_WriteBuffer:
-                  case MessageType_CopyBuffer:
-                  case MessageType_FillBuffer:
-                  case MessageType_ReadBufferRect:
-                  case MessageType_WriteBufferRect:
-                  case MessageType_CopyBufferRect:
-                  case MessageType_CopyImage2Buffer:
-                  case MessageType_CopyBuffer2Image:
-                  case MessageType_CopyImage2Image:
-                  case MessageType_ReadImageRect:
-                  case MessageType_WriteImageRect:
-                  case MessageType_FillImageRect:
-                  case MessageType_RunKernel:
-                  case MessageType_Barrier:
-                  case MessageType_Marker:
-                  case MessageType_RunCommandBuffer: {
-                    Ctx->queuedPush(R);
-                    break;
-                  }
-                  case MessageType_NotifyEvent: {
-                    // TODO: this message should probably contain an actual
-                    // status... (see also rdma thread)
-                    Ctx->notifyEvent(R->Body.event_id, CL_COMPLETE);
-                    delete R;
-                    break;
-                  }
-
-                  default: {
-                    Ctx->unknownRequest(R);
-                    break;
-                  }
-                  }
-
-                } else {
-                  POCL_MSG_ERR(
-                      "Client sent request for nonexistent context %" PRIu64
-                      ", ignoring \n",
-                      R->Body.session);
-                  delete R;
-                }
+                POCL_MSG_ERR("Wrong request on new connection, expected "
+                             "CreateOrAttachSession\n");
+                DroppedConnections.push_back(OpenClientConnections.at(i));
               }
-
-              /* R is now someone else's responsibility, simply "leak" it */
-              IncompleteRequests.at(i) = new Request();
             }
           } else {
             POCL_MSG_ERR("Something went wrong while reading request, closing "
@@ -1086,11 +997,6 @@ void PoclDaemon::readAllClientSocketsThread() {
           std::swap(OpenClientConnections.at(i), OpenClientConnections.back());
           OpenClientConnections.pop_back();
 
-          std::swap(SocketContexts.at(i), SocketContexts.back());
-          VirtualContextBase *vctx = SocketContexts.back();
-          DroppedVCtxs.insert(vctx);
-          SocketContexts.pop_back();
-
           std::swap(IncompleteRequests.at(i), IncompleteRequests.back());
           delete IncompleteRequests.back();
           IncompleteRequests.pop_back();
@@ -1101,37 +1007,29 @@ void PoclDaemon::readAllClientSocketsThread() {
       }
     }
     DroppedConnections.clear();
-
-    // TODO: The reconnect should have a time window as it holds resources.
-    // Especially with SVM on, it will hold the SVMPool which can be a large
-    // chunk of virt mem. Let's not enable reconnect by default until this is
-    // sanitized.
-    if (!pocl_get_bool_option("POCLD_ALLOW_CLIENT_RECONNECT", 0)) {
-      // Free unusued vctxs if reconnect is not enabled.
-      for (auto VContext : DroppedVCtxs) {
-        if (std::find(SocketContexts.begin(), SocketContexts.end(), VContext) !=
-            SocketContexts.end())
-          continue;
-        VContext->requestExit(0,
-                              "Client disconnected and reconnect not enabled.");
-        std::unique_lock<std::mutex> L(SessionListMtx);
-        uint64_t Session = 0;
-        for (auto it : ClientSessions) {
-          if (it.second == VContext) {
-            Session = it.first;
-            break;
-          }
-        }
-        if (Session != 0) {
-          SessionKeys.erase(Session);
-          ClientSessions.erase(Session);
-        }
-        delete VContext;
-      }
-    }
-    DroppedVCtxs.clear();
   }
 
   /* Close all remaining sockets, including the client listeners */
   OpenClientConnections.clear();
+}
+
+void PoclDaemon::contextDeleterThread() {
+  std::unique_lock<std::mutex> L(ContextDeleterMtx);
+  while (1) {
+    if (ContextDeleteQueue.empty()) {
+      if (exit_helper.exit_requested())
+        return;
+      ContextDeleterCond.wait(L);
+    } else {
+      VirtualContextBase *Ctx = ContextDeleteQueue.back();
+      ContextDeleteQueue.pop_back();
+      L.unlock();
+
+      POCL_MSG_PRINT_GENERAL("Deleting context...\n");
+      delete Ctx;
+      POCL_MSG_PRINT_GENERAL("Context deleted.\n");
+
+      L.lock();
+    }
+  }
 }

--- a/pocld/daemon.hh
+++ b/pocld/daemon.hh
@@ -89,27 +89,46 @@ public:
    * poll(2) is invoked, putting the thread to sleep until something happens.
    *
    * Once poll returns, two things happen: if there are new connection requests
-   * on the client listener sockets, they are accepted. Once both fds of the
-   * (command, stream) pairs have been obtained, the client handshake is
-   * performed and the fds are associated with a new or existing client context
-   * based on the handshake.
+   * on the client listener sockets, they are accepted.
    *
    * After the special case of the listener sockets, if there are further events
    * in the poll result, the respective fds are handed to Result::read for
    * reading a piece of the next command sent over that socket. Similar to the
    * pollfd list, the function keeps a list of in-flight Requests for this
-   * purpose. If there are any read errors or poll results indicating that a
-   * socket was closed, the corresponding fd is pushed into a list for cleanup.
+   * purpose. Once a valid handshake or request for a new session has been
+   * received, the fd is handed off to the respective VirtualCLContext.
    *
    * Finally, the function goes over the "dead" fds list, closes them and
    * removes the fd and its in-flight Request.
    */
   void readAllClientSocketsThread();
 
-  /** Block until the main I/O thread exits. */
+  /**
+   * \brief Push Ctx to the deleter thread to be destroyed
+   *
+   * Properly deinitializing a VirtualCLContext can take a bit of time, so that
+   * process is delegated to a separate thread in order to not block the socket
+   * polling thread.
+   */
+  void releaseContextDeferred(VirtualContextBase *Ctx) {
+    std::unique_lock<std::mutex> L(ContextDeleterMtx);
+    ContextDeleteQueue.push_back(Ctx);
+    ContextDeleterCond.notify_one();
+  }
+
+  /**
+   * Main loop for the thread in charge of deleting VirtualCLContexts
+   */
+  void contextDeleterThread();
+
+  /** Block until the main I/O and context deleter threads exit. */
   void waitForExit() {
     if (ClientPoller.joinable())
       ClientPoller.join();
+    if (ContextDeleter.joinable()) {
+      ContextDeleterCond.notify_one();
+      ContextDeleter.join();
+    }
   }
 
   /* returns nullptr on error */
@@ -121,18 +140,18 @@ private:
   /** Port numbers that the server is listening on */
   struct ServerPorts ListenPorts;
   std::vector<std::shared_ptr<Connection>> OpenClientConnections;
-  /** Hacky helper for keeping track of which context is associated with the
-   * socket at a given index so the contexts can be dropped when the socket
-   * disconnects if reconnecting is not allowed. */
-  std::vector<VirtualContextBase *> SocketContexts;
   size_t NumListenFds;
   std::mutex SessionListMtx;
   std::unordered_map<uint64_t, VirtualContextBase *> ClientSessions;
   std::unordered_map<uint64_t, std::array<uint8_t, AUTHKEY_LENGTH>> SessionKeys;
+  std::thread ContextDeleter;
+  std::mutex ContextDeleterMtx;
+  std::condition_variable ContextDeleterCond;
+  std::vector<VirtualContextBase *> ContextDeleteQueue;
   std::atomic_uint64_t LastSessionId;
   std::thread ClientPoller;
-  peer_listener_data_t peer_listener_data;
-  std::thread peer_listener_th;
+  peer_listener_data_t PeerListenerData;
+  std::thread PeerListenerThread;
 #ifdef ENABLE_REMOTE_ADVERTISEMENT_AVAHI
   AvahiAdvertise *avahiAdvertiseP;
 #endif

--- a/pocld/reply_th.cc
+++ b/pocld/reply_th.cc
@@ -128,6 +128,17 @@ ReplyQueueThread::ReplyQueueThread(
 
 ReplyQueueThread::~ReplyQueueThread() {
   eh->requestExit(ThreadIdentifier.c_str(), 0);
+
+  {
+    std::unique_lock<std::mutex> Lock(IOMutex);
+    IONotifier.notify_one();
+  }
+
+  {
+    std::unique_lock<std::mutex> Lock(ConnectionGuard);
+    ConnectionNotifier.notify_one();
+  }
+
   IOThread.join();
 }
 
@@ -135,11 +146,8 @@ void ReplyQueueThread::pushReply(Reply *reply) {
   if (eh->exit_requested())
     return;
 
-  {
-    std::unique_lock<std::mutex> Lock(io_mutex);
-    IOInflight.push_back(reply);
-  }
-
+  std::unique_lock<std::mutex> Lock(IOMutex);
+  IOInflight.push_back(reply);
   IONotifier.notify_one();
 }
 
@@ -153,13 +161,27 @@ void ReplyQueueThread::setConnection(
 void ReplyQueueThread::writeThread() {
   size_t i = 0;
   while (1) {
-  RETRY:
     if (eh->exit_requested())
-      return;
+      break;
 
-    std::unique_lock<std::mutex> InflightLock(io_mutex);
+    {
+      std::unique_lock<std::mutex> ConnectionLock(ConnectionGuard);
+      if (Conn.get() == nullptr) {
+        ConnectionNotifier.wait(ConnectionLock);
+        continue;
+      }
+    }
+
+    std::unique_lock<std::mutex> InflightLock(IOMutex);
     if ((IOInflight.size() > 0)) {
       Reply *reply = IOInflight[i];
+      if (!reply) {
+        if (i != IOInflight.size() - 1) {
+          std::swap(IOInflight[i], IOInflight[IOInflight.size() - 1]);
+        }
+        IOInflight.pop_back();
+        continue;
+      }
       InflightLock.unlock();
 
       cl_int Status =
@@ -240,18 +262,23 @@ void ReplyQueueThread::writeThread() {
             uint32_t(reply->rep.failed));
 
         // WRITE REPLY
-        CHECK_WRITE_RETRY(Conn->writeFull(&reply->rep, sizeof(ReplyMsg_t)),
-                          ThreadIdentifier.c_str());
+        if (Conn->writeFull(&reply->rep, sizeof(ReplyMsg_t)) < 0) {
+          Conn.reset();
+          virtualContext->connectionLost();
+          continue;
+        }
 
         // TODO: handle reconnecting & resending when RDMA is used
         if (reply->extra_size > 0 && !reply->extra_data.empty()) {
           POCL_MSG_PRINT_INFO("%s: WRITING EXTRA: %" PRIuS " \n",
                               ThreadIdentifier.c_str(), reply->extra_size);
-          CHECK_WRITE_RETRY(
-              Conn->writeFull(reply->extra_data.data(), reply->extra_size),
-              ThreadIdentifier.c_str());
+          if (Conn->writeFull(reply->extra_data.data(), reply->extra_size) <
+              0) {
+            Conn.reset();
+            virtualContext->connectionLost();
+            continue;
+          }
         }
-
         ConnectionLock.unlock();
 
         POCL_MSG_PRINT_GENERAL("%s: MESSAGE FULLY WRITTEN, ID: %" PRIu64 "\n",
@@ -288,11 +315,9 @@ void ReplyQueueThread::writeThread() {
         // InflightLock is dropped after this
       }
     } else {
-      auto now = std::chrono::system_clock::now();
-      std::chrono::duration<unsigned long> d(3);
-      now += d;
-      i = 0;
-      IONotifier.wait_until(InflightLock, now);
+      IONotifier.wait(InflightLock);
     }
   }
+
+  POCL_MSG_PRINT_GENERAL("%s: Terminating\n", ThreadIdentifier.c_str());
 }

--- a/pocld/reply_th.hh
+++ b/pocld/reply_th.hh
@@ -47,7 +47,7 @@ class ReplyQueueThread {
   std::string ThreadIdentifier;
   VirtualContextBase *virtualContext;
   std::vector<Reply *> IOInflight;
-  std::mutex io_mutex;
+  std::mutex IOMutex;
   std::condition_variable IONotifier;
   std::thread IOThread;
   ExitHelper *eh;

--- a/pocld/request_th.cc
+++ b/pocld/request_th.cc
@@ -41,7 +41,7 @@
 RequestQueueThread::RequestQueueThread(std::shared_ptr<Connection> Conn,
                                        VirtualContextBase *c, ExitHelper *e,
                                        const char *id_str)
-    : InboundConnection(Conn), virtualContext(c), eh(e),
+    : InboundConnection(Conn), VirtualContext(c), eh(e),
       ThreadIdentifier(id_str) {
   IOThread = std::thread{&RequestQueueThread::readThread, this};
 }
@@ -67,12 +67,13 @@ void RequestQueueThread::readThread() {
 
   while (1) {
     if (eh->exit_requested())
-      return;
+      break;
 
     std::unique_lock<std::mutex> l(ConnectionGuard);
-
-    if (InboundConnection.get() == nullptr)
+    if (InboundConnection.get() == nullptr) {
       ConnectionNotifier.wait(l);
+      continue;
+    }
 
     pfd.fd = InboundConnection->pollableFd();
     /* HACK: Timeout after 1s so peer request threads don't get stuck when the
@@ -90,26 +91,29 @@ void RequestQueueThread::readThread() {
         // system is out of memory. Can't really recover from either case at
         // runtime so let's just bail.
         eh->requestExit("Fatal error during poll(2) in RequestQueueThread", e);
-        return;
+        VirtualContext->connectionLost();
+        break;
       }
     }
     if (pfd.revents & (POLLERR | POLLNVAL | POLLHUP | POLLRDHUP)) {
       InboundConnection.reset();
+      VirtualContext->connectionLost();
       continue;
     }
     if (!(pfd.revents & POLLIN))
       continue;
 
-    Request *IncomingRequest = new(std::nothrow) Request();
+    Request *IncomingRequest = new (std::nothrow) Request();
     if (IncomingRequest == nullptr) {
       eh->requestExit("Out of host memory in in RequestQueueThread", ENOMEM);
-      return;
+      break;
     }
     while (!IncomingRequest->IsFullyRead) {
       if (!IncomingRequest->read(InboundConnection.get())) {
         delete IncomingRequest;
         IncomingRequest = nullptr;
         InboundConnection.reset();
+        VirtualContext->connectionLost();
         continue;
       }
     }
@@ -117,6 +121,7 @@ void RequestQueueThread::readThread() {
     l.unlock();
 
     switch (IncomingRequest->Body.message_type) {
+    case MessageType_ServerInfo:
     case MessageType_ConnectPeer:
     case MessageType_DeviceInfo:
     case MessageType_CreateBuffer:
@@ -127,6 +132,8 @@ void RequestQueueThread::readThread() {
     case MessageType_FreeSampler:
     case MessageType_CreateImage:
     case MessageType_FreeImage:
+    case MessageType_CreateCommandBuffer:
+    case MessageType_FreeCommandBuffer:
     case MessageType_CreateKernel:
     case MessageType_FreeKernel:
     case MessageType_BuildProgramFromSource:
@@ -134,13 +141,14 @@ void RequestQueueThread::readThread() {
     case MessageType_BuildProgramFromSPIRV:
     case MessageType_CompileProgramFromSource:
     case MessageType_CompileProgramFromSPIRV:
-    case MessageType_LinkProgram:
     case MessageType_BuildProgramWithBuiltins:
+    case MessageType_BuildProgramWithDefinedBuiltins:
+    case MessageType_LinkProgram:
     case MessageType_FreeProgram:
     case MessageType_MigrateD2D:
     case MessageType_RdmaBufferRegistration:
     case MessageType_Shutdown: {
-      virtualContext->nonQueuedPush(IncomingRequest);
+      VirtualContext->nonQueuedPush(IncomingRequest);
       break;
     }
     case MessageType_ReadBuffer:
@@ -156,24 +164,27 @@ void RequestQueueThread::readThread() {
     case MessageType_ReadImageRect:
     case MessageType_WriteImageRect:
     case MessageType_FillImageRect:
-    case MessageType_RunKernel: {
-      virtualContext->queuedPush(IncomingRequest);
+    case MessageType_RunKernel:
+    case MessageType_Barrier:
+    case MessageType_Marker:
+    case MessageType_RunCommandBuffer: {
+      VirtualContext->queuedPush(IncomingRequest);
       break;
     }
     case MessageType_NotifyEvent: {
       // TODO: this message should probably contain an actual status... (see
       // also rdma thread)
-      virtualContext->notifyEvent(IncomingRequest->Body.event_id, CL_COMPLETE);
+      VirtualContext->notifyEvent(IncomingRequest->Body.event_id, CL_COMPLETE);
       delete IncomingRequest;
       break;
     }
 
     default: {
-      virtualContext->unknownRequest(IncomingRequest);
+      VirtualContext->unknownRequest(IncomingRequest);
       break;
     }
     }
-
-    // TODO reply fail
   }
+
+  POCL_MSG_PRINT_GENERAL("%s: Terminating\n", ThreadIdentifier.c_str());
 }

--- a/pocld/request_th.hh
+++ b/pocld/request_th.hh
@@ -39,7 +39,7 @@ class RequestQueueThread {
   std::mutex ConnectionGuard;
   std::condition_variable ConnectionNotifier;
   std::shared_ptr<Connection> InboundConnection;
-  VirtualContextBase *virtualContext;
+  VirtualContextBase *VirtualContext;
   std::thread IOThread;
   ExitHelper *eh;
   std::string ThreadIdentifier;

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -913,6 +913,7 @@ void SharedCLContext::notifyEvent(uint64_t id, cl_int status) {
     POCL_MSG_PRINT_EVENTS(
         "no event %" PRIu64 " found, creating new user event\n", id);
   }
+  lock.unlock();
   for (auto &q : QueueMap) {
     q.second->notify();
   }

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -147,7 +147,7 @@ class SharedCLContext final : public SharedContextBase {
 
   std::mutex MainMutex;
   // threads
-  std::unordered_map<uint32_t, CommandQueueUPtr> QueueThreadMap;
+  std::unordered_map<uint32_t, CommandQueueUPtr> QueueMap;
 
   ReplyQueueThread *slow, *fast;
 
@@ -667,7 +667,7 @@ SharedCLContext::SharedCLContext(cl::Platform *p, unsigned pid,
   for (size_t i = 0; i < CLDevices.size(); ++i) {
     QueueIDMap[DEFAULT_QUE_ID + i] = clCommandQueuePtr(new cl::CommandQueue(
         ContextWithAllDevices, CLDevices[i])); // TODO QUEUE_PROPERTIES
-    QueueThreadMap[DEFAULT_QUE_ID + i] =
+    QueueMap[DEFAULT_QUE_ID + i] =
         CommandQueueUPtr(new CommandQueue(this, (DEFAULT_QUE_ID + i), i, s, f));
   }
 
@@ -887,7 +887,7 @@ void SharedCLContext::queuedPush(Request *req) {
     std::unique_lock<std::mutex> lock(MainMutex);
     // TODO reply fail
     assert(QueueIDMap.find(cq_id) != QueueIDMap.end());
-    CommandQueue *cq = QueueThreadMap[cq_id].get();
+    CommandQueue *cq = QueueMap[cq_id].get();
     assert(cq != nullptr);
     cq->push(req);
   }
@@ -913,7 +913,7 @@ void SharedCLContext::notifyEvent(uint64_t id, cl_int status) {
     POCL_MSG_PRINT_EVENTS(
         "no event %" PRIu64 " found, creating new user event\n", id);
   }
-  for (auto &q : QueueThreadMap) {
+  for (auto &q : QueueMap) {
     q.second->notify();
   }
 }
@@ -1302,7 +1302,7 @@ int SharedCLContext::createQueue(uint32_t queue_id, uint32_t dev_id) {
   {
     std::unique_lock<std::mutex> lock(MainMutex);
     QueueIDMap[queue_id] = p;
-    QueueThreadMap[queue_id] = std::move(que);
+    QueueMap[queue_id] = std::move(que);
   }
   POCL_MSG_PRINT_INFO("P %u Create Queue %" PRIu32 "\n", plat_id, queue_id);
   return 0;
@@ -1311,11 +1311,11 @@ int SharedCLContext::createQueue(uint32_t queue_id, uint32_t dev_id) {
 int SharedCLContext::freeQueue(uint32_t queue_id) {
   {
     std::unique_lock<std::mutex> lock(MainMutex);
-    if (QueueThreadMap.find(queue_id) == QueueThreadMap.end()) {
+    if (QueueMap.find(queue_id) == QueueMap.end()) {
       POCL_MSG_ERR("P %u Free Queue %" PRIu32 "\n", plat_id, queue_id);
       return CL_INVALID_COMMAND_QUEUE;
     }
-    QueueThreadMap.erase(queue_id);
+    QueueMap.erase(queue_id);
     QueueIDMap.erase(queue_id);
   }
   POCL_MSG_PRINT_INFO("P %u Free Queue %" PRIu32 "\n", plat_id, queue_id);

--- a/pocld/virtual_cl_context.cc
+++ b/pocld/virtual_cl_context.cc
@@ -22,6 +22,7 @@
    IN THE SOFTWARE.
 */
 
+#include <atomic>
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
@@ -47,6 +48,7 @@
 #include "traffic_monitor.hh"
 
 #include "messages.h"
+#include "pocl_runtime_config.h"
 
 SharedContextBase *createSharedCLContext(cl::Platform *platform, size_t pid,
                                          VirtualContextBase *v,
@@ -95,6 +97,9 @@ public:
 class VirtualCLContext : public VirtualContextBase {
   PoclDaemon *Daemon;
   ExitHelper ExitSignal;
+  std::atomic<int> DeleteRequested;
+  RequestQueueThreadUPtr ReadSlow;
+  RequestQueueThreadUPtr ReadFast;
   ReplyQueueThreadUPtr WriteSlow;
   ReplyQueueThreadUPtr WriteFast;
 #ifdef ENABLE_RDMA
@@ -150,6 +155,7 @@ public:
   VirtualCLContext() = default;
 
   ~VirtualCLContext() {
+    POCL_MSG_PRINT_GENERAL("VCTX: ~VirtualCLContext\n");
     // stop threads
     assert(ExitSignal.exit_requested());
     MainCond.notify_one();
@@ -158,11 +164,12 @@ public:
     QueuedCond.notify_one();
     if (QueuedThread.joinable())
       QueuedThread.join();
-    POCL_MSG_PRINT_GENERAL("VCTX: DEST\n");
 
-    // Wake up IO threads in case they were waiting for a connection
-    WriteFast->setConnection(nullptr);
-    WriteSlow->setConnection(nullptr);
+    // Wake up IO threads so they can exit
+    ReadFast->setConnection(nullptr);
+    ReadSlow->setConnection(nullptr);
+    WriteFast->pushReply(nullptr);
+    WriteSlow->pushReply(nullptr);
 
     // make sure no shared context tries to broadcast stuff
     std::unique_lock<std::mutex> Lock(MainMutex);
@@ -177,8 +184,10 @@ public:
   virtual size_t init(PoclDaemon *d, ClientConnections_t conns,
                       uint64_t session, CreateOrAttachSessionMsg_t &params);
 
-  virtual void replaceConnections(std::shared_ptr<Connection> Command,
-                                  std::shared_ptr<Connection> Stream) override;
+  virtual void setConnection(std::shared_ptr<Connection> Conn, bool IsFast,
+                             bool IsReplyChannel) override;
+
+  virtual void connectionLost() override;
 
   virtual void nonQueuedPush(Request *req) override;
 
@@ -264,6 +273,7 @@ size_t VirtualCLContext::init(PoclDaemon *d, ClientConnections_t conns,
   current_printf_position = 0;
   TotalDevices = 0;
   peer_id = params.peer_id;
+  DeleteRequested = 0;
 #ifdef ENABLE_RDMA
   client_uses_rdma = params.use_rdma;
   if (client_uses_rdma) {
@@ -273,10 +283,6 @@ size_t VirtualCLContext::init(PoclDaemon *d, ClientConnections_t conns,
 
   std::string id_string = std::to_string(session);
   netstat.reset(new TrafficMonitor(&ExitSignal, id_string));
-  if (conns.low_latency.get())
-    conns.low_latency->setMeter(netstat);
-  if (conns.bulk_throughput.get())
-    conns.bulk_throughput->setMeter(netstat);
 
 #ifdef ENABLE_RDMA
   if (client_uses_rdma) {
@@ -288,10 +294,10 @@ size_t VirtualCLContext::init(PoclDaemon *d, ClientConnections_t conns,
                             &client_mem_regions, &client_regions_mutex));
   }
 #endif
-  WriteSlow = ReplyQueueThreadUPtr(
-      new ReplyQueueThread(conns.bulk_throughput, this, &ExitSignal, "WT_S"));
-  WriteFast = ReplyQueueThreadUPtr(
-      new ReplyQueueThread(conns.low_latency, this, &ExitSignal, "WT_F"));
+  WriteSlow.reset(new ReplyQueueThread({}, this, &ExitSignal, "WT_S"));
+  WriteFast.reset(new ReplyQueueThread({}, this, &ExitSignal, "WT_F"));
+  ReadSlow.reset(new RequestQueueThread({}, this, &ExitSignal, "RT_S"));
+  ReadFast.reset(new RequestQueueThread({}, this, &ExitSignal, "RT_F"));
 
   peers = PeerHandlerUPtr(new PeerHandler(peer_id, conns.incoming_peer_mutex,
                                           conns.incoming_peer_queue, this,
@@ -307,16 +313,28 @@ size_t VirtualCLContext::init(PoclDaemon *d, ClientConnections_t conns,
   return TotalDevices;
 }
 
-void VirtualCLContext::replaceConnections(
-    std::shared_ptr<Connection> Latency,
-    std::shared_ptr<Connection> Throughput) {
-  if (Latency.get()) {
-    Latency->setMeter(netstat);
-    WriteFast->setConnection(Latency);
+void VirtualCLContext::setConnection(std::shared_ptr<Connection> NewConnection,
+                                     bool IsFast, bool IsReplyChannel) {
+  NewConnection->setMeter(netstat);
+  if (IsFast) {
+    if (IsReplyChannel)
+      WriteFast->setConnection(NewConnection);
+    else
+      ReadFast->setConnection(NewConnection);
+  } else {
+    if (IsReplyChannel)
+      WriteSlow->setConnection(NewConnection);
+    else
+      ReadSlow->setConnection(NewConnection);
   }
-  if (Throughput.get()) {
-    Throughput->setMeter(netstat);
-    WriteSlow->setConnection(Throughput);
+}
+
+void VirtualCLContext::connectionLost() {
+  if (!pocl_get_bool_option("POCLD_ALLOW_CLIENT_RECONNECT", 0) &&
+      !DeleteRequested) {
+    DeleteRequested = 1;
+    ExitSignal.requestExit("Connection lost", 1);
+    Daemon->releaseContextDeferred(this);
   }
 }
 

--- a/pocld/virtual_cl_context.cc
+++ b/pocld/virtual_cl_context.cc
@@ -116,6 +116,11 @@ class VirtualCLContext : public VirtualContextBase {
   std::mutex MainMutex;
   std::deque<Request *> MainQueue;
 
+  std::thread QueuedThread;
+  std::condition_variable QueuedCond;
+  std::mutex QueuedMutex;
+  std::deque<Request *> QueuedQueue;
+
 #ifdef ENABLE_RDMA
   std::shared_ptr<RdmaConnection> client_rdma;
 #ifdef RDMA_USE_SVM
@@ -150,6 +155,9 @@ public:
     MainCond.notify_one();
     if (MainThread.joinable())
       MainThread.join();
+    QueuedCond.notify_one();
+    if (QueuedThread.joinable())
+      QueuedThread.join();
     POCL_MSG_PRINT_GENERAL("VCTX: DEST\n");
 
     // Wake up IO threads in case they were waiting for a connection
@@ -193,6 +201,8 @@ public:
   virtual void unknownRequest(Request *req) override;
 
   virtual int run() override;
+
+  virtual int queuedRun() override;
 
   virtual SharedContextBase *getDefaultContext() override {
     return SharedContextList.empty() ? nullptr : SharedContextList[0];
@@ -288,6 +298,7 @@ size_t VirtualCLContext::init(PoclDaemon *d, ClientConnections_t conns,
                                           &ExitSignal, netstat));
   initPlatforms();
   MainThread = std::move(std::thread(&VirtualCLContext::run, this));
+  QueuedThread = std::move(std::thread(&VirtualCLContext::queuedRun, this));
 
   POCL_MSG_PRINT_INFO("Created shared contexts for %" PRIuS
                       " platforms / %" PRIuS " devices\n",
@@ -356,7 +367,10 @@ void VirtualCLContext::queuedPush(Request *req) {
   POCL_MSG_PRINT_GENERAL(
       "VCTX QUEUED PUSH (msg: %" PRIu64 ", event: %" PRIu64 ")\n",
       uint64_t(req->Body.msg_id), uint64_t(req->Body.event_id));
-  SharedContextList[req->Body.pid]->queuedPush(req);
+
+  std::unique_lock<std::mutex> Lock(QueuedMutex);
+  QueuedQueue.push_back(req);
+  QueuedCond.notify_one();
 }
 
 void VirtualCLContext::notifyEvent(uint64_t event_id, cl_int status) {
@@ -428,6 +442,32 @@ int VirtualCLContext::checkPlatformDeviceValidity(Request *req) {
 
 /****************************************************************************************************************/
 /****************************************************************************************************************/
+
+int VirtualCLContext::queuedRun() {
+  Reply *reply;
+  while (1) {
+
+    if (ExitSignal.exit_requested()) {
+      auto e = ExitSignal.status();
+      POCL_MSG_PRINT_GENERAL("VCTX: exit req, status: %d\n", e);
+      return e;
+    }
+
+    std::unique_lock<std::mutex> Lock(QueuedMutex);
+    if (QueuedQueue.size() > 0) {
+      Request *R = QueuedQueue.front();
+      QueuedQueue.pop_front();
+      Lock.unlock();
+
+      SharedContextList[R->Body.pid]->queuedPush(R);
+    } else {
+      auto now = std::chrono::system_clock::now();
+      std::chrono::duration<unsigned long> d(3);
+      now += d;
+      QueuedCond.wait_until(Lock, now);
+    }
+  }
+}
 
 int VirtualCLContext::run() {
   Reply *reply;

--- a/pocld/virtual_cl_context.cc
+++ b/pocld/virtual_cl_context.cc
@@ -27,6 +27,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <memory>
+#include <queue>
 #include <unordered_set>
 
 #include "CL/cl_ext.h"
@@ -119,12 +120,12 @@ class VirtualCLContext : public VirtualContextBase {
   std::thread MainThread;
   std::condition_variable MainCond;
   std::mutex MainMutex;
-  std::deque<Request *> MainQueue;
+  std::queue<Request *> MainQueue;
 
   std::thread QueuedThread;
   std::condition_variable QueuedCond;
   std::mutex QueuedMutex;
-  std::deque<Request *> QueuedQueue;
+  std::queue<Request *> QueuedQueue;
 
 #ifdef ENABLE_RDMA
   std::shared_ptr<RdmaConnection> client_rdma;
@@ -373,7 +374,7 @@ void VirtualCLContext::nonQueuedPush(Request *req) {
                          uint64_t(req->Body.msg_id));
 
   std::unique_lock<std::mutex> Lock(MainMutex);
-  MainQueue.push_back(req);
+  MainQueue.push(req);
   MainCond.notify_one();
 }
 
@@ -387,7 +388,7 @@ void VirtualCLContext::queuedPush(Request *req) {
       uint64_t(req->Body.msg_id), uint64_t(req->Body.event_id));
 
   std::unique_lock<std::mutex> Lock(QueuedMutex);
-  QueuedQueue.push_back(req);
+  QueuedQueue.push(req);
   QueuedCond.notify_one();
 }
 
@@ -474,7 +475,7 @@ int VirtualCLContext::queuedRun() {
     std::unique_lock<std::mutex> Lock(QueuedMutex);
     if (QueuedQueue.size() > 0) {
       Request *R = QueuedQueue.front();
-      QueuedQueue.pop_front();
+      QueuedQueue.pop();
       Lock.unlock();
 
       SharedContextList[R->Body.pid]->queuedPush(R);
@@ -500,7 +501,7 @@ int VirtualCLContext::run() {
     std::unique_lock<std::mutex> Lock(MainMutex);
     if (MainQueue.size() > 0) {
       Request *request = MainQueue.front();
-      MainQueue.pop_front();
+      MainQueue.pop();
       Lock.unlock();
 
       reply = nullptr;

--- a/pocld/virtual_cl_context.hh
+++ b/pocld/virtual_cl_context.hh
@@ -38,8 +38,10 @@ class VirtualContextBase {
 public:
   virtual ~VirtualContextBase() {}
 
-  virtual void replaceConnections(std::shared_ptr<Connection> Command,
-                                  std::shared_ptr<Connection> Stream) = 0;
+  virtual void setConnection(std::shared_ptr<Connection> Conn, bool IsFast,
+                             bool IsReplyChannel) = 0;
+
+  virtual void connectionLost() = 0;
 
   virtual void nonQueuedPush(Request *req) = 0;
 

--- a/pocld/virtual_cl_context.hh
+++ b/pocld/virtual_cl_context.hh
@@ -61,6 +61,8 @@ public:
 
   virtual int run() = 0;
 
+  virtual int queuedRun() = 0;
+
   virtual SharedContextBase *getDefaultContext() = 0;
 };
 


### PR DESCRIPTION
Makes reorganize remote and pocld threads a bit to simplify things. Originally meant to resolve issues with connections timing out as socket receive buffers got overfull, but ended up making command processing substantially faster in some applications.