### PR TITLE
remote: Kernel build fixes

### DIFF
--- a/doc/sphinx/source/notes_7_3.rst
+++ b/doc/sphinx/source/notes_7_3.rst
@@ -49,6 +49,9 @@ Remote driver
 * Server-to-server completion notifications are elided when possible to reduce
   overhead in setups with a large number of servers in the same context
 * Server-to-server buffer migrations are now properly asynchronous
+* Fixes for compiling kernels for multiple devices
+* Fixed fetching program binaries and recreating programs from previously built
+  binaries
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 OpenASIP (ttasim) driver

--- a/lib/CL/devices/remote/remote.c
+++ b/lib/CL/devices/remote/remote.c
@@ -1242,12 +1242,6 @@ int pocl_remote_link_program (cl_program program, cl_uint device_i,
 
   char program_bc_path[POCL_MAX_PATHNAME_LENGTH];
 
-  /* We are creating a new program out of the previously compiled programs,
-     there is no build dir for the linked program yet. */
-  create_build_hash (program, device, device_i);
-  pocl_cache_create_program_cachedir (program, device_i, NULL, 0,
-                                      program_bc_path);
-
   num_relevant_devices = setup_relevant_devices (
       program, device, build_indexes, build_logs, relevant_devices,
       relevant_platforms, binaries, binary_sizes, &total_binary_request_size);
@@ -1306,6 +1300,9 @@ int pocl_remote_link_program (cl_program program, cl_uint device_i,
         assert (program->binary_sizes[real_i] > 0);
         POCL_MSG_PRINT_REMOTE ("BINARY SIZE [%u]: %zu \n", real_i,
                                program->binary_sizes[real_i]);
+        create_build_hash (program, device, device_i);
+        pocl_cache_create_program_cachedir (program, device_i, NULL, 0,
+                                            program_bc_path);
 
         pocl_cache_program_bc_path (program_bc_path, program, real_i);
         err = pocl_cache_write_generic_objfile (

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -3397,7 +3397,10 @@ int SharedCLContext::runCommandBuffer(uint64_t ev_id, EventTiming_t &evt,
         cl::Buffer *b = nullptr;
         { FIND_BUFFER; }
         cl::CommandQueue *cq = &Queues[R->Body.cq_id];
-        std::vector<cl::Event> dependencies = std::move(Deps);
+        // Alias the correct values to the names that fillB expects. Note that
+        // this shadows the respective function parameters in this scope.
+        std::vector<cl::Event> Dependencies = std::move(Deps);
+        cl::Event &event = InternalEvent;
         switch (R->Body.m.fill_buffer.pattern_size) {
         case 1:
           fillB(cl_uchar);

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -1659,8 +1659,15 @@ int SharedCLContext::buildOrLinkProgram(
     plat_binaries.resize(DeviceList.size());
     for (size_t i = 0; i < DeviceList.size(); ++i) {
       uint64_t id = ((uint64_t)plat_id << 32) + DeviceList[i];
-      assert(InputBinaries.find(id) != InputBinaries.end());
-      plat_binaries[i] = InputBinaries[id];
+      auto Bin = InputBinaries.find(id);
+      assert(Bin != InputBinaries.end());
+      plat_binaries[i] = Bin->second;
+    }
+    // The number of binaries MUST match the number of devices, so when working
+    // around multi-device driver issues, copy a likely valid binary for the
+    // devices that didn't get one from the client.
+    for (size_t i = DeviceList.size(); i < program->devices.size(); ++i) {
+      plat_binaries.push_back(InputBinaries.begin()->second);
     }
 
     clProgramPtr pp(new cl::Program(ContextWithAllDevices, program->devices,
@@ -1732,19 +1739,29 @@ int SharedCLContext::buildOrLinkProgram(
   }
 
   if (!LinkOnly) {
+    const char *Options = opts.c_str();
+    // When building from a binary, options should be either NULL or exactly the
+    // same options in the same order as when the binary was originally built,
+    // else behaviour is implementation-defined and in practice not usable.
+    if (is_binary)
+      Options = nullptr;
+
     // build
     if (CompileOnly) {
-      err = p->compile(opts, program->devices, {}, {});
+      err = p->compile(Options, program->devices, {}, {});
     } else {
-      err = p->build(program->devices, opts.c_str());
+      err = p->build(program->devices, Options);
     }
   }
 
   // even if build failed, return build log
   auto buildInfo = p->getBuildInfo<CL_PROGRAM_BUILD_LOG>();
   if (buildInfo.size() > 0) {
-    size_t i = 0;
+    size_t i, j = 0;
     for (const auto &pair : buildInfo) {
+      for (i = 0; i < DeviceList.size(); ++i)
+        if (pair.first == CLDevices[DeviceList[i]])
+          break;
       if (i < DeviceList.size()) {
         // assert (pair.first() == program->devices[i]);
         uint64_t id = ((uint64_t)plat_id << 32) + DeviceList[i];
@@ -1753,11 +1770,12 @@ int SharedCLContext::buildOrLinkProgram(
         POCL_MSG_PRINT_GENERAL("Platform %u Device %" PRIu32 " Build log: \n%s",
                                plat_id, DeviceList[i], build_logs[id].c_str());
       } else {
-        POCL_MSG_PRINT_GENERAL("Platform %u Unknown Device %" PRIuS
-                               " Build log: \n%s",
-                               plat_id, i, pair.second.c_str());
+        POCL_MSG_PRINT_GENERAL(
+            "Platform %u Unknown Device %u: %s Build log: \n%s", plat_id,
+            (unsigned)j, pair.first.getInfo<CL_DEVICE_NAME>().c_str(),
+            pair.second.c_str());
       }
-      ++i;
+      ++j;
     }
   }
 

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -2067,7 +2067,7 @@ int SharedCLContext::createKernel(uint32_t kernel_id, uint32_t program_id,
 
   if (!found) {
     POCL_MSG_ERR("Invalid kernel name: %s\n", name);
-    return CL_INVALID_ARG_VALUE;
+    return CL_INVALID_KERNEL_NAME;
   }
 
   k->isFakeBuiltin = program->isFakeBuiltin;

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -1470,6 +1470,7 @@ int SharedCLContext::buildOrLinkProgram(
   std::vector<cl::Platform> Platforms;
   cl::Platform::get(&Platforms);
   bool NvidiaPlatform = std::string(Platforms.at(plat_id).getInfo<CL_PLATFORM_NAME>()) == std::string("NVIDIA CUDA");
+  bool RocmPlatform = std::string(Platforms.at(plat_id).getInfo<CL_PLATFORM_NAME>()) == std::string("AMD Accelerated Parallel Processing");
 
   POCL_MSG_PRINT_INFO("P %u Building Program %" PRIu32 "\n", plat_id,
                       program_id);
@@ -1480,6 +1481,11 @@ int SharedCLContext::buildOrLinkProgram(
     assert(DeviceList[i] < CLDevices.size());
     program->devices[i] = CLDevices[DeviceList[i]];
   }
+
+  // ROCm 6.4.4 segfaults when linking multiple programs together if they were
+  // only compiled for a subset of devices in the context.
+  if (RocmPlatform)
+    program->devices = CLDevices;
 
   if (options == nullptr)
     options = "";

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -1467,17 +1467,9 @@ int SharedCLContext::buildOrLinkProgram(
   std::vector<cl::Kernel> prebuilt_kernels;
   SPIRVParser::OpenCLFunctionInfoMap KernelInfoMap;
 
-  size_t NvidiaCount = 0;
-  for (auto i : DeviceList) {
-    std::string vendor = CLDevices[i].getInfo<CL_DEVICE_VENDOR>();
-    std::string device_version = CLDevices[i].getInfo<CL_DEVICE_VERSION>();
-    if (vendor.find("NVIDIA") != std::string::npos &&
-        !(device_version.find("PoCL") != std::string::npos &&
-          device_version.find("CUDA") != std::string::npos)) {
-      NvidiaCount++;
-    }
-  }
-  bool AlwaysBuildAll = DeviceList.empty() || NvidiaCount > 0;
+  std::vector<cl::Platform> Platforms;
+  cl::Platform::get(&Platforms);
+  bool NvidiaPlatform = std::string(Platforms.at(plat_id).getInfo<CL_PLATFORM_NAME>()) == std::string("NVIDIA CUDA");
 
   POCL_MSG_PRINT_INFO("P %u Building Program %" PRIu32 "\n", plat_id,
                       program_id);
@@ -1498,14 +1490,13 @@ int SharedCLContext::buildOrLinkProgram(
   // from sources, but some implementations seem to return metadata
   // also for binaries/SPIR-V.
   //
-  // https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/
-  // clGetKernelArgInfo.html*/
+  // https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/clGetKernelArgInfo.html
   //
   // HACK: Strictly speaking -cl-kernel-arg-info is not a valid option to
   // clLinkProgram, but the proprietery NVIDIA driver seems to 1) accept it and
   // 2) strip argument info in clLinkProgram if that option is NOT given, so
   // special case NVIDIA-only builds.
-  if (NvidiaCount == DeviceList.size() || !LinkOnly) {
+  if (NvidiaPlatform || !LinkOnly) {
     opts += " -cl-kernel-arg-info";
   }
 
@@ -1735,16 +1726,10 @@ int SharedCLContext::buildOrLinkProgram(
 
   if (!LinkOnly) {
     // build
-    if (AlwaysBuildAll) {
-      // XXX: hacky workaround for wonky behaviour with certain drivers
-      // when compiling a program for only a subset of the context's devices
-      err = CompileOnly ? p->compile(opts.c_str()) : p->build(opts.c_str());
+    if (CompileOnly) {
+      err = p->compile(opts, program->devices, {}, {});
     } else {
-      if (CompileOnly) {
-        err = p->compile(opts, program->devices, {}, {});
-      } else {
-        err = p->build(program->devices, opts.c_str());
-      }
+      err = p->build(program->devices, opts.c_str());
     }
   }
 
@@ -1845,7 +1830,20 @@ int SharedCLContext::buildOrLinkProgram(
         uint64_t id = ((uint64_t)plat_id << 32) + DeviceList[i];
         POCL_MSG_PRINT_GENERAL("Writing binary for Dev ID: %u / %" PRIu32 " \n",
                                plat_id, DeviceList[i]);
-        output_binaries[id] = std::move(binaries[j]);
+        if (NvidiaPlatform) {
+          if (binaries[j].empty()) {
+            for (size_t n = 0; n < binaries.size(); ++n) {
+              if (!binaries[n].empty()) {
+                output_binaries[id] = binaries[n];
+                break;
+              }
+            }
+          } else {
+            output_binaries[id] = binaries[j];
+          }
+        } else {
+          output_binaries[id] = std::move(binaries[j]);
+        }
       }
     }
   }

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -1467,15 +1467,17 @@ int SharedCLContext::buildOrLinkProgram(
   std::vector<cl::Kernel> prebuilt_kernels;
   SPIRVParser::OpenCLFunctionInfoMap KernelInfoMap;
 
-  bool AlwaysBuildAll = DeviceList.empty();
+  size_t NvidiaCount = 0;
   for (auto i : DeviceList) {
     std::string vendor = CLDevices[i].getInfo<CL_DEVICE_VENDOR>();
     std::string device_version = CLDevices[i].getInfo<CL_DEVICE_VERSION>();
     if (vendor.find("NVIDIA") != std::string::npos &&
         !(device_version.find("PoCL") != std::string::npos &&
-          device_version.find("CUDA") != std::string::npos))
-      AlwaysBuildAll = true;
+          device_version.find("CUDA") != std::string::npos)) {
+      NvidiaCount++;
+    }
   }
+  bool AlwaysBuildAll = DeviceList.empty() || NvidiaCount > 0;
 
   POCL_MSG_PRINT_INFO("P %u Building Program %" PRIu32 "\n", plat_id,
                       program_id);
@@ -1492,13 +1494,33 @@ int SharedCLContext::buildOrLinkProgram(
 
   std::string opts(options);
 
-  /* Kernel argument information is only available when building
-     from sources, but some implementations seem to return metadata
-     also for binaries/SPIR-V.
+  // Kernel argument information is only available when building
+  // from sources, but some implementations seem to return metadata
+  // also for binaries/SPIR-V.
+  //
+  // https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/
+  // clGetKernelArgInfo.html*/
+  //
+  // HACK: Strictly speaking -cl-kernel-arg-info is not a valid option to
+  // clLinkProgram, but the proprietery NVIDIA driver seems to 1) accept it and
+  // 2) strip argument info in clLinkProgram if that option is NOT given, so
+  // special case NVIDIA-only builds.
+  if (NvidiaCount == DeviceList.size() || !LinkOnly) {
+    opts += " -cl-kernel-arg-info";
+  }
 
-     https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/
-     clGetKernelArgInfo.html*/
-  opts += " -cl-kernel-arg-info";
+  // HACK: pocl_build.c/process_options() replaces -cl-denorms-are-zero with a
+  // clang-specific option that is not valid to pass to OpenCL functions.
+  // Revert the change here to avoid problems with drivers that don't use clang
+  // to compile kernels.
+  {
+    const char *FdenormalStr = "-fdenormal-fp-math=positive-zero";
+    auto FdenormalPos = opts.find(FdenormalStr);
+    if (FdenormalPos != opts.npos) {
+      opts.replace(FdenormalPos, FdenormalPos + ::strlen(FdenormalStr),
+                   "-cl-denorms-are-zero");
+    }
+  }
 
   if (LinkOnly) {
     // Collect the previously built programs from the server-side cache and link

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -1498,11 +1498,10 @@ int SharedCLContext::buildOrLinkProgram(
   //
   // https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/clGetKernelArgInfo.html
   //
-  // HACK: Strictly speaking -cl-kernel-arg-info is not a valid option to
-  // clLinkProgram, but the proprietery NVIDIA driver seems to 1) accept it and
-  // 2) strip argument info in clLinkProgram if that option is NOT given, so
-  // special case NVIDIA-only builds.
-  if (NvidiaPlatform || !LinkOnly) {
+  // ROCm errors if this is passed to clLinkProgram but NVIDIA and PoCL will
+  // strip out argument info if it is only given to clCompileProgram and not
+  // clLinkProgram.
+  if (!(RocmPlatform && LinkOnly)) {
     opts += " -cl-kernel-arg-info";
   }
 

--- a/pocld/shared_cl_context.cc
+++ b/pocld/shared_cl_context.cc
@@ -1484,7 +1484,9 @@ int SharedCLContext::buildOrLinkProgram(
 
   // ROCm 6.4.4 segfaults when linking multiple programs together if they were
   // only compiled for a subset of devices in the context.
-  if (RocmPlatform)
+  // NVIDIA 595.71.05 silently fails kernel compilation when compiling for a
+  // subset of devices that does not include the first device in the context.
+  if (RocmPlatform || NvidiaPlatform)
     program->devices = CLDevices;
 
   if (options == nullptr)


### PR DESCRIPTION
Mostly trial and error workarounds for various driver behaviours that I'm not convinced are entirely up to spec...

Fetching kernel binaries and trying to recreate the same programs from them later was also horribly broken. This PR makes that kind of application-driven caching work, but pocl's automatic client-side caching when building the same kernels again from source does not seem to kick in.