### PR TITLE
remote: Skip server-to-server notifications when possible

### DIFF
--- a/doc/sphinx/source/notes_7_3.rst
+++ b/doc/sphinx/source/notes_7_3.rst
@@ -46,6 +46,8 @@ Remote driver
   in the client's submit queue and pocld's reply queue.
 * Fixed some issues where one of the client-server sockets would abruptly
   disconnect for no obvious reason.
+* Server-to-server completion notifications are elided when possible to reduce
+  overhead in setups with a large number of servers in the same context
 * Server-to-server buffer migrations are now properly asynchronous
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/include/messages.h
+++ b/include/messages.h
@@ -713,6 +713,9 @@ extern "C"
     uint32_t did;
     uint32_t client_did;
     uint32_t waitlist_size;
+    /* Set to 1 for commands whose completion does not need to be broadcast to
+     * other remotes. */
+    uint32_t skip_peer_notify;
 
     uint32_t message_type;
     uint64_t obj_id;

--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -3348,6 +3348,8 @@ pocl_network_migrate_d2d (uint32_t cq_id, uint32_t mem_id, uint32_t size_id,
 
   ID_REQUEST (MigrateD2D, mem_id);
   req->cq_id = cq_id;
+  /* Migrations can generate unexpected cross-platform dependencies */
+  req->skip_peer_notify = 0;
 
   req->m.migrate.source_pid = source->remote_platform_index;
   req->m.migrate.source_did = source->remote_device_index;
@@ -3383,6 +3385,7 @@ pocl_network_read (uint32_t cq_id, remote_device_data_t *ddata,
 
   ID_REQUEST (ReadBuffer, mem_id);
   req->cq_id = cq_id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
   req->m.read.src_offset = offset;
   req->m.read.size = size;
   req->m.read.content_size_id = size_id;
@@ -3414,6 +3417,7 @@ pocl_network_write (uint32_t cq_id, remote_device_data_t *ddata,
 
   ID_REQUEST (WriteBuffer, mem_id);
   req->cq_id = cq_id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
   req->m.write.dst_offset = offset;
   req->m.write.size = size;
 
@@ -3457,6 +3461,7 @@ pocl_network_copy (uint32_t cq_id, remote_device_data_t *ddata,
 
   REQUEST (CopyBuffer);
   req->cq_id = cq_id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
   req->m.copy.src_buffer_id = src_id;
   req->m.copy.dst_buffer_id = dst_id;
   req->m.copy.size_buffer_id = content_size_id;
@@ -3489,6 +3494,7 @@ pocl_network_read_rect (uint32_t cq_id, remote_device_data_t *ddata,
 
   ID_REQUEST (ReadBufferRect, src_id);
   req->cq_id = cq_id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
 
   req->m.read_rect.buffer_origin.x = buffer_origin[0];
   req->m.read_rect.buffer_origin.y = buffer_origin[1];
@@ -3529,6 +3535,7 @@ pocl_network_write_rect (uint32_t cq_id, remote_device_data_t *ddata,
 
   ID_REQUEST (WriteBufferRect, dst_id);
   req->cq_id = cq_id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
 
   req->m.write_rect.buffer_origin.x = buffer_origin[0];
   req->m.write_rect.buffer_origin.y = buffer_origin[1];
@@ -3579,6 +3586,7 @@ pocl_network_copy_rect (
 
   REQUEST (CopyBufferRect);
   req->cq_id = cq_id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
 
   req->m.copy_rect.src_buffer_id = src_id;
   req->m.copy_rect.dst_buffer_id = dst_id;
@@ -3620,6 +3628,7 @@ pocl_network_fill_buffer (uint32_t cq_id, remote_device_data_t *ddata,
 
   ID_REQUEST (FillBuffer, mem_id);
   req->cq_id = cq_id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
   req->m.fill_buffer.dst_offset = offset;
   req->m.fill_buffer.size = size;
   req->m.fill_buffer.pattern_size = pattern_size;
@@ -3655,6 +3664,7 @@ pocl_network_run_kernel (uint32_t cq_id, remote_device_data_t *ddata,
 
   ID_REQUEST (RunKernel, kernel_id);
   req->cq_id = cq_id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
   req->m.run_kernel.global = global;
   req->m.run_kernel.local = local;
   req->m.run_kernel.offset = offset;
@@ -3716,6 +3726,7 @@ pocl_network_barrier_or_marker (uint32_t cq_id,
   if (node->type == CL_COMMAND_BARRIER)
     req->message_type = MessageType_Barrier;
   req->cq_id = node->sync.event.event->queue->id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
 
   SEND_REQ_FAST;
 
@@ -3734,6 +3745,7 @@ pocl_network_run_command_buffer (remote_device_data_t *ddata,
 
   ID_REQUEST (RunCommandBuffer, node->command.replay.buffer->id);
   req->cq_id = node->sync.event.event->queue->id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
 
   TP_COMMAND_BUFFER (req->msg_id, node->sync.event.event->id,
                      node->command.run_cmdbuf.id, node->sync.event.event->id);
@@ -3758,6 +3770,7 @@ pocl_network_copy_image_rect (uint32_t cq_id, remote_device_data_t *ddata,
 
   REQUEST (CopyImage2Image);
   req->cq_id = cq_id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
   req->m.copy_img2img.src_image_id = src_remote_id;
   req->m.copy_img2img.dst_image_id = dst_remote_id;
 
@@ -3794,6 +3807,7 @@ pocl_network_copy_buf2img (uint32_t cq_id, remote_device_data_t *ddata,
 
   ID_REQUEST (CopyBuffer2Image, dst_remote_id);
   req->cq_id = cq_id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
 
   req->m.copy_buf2img.origin.x = origin[0];
   req->m.copy_buf2img.origin.y = origin[1];
@@ -3828,6 +3842,7 @@ pocl_network_write_image_rect (uint32_t cq_id, remote_device_data_t *ddata,
 
   ID_REQUEST (WriteImageRect, dst_remote_id);
   req->cq_id = cq_id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
 
   req->m.write_image_rect.origin.x = origin[0];
   req->m.write_image_rect.origin.y = origin[1];
@@ -3875,6 +3890,7 @@ pocl_network_copy_img2buf (uint32_t cq_id, remote_device_data_t *ddata,
 
   ID_REQUEST (CopyImage2Buffer, src_remote_id);
   req->cq_id = cq_id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
 
   req->m.copy_img2buf.origin.x = origin[0];
   req->m.copy_img2buf.origin.y = origin[1];
@@ -3908,6 +3924,7 @@ pocl_network_read_image_rect (uint32_t cq_id, remote_device_data_t *ddata,
 
   ID_REQUEST (ReadImageRect, src_remote_id);
   req->cq_id = cq_id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
 
   /* REPLY */
   netcmd->rep_extra_data = p;
@@ -3944,6 +3961,7 @@ pocl_network_fill_image (uint32_t cq_id, remote_device_data_t *ddata,
 
   ID_REQUEST (FillImageRect, image_id);
   req->cq_id = cq_id;
+  req->skip_peer_notify = node->sync.event.event->implicit_event;
 
   req->m.fill_image.origin.x = origin[0];
   req->m.fill_image.origin.y = origin[1];

--- a/lib/CL/devices/remote/communication.c
+++ b/lib/CL/devices/remote/communication.c
@@ -912,9 +912,37 @@ pocl_remote_reader_pthread (void *aa)
       int fd = connection->fd;
       if (fd < 0)
         {
+          int reconnected;
         TRY_RECONNECT:
-          connection->fd = -1;
-          break;
+          reconnected = pocl_remote_reconnect_socket (remote, connection);
+          if (reconnected != CL_SUCCESS)
+            {
+              if (connection->reconnect_attempts
+                  >= POCL_REMOTE_RECONNECT_MAX_ATTEMPTS)
+                {
+                  network_command *cmd = NULL, *tmp = NULL;
+                  POCL_LOCK (inflight->mutex);
+                  /* Each command in the inflight queue of the failed server
+                   * has to be handled and marked as failed to prevent
+                   * deadlock. */
+                  DL_FOREACH_SAFE (inflight->queue, cmd, tmp)
+                    {
+                      DL_DELETE (inflight->queue, cmd);
+                      finish_running_cmd (remote, cmd, NETCMD_FAILED);
+                    }
+                  POCL_UNLOCK (inflight->mutex);
+
+#if defined(ENABLE_REMOTE_DISCOVERY_AVAHI)                                    \
+  || defined(ENABLE_REMOTE_DISCOVERY_DHT)                                     \
+  || defined(ENABLE_REMOTE_DISCOVERY_ANDROID)
+                  POCL_LOCK (connection->discovery_reconnect_guard.mutex);
+                  POCL_WAIT_COND (connection->discovery_reconnect_guard.cond,
+                                  connection->discovery_reconnect_guard.mutex);
+                  POCL_UNLOCK (connection->discovery_reconnect_guard.mutex);
+#endif
+                }
+              continue;
+            }
         }
 
       /* READ MSG */
@@ -1305,8 +1333,39 @@ pocl_remote_writer_pthread (void *aa)
           if (0)
             {
             /* This is only hit if there is an error from CHECK_WRITE */
+            int reconnected;
             TRY_RECONNECT:
-              return NULL;
+              reconnected = pocl_remote_reconnect_socket (remote, connection);
+              if (reconnected != CL_SUCCESS)
+                {
+                  if (connection->reconnect_attempts
+                      >= POCL_REMOTE_RECONNECT_MAX_ATTEMPTS)
+                    {
+                      network_command *cmd = NULL, *tmp = NULL;
+                      POCL_LOCK (this->mutex);
+                      /* Each command in the inflight queue of the failed
+                       * server has to be handled and marked as failed to
+                       * prevent deadlock. */
+                      DL_FOREACH_SAFE (this->queue, cmd, tmp)
+                        {
+                          DL_DELETE (this->queue, cmd);
+                          finish_running_cmd (remote, cmd, NETCMD_FAILED);
+                        }
+                      POCL_UNLOCK (this->mutex);
+
+#if defined(ENABLE_REMOTE_DISCOVERY_AVAHI)                                    \
+  || defined(ENABLE_REMOTE_DISCOVERY_DHT)                                     \
+  || defined(ENABLE_REMOTE_DISCOVERY_ANDROID)
+                      POCL_LOCK (connection->discovery_reconnect_guard.mutex);
+                      POCL_WAIT_COND (
+                        connection->discovery_reconnect_guard.cond,
+                        connection->discovery_reconnect_guard.mutex);
+                      POCL_UNLOCK (
+                        connection->discovery_reconnect_guard.mutex);
+#endif
+                    }
+                  continue;
+                }
             }
 
           /* WRITE DATA */

--- a/lib/CL/pocl_mem_management.c
+++ b/lib/CL/pocl_mem_management.c
@@ -113,7 +113,7 @@ _cl_command_node* pocl_mem_manager_new_command ()
   if ((cmd = mm->cmd_list))
     LL_DELETE (mm->cmd_list, cmd);
   POCL_UNLOCK (mm->cmd_lock);
-  
+
   if (cmd)
     {
       memset (cmd, 0, sizeof (struct _cl_command_node));
@@ -143,7 +143,7 @@ event_node* pocl_mem_manager_new_event_node ()
   if ((ed = mm->event_node_list))
     LL_DELETE (mm->event_node_list, ed);
   POCL_UNLOCK (mm->event_node_lock);
-  
+
   if (ed)
     {
       memset (ed, 0, sizeof(event_node));
@@ -900,6 +900,8 @@ FINISH_VER_SETUP:
 
       cmd_export->command.migrate.type = ENQUEUE_MIGRATE_TYPE_D2H;
       cmd_export->command.migrate.implicit = 1;
+      cmd_export->command.migrate.last_write_id
+        = previous_last_event ? previous_last_event->id : 0;
       cmd_export->command.migrate.migration_size = migration_size;
       cmd_export->command.migrate.num_buffers = 1;
       cmd_export->migr_infos
@@ -949,6 +951,8 @@ FINISH_VER_SETUP:
           cmd_import->command.migrate.implicit = 1;
           cmd_import->command.migrate.migration_size = migration_size;
         }
+      cmd_import->command.migrate.last_write_id
+        = previous_last_event ? previous_last_event->id : 0;
       cmd_import->command.migrate.num_buffers = 1;
       cmd_import->migr_infos
         = pocl_append_unique_migration_info (NULL, mem, 0);

--- a/pocld/rdma_reply_th.cc
+++ b/pocld/rdma_reply_th.cc
@@ -143,11 +143,23 @@ void RdmaReplyThread::rdmaWriterThread() {
         Netstat->txConfirmed(sizeof(ReplyMsg_t) + data_size);
 
       virtualContext->notifyEvent(reply->req->Body.event_id, CL_COMPLETE);
-      Request peer_notice{};
-      peer_notice.Body.msg_id = reply->rep.msg_id;
-      peer_notice.Body.event_id = reply->req->Body.event_id;
-      peer_notice.Body.message_type = MessageType_NotifyEvent;
-      virtualContext->broadcastToPeers(peer_notice);
+      ReplyMessageType t =
+          static_cast<ReplyMessageType>(reply->req->Body.message_type);
+
+      if (!reply->req->Body.skip_peer_notify) {
+        Request PeerNotice{};
+        PeerNotice.Body.msg_id = reply->rep.msg_id;
+        PeerNotice.Body.event_id = reply->req->Body.event_id;
+        PeerNotice.Body.message_type = MessageType_NotifyEvent;
+        POCL_MSG_PRINT_EVENTS(
+            "Notify for %s %lu (%lu)\n", pocld_reply_type_to_str(t),
+            reply->req->Body.event_id, reply->req->Body.msg_id);
+        virtualContext->broadcastToPeers(PeerNotice);
+      } else {
+        POCL_MSG_PRINT_EVENTS(
+            "Skipping notify for %s %lu (%lu)\n", pocld_reply_type_to_str(t),
+            reply->req->Body.event_id, reply->req->Body.msg_id);
+      }
 
       delete reply;
     } else {

--- a/pocld/reply_th.cc
+++ b/pocld/reply_th.cc
@@ -283,11 +283,21 @@ void ReplyQueueThread::writeThread() {
 
       if (Completed->event()) {
         virtualContext->notifyEvent(Completed->req->Body.event_id, Status);
-        Request PeerNotice{};
-        PeerNotice.Body.msg_id = Completed->rep.msg_id;
-        PeerNotice.Body.event_id = Completed->req->Body.event_id;
-        PeerNotice.Body.message_type = MessageType_NotifyEvent;
-        virtualContext->broadcastToPeers(PeerNotice);
+
+        if (!Completed->req->Body.skip_peer_notify) {
+          Request PeerNotice{};
+          PeerNotice.Body.msg_id = Completed->rep.msg_id;
+          PeerNotice.Body.event_id = Completed->req->Body.event_id;
+          PeerNotice.Body.message_type = MessageType_NotifyEvent;
+          POCL_MSG_PRINT_EVENTS(
+              "Notify for %s %lu (%lu)\n", pocld_reply_type_to_str(t),
+              Completed->req->Body.event_id, Completed->req->Body.msg_id);
+          virtualContext->broadcastToPeers(PeerNotice);
+        } else {
+          POCL_MSG_PRINT_EVENTS(
+              "Skipping notify for %s %lu (%lu)\n", pocld_reply_type_to_str(t),
+              Completed->req->Body.event_id, Completed->req->Body.msg_id);
+        }
       }
 
       // pop the successfully written reply from the queue

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -873,10 +873,13 @@ void SharedCLContext::notifyEvent(uint64_t id, cl_int status) {
     auto Res = Eventmap.insert({id, u});
     if (Res.second) {
       POCL_MSG_PRINT_EVENTS("Created user event for %" PRIu64 "\n", id);
+    } else {
+      POCL_MSG_PRINT_EVENTS("Event %" PRIu64 " was already registered\n", id);
     }
     Evt = Res.first->second;
   }
 
+  // Go through pending commands and unblock any that depend on this event
   for (auto &q : QueueMap) {
     q.second->notify({id, Evt});
   }

--- a/pocld/virtual_cl_context.cc
+++ b/pocld/virtual_cl_context.cc
@@ -1271,4 +1271,3 @@ VirtualContextBase *createVirtualContext(PoclDaemon *d,
   vctx->init(d, conns, session, params);
   return vctx;
 }
-


### PR DESCRIPTION
I.e. when the application hasn't taken a reference to the event in question and thus can't add it as a dependency on a command queue on a different server.

Additionally, the previous changes in the PR stack make it possible to get rid of the blocking read in server-to-server migrations, making them properly asynchronous.