### PR TITLE
tests: share the command-buffer extension loading between the CB tests

### DIFF
--- a/tests/runtime/command_buffer_common.h
+++ b/tests/runtime/command_buffer_common.h
@@ -1,0 +1,85 @@
+/* Shared cl_khr_command_buffer entry point loading for the runtime tests.
+
+   Copyright (c) 2026 PoCL developers
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to
+   deal in the Software without restriction, including without limitation the
+   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+   sell copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+   IN THE SOFTWARE.
+*/
+
+#ifndef POCL_TESTS_COMMAND_BUFFER_COMMON_H
+#define POCL_TESTS_COMMAND_BUFFER_COMMON_H
+
+#include <stdio.h>
+
+#include <CL/cl.h>
+#include <CL/cl_ext.h>
+
+/* Union of the entry points the command-buffer tests use; each test reads the
+   subset it needs. */
+struct cmdbuf_ext
+{
+  clCreateCommandBufferKHR_fn clCreateCommandBufferKHR;
+  clCommandCopyBufferKHR_fn clCommandCopyBufferKHR;
+  clCommandCopyBufferRectKHR_fn clCommandCopyBufferRectKHR;
+  clCommandCopyBufferToImageKHR_fn clCommandCopyBufferToImageKHR;
+  clCommandCopyImageKHR_fn clCommandCopyImageKHR;
+  clCommandCopyImageToBufferKHR_fn clCommandCopyImageToBufferKHR;
+  clCommandFillBufferKHR_fn clCommandFillBufferKHR;
+  clCommandFillImageKHR_fn clCommandFillImageKHR;
+  clCommandNDRangeKernelKHR_fn clCommandNDRangeKernelKHR;
+  clCommandBarrierWithWaitListKHR_fn clCommandBarrierWithWaitListKHR;
+  clFinalizeCommandBufferKHR_fn clFinalizeCommandBufferKHR;
+  clEnqueueCommandBufferKHR_fn clEnqueueCommandBufferKHR;
+  clReleaseCommandBufferKHR_fn clReleaseCommandBufferKHR;
+  clGetCommandBufferInfoKHR_fn clGetCommandBufferInfoKHR;
+};
+
+/* Resolve the entry points for `platform`. Returns 0, or 77 (the ctest skip
+   code) if the platform does not implement command buffers. */
+static inline int
+cmdbuf_load_ext (cl_platform_id platform, struct cmdbuf_ext *ext)
+{
+#define CMDBUF_GET(name)                                                      \
+  ext->name = clGetExtensionFunctionAddressForPlatform (platform, #name)
+
+  CMDBUF_GET (clCreateCommandBufferKHR);
+  if (ext->clCreateCommandBufferKHR == NULL)
+    {
+      printf ("Command buffers are not supported, skipping test\n");
+      return 77;
+    }
+
+  CMDBUF_GET (clCommandCopyBufferKHR);
+  CMDBUF_GET (clCommandCopyBufferRectKHR);
+  CMDBUF_GET (clCommandCopyBufferToImageKHR);
+  CMDBUF_GET (clCommandCopyImageKHR);
+  CMDBUF_GET (clCommandCopyImageToBufferKHR);
+  CMDBUF_GET (clCommandFillBufferKHR);
+  CMDBUF_GET (clCommandFillImageKHR);
+  CMDBUF_GET (clCommandNDRangeKernelKHR);
+  CMDBUF_GET (clCommandBarrierWithWaitListKHR);
+  CMDBUF_GET (clFinalizeCommandBufferKHR);
+  CMDBUF_GET (clEnqueueCommandBufferKHR);
+  CMDBUF_GET (clReleaseCommandBufferKHR);
+  CMDBUF_GET (clGetCommandBufferInfoKHR);
+  return 0;
+
+#undef CMDBUF_GET
+}
+
+#endif

--- a/tests/runtime/test_command_buffer.c
+++ b/tests/runtime/test_command_buffer.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "command_buffer_common.h"
 #include "poclu.h"
 
 #define STR(x) #x
@@ -33,19 +34,7 @@ int
 main (int _argc, char **_argv)
 {
 #if defined(cl_khr_command_buffer) && cl_khr_command_buffer == 1
-  struct
-  {
-    clCreateCommandBufferKHR_fn clCreateCommandBufferKHR;
-    clCommandCopyBufferKHR_fn clCommandCopyBufferKHR;
-    clCommandCopyBufferRectKHR_fn clCommandCopyBufferRectKHR;
-    clCommandFillBufferKHR_fn clCommandFillBufferKHR;
-    clCommandNDRangeKernelKHR_fn clCommandNDRangeKernelKHR;
-    clCommandBarrierWithWaitListKHR_fn clCommandBarrierWithWaitListKHR;
-    clFinalizeCommandBufferKHR_fn clFinalizeCommandBufferKHR;
-    clEnqueueCommandBufferKHR_fn clEnqueueCommandBufferKHR;
-    clReleaseCommandBufferKHR_fn clReleaseCommandBufferKHR;
-    clGetCommandBufferInfoKHR_fn clGetCommandBufferInfoKHR;
-  } ext;
+  struct cmdbuf_ext ext;
 
   cl_platform_id platform;
   CHECK_CL_ERROR (clGetPlatformIDs (1, &platform, NULL));
@@ -53,33 +42,9 @@ main (int _argc, char **_argv)
   CHECK_CL_ERROR (
       clGetDeviceIDs (platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL));
 
-  ext.clCreateCommandBufferKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clCreateCommandBufferKHR");
-  if (ext.clCreateCommandBufferKHR == NULL)
-    {
-      printf ("Command buffers are not supported, skipping test\n");
-      return 77;
-    }
-
-  ext.clCommandCopyBufferKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clCommandCopyBufferKHR");
-  ext.clCommandCopyBufferRectKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clCommandCopyBufferRectKHR");
-  ext.clCommandFillBufferKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clCommandFillBufferKHR");
-  ext.clCommandNDRangeKernelKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clCommandNDRangeKernelKHR");
-  ext.clCommandBarrierWithWaitListKHR
-      = clGetExtensionFunctionAddressForPlatform (
-          platform, "clCommandBarrierWithWaitListKHR");
-  ext.clFinalizeCommandBufferKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clFinalizeCommandBufferKHR");
-  ext.clEnqueueCommandBufferKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clEnqueueCommandBufferKHR");
-  ext.clReleaseCommandBufferKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clReleaseCommandBufferKHR");
-  ext.clGetCommandBufferInfoKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clGetCommandBufferInfoKHR");
+  int skip = cmdbuf_load_ext (platform, &ext);
+  if (skip != 0)
+    return skip;
 
   cl_int error;
   cl_context context = clCreateContext (NULL, 1, &device, NULL, NULL, &error);

--- a/tests/runtime/test_command_buffer_images.c
+++ b/tests/runtime/test_command_buffer_images.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "command_buffer_common.h"
 #include "poclu.h"
 
 #define STR(x) #x
@@ -33,18 +34,7 @@ int
 main (int _argc, char **_argv)
 {
 #if defined(cl_khr_command_buffer) && cl_khr_command_buffer == 1
-  struct
-  {
-    clCreateCommandBufferKHR_fn clCreateCommandBufferKHR;
-    clCommandCopyBufferToImageKHR_fn clCommandCopyBufferToImageKHR;
-    clCommandCopyImageToBufferKHR_fn clCommandCopyImageToBufferKHR;
-    clCommandCopyImageKHR_fn clCommandCopyImageKHR;
-    clCommandFillImageKHR_fn clCommandFillImageKHR;
-    clFinalizeCommandBufferKHR_fn clFinalizeCommandBufferKHR;
-    clEnqueueCommandBufferKHR_fn clEnqueueCommandBufferKHR;
-    clReleaseCommandBufferKHR_fn clReleaseCommandBufferKHR;
-    clGetCommandBufferInfoKHR_fn clGetCommandBufferInfoKHR;
-  } ext;
+  struct cmdbuf_ext ext;
 
   cl_platform_id platform;
   CHECK_CL_ERROR (clGetPlatformIDs (1, &platform, NULL));
@@ -52,32 +42,9 @@ main (int _argc, char **_argv)
   CHECK_CL_ERROR (
       clGetDeviceIDs (platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL));
 
-  ext.clCreateCommandBufferKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clCreateCommandBufferKHR");
-  if (ext.clCreateCommandBufferKHR == NULL)
-    {
-      printf ("Command buffers are not supported, skipping test\n");
-      return 77;
-    }
-
-  ext.clCommandCopyBufferToImageKHR
-      = clGetExtensionFunctionAddressForPlatform (
-          platform, "clCommandCopyBufferToImageKHR");
-  ext.clCommandCopyImageToBufferKHR
-      = clGetExtensionFunctionAddressForPlatform (
-          platform, "clCommandCopyImageToBufferKHR");
-  ext.clCommandCopyImageKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clCommandCopyImageKHR");
-  ext.clCommandFillImageKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clCommandFillImageKHR");
-  ext.clFinalizeCommandBufferKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clFinalizeCommandBufferKHR");
-  ext.clEnqueueCommandBufferKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clEnqueueCommandBufferKHR");
-  ext.clReleaseCommandBufferKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clReleaseCommandBufferKHR");
-  ext.clGetCommandBufferInfoKHR = clGetExtensionFunctionAddressForPlatform (
-      platform, "clGetCommandBufferInfoKHR");
+  int skip = cmdbuf_load_ext (platform, &ext);
+  if (skip != 0)
+    return skip;
 
   cl_int error;
   cl_context context = clCreateContext (NULL, 1, &device, NULL, NULL, &error);


### PR DESCRIPTION
Split out of #2306 as requested there.

`test_command_buffer` and `test_command_buffer_images` each carried their own copy of the entry-point struct and the ~20 lines of `clGetExtensionFunctionAddressForPlatform` boilerplate, differing only in which subset they declared.

`tests/runtime/command_buffer_common.h` now holds one struct with the union of what the two use, plus a loader that also owns the "not supported, skipping test" 77 return. Each test reads the subset it needs, so neither changes beyond the two lines replacing the block.

No behaviour change. `runtime/test_command_buffer` and `runtime/test_command_buffer_images` pass unchanged; full `ctest` 341/341 here (CPU device, LLVM 20, aarch64).

`test_command_buffer_multi_device` has the same struct and loader, but establishes command-buffer support through a different path before loading, so converting it is a slightly different change — happy to fold it in if you'd prefer it in one go.
